### PR TITLE
 fixed -Wreorder warning issue with g++/clang++

### DIFF
--- a/dev/storage.h
+++ b/dev/storage.h
@@ -234,11 +234,11 @@ namespace sqlite_orm {
             storage_t(const storage_t &other):
             filename(other.filename),
             impl(other.impl),
+            currentTransaction(other.currentTransaction),
             inMemory(other.inMemory),
-            pragma(*this),
-            limit(*this),
             collatingFunctions(other.collatingFunctions),
-            currentTransaction(other.currentTransaction)
+            pragma(*this),
+            limit(*this)
             {}
             
         protected:

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -6240,11 +6240,11 @@ namespace sqlite_orm {
             storage_t(const storage_t &other):
             filename(other.filename),
             impl(other.impl),
+            currentTransaction(other.currentTransaction),
             inMemory(other.inMemory),
-            pragma(*this),
-            limit(*this),
             collatingFunctions(other.collatingFunctions),
-            currentTransaction(other.currentTransaction)
+            pragma(*this),
+            limit(*this)
             {}
             
         protected:


### PR DESCRIPTION
In `dev` as you asked.  Feel free to close the other PR.  Let me know if you need anything further.