### PR TITLE
Fix empty blobs (empty vector<char>)

### DIFF
--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -2801,7 +2801,9 @@ namespace sqlite_orm {
     >
     {
         int bind(sqlite3_stmt *stmt, int index, const V &value) {
-            return sqlite3_bind_blob(stmt, index, (const void *)&value.front(), int(value.size()), SQLITE_TRANSIENT);
+            if (!value.empty())
+               return sqlite3_bind_blob(stmt, index, (const void *)&value.front(), int(value.size()), SQLITE_TRANSIENT);
+           return sqlite3_bind_blob(stmt, index, nullptr, 0, SQLITE_TRANSIENT);
         }
     };
 


### PR DESCRIPTION
Throws exception when trying to access the value.front()