### PR TITLE
add_library(... INTERFACE), std::iterator_traits fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,14 @@
 cmake_minimum_required (VERSION 3.2)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 project(sqlite_orm)
 
 option(SqliteOrm_BuildTests "Build sqlite_orm unit tests" ON)
 
 set(SqliteOrm_INCLUDE "${CMAKE_CURRENT_SOURCE_DIR}/include")
+add_library(sqlite_orm INTERFACE)
+target_include_directories(sqlite_orm INTERFACE include)
 
 # Tests
 include(CTest)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -4,11 +4,5 @@ file(GLOB files "*.cpp")
 foreach(file ${files})
     get_filename_component(file_basename ${file} NAME_WE)
     add_executable(${file_basename} ${file})
-    set_target_properties(${file_basename} PROPERTIES
-            CXX_STANDARD 14
-            CXX_STANDARD_REQUIRED ON
-    )
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -lc++abi")
-    target_include_directories(${file_basename} PRIVATE ${SqliteOrm_INCLUDE})
-    target_link_libraries(${file_basename} PRIVATE dl sqlite3 pthread)
+    target_link_libraries(${file_basename} PRIVATE sqlite_orm sqlite3)
 endforeach()

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -4334,6 +4334,12 @@ namespace sqlite_orm {
                     }
                     
                 public:
+                    using value_type = T;
+                    using difference_type = std::ptrdiff_t;
+                    using pointer = value_type *;
+                    using reference = value_type &;
+                    using iterator_category = std::input_iterator_tag;
+
                     iterator_t(sqlite3_stmt * stmt_, view_t<T, Args...> &view_):stmt(std::make_shared<sqlite3_stmt *>(stmt_)),view(view_){
                         this->operator++();
                     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,18 +8,10 @@ else()
     add_subdirectory(third_party/sqlite)
 endif()
 
-set(SqliteOrm_UnitTarget unit_tests)
+add_executable(unit_tests tests.cpp)
 
-add_executable(${SqliteOrm_UnitTarget} tests.cpp)
-
-target_include_directories(${SqliteOrm_UnitTarget} PRIVATE ${SqliteOrm_INCLUDE})
-
-target_link_libraries(${SqliteOrm_UnitTarget} PRIVATE dl sqlite3 pthread)
-
-set_target_properties(${SqliteOrm_UnitTarget} PROPERTIES
-    CXX_STANDARD 14
-    CXX_STANDARD_REQUIRED ON)
+target_link_libraries(unit_tests PRIVATE sqlite_orm sqlite3)
 
 add_test(NAME "All_in_one_unit_test"
-    COMMAND ${SqliteOrm_UnitTarget}
+    COMMAND unit_tests
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/third_party/sqlite/CMakeLists.txt
+++ b/tests/third_party/sqlite/CMakeLists.txt
@@ -16,3 +16,4 @@ add_custom_command(
     ${CMAKE_COMMAND} -E tar xfz ${SQLITE3_ARCH_NAME})
 
 add_library(sqlite3 sqlite-amalgamation-3210000/sqlite3.c)
+target_link_libraries(sqlite3 dl pthread)


### PR DESCRIPTION
Hello! Thanks for a great library! I had some minor issues with it I'd like to discuss, some of these changes might be more relevant than others, but here it goes!

## add_library(... INTERFACE)
By declaring an `INTERFACE` library (header-only),
the `include` directory can be specified once with the library
instead of with each user of it (`examples`, `tests` etc).

## std::iterator_traits fixes
I got some compiler errors in `iteration.cpp` using `g++7`,
since the `storage_t::view_t::iterator_t` seem to lack the standard
iterator `typedef`s like `value_type` etc.
http://en.cppreference.com/w/cpp/iterator/iterator_traits
specifies the fields needed. As can be read there:
```
If Iterator does not have all five member types difference_type, value_type, pointer, reference, and iterator_category, then this template has no members by any of those names (std::iterator_traits is SFINAE-friendly)
```
which means that all 5 need to be declared.
I am tempted to use `std::iterator` (see http://en.cppreference.com/w/cpp/iterator/iterator)
which would save a few lines, but as it is deprecated with C++17 I decided not to.