### PR TITLE
Visual Studio 2017 warnings fix

### DIFF
--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -3631,7 +3631,7 @@ namespace sqlite_orm {
                 auto query = ss.str();
                 auto rc = sqlite3_exec(db,
                                        query.c_str(),
-                                       [](void *data, int argc, char **argv,char **/*azColName*/) -> int {
+                                       [](void *data, int argc, char **argv,char ** /*azColName*/) -> int {
                                            auto &res = *(bool*)data;
                                            if(argc){
                                                res = !!std::atoi(argv[0]);
@@ -4510,7 +4510,7 @@ namespace sqlite_orm {
                     this->set_pragma("auto_vacuum", value);
                 }
                 
-                friend class storage_t<Ts...>;
+                friend struct storage_t<Ts...>;
                 
             protected:
                 storage_type &storage;
@@ -7198,7 +7198,7 @@ namespace sqlite_orm {
                 std::string sql = std::string("SELECT name FROM sqlite_master WHERE type='table'");
                 typedef std::vector<std::string> Data;
                 int res = sqlite3_exec(connection->get_db(), sql.c_str(),
-                                       [] (void *data, int argc, char **argv, char **/*columnName*/) -> int {
+                                       [] (void *data, int argc, char **argv, char ** /*columnName*/) -> int {
                                            auto& tableNames = *(Data*)data;
                                            for(int i = 0; i < argc; i++) {
                                                if(argv[i]){


### PR DESCRIPTION
Just a quick fix for the couple of warning generated by Visual Studio 2017 compiler:

1>d:\projects\sqlite\sqlite_orm\include\sqlite_orm\sqlite_orm.h(3634): warning C4138: '*/' found outside of comment
1>d:\projects\sqlite\sqlite_orm\include\sqlite_orm\sqlite_orm.h(7201): warning C4138: '*/' found outside of comment
1>d:\projects\sqlite\sqlite_orm\include\sqlite_orm\sqlite_orm.h(4513): warning C4099: 'sqlite_orm::internal::storage_t<Ts...>': type name first seen using 'struct' now seen using 'class'
1>d:\projects\sqlite\sqlite_orm\include\sqlite_orm\sqlite_orm.h(4547): note: see reference to class template instantiation 'sqlite_orm::internal::storage_t<Ts...>::pragma_t' being compiled
1>d:\projects\sqlite\sqlite_orm\include\sqlite_orm\sqlite_orm.h(7234): note: see reference to class template instantiation 'sqlite_orm::internal::storage_t<Ts...>' being compiled
1>d:\projects\sqlite\sqlite_orm\include\sqlite_orm\sqlite_orm.h(4513): warning C4099: 'sqlite_orm::internal::storage_t<sqlite_orm::table_t<sqlite_orm::internal::column_t<ErrorLogEntry,std::string>,sqlite_orm::internal::column_t<ErrorLogEntry,std::string>,sqlite_orm::internal::column_t<ErrorLogEntry,std::vector<char,std::allocator<char>>>>>': type name first seen using 'struct' now seen using 'class'
1>d:\projects\sqlite\sqlite_orm\include\sqlite_orm\sqlite_orm.h(4292): note: see declaration of 'sqlite_orm::internal::storage_t<sqlite_orm::table_t<sqlite_orm::internal::column_t<ErrorLogEntry,std::string>,sqlite_orm::internal::column_t<ErrorLogEntry,std::string>,sqlite_orm::internal::column_t<ErrorLogEntry,std::vector<char,std::allocator<char>>>>>'
1>d:\projects\sqlite\sqlite_orm\include\sqlite_orm\sqlite_orm.h(7233): note: see reference to class template instantiation 'sqlite_orm::internal::storage_t<sqlite_orm::table_t<sqlite_orm::internal::column_t<ErrorLogEntry,std::string>,sqlite_orm::internal::column_t<ErrorLogEntry,std::string>,sqlite_orm::internal::column_t<ErrorLogEntry,std::vector<char,std::allocator<char>>>>>::pragma_t' being compiled
1>d:\projects\sqlite\sqlite_test\sqlite_test\sqlite_test.cpp(25): note: see reference to class template instantiation 'sqlite_orm::internal::storage_t<sqlite_orm::table_t<sqlite_orm::internal::column_t<ErrorLogEntry,std::string>,sqlite_orm::internal::column_t<ErrorLogEntry,std::string>,sqlite_orm::internal::column_t<ErrorLogEntry,std::vector<char,std::allocator<char>>>>