### PR TITLE
Prefer unique_ptr over shared_ptr

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,10 +121,10 @@ try{
 }
 ```
 
-Probably you may not like throwing exceptions. Me too. Exception `std::system_error` is thrown because return type in `get` function is not nullable. You can use alternative version `get_no_throw` which returns `std::unique_ptr` and doesn't throw `not_found_exception` if nothing found - just returns `nullptr`.
+Probably you may not like throwing exceptions. Me too. Exception `std::system_error` is thrown because return type in `get` function is not nullable. You can use alternative version `get_pointer` which returns `std::unique_ptr` and doesn't throw `not_found_exception` if nothing found - just returns `nullptr`.
 
 ```c++
-if(auto user = storage.get_no_throw<User>(insertedId)){
+if(auto user = storage.get_pointer<User>(insertedId)){
     cout << "user = " << user->firstName << " " << user->lastName << endl;
 }else{
     cout << "no user with id " << insertedId << endl;
@@ -183,7 +183,7 @@ for(auto &user : storage.iterate<User>()) {
 
 `iterate` member function returns adapter object that has `begin` and `end` member functions returning iterators that fetch object on dereference operator call.
 
-CRUD functions `get`, `get_no_throw`, `remove`, `update` (not `insert`) work only if your type has a primary key column. If you try to `get` an object that is mapped to your storage but has no primary key column a `std::system_error` will be thrown cause `sqlite_orm` cannot detect an id. If you want to know how to perform a storage without primary key take a look at `date_time.cpp` example in `examples` folder.
+CRUD functions `get`, `get_pointer`, `remove`, `update` (not `insert`) work only if your type has a primary key column. If you try to `get` an object that is mapped to your storage but has no primary key column a `std::system_error` will be thrown cause `sqlite_orm` cannot detect an id. If you want to know how to perform a storage without primary key take a look at `date_time.cpp` example in `examples` folder.
 
 # Aggregate Functions
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ struct User{
     std::string firstName;
     std::string lastName;
     int birthDate;
-    std::shared_ptr<std::string> imageUrl;      
+    std::unique_ptr<std::string> imageUrl;
     int typeId;
 };
 
@@ -96,7 +96,7 @@ More details about making storage can be found in [tutorial](https://github.com/
 Let's create and insert new `User` into database. First we need to create a `User` object with any id and call `insert` function. It will return id of just created user or throw exception if something goes wrong.
 
 ```c++
-User user{-1, "Jonh", "Doe", 664416000, std::make_shared<std::string>("url_to_heaven"), 3 };
+User user{-1, "Jonh", "Doe", 664416000, std::make_unique<std::string>("url_to_heaven"), 3 };
     
 auto insertedId = storage.insert(user);
 cout << "insertedId = " << insertedId << endl;      //  insertedId = 8
@@ -121,7 +121,7 @@ try{
 }
 ```
 
-Probably you may not like throwing exceptions. Me too. Exception `std::system_error` is thrown because return type in `get` function is not nullable. You can use alternative version `get_no_throw` which returns `std::shared_ptr` and doesn't throw `not_found_exception` if nothing found - just returns `nullptr`.
+Probably you may not like throwing exceptions. Me too. Exception `std::system_error` is thrown because return type in `get` function is not nullable. You can use alternative version `get_no_throw` which returns `std::unique_ptr` and doesn't throw `not_found_exception` if nothing found - just returns `nullptr`.
 
 ```c++
 if(auto user = storage.get_no_throw<User>(insertedId)){
@@ -131,7 +131,7 @@ if(auto user = storage.get_no_throw<User>(insertedId)){
 }
 ```
 
-`std::shared_ptr` is used as optional in `sqlite_orm`. Of course there is class optional in C++14 located at `std::experimental::optional`. But we don't want to use it until it is `experimental`.
+`std::unique_ptr` is used as optional in `sqlite_orm`. Of course there is class optional in C++14 located at `std::experimental::optional`. But we don't want to use it until it is `experimental`.
 
 We can also update our user. It updates row by id provided in `user` object and sets all other non `primary_key` fields to values stored in the passed `user` object. So you can just assign members to `user` object you want and call `update`
 
@@ -218,21 +218,21 @@ cout << "concatedUserIdWithDashes = " << concatedUserIdWithDashes << endl;      
 
 //  SELECT MAX(id) FROM users
 if(auto maxId = storage.max(&User::id)){    
-    cout << "maxId = " << *maxId <<endl;    //  maxId = 12  (maxId is std::shared_ptr<int>)
+    cout << "maxId = " << *maxId <<endl;    //  maxId = 12  (maxId is std::unique_ptr<int>)
 }else{
     cout << "maxId is null" << endl;
 }
     
 //  SELECT MAX(first_name) FROM users
 if(auto maxFirstName = storage.max(&User::firstName)){ 
-    cout << "maxFirstName = " << *maxFirstName << endl; //  maxFirstName = Jonh (maxFirstName is std::shared_ptr<std::string>)
+    cout << "maxFirstName = " << *maxFirstName << endl; //  maxFirstName = Jonh (maxFirstName is std::unique_ptr<std::string>)
 }else{
     cout << "maxFirstName is null" << endl;
 }
 
 //  SELECT MIN(id) FROM users
 if(auto minId = storage.min(&User::id)){    
-    cout << "minId = " << *minId << endl;   //  minId = 1 (minId is std::shared_ptr<int>)
+    cout << "minId = " << *minId << endl;   //  minId = 1 (minId is std::unique_ptr<int>)
 }else{
     cout << "minId is null" << endl;
 }
@@ -245,7 +245,7 @@ if(auto minLastName = storage.min(&User::lastName)){
 }
 
 //  SELECT SUM(id) FROM users
-if(auto sumId = storage.sum(&User::id)){    //  sumId is std::shared_ptr<int>
+if(auto sumId = storage.sum(&User::id)){    //  sumId is std::unique_ptr<int>
     cout << "sumId = " << *sumId << endl;
 }else{
     cout << "sumId is null" << endl;

--- a/dev/column.h
+++ b/dev/column.h
@@ -2,7 +2,7 @@
 
 #include <tuple>    //  std::tuple
 #include <string>   //  std::string
-#include <memory>   //  std::shared_ptr
+#include <memory>   //  std::unique_ptr
 #include <type_traits>  //  std::true_type, std::false_type, std::is_same, std::enable_if
 
 #include "type_is_nullable.h"
@@ -85,12 +85,12 @@ namespace sqlite_orm {
              *  Simplified interface for `DEFAULT` constraint
              *  @return string representation of default value if it exists otherwise nullptr
              */
-            std::shared_ptr<std::string> default_value() {
-                std::shared_ptr<std::string> res;
+            std::unique_ptr<std::string> default_value() {
+                std::unique_ptr<std::string> res;
                 tuple_helper::iterator<std::tuple_size<constraints_type>::value - 1, Op...>()(constraints, [&res](auto &v){
                     auto dft = internal::default_value_extractor()(v);
                     if(dft){
-                        res = dft;
+                        res = std::move(dft);
                     }
                 });
                 return res;

--- a/dev/column_result.h
+++ b/dev/column_result.h
@@ -74,7 +74,7 @@ namespace sqlite_orm {
         
         template<class St, class T>
         struct column_result_t<St, core_functions::abs_t<T>, void> {
-            using type = std::shared_ptr<double>;
+            using type = std::unique_ptr<double>;
         };
         
         template<class St, class T>
@@ -149,7 +149,7 @@ namespace sqlite_orm {
         
         template<class St, class T>
         struct column_result_t<St, aggregate_functions::sum_t<T>, void> {
-            using type = std::shared_ptr<double>;
+            using type = std::unique_ptr<double>;
         };
         
         template<class St, class T>
@@ -169,12 +169,12 @@ namespace sqlite_orm {
         
         template<class St, class T>
         struct column_result_t<St, aggregate_functions::max_t<T>, void> {
-            using type = std::shared_ptr<typename column_result_t<St, T>::type>;
+            using type = std::unique_ptr<typename column_result_t<St, T>::type>;
         };
         
         template<class St, class T>
         struct column_result_t<St, aggregate_functions::min_t<T>, void> {
-            using type = std::shared_ptr<typename column_result_t<St, T>::type>;
+            using type = std::unique_ptr<typename column_result_t<St, T>::type>;
         };
         
         template<class St>

--- a/dev/default_value_extractor.h
+++ b/dev/default_value_extractor.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <memory>   //  std::shared_ptr
+#include <memory>   //  std::unique_ptr
 #include <string>   //  std::string
 #include <sstream>  //  std::stringstream
 
@@ -17,15 +17,15 @@ namespace sqlite_orm {
         struct default_value_extractor {
             
             template<class A>
-            std::shared_ptr<std::string> operator() (const A &) {
+            std::unique_ptr<std::string> operator() (const A &) {
                 return {};
             }
             
             template<class T>
-            std::shared_ptr<std::string> operator() (const constraints::default_t<T> &t) {
+            std::unique_ptr<std::string> operator() (const constraints::default_t<T> &t) {
                 std::stringstream ss;
                 ss << t.value;
-                return std::make_shared<std::string>(ss.str());
+                return std::make_unique<std::string>(ss.str());
             }
         };
         

--- a/dev/sqlite_type.h
+++ b/dev/sqlite_type.h
@@ -3,7 +3,7 @@
 #include <map>  //  std::map
 #include <string>   //  std::string
 #include <regex>    //  std::regex, std::regex_match
-#include <memory>   //  std::make_shared, std::shared_ptr
+#include <memory>   //  std::make_unique, std::unique_ptr
 #include <vector>   //  std::vector
 #include <cctype>   //  std::toupper
 
@@ -22,7 +22,7 @@ namespace sqlite_orm {
     /**
      *  @param str case doesn't matter - it is uppercased before comparing.
      */
-    inline std::shared_ptr<sqlite_type> to_sqlite_type(const std::string &str) {
+    inline std::unique_ptr<sqlite_type> to_sqlite_type(const std::string &str) {
         auto asciiStringToUpper = [](std::string &s){
             std::transform(s.begin(),
                            s.end(),
@@ -71,7 +71,7 @@ namespace sqlite_orm {
         for(auto &p : typeMap) {
             for(auto &r : p.second) {
                 if(std::regex_match(upperStr, r)){
-                    return std::make_shared<sqlite_type>(p.first);
+                    return std::make_unique<sqlite_type>(p.first);
                 }
             }
         }

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <memory>   //  std::shared_ptr, std::make_shared
+#include <memory>   //  std::unique/shared_ptr, std::make_unique/shared
 #include <string>   //  std::string
 #include <sqlite3.h>
 #include <type_traits>  //  std::remove_reference, std::is_base_of, std::decay, std::false_type, std::true_type
@@ -68,7 +68,7 @@ namespace sqlite_orm {
                 
                 view_t(storage_t &stor, decltype(connection) conn, Args&& ...args):
                 storage(stor),
-                connection(conn),
+                connection(std::move(conn)),
                 query([&args..., &stor]{
                     std::string q;
                     stor.template generate_select_asterisk<T>(&q, args...);
@@ -77,21 +77,23 @@ namespace sqlite_orm {
                 
                 struct iterator_t {
                 protected:
-                    std::shared_ptr<sqlite3_stmt *> stmt;
+                    sqlite3_stmt *stmt;
                     view_t<T, Args...> &view;
-                    std::shared_ptr<T> temp;
+                    // shared_ptr is used over unique_ptr here
+                    // so that the iterator can be copyable.
+                    std::shared_ptr<T> current;
                     
-                    void extract_value(decltype(temp) &temp) {
-                        temp = std::make_shared<T>();
+                    void extract_value(std::unique_ptr<T> &temp) {
+                        temp = std::make_unique<T>();
                         auto &storage = this->view.storage;
                         auto &impl = storage.template get_impl<T>();
                         auto index = 0;
                         impl.table.for_each_column([&index, &temp, this] (auto &c) {
                             using field_type = typename std::decay<decltype(c)>::type::field_type;
-                            auto value = row_extractor<field_type>().extract(*this->stmt, index++);
+                            auto value = row_extractor<field_type>().extract(this->stmt, index++);
                             if(c.member_pointer){
                                 auto member_pointer = c.member_pointer;
-                                (*temp).*member_pointer = value;
+                                (*temp).*member_pointer = std::move(value);
                             }else{
                                 ((*temp).*(c.setter))(std::move(value));
                             }
@@ -105,7 +107,7 @@ namespace sqlite_orm {
                     using reference = value_type &;
                     using iterator_category = std::input_iterator_tag;
                     
-                    iterator_t(sqlite3_stmt * stmt_, view_t<T, Args...> &view_): stmt(std::make_shared<sqlite3_stmt *>(stmt_)), view(view_) {
+                    iterator_t(sqlite3_stmt * stmt_, view_t<T, Args...> &view_): stmt(stmt_), view(view_) {
                         this->operator++();
                     }
                     
@@ -118,41 +120,43 @@ namespace sqlite_orm {
                     iterator_t& operator=(const iterator_t&) = default;
                     
                     ~iterator_t() {
-                        if(this->stmt){
-                            statement_finalizer f{*this->stmt};
-                        }
+                        statement_finalizer f{this->stmt};
                     }
                     
                     T& operator*() {
                         if(!this->stmt) {
                             throw std::system_error(std::make_error_code(orm_error_code::trying_to_dereference_null_iterator));
                         }
-                        if(!this->temp){
-                            this->extract_value(this->temp);
+                        if(!this->current){
+                            std::unique_ptr<T> value;
+                            this->extract_value(value);
+                            this->current = std::move(value);
                         }
-                        return *this->temp;
+                        return *this->current;
                     }
                     
                     T* operator->() {
                         if(!this->stmt) {
                             throw std::system_error(std::make_error_code(orm_error_code::trying_to_dereference_null_iterator));
                         }
-                        if(!this->temp){
-                            this->extract_value(this->temp);
+                        if(!this->current){
+                            std::unique_ptr<T> value;
+                            this->extract_value(value);
+                            this->current = std::move(value);
                         }
-                        return &*this->temp;
+                        return &*this->current;
                     }
                     
                     void operator++() {
-                        if(this->stmt && *this->stmt){
-                            auto ret = sqlite3_step(*this->stmt);
+                        if(this->stmt){
+                            auto ret = sqlite3_step(this->stmt);
                             switch(ret){
                                 case SQLITE_ROW:
-                                    this->temp = nullptr;
+                                    this->current = nullptr;
                                     break;
                                 case SQLITE_DONE:{
-                                    statement_finalizer f{*this->stmt};
-                                    *this->stmt = nullptr;
+                                    statement_finalizer f{this->stmt};
+                                    this->stmt = nullptr;
                                 }break;
                                 default:{
                                     throw std::system_error(std::error_code(sqlite3_errcode(this->view.connection->get_db()), get_sqlite_error_category()));
@@ -167,7 +171,7 @@ namespace sqlite_orm {
                     
                     bool operator==(const iterator_t &other) const {
                         if(this->stmt && other.stmt){
-                            return *this->stmt == *other.stmt;
+                            return this->stmt == other.stmt;
                         }else{
                             if(!this->stmt && !other.stmt){
                                 return true;
@@ -1831,7 +1835,7 @@ namespace sqlite_orm {
             }
             
             template<class F, class O, class ...Args>
-            std::string group_concat_internal(F O::*m, std::shared_ptr<const std::string> y, Args&& ...args) {
+            std::string group_concat_internal(F O::*m, std::unique_ptr<const std::string> y, Args&& ...args) {
                 this->assert_mapped_type<O>();
                 
                 auto connection = this->get_or_create_connection();
@@ -1895,7 +1899,7 @@ namespace sqlite_orm {
                                     using field_type = typename decltype(c)::field_type;
                                     auto value = row_extractor<field_type>().extract(stmt, index++);
                                     if(c.member_pointer){
-                                        obj.*c.member_pointer = value;
+                                        obj.*c.member_pointer = std::move(value);
                                     }else{
                                         ((obj).*(c.setter))(std::move(value));
                                     }
@@ -1928,7 +1932,7 @@ namespace sqlite_orm {
                 
                 auto connection = this->get_or_create_connection();
                 auto &impl = this->get_impl<O>();
-                std::shared_ptr<O> res;
+                std::unique_ptr<O> res;
                 std::stringstream ss;
                 ss << "SELECT ";
                 auto columnNames = impl.table.column_names();
@@ -1970,7 +1974,7 @@ namespace sqlite_orm {
                                     using field_type = typename decltype(c)::field_type;
                                     auto value = row_extractor<field_type>().extract(stmt, index++);
                                     if(c.member_pointer){
-                                        res.*c.member_pointer = value;
+                                        res.*c.member_pointer = std::move(value);
                                     }else{
                                         ((res).*(c.setter))(std::move(value));
                                     }
@@ -1993,16 +1997,16 @@ namespace sqlite_orm {
             }
             
             /**
-             *  The same as `get` function but doesn't throw an exception if noting found but returns std::shared_ptr with null value.
+             *  The same as `get` function but doesn't throw an exception if noting found but returns std::unique_ptr with null value.
              *  throws std::system_error in case of db error.
              */
             template<class O, class ...Ids>
-            std::shared_ptr<O> get_no_throw(Ids ...ids) {
+            std::unique_ptr<O> get_no_throw(Ids ...ids) {
                 this->assert_mapped_type<O>();
                 
                 auto connection = this->get_or_create_connection();
                 auto &impl = this->get_impl<O>();
-                std::shared_ptr<O> res;
+                std::unique_ptr<O> res;
                 std::stringstream ss;
                 ss << "SELECT ";
                 auto columnNames = impl.table.column_names();
@@ -2044,12 +2048,12 @@ namespace sqlite_orm {
                                     using field_type = typename decltype(c)::field_type;
                                     auto value = row_extractor<field_type>().extract(stmt, index++);
                                     if(c.member_pointer){
-                                        res.*c.member_pointer = value;
+                                        res.*c.member_pointer = std::move(value);
                                     }else{
                                         ((res).*(c.setter))(std::move(value));
                                     }
                                 });
-                                return std::make_shared<O>(std::move(res));
+                                return std::make_unique<O>(std::move(res));
                             }break;
                             case SQLITE_DONE:{
                                 return {};
@@ -2198,26 +2202,26 @@ namespace sqlite_orm {
              */
             template<class F, class O, class ...Args>
             std::string group_concat(F O::*m, const std::string &y, Args&& ...args) {
-                return this->group_concat_internal(m, std::make_shared<std::string>(y), std::forward<Args>(args)...);
+                return this->group_concat_internal(m, std::make_unique<std::string>(y), std::forward<Args>(args)...);
             }
             
             template<class F, class O, class ...Args>
             std::string group_concat(F O::*m, const char *y, Args&& ...args) {
-                return this->group_concat_internal(m, std::make_shared<std::string>(y), std::forward<Args>(args)...);
+                return this->group_concat_internal(m, std::make_unique<std::string>(y), std::forward<Args>(args)...);
             }
             
             /**
              *  MAX(x) query.
              *  @param m is a class member pointer (the same you passed into make_column).
-             *  @return std::shared_ptr with max value or null if sqlite engine returned null.
+             *  @return std::unique_ptr with max value or null if sqlite engine returned null.
              */
             template<class F, class O, class ...Args, class Ret = typename column_result_t<self, F O::*>::type>
-            std::shared_ptr<Ret> max(F O::*m, Args&& ...args) {
+            std::unique_ptr<Ret> max(F O::*m, Args&& ...args) {
                 this->assert_mapped_type<O>();
                 
                 auto connection = this->get_or_create_connection();
                 auto &impl = this->get_impl<O>();
-                std::shared_ptr<Ret> res;
+                std::unique_ptr<Ret> res;
                 std::stringstream ss;
                 ss << "SELECT " << static_cast<std::string>(sqlite_orm::max(0)) << "(";
                 auto columnName = this->string_from_expression(m);
@@ -2228,10 +2232,10 @@ namespace sqlite_orm {
                     auto rc = sqlite3_exec(connection->get_db(),
                                            query.c_str(),
                                            [](void *data, int argc, char **argv,char **)->int{
-                                               auto &res = *(std::shared_ptr<Ret>*)data;
+                                               auto &res = *(std::unique_ptr<Ret>*)data;
                                                if(argc){
                                                    if(argv[0]){
-                                                       res = std::make_shared<Ret>(row_extractor<Ret>().extract(argv[0]));
+                                                       res = std::make_unique<Ret>(row_extractor<Ret>().extract(argv[0]));
                                                    }
                                                }
                                                return 0;
@@ -2248,15 +2252,15 @@ namespace sqlite_orm {
             /**
              *  MIN(x) query.
              *  @param m is a class member pointer (the same you passed into make_column).
-             *  @return std::shared_ptr with min value or null if sqlite engine returned null.
+             *  @return std::unique_ptr with min value or null if sqlite engine returned null.
              */
             template<class F, class O, class ...Args, class Ret = typename column_result_t<self, F O::*>::type>
-            std::shared_ptr<Ret> min(F O::*m, Args&& ...args) {
+            std::unique_ptr<Ret> min(F O::*m, Args&& ...args) {
                 this->assert_mapped_type<O>();
                 
                 auto connection = this->get_or_create_connection();
                 auto &impl = this->get_impl<O>();
-                std::shared_ptr<Ret> res;
+                std::unique_ptr<Ret> res;
                 std::stringstream ss;
                 ss << "SELECT " << static_cast<std::string>(sqlite_orm::min(0)) << "(";
                 auto columnName = this->string_from_expression(m);
@@ -2267,10 +2271,10 @@ namespace sqlite_orm {
                     auto rc = sqlite3_exec(connection->get_db(),
                                            query.c_str(),
                                            [](void *data, int argc, char **argv,char **)->int{
-                                               auto &res = *(std::shared_ptr<Ret>*)data;
+                                               auto &res = *(std::unique_ptr<Ret>*)data;
                                                if(argc){
                                                    if(argv[0]){
-                                                       res = std::make_shared<Ret>(row_extractor<Ret>().extract(argv[0]));
+                                                       res = std::make_unique<Ret>(row_extractor<Ret>().extract(argv[0]));
                                                    }
                                                }
                                                return 0;
@@ -2287,15 +2291,15 @@ namespace sqlite_orm {
             /**
              *  SUM(x) query.
              *  @param m is a class member pointer (the same you passed into make_column).
-             *  @return std::shared_ptr with sum value or null if sqlite engine returned null.
+             *  @return std::unique_ptr with sum value or null if sqlite engine returned null.
              */
             template<class F, class O, class ...Args, class Ret = typename column_result_t<self, F O::*>::type>
-            std::shared_ptr<Ret> sum(F O::*m, Args&& ...args) {
+            std::unique_ptr<Ret> sum(F O::*m, Args&& ...args) {
                 this->assert_mapped_type<O>();
                 
                 auto connection = this->get_or_create_connection();
                 auto &impl = this->get_impl<O>();
-                std::shared_ptr<Ret> res;
+                std::unique_ptr<Ret> res;
                 std::stringstream ss;
                 ss << "SELECT " << static_cast<std::string>(sqlite_orm::sum(0)) << "(";
                 auto columnName = this->string_from_expression(m);
@@ -2306,9 +2310,9 @@ namespace sqlite_orm {
                     auto rc = sqlite3_exec(connection->get_db(),
                                            query.c_str(),
                                            [](void *data, int argc, char **argv, char **)->int{
-                                               auto &res = *(std::shared_ptr<Ret>*)data;
+                                               auto &res = *(std::unique_ptr<Ret>*)data;
                                                if(argc){
-                                                   res = std::make_shared<Ret>(row_extractor<Ret>().extract(argv[0]));
+                                                   res = std::make_unique<Ret>(row_extractor<Ret>().extract(argv[0]));
                                                }
                                                return 0;
                                            }, &res, nullptr);

--- a/dev/table.h
+++ b/dev/table.h
@@ -280,7 +280,7 @@ namespace sqlite_orm {
     
     /**
      *  Function used for table creation. Do not use table constructor - use this function
-     *  cause table class is templated and its constructing too (just like std::make_shared or std::make_pair).
+     *  cause table class is templated and its constructing too (just like std::make_unique or std::make_pair).
      */
     template<class ...Cs, class T = typename std::tuple_element<0, std::tuple<Cs...>>::type::object_type>
     internal::table_t<T, Cs...> make_table(const std::string &name, Cs&& ...args) {

--- a/examples/composite_key.cpp
+++ b/examples/composite_key.cpp
@@ -46,7 +46,7 @@ int main() {
     });
     auto bebeRexha = storage.get<User>(1, "Bebe");
     cout << "bebeRexha = " << storage.dump(bebeRexha) << endl;
-    auto bebeRexhaMaybe = storage.get_no_throw<User>(1, "Bebe");
+    auto bebeRexhaMaybe = storage.get_pointer<User>(1, "Bebe");
     try{
         //  2 and 'Drake' values will be ignored cause they are primary keys
         storage.insert(User{ 2, "Drake", "Singer" });

--- a/examples/core_functions.cpp
+++ b/examples/core_functions.cpp
@@ -70,7 +70,7 @@ int main(int argc, char **argv) {
     cout << "customTwo = {" << std::get<0>(customTwo.front()) << ", " << std::get<1>(customTwo.front()) << "}" << endl;
     
     //  SELECT ABS(points) FROM marvel
-    auto absPoints = storage.select(abs(&MarvelHero::points));  //  std::vector<std::shared_ptr<int>>
+    auto absPoints = storage.select(abs(&MarvelHero::points));  //  std::vector<std::unique_ptr<int>>
     cout << "absPoints: ";
     for(auto &value : absPoints) {
         if(value) {

--- a/examples/custom_aliases.cpp
+++ b/examples/custom_aliases.cpp
@@ -3,6 +3,8 @@
  */
 
 #include <sqlite_orm/sqlite_orm.h>
+
+#include <cassert>
 #include <string>
 #include <iostream>
 

--- a/examples/enum_binding.cpp
+++ b/examples/enum_binding.cpp
@@ -41,11 +41,11 @@ std::string GenderToString(Gender gender) {
  *  that's why I placed it separatedly. You can use any transformation type/form
  *  (for example BETTER_ENUM https://github.com/aantron/better-enums)
  */
-std::shared_ptr<Gender> GenderFromString(const std::string &s) {
+std::unique_ptr<Gender> GenderFromString(const std::string &s) {
     if(s == "female") {
-        return std::make_shared<Gender>(Gender::Female);
+        return std::make_unique<Gender>(Gender::Female);
     }else if(s == "male") {
-        return std::make_shared<Gender>(Gender::Male);
+        return std::make_unique<Gender>(Gender::Male);
     }
     return nullptr;
 }

--- a/examples/key_value.cpp
+++ b/examples/key_value.cpp
@@ -9,7 +9,7 @@
  object (KeyValue is a class mapped to the storage) with arguments and calls REPLACE. REPLACE (shorter version of INSERT OR REPLACE)
  removes row with a given primary key if it exists and inserts a given value in the table.
  After this there is a row in the `key_value` table with key and value passed into `setValue` function.
- `getValue` performs `get_no_throw` by id and returns its value or returns empty string if nothing obtained from db.
+ `getValue` performs `get_pointer` by id and returns its value or returns empty string if nothing obtained from db.
  ******/
 
 #include <sqlite_orm/sqlite_orm.h>
@@ -45,7 +45,7 @@ void setValue(const std::string &key, const std::string &value) {
 
 std::string getValue(const std::string &key) {
     using namespace sqlite_orm;
-    if(auto kv = getStorage().get_no_throw<KeyValue>(key)){
+    if(auto kv = getStorage().get_pointer<KeyValue>(key)){
         return kv->value;
     }else{
         return {};

--- a/examples/left_and_inner_join.cpp
+++ b/examples/left_and_inner_join.cpp
@@ -13,25 +13,25 @@ using std::cout;
 using std::endl;
 
 struct Artist {
-    std::shared_ptr<int> artistId;
-    std::shared_ptr<std::string> name;
+    std::unique_ptr<int> artistId;
+    std::unique_ptr<std::string> name;
 };
 
 struct Album {
-    std::shared_ptr<int> albumId;
-    std::shared_ptr<std::string> title;
-    std::shared_ptr<int> artistId;
+    std::unique_ptr<int> albumId;
+    std::unique_ptr<std::string> title;
+    std::unique_ptr<int> artistId;
 };
 
 struct Track {
     int trackId;
     std::string name;
-    std::shared_ptr<int> albumId;
+    std::unique_ptr<int> albumId;
     int mediaTypeId;
-    std::shared_ptr<int> genreId;
-    std::shared_ptr<std::string> composer;
+    std::unique_ptr<int> genreId;
+    std::unique_ptr<std::string> composer;
     long milliseconds;
-    std::shared_ptr<long> bytes;
+    std::unique_ptr<long> bytes;
     double unitPrice;
 };
 

--- a/examples/nullable_enum_binding.cpp
+++ b/examples/nullable_enum_binding.cpp
@@ -19,19 +19,19 @@ enum class Gender {
     Female,
 };
 
-std::shared_ptr<std::string> GenderToString(Gender gender) {
+std::unique_ptr<std::string> GenderToString(Gender gender) {
     switch(gender){
-        case Gender::Female:return std::make_shared<std::string>("female");
-        case Gender::Male:return std::make_shared<std::string>("male");
+        case Gender::Female:return std::make_unique<std::string>("female");
+        case Gender::Male:return std::make_unique<std::string>("male");
         case Gender::None:return {};
     }
 }
 
-std::shared_ptr<Gender> GenderFromString(const std::string &s) {
+std::unique_ptr<Gender> GenderFromString(const std::string &s) {
     if(s == "female") {
-        return std::make_shared<Gender>(Gender::Female);
+        return std::make_unique<Gender>(Gender::Female);
     }else if(s == "male") {
-        return std::make_shared<Gender>(Gender::Male);
+        return std::make_unique<Gender>(Gender::Male);
     }
     return nullptr;
 }

--- a/examples/select.cpp
+++ b/examples/select.cpp
@@ -10,8 +10,8 @@ struct Employee {
     int id;
     std::string name;
     int age;
-    std::shared_ptr<std::string> address;   //  optional
-    std::shared_ptr<double> salary; //  optional
+    std::unique_ptr<std::string> address;   //  optional
+    std::unique_ptr<double> salary; //  optional
 };
 
 using namespace sqlite_orm;
@@ -31,13 +31,13 @@ int main(int argc, char **argv) {
     storage.remove_all<Employee>(); //  remove all old employees in case they exist in db..
     
     //  create employees..
-    Employee paul{-1, "Paul", 32, std::make_shared<std::string>("California"), std::make_shared<double>(20000.0) };
-    Employee allen{-1, "Allen", 25, std::make_shared<std::string>("Texas"), std::make_shared<double>(15000.0) };
-    Employee teddy{-1, "Teddy", 23, std::make_shared<std::string>("Norway"), std::make_shared<double>(20000.0) };
-    Employee mark{-1, "Mark", 25, std::make_shared<std::string>("Rich-Mond"), std::make_shared<double>(65000.0) };
-    Employee david{-1, "David", 27, std::make_shared<std::string>("Texas"), std::make_shared<double>(85000.0) };
-    Employee kim{-1, "Kim", 22, std::make_shared<std::string>("South-Hall"), std::make_shared<double>(45000.0) };
-    Employee james{-1, "James", 24, std::make_shared<std::string>("Houston"), std::make_shared<double>(10000.0) };
+    Employee paul{-1, "Paul", 32, std::make_unique<std::string>("California"), std::make_unique<double>(20000.0) };
+    Employee allen{-1, "Allen", 25, std::make_unique<std::string>("Texas"), std::make_unique<double>(15000.0) };
+    Employee teddy{-1, "Teddy", 23, std::make_unique<std::string>("Norway"), std::make_unique<double>(20000.0) };
+    Employee mark{-1, "Mark", 25, std::make_unique<std::string>("Rich-Mond"), std::make_unique<double>(65000.0) };
+    Employee david{-1, "David", 27, std::make_unique<std::string>("Texas"), std::make_unique<double>(85000.0) };
+    Employee kim{-1, "Kim", 22, std::make_unique<std::string>("South-Hall"), std::make_unique<double>(45000.0) };
+    Employee james{-1, "James", 24, std::make_unique<std::string>("Houston"), std::make_unique<double>(10000.0) };
     
     //  insert employees. `insert` function returns id of inserted object..
     paul.id = storage.insert(paul);
@@ -67,7 +67,7 @@ int main(int argc, char **argv) {
     auto idsNamesSalarys = storage.select(columns(&Employee::id,
                                                   &Employee::name,
                                                   &Employee::salary));
-    //  decltype(idsNamesSalarys) = std::vector<std::tuple<int, std::string, std::shared_ptr<double>>>
+    //  decltype(idsNamesSalarys) = std::vector<std::tuple<int, std::string, std::unique_ptr<double>>>
     for(auto &tpl : idsNamesSalarys) {
         cout << "id = " << std::get<0>(tpl) << ", name = " << std::get<1>(tpl) << ", salary = ";
         if(std::get<2>(tpl)){

--- a/examples/unique.cpp
+++ b/examples/unique.cpp
@@ -11,7 +11,7 @@ using std::cerr;
 struct Entry {
     int id;
     std::string uniqueColumn;
-    std::shared_ptr<std::string> nullableColumn;
+    std::unique_ptr<std::string> nullableColumn;
 };
 
 int main(int argc, char **argv) {
@@ -27,12 +27,12 @@ int main(int argc, char **argv) {
     try {
         auto sameString = "Bebe Rexha";
         
-        auto id1 = storage.insert(Entry{ 0, sameString, std::make_shared<std::string>("The way I are") });
+        auto id1 = storage.insert(Entry{ 0, sameString, std::make_unique<std::string>("The way I are") });
         cout << "inserted " << storage.dump(storage.get<Entry>(id1)) << endl;
         
         //  it's ok but the next line will throw std::system_error
         
-        auto id2 = storage.insert(Entry{ 0, sameString, std::make_shared<std::string>("I got you") });
+        auto id2 = storage.insert(Entry{ 0, sameString, std::make_unique<std::string>("I got you") });
         cout << "inserted " << storage.dump(storage.get<Entry>(id2)) << endl;
     } catch (std::system_error e) {
         cerr << e.what() << endl;

--- a/examples/update.cpp
+++ b/examples/update.cpp
@@ -30,10 +30,10 @@ inline auto initStorage(const std::string &path) {
 
 using Storage = decltype(initStorage(""));
 
-static std::shared_ptr<Storage> stor;
+static std::unique_ptr<Storage> stor;
 
 int main(int argc, char **argv) {
-    stor = std::make_shared<Storage>(initStorage("update.sqlite"));
+    stor = std::make_unique<Storage>(initStorage("update.sqlite"));
     stor->sync_schema();
     stor->remove_all<Employee>();
 

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -6537,7 +6537,11 @@ namespace sqlite_orm {
                 
                 struct iterator_t {
                 protected:
-                    sqlite3_stmt *stmt;
+                    // The double-indirection is so that copies of the iterator
+                    // share the same sqlite3_stmt from a sqlite3_prepare_v2()
+                    // call. When one finishes iterating it, the pointer
+                    // inside the shared_ptr is nulled out in all copies.
+                    std::shared_ptr<sqlite3_stmt *> stmt;
                     view_t<T, Args...> &view;
                     // shared_ptr is used over unique_ptr here
                     // so that the iterator can be copyable.
@@ -6550,7 +6554,7 @@ namespace sqlite_orm {
                         auto index = 0;
                         impl.table.for_each_column([&index, &temp, this] (auto &c) {
                             using field_type = typename std::decay<decltype(c)>::type::field_type;
-                            auto value = row_extractor<field_type>().extract(this->stmt, index++);
+                            auto value = row_extractor<field_type>().extract(*this->stmt, index++);
                             if(c.member_pointer){
                                 auto member_pointer = c.member_pointer;
                                 (*temp).*member_pointer = std::move(value);
@@ -6567,7 +6571,7 @@ namespace sqlite_orm {
                     using reference = value_type &;
                     using iterator_category = std::input_iterator_tag;
                     
-                    iterator_t(sqlite3_stmt * stmt_, view_t<T, Args...> &view_): stmt(stmt_), view(view_) {
+                    iterator_t(sqlite3_stmt * stmt_, view_t<T, Args...> &view_): stmt(std::make_shared<sqlite3_stmt *>(stmt_)), view(view_) {
                         this->operator++();
                     }
                     
@@ -6580,7 +6584,9 @@ namespace sqlite_orm {
                     iterator_t& operator=(const iterator_t&) = default;
                     
                     ~iterator_t() {
-                        statement_finalizer f{this->stmt};
+                        if(this->stmt){
+                            statement_finalizer f{*this->stmt};
+                        }
                     }
                     
                     T& operator*() {
@@ -6608,15 +6614,15 @@ namespace sqlite_orm {
                     }
                     
                     void operator++() {
-                        if(this->stmt){
-                            auto ret = sqlite3_step(this->stmt);
+                        if(this->stmt && *this->stmt){
+                            auto ret = sqlite3_step(*this->stmt);
                             switch(ret){
                                 case SQLITE_ROW:
                                     this->current = nullptr;
                                     break;
                                 case SQLITE_DONE:{
-                                    statement_finalizer f{this->stmt};
-                                    this->stmt = nullptr;
+                                    statement_finalizer f{*this->stmt};
+                                    *this->stmt = nullptr;
                                 }break;
                                 default:{
                                     throw std::system_error(std::error_code(sqlite3_errcode(this->view.connection->get_db()), get_sqlite_error_category()));
@@ -6631,7 +6637,7 @@ namespace sqlite_orm {
                     
                     bool operator==(const iterator_t &other) const {
                         if(this->stmt && other.stmt){
-                            return this->stmt == other.stmt;
+                            return *this->stmt == *other.stmt;
                         }else{
                             if(!this->stmt && !other.stmt){
                                 return true;

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -8467,7 +8467,7 @@ namespace sqlite_orm {
              *  throws std::system_error in case of db error.
              */
             template<class O, class ...Ids>
-            std::unique_ptr<O> get_no_throw(Ids ...ids) {
+            std::unique_ptr<O> get_pointer(Ids ...ids) {
                 this->assert_mapped_type<O>();
                 
                 auto connection = this->get_or_create_connection();
@@ -8535,7 +8535,25 @@ namespace sqlite_orm {
                     throw std::system_error(std::make_error_code(orm_error_code::table_has_no_primary_key_column));
                 }
             }
-            
+
+            /**
+             * A previous version of get_pointer() that returns a shared_ptr
+             * instead of a unique_ptr. New code should prefer get_pointer()
+             * unless the data needs to be shared.
+             *
+             * @note
+             * Most scenarios don't need shared ownership of data, so we should prefer
+             * unique_ptr when possible. It's more efficient, doesn't require atomic
+             * ops for a reference count (which can cause major slowdowns on
+             * weakly-ordered platforms like ARM), and can be easily promoted to a
+             * shared_ptr, exactly like we're doing here.
+             * (Conversely, you _can't_ go from shared back to unique.)
+             */
+            template<class O, class ...Ids>
+            std::shared_ptr<O> get_no_throw(Ids ...ids) {
+                return std::shared_ptr<O>(get_pointer<O>(std::forward<Ids>(ids)...));
+            }
+
             /**
              *  SELECT COUNT(*) with no conditions routine. https://www.sqlite.org/lang_aggfunc.html#count
              *  @return Number of O object in table.

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -1062,8 +1062,8 @@ void testForeignKey() {
 
     struct Visit {
         int id;
-        std::shared_ptr<int> location;
-        std::shared_ptr<int> user;
+        std::unique_ptr<int> location;
+        std::unique_ptr<int> user;
         int visited_at;
         uint8_t mark;
     };
@@ -1241,8 +1241,8 @@ void testTypeParsing() {
     assert(type_is_nullable<long double>::value == false);
     assert(type_is_nullable<long double>::value == false);
     assert(type_is_nullable<std::string>::value == false);
-    assert(type_is_nullable<std::shared_ptr<int>>::value == true);
-    assert(type_is_nullable<std::shared_ptr<std::string>>::value == true);
+    assert(type_is_nullable<std::unique_ptr<int>>::value == true);
+    assert(type_is_nullable<std::unique_ptr<std::string>>::value == true);
     assert(type_is_nullable<std::unique_ptr<int>>::value == true);
     assert(type_is_nullable<std::unique_ptr<std::string>>::value == true);
 
@@ -1262,8 +1262,8 @@ void testSyncSchema() {
     struct UserBefore {
         int id;
         std::string name;
-        std::shared_ptr<int> categoryId;
-        std::shared_ptr<std::string> surname;
+        std::unique_ptr<int> categoryId;
+        std::unique_ptr<std::string> surname;
     };
 
     //  this is an new version of user..
@@ -1296,15 +1296,14 @@ void testSyncSchema() {
     storage.remove_all<UserBefore>();
 
     //  create c++ objects to insert into table..
-    std::vector<UserBefore> usersToInsert {
-        { -1, "Michael", nullptr, std::make_shared<std::string>("Scofield") },
-        { -1, "Lincoln", std::make_shared<int>(4), std::make_shared<std::string>("Burrows") },
-        { -1, "Sucre", nullptr, nullptr },
-        { -1, "Sara", std::make_shared<int>(996), std::make_shared<std::string>("Tancredi") },
-        { -1, "John", std::make_shared<int>(100500), std::make_shared<std::string>("Abruzzi") },
-        { -1, "Brad", std::make_shared<int>(65), nullptr },
-        { -1, "Paul", std::make_shared<int>(65), nullptr },
-    };
+    std::vector<UserBefore> usersToInsert;
+    usersToInsert.push_back({-1, "Michael", nullptr, std::make_unique<std::string>("Scofield")});
+    usersToInsert.push_back({-1, "Lincoln", std::make_unique<int>(4), std::make_unique<std::string>("Burrows")});
+    usersToInsert.push_back({-1, "Sucre", nullptr, nullptr});
+    usersToInsert.push_back({-1, "Sara", std::make_unique<int>(996), std::make_unique<std::string>("Tancredi")});
+    usersToInsert.push_back({-1, "John", std::make_unique<int>(100500), std::make_unique<std::string>("Abruzzi")});
+    usersToInsert.push_back({-1, "Brad", std::make_unique<int>(65), nullptr});
+    usersToInsert.push_back({-1, "Paul", std::make_unique<int>(65), nullptr});
 
     for(auto &user : usersToInsert) {
         auto insertedId = storage.insert(user);

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -1474,7 +1474,7 @@ void testSelect() {
     assert(firstRow->afterWord == "hey");
     assert(firstRow->occurances == 5);
 
-    auto secondRow = storage.get_no_throw<Word>(secondId);
+    auto secondRow = storage.get_pointer<Word>(secondId);
     assert(secondRow);
     assert(secondRow->currentWord == "corruption");
     assert(secondRow->beforeWord == "blood");


### PR DESCRIPTION
Most scenarios don't need shared ownership of data, so we should prefer unique_ptr when possible. It's more efficient, doesn't require atomic ops for a reference count (which can cause major slowdowns on weakly-ordered platforms like ARM), and can be promoted by the user to a
shared_ptr as-needed. (Conversely, you _can't_ go from shared back to unique.)

This replaces all instances of shared_ptr with unique_ptr except for two
cases:

1. iterator_t's current item is shared among copies,
   as move-only iterators aren't currently allowed.
   (http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0902r0.html)

2. The internal::connection returned by get_or_create_connection() is
   shared among those who call that function.

Another interesting step would be to use optional<T>, either from Boost
or from C++17, to avoid heap allocations where they aren't necessary.

See also:
https://herbsutter.com/2013/05/29/gotw-89-solution-smart-pointers/

I understand that this would be a fairly significant change to the public API, so let me know how you'd like to handle that if you like the changes.