### PR TITLE
Various fixes for GCC 8.3 and Clang 8 warnings

### DIFF
--- a/dev/constraints.h
+++ b/dev/constraints.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cassert>
 #include <string>   //  std::string
 #include <tuple>    //  std::tuple, std::make_tuple
 #include <sstream>  //  std::stringstream

--- a/dev/constraints.h
+++ b/dev/constraints.h
@@ -315,7 +315,7 @@ namespace sqlite_orm {
                     case decltype(argument)::nocase: return "NOCASE";
                     case decltype(argument)::rtrim: return "RTRIM";
                 }
-                assert(false);
+                throw std::domain_error("Invalid collate_argument enum");
             }
         };
         

--- a/dev/constraints.h
+++ b/dev/constraints.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cassert>
 #include <string>   //  std::string
 #include <tuple>    //  std::tuple, std::make_tuple
 #include <sstream>  //  std::stringstream
@@ -314,6 +315,7 @@ namespace sqlite_orm {
                     case decltype(argument)::nocase: return "NOCASE";
                     case decltype(argument)::rtrim: return "RTRIM";
                 }
+                assert(false);
             }
         };
         

--- a/dev/row_extractor.h
+++ b/dev/row_extractor.h
@@ -147,7 +147,7 @@ namespace sqlite_orm {
         std::vector<char> extract(const char *row_value) {
             if(row_value){
                 auto len = ::strlen(row_value);
-                return this->go(row_value, static_cast<int>(len));
+                return this->go(row_value, len);
             }else{
                 return {};
             }
@@ -161,7 +161,7 @@ namespace sqlite_orm {
         
     protected:
         
-        std::vector<char> go(const char *bytes, int len) {
+        std::vector<char> go(const char *bytes, size_t len) {
             if(len){
                 std::vector<char> res;
                 res.reserve(len);
@@ -209,7 +209,7 @@ namespace sqlite_orm {
         std::vector<char> extract(const char *row_value) {
             if(row_value){
                 auto len = ::strlen(row_value);
-                return this->go(row_value, static_cast<int>(len));
+                return this->go(row_value, len);
             }else{
                 return {};
             }
@@ -217,13 +217,13 @@ namespace sqlite_orm {
         
         std::vector<char> extract(sqlite3_stmt *stmt, int columnIndex) {
             auto bytes = static_cast<const char *>(sqlite3_column_blob(stmt, columnIndex));
-            auto len = sqlite3_column_bytes(stmt, columnIndex);
+            auto len = static_cast<size_t>(sqlite3_column_bytes(stmt, columnIndex));
             return this->go(bytes, len);
         }
         
     protected:
         
-        std::vector<char> go(const char *bytes, int len) {
+        std::vector<char> go(const char *bytes, size_t len) {
             if(len){
                 std::vector<char> res;
                 res.reserve(len);

--- a/dev/select_constraints.h
+++ b/dev/select_constraints.h
@@ -228,7 +228,7 @@ namespace sqlite_orm {
          *  Generic way to get DISTINCT value from any type.
          */
         template<class T>
-        bool get_distinct(const T &t) {
+        bool get_distinct(const T &) {
             return false;
         }
         

--- a/dev/static_magic.h
+++ b/dev/static_magic.h
@@ -8,10 +8,10 @@ namespace sqlite_orm {
     namespace static_magic {
         
         template <typename T, typename F>
-        auto static_if(std::true_type, T t, F f) { return t; }
+        auto static_if(std::true_type, T t, F) { return t; }
         
         template <typename T, typename F>
-        auto static_if(std::false_type, T t, F f) { return f; }
+        auto static_if(std::false_type, T, F f) { return f; }
         
         template <bool B, typename T, typename F>
         auto static_if(T t, F f) { return static_if(std::integral_constant<bool, B>{}, t, f); }

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -318,7 +318,7 @@ namespace sqlite_orm {
                 std::stringstream ss;
                 std::vector<std::string> columnNames;
                 using columns_type_t = typename std::decay<decltype(fk)>::type::columns_type;
-                constexpr const int columnsCount = std::tuple_size<columns_type_t>::value;
+                constexpr const size_t columnsCount = std::tuple_size<columns_type_t>::value;
                 columnNames.reserve(columnsCount);
                 tuple_helper::iterator<columnsCount - 1, Cs...>()(fk.columns, [&columnNames, this](auto &v){
                     columnNames.push_back(this->impl.column_name(v));
@@ -334,7 +334,7 @@ namespace sqlite_orm {
                 ss << ") REFERENCES ";
                 std::vector<std::string> referencesNames;
                 using references_type_t = typename std::decay<decltype(fk)>::type::references_type;
-                constexpr const int referencesCount = std::tuple_size<references_type_t>::value;
+                constexpr const size_t referencesCount = std::tuple_size<references_type_t>::value;
                 referencesNames.reserve(referencesCount);
                 {
                     using first_reference_t = typename std::tuple_element<0, references_type_t>::type;
@@ -438,7 +438,7 @@ namespace sqlite_orm {
             std::string escape(std::string text) {
                 for(size_t i = 0; i < text.length(); ) {
                     if(text[i] == '\''){
-                        text.insert(text.begin() + i, '\'');
+                        text.insert(text.begin() + static_cast<ptrdiff_t>(i), '\'');
                         i += 2;
                     }
                     else
@@ -471,12 +471,12 @@ namespace sqlite_orm {
             }
             
             template<class T>
-            std::string string_from_expression(const alias_holder<T> &holder, bool noTableName = false, bool /*escape*/ = false) {
+            std::string string_from_expression(const alias_holder<T> &, bool /*noTableName*/ = false, bool /*escape*/ = false) {
                 return T::get();
             }
             
             template<class T, class E>
-            std::string string_from_expression(const as_t<T, E> &als, bool noTableName = false, bool /*escape*/ = false) {
+            std::string string_from_expression(const as_t<T, E> &als, bool /*noTableName*/ = false, bool /*escape*/ = false) {
                 auto tableAliasString = alias_extractor<T>::get();
                 return this->string_from_expression(als.expression) + " AS " + tableAliasString;
             }
@@ -667,7 +667,7 @@ namespace sqlite_orm {
             }
             
             template<class T>
-            std::string string_from_expression(const aggregate_functions::count_asterisk_t<T> &f, bool /*noTableName*/ = false, bool /*escape*/ = false) {
+            std::string string_from_expression(const aggregate_functions::count_asterisk_t<T> &, bool /*noTableName*/ = false, bool /*escape*/ = false) {
                 return this->string_from_expression(aggregate_functions::count_asterisk_without_type{});
             }
             
@@ -829,9 +829,9 @@ namespace sqlite_orm {
                     args.emplace_back(std::move(expression));
                 });
                 ss << static_cast<std::string>(f) << "(";
-                auto lim = int(args.size());
+                const auto lim = static_cast<int>(args.size());
                 for(auto i = 0; i < lim; ++i) {
-                    ss << args[i];
+                    ss << args[static_cast<size_t>(i)];
                     if(i < lim - 1) {
                         ss << ", ";
                     }else{
@@ -868,7 +868,7 @@ namespace sqlite_orm {
             }
             
             template<class T, class F>
-            std::string string_from_expression(const column_pointer<T, F> &c, bool noTableName = false, bool escape = false) {
+            std::string string_from_expression(const column_pointer<T, F> &c, bool noTableName = false, bool /*escape*/ = false) {
                 std::stringstream ss;
                 if(!noTableName){
                     ss << "'" << this->impl.template find_table_name<T>() << "'.";
@@ -889,7 +889,7 @@ namespace sqlite_orm {
             }
             
             template<class T>
-            std::vector<std::string> get_column_names(const internal::asterisk_t<T> &ast) {
+            std::vector<std::string> get_column_names(const internal::asterisk_t<T> &) {
                 std::vector<std::string> res;
                 res.push_back("*");
                 return res;
@@ -898,7 +898,7 @@ namespace sqlite_orm {
             template<class ...Args>
             std::vector<std::string> get_column_names(const internal::columns_t<Args...> &cols) {
                 std::vector<std::string> columnNames;
-                columnNames.reserve(cols.count());
+                columnNames.reserve(static_cast<size_t>(cols.count()));
                 cols.for_each([&columnNames, this](auto &m) {
                     auto columnName = this->string_from_expression(m);
                     if(columnName.length()){
@@ -1783,7 +1783,7 @@ namespace sqlite_orm {
             }
             
             template<class T, class F>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const column_pointer<T, F> &c) {
+            std::set<std::pair<std::string, std::string>> parse_table_name(const column_pointer<T, F> &) {
                 std::set<std::pair<std::string, std::string>> res;
                 res.insert({this->impl.template find_table_name<T>(), ""});
                 return res;
@@ -1795,7 +1795,7 @@ namespace sqlite_orm {
             }
             
             template<class T>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const aggregate_functions::count_asterisk_t<T> &c) {
+            std::set<std::pair<std::string, std::string>> parse_table_name(const aggregate_functions::count_asterisk_t<T> &) {
                 auto tableName = this->impl.template find_table_name<T>();
                 if(!tableName.empty()){
                     return {std::make_pair(std::move(tableName), "")};
@@ -1809,7 +1809,7 @@ namespace sqlite_orm {
             }
             
             template<class T>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const asterisk_t<T> &ast) {
+            std::set<std::pair<std::string, std::string>> parse_table_name(const asterisk_t<T> &) {
                 auto tableName = this->impl.template find_table_name<T>();
                 return {std::make_pair(std::move(tableName), "")};
             }

--- a/dev/storage_impl.h
+++ b/dev/storage_impl.h
@@ -62,7 +62,7 @@ namespace sqlite_orm {
                                 break;
                             }
                             dbTableInfo.erase(dbColumnInfoIt);
-                            storageTableInfo.erase(storageTableInfo.begin() + storageColumnInfoIndex);
+                            storageTableInfo.erase(storageTableInfo.begin() + static_cast<ptrdiff_t>(storageColumnInfoIndex));
                             --storageColumnInfoIndex;
                         }else{
                             

--- a/dev/sync_schema_result.h
+++ b/dev/sync_schema_result.h
@@ -51,5 +51,6 @@ namespace sqlite_orm {
             case sync_schema_result::new_columns_added_and_old_columns_removed: return os << "old excess columns removed and new columns added";
             case sync_schema_result::dropped_and_recreated: return os << "old table dropped and recreated";
         }
+        return os;
     }
 }

--- a/dev/table.h
+++ b/dev/table.h
@@ -65,26 +65,28 @@ namespace sqlite_orm {
                     using member_pointer_t = typename column_type::member_pointer_t;
                     using getter_type = typename column_type::getter_type;
                     using setter_type = typename column_type::setter_type;
+                    // Make static_if have at least one input as a workaround for GCC bug:
+                    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64095
                     if(!res){
-                        static_if<std::is_same<C, member_pointer_t>{}>([&res, &obj, &col, &c]{
+                        static_if<std::is_same<C, member_pointer_t>{}>([&res, &obj, &col](const C& c){
                             if(compare_any(col.member_pointer, c)){
                                 res = &(obj.*col.member_pointer);
                             }
-                        })();
+                        })(c);
                     }
                     if(!res){
-                        static_if<std::is_same<C, getter_type>{}>([&res, &obj, &col, &c]{
+                        static_if<std::is_same<C, getter_type>{}>([&res, &obj, &col](const C& c){
                             if(compare_any(col.getter, c)){
                                 res = &((obj).*(col.getter))();
                             }
-                        })();
+                        })(c);
                     }
                     if(!res){
-                        static_if<std::is_same<C, setter_type>{}>([&res, &obj, &col, &c]{
+                        static_if<std::is_same<C, setter_type>{}>([&res, &obj, &col](const C& c){
                             if(compare_any(col.setter, c)){
                                 res = &((obj).*(col.getter))();
                             }
-                        })();
+                        })(c);
                     }
                 });
                 return res;

--- a/examples/blob.cpp
+++ b/examples/blob.cpp
@@ -14,7 +14,7 @@ struct User {
     std::vector<char> hash; //  binary format
 };
 
-int main(int argc, char **argv) {
+int main(int, char **) {
     using namespace sqlite_orm;
     auto storage = make_storage("blob.sqlite",
                                 make_table("users",

--- a/examples/collate.cpp
+++ b/examples/collate.cpp
@@ -19,7 +19,7 @@ struct Foo {
     int baz;
 };
 
-int main(int argc, char** argv) {
+int main(int, char**) {
 
     using namespace sqlite_orm;
     auto storage = make_storage("collate.sqlite",

--- a/examples/composite_key.cpp
+++ b/examples/composite_key.cpp
@@ -52,7 +52,7 @@ int main() {
     try{
         //  2 and 'Drake' values will be ignored cause they are primary keys
         storage.insert(User{ 2, "Drake", "Singer" });
-    }catch(std::system_error e){
+    }catch(const std::system_error& e){
         cout << "exception = " << e.what() << endl;
     }
     storage.replace(User{ 2, "The Weeknd", "Singer" });

--- a/examples/core_functions.cpp
+++ b/examples/core_functions.cpp
@@ -13,7 +13,7 @@ struct MarvelHero {
     short points;
 };
 
-int main(int argc, char **argv) {
+int main(int, char **argv) {
     cout << "path = " << argv[0] << endl;
     
     using namespace sqlite_orm;

--- a/examples/cross_join.cpp
+++ b/examples/cross_join.cpp
@@ -30,7 +30,7 @@ static auto initStorage(const std::string &path) {
                                    make_column("suit", &Suit::suit)));
 }
 
-int main(int argc, char **argv) {
+int main(int, char **) {
     using namespace DataModel;
     
     using Storage = decltype(initStorage(""));

--- a/examples/custom_aliases.cpp
+++ b/examples/custom_aliases.cpp
@@ -41,7 +41,7 @@ struct CompanyNameAlias : alias_tag {
     }
 };
 
-int main(int argc, char* argv[]) {
+int main(int, char** argv) {
     cout << argv[0] << endl;
     
     auto storage = make_storage("custom_aliases.sqlite",

--- a/examples/distinct.cpp
+++ b/examples/distinct.cpp
@@ -28,7 +28,7 @@ auto initStorage(const std::string &path) {
 }
 using Storage = decltype(initStorage(""));
 
-int main(int argc, char **argv) {
+int main(int, char **) {
     
     Storage storage = initStorage("distinct.sqlite");
     

--- a/examples/enum_binding.cpp
+++ b/examples/enum_binding.cpp
@@ -1,5 +1,7 @@
 
 #include <sqlite_orm/sqlite_orm.h>
+
+#include <cassert>
 #include <iostream>
 #include <memory>
 
@@ -30,6 +32,7 @@ std::string GenderToString(Gender gender) {
         case Gender::Female:return "female";
         case Gender::Male:return "male";
     }
+    assert(false); // unreachable
 }
 
 /**

--- a/examples/enum_binding.cpp
+++ b/examples/enum_binding.cpp
@@ -1,7 +1,6 @@
 
 #include <sqlite_orm/sqlite_orm.h>
 
-#include <cassert>
 #include <iostream>
 #include <memory>
 

--- a/examples/enum_binding.cpp
+++ b/examples/enum_binding.cpp
@@ -32,7 +32,7 @@ std::string GenderToString(Gender gender) {
         case Gender::Female:return "female";
         case Gender::Male:return "male";
     }
-    assert(false); // unreachable
+    throw std::domain_error("Invalid Gender enum");
 }
 
 /**

--- a/examples/exists.cpp
+++ b/examples/exists.cpp
@@ -41,7 +41,7 @@ struct Order {
     std::string agentCode;
 };
 
-int main(int argc, char **argv) {
+int main(int, char **) {
     using namespace sqlite_orm;
     
     auto storage = make_storage("exists.sqlite",
@@ -77,18 +77,18 @@ int main(int argc, char **argv) {
     storage.remove_all<Agent>();
     storage.remove_all<Customer>();
     
-    storage.replace(Agent{"A007", "Ramasundar", "Bangalore", 0.15, "077-25814763"});
-    storage.replace(Agent{"A003", "Alex", "London", 0.13, "075-12458969"});
-    storage.replace(Agent{"A008", "Alford", "New York", 0.12, "044-25874365"});
-    storage.replace(Agent{"A011", "Ravi Kumar", "Bangalore", 0.15, "077-45625874"});
-    storage.replace(Agent{"A010", "Santakumar", "Chennai", 0.14, "007-22388644"});
-    storage.replace(Agent{"A012", "Lucida", "San Jose", 0.12, "044-52981425"});
-    storage.replace(Agent{"A005", "Anderson", "Brisban", 0.13, "045-21447739"});
-    storage.replace(Agent{"A001", "Subbarao", "Bangalore", 0.14, "077-12346674"});
-    storage.replace(Agent{"A002", "Mukesh", "Mumbai", 0.11, "029-12358964"});
-    storage.replace(Agent{"A006", "McDen", "London", 0.15, "078-22255588"});
-    storage.replace(Agent{"A004", "Ivan", "Torento", 0.15, "008-22544166"});
-    storage.replace(Agent{"A009", "Benjamin", "Hampshair", 0.11, "008-22536178"});
+    storage.replace(Agent{"A007", "Ramasundar", "Bangalore", 0.15, "077-25814763", ""});
+    storage.replace(Agent{"A003", "Alex", "London", 0.13, "075-12458969", ""});
+    storage.replace(Agent{"A008", "Alford", "New York", 0.12, "044-25874365", ""});
+    storage.replace(Agent{"A011", "Ravi Kumar", "Bangalore", 0.15, "077-45625874", ""});
+    storage.replace(Agent{"A010", "Santakumar", "Chennai", 0.14, "007-22388644", ""});
+    storage.replace(Agent{"A012", "Lucida", "San Jose", 0.12, "044-52981425", ""});
+    storage.replace(Agent{"A005", "Anderson", "Brisban", 0.13, "045-21447739", ""});
+    storage.replace(Agent{"A001", "Subbarao", "Bangalore", 0.14, "077-12346674", ""});
+    storage.replace(Agent{"A002", "Mukesh", "Mumbai", 0.11, "029-12358964", ""});
+    storage.replace(Agent{"A006", "McDen", "London", 0.15, "078-22255588", ""});
+    storage.replace(Agent{"A004", "Ivan", "Torento", 0.15, "008-22544166", ""});
+    storage.replace(Agent{"A009", "Benjamin", "Hampshair", 0.11, "008-22536178", ""});
     
     storage.replace(Customer{"C00013", "Holmes", "London", "London", "UK", 2, 6000.00, 5000.00, 7000.00, 4000.00, "BBBBBBB", "A003"});
     storage.replace(Customer{"C00001", "Micheal", "New York", "New York", "USA", 2, 3000.00, 5000.00, 2000.00, 6000.00, "CCCCCCC", "A008"});

--- a/examples/foreign_key.cpp
+++ b/examples/foreign_key.cpp
@@ -23,7 +23,7 @@ struct Track {
     std::unique_ptr<int> trackArtist;    //  must map to &Artist::artistId
 };
 
-int main(int argc, char **argv) {
+int main(int, char **argv) {
     cout << "path = " << argv[0] << endl;
     
     using namespace sqlite_orm;
@@ -57,7 +57,7 @@ int main(int argc, char **argv) {
             //  does not correspond to row in the artist table.
             storage.replace(Track{ 14, "Mr. Bojangles", std::make_unique<int>(3) });
             assert(0);
-        }catch(std::system_error e) {
+        }catch(const std::system_error& e) {
             cout << e.what() << endl;
         }
         
@@ -71,7 +71,7 @@ int main(int argc, char **argv) {
         try{
             storage.update_all(set(assign(&Track::trackArtist, 3)), where(is_equal(&Track::trackName, "Mr. Bojangles")));
             assert(0);
-        }catch(std::system_error e) {
+        }catch(const std::system_error& e) {
             cout << e.what() << endl;
         }
         
@@ -91,7 +91,7 @@ int main(int argc, char **argv) {
             //  the track table contains a row that refer to it.
             storage.remove_all<Artist>(where(is_equal(&Artist::artistName, "Frank Sinatra")));
             assert(0);
-        }catch(std::system_error e) {
+        }catch(const std::system_error& e) {
             cout << e.what() << endl;
         }
         
@@ -105,7 +105,7 @@ int main(int argc, char **argv) {
             //  exists records in the track table that refer to it.
             storage.update_all(set(assign(&Artist::artistId, 4)), where(is_equal(&Artist::artistName, "Dean Martin")));
             assert(0);
-        }catch(std::system_error e) {
+        }catch(const std::system_error& e) {
             cout << e.what() << endl;
         }
         
@@ -197,7 +197,7 @@ int main(int argc, char **argv) {
         try{
             storage.remove_all<Artist>(where(c(&Artist::artistName) == "Sammy Davis Jr."));
             assert(0);
-        }catch(std::system_error e) {
+        }catch(const std::system_error& e) {
             cout << e.what() << endl;
         }
         

--- a/examples/group_by.cpp
+++ b/examples/group_by.cpp
@@ -17,7 +17,7 @@ struct Employee {
     double salary;
 };
 
-int main(int argc, char **argv) {
+int main(int, char **) {
     using namespace sqlite_orm;
     
     auto storage = make_storage("group_by.sqlite",

--- a/examples/in_memory.cpp
+++ b/examples/in_memory.cpp
@@ -15,7 +15,7 @@ struct RapArtist {
     std::string name;
 };
 
-int main(int argc, char **argv) {
+int main(int, char **) {
     
     auto storage = make_storage(":memory:",
                                 make_table("rap_artists",

--- a/examples/index.cpp
+++ b/examples/index.cpp
@@ -25,7 +25,7 @@ auto storage = make_storage("index.sqlite",
                                        make_column("last_name", &Contract::lastName),
                                        make_column("email", &Contract::email)));
 
-int main(int argc, char **argv) {
+int main(int, char **) {
     
     storage.sync_schema();
     storage.remove_all<Contract>();
@@ -41,7 +41,7 @@ int main(int argc, char **argv) {
             "Doe",
             "john.doe@sqlitetutorial.net",
         });
-    }catch(std::system_error e){
+    }catch(const std::system_error& e){
         cout << e.what() << endl;
     }
     std::vector<Contract> moreContracts = {

--- a/examples/insert.cpp
+++ b/examples/insert.cpp
@@ -23,7 +23,7 @@ struct DetailedEmployee : public Employee {
     std::string birthDate;
 };
 
-int main(int argc, char **argv) {
+int main(int, char **) {
     using namespace sqlite_orm;
     
     auto storage = make_storage("insert.sqlite",

--- a/examples/iteration.cpp
+++ b/examples/iteration.cpp
@@ -12,7 +12,7 @@ struct MarvelHero {
     std::string abilities;
 };
 
-int main(int argc, char **argv) {
+int main(int, char **) {
     using namespace sqlite_orm;
     auto storage = make_storage("iteration.sqlite",
                                 make_table("marvel",
@@ -57,7 +57,7 @@ int main(int argc, char **argv) {
     }
     
     std::vector<MarvelHero> heroesByAlgorithm;
-    heroesByAlgorithm.reserve(storage.count<MarvelHero>());
+    heroesByAlgorithm.reserve(static_cast<size_t>(storage.count<MarvelHero>()));
     {
         auto view = storage.iterate<MarvelHero>();
         std::copy(view.begin(),

--- a/examples/key_value.cpp
+++ b/examples/key_value.cpp
@@ -56,7 +56,7 @@ int storedKeysCount() {
     return getStorage().count<KeyValue>();
 }
 
-int main(int argc, char **argv) {
+int main(int, char **argv) {
     
     cout << argv[0] << endl;    //  to know executable path in case if you need to access sqlite directly from sqlite client
     

--- a/examples/left_and_inner_join.cpp
+++ b/examples/left_and_inner_join.cpp
@@ -57,7 +57,7 @@ inline auto initStorage(const std::string &path){
                                    make_column("UnitPrice", &Track::unitPrice)));
 }
 
-int main(int argc, char **argv) {
+int main(int, char **) {
     
     auto storage = initStorage("chinook.db");
 

--- a/examples/multi_table_select.cpp
+++ b/examples/multi_table_select.cpp
@@ -23,7 +23,7 @@ struct ReqDetail {
     double itemCost;
 };
 
-int main(int argc, char **argv) {
+int main(int, char **) {
     
     using namespace sqlite_orm;
     auto storage = make_storage("multi_table_select.sqlite",

--- a/examples/nullable_enum_binding.cpp
+++ b/examples/nullable_enum_binding.cpp
@@ -1,4 +1,5 @@
 
+#include <cassert>
 #include <sqlite_orm/sqlite_orm.h>
 #include <iostream>
 #include <memory>
@@ -25,6 +26,7 @@ std::unique_ptr<std::string> GenderToString(Gender gender) {
         case Gender::Male:return std::make_unique<std::string>("male");
         case Gender::None:return {};
     }
+    assert(false);
 }
 
 std::unique_ptr<Gender> GenderFromString(const std::string &s) {
@@ -104,7 +106,7 @@ namespace sqlite_orm {
     };
 }
 
-int main(int argc, char **argv) {
+int main(int, char **) {
     using namespace sqlite_orm;
     auto storage = make_storage("nullable_enum.sqlite",
                                 make_table("users",

--- a/examples/nullable_enum_binding.cpp
+++ b/examples/nullable_enum_binding.cpp
@@ -1,5 +1,4 @@
 
-#include <cassert>
 #include <sqlite_orm/sqlite_orm.h>
 #include <iostream>
 #include <memory>

--- a/examples/nullable_enum_binding.cpp
+++ b/examples/nullable_enum_binding.cpp
@@ -26,7 +26,7 @@ std::unique_ptr<std::string> GenderToString(Gender gender) {
         case Gender::Male:return std::make_unique<std::string>("male");
         case Gender::None:return {};
     }
-    assert(false);
+    throw std::domain_error("Invalid Gender enum");
 }
 
 std::unique_ptr<Gender> GenderFromString(const std::string &s) {

--- a/examples/private_class_members.cpp
+++ b/examples/private_class_members.cpp
@@ -43,7 +43,7 @@ public:
     }
 };
 
-int main(int argc, char **argv) {
+int main(int, char **) {
     using namespace sqlite_orm;
     auto storage = make_storage("private.sqlite",
                                 make_table("players",

--- a/examples/select.cpp
+++ b/examples/select.cpp
@@ -19,7 +19,7 @@ using namespace sqlite_orm;
 using std::cout;
 using std::endl;
 
-int main(int argc, char **argv) {
+int main(int, char **) {
     auto storage = make_storage("select.sqlite",
                                 make_table("COMPANY",
                                            make_column("ID", &Employee::id, primary_key()),

--- a/examples/subentities.cpp
+++ b/examples/subentities.cpp
@@ -79,20 +79,20 @@ Student getStudent(int studentId) {
     return res; //  must be moved automatically by compiler
 }
 
-int main(int argc, char **argv) {
+int main(int, char **) {
     decltype(Student::id) mikeId;
     decltype(Student::id) annaId;
     
     {
         storage.sync_schema();    // create tables if they don't exist
         
-        Student mike{ -1, "Mike", 123 };    //  create student named `Mike` without marks and without id
+        Student mike{ -1, "Mike", 123, {} };    //  create student named `Mike` without marks and without id
         mike.marks = { 3, 4, 5 };
         mike.id = addStudent(mike);
         mikeId = mike.id;
         
         //  also let's create another students with marks..
-        Student anna{ -1, "Anna", 555 };
+        Student anna{ -1, "Anna", 555, {} };
         anna.marks.push_back(6);
         anna.marks.push_back(7);
         anna.id = addStudent(anna);

--- a/examples/subquery.cpp
+++ b/examples/subquery.cpp
@@ -38,7 +38,7 @@ struct JobHistory {
     decltype(Employee::departmentId) departmentId;
 };
 
-int main(int argc, char **argv) {
+int main(int, char **) {
     using namespace sqlite_orm;
     auto storage = make_storage("subquery.sqlite",
                                 make_table("employees",

--- a/examples/synchronous.cpp
+++ b/examples/synchronous.cpp
@@ -13,7 +13,7 @@ struct Query
     uint16_t type;
 };
 
-int main(int argc, char** argv) {
+int main(int, char**) {
 
     using namespace sqlite_orm;
 

--- a/examples/unique.cpp
+++ b/examples/unique.cpp
@@ -14,7 +14,7 @@ struct Entry {
     std::unique_ptr<std::string> nullableColumn;
 };
 
-int main(int argc, char **argv) {
+int main(int, char **) {
     using namespace sqlite_orm;
     auto storage = make_storage("unique.sqlite",
                                 make_table("unique_test",
@@ -34,7 +34,7 @@ int main(int argc, char **argv) {
         
         auto id2 = storage.insert(Entry{ 0, sameString, std::make_unique<std::string>("I got you") });
         cout << "inserted " << storage.dump(storage.get<Entry>(id2)) << endl;
-    } catch (std::system_error e) {
+    } catch (const std::system_error& e) {
         cerr << e.what() << endl;
     }
     

--- a/examples/update.cpp
+++ b/examples/update.cpp
@@ -32,7 +32,7 @@ using Storage = decltype(initStorage(""));
 
 static std::unique_ptr<Storage> stor;
 
-int main(int argc, char **argv) {
+int main(int, char **) {
     stor = std::make_unique<Storage>(initStorage("update.sqlite"));
     stor->sync_schema();
     stor->remove_all<Employee>();

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -715,7 +715,7 @@ namespace sqlite_orm {
                     case decltype(argument)::nocase: return "NOCASE";
                     case decltype(argument)::rtrim: return "RTRIM";
                 }
-                assert(false);
+                throw std::domain_error("Invalid collate_argument enum");
             }
         };
         

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -400,7 +400,6 @@ namespace sqlite_orm {
 }
 #pragma once
 
-#include <cassert>
 #include <string>   //  std::string
 #include <tuple>    //  std::tuple, std::make_tuple
 #include <sstream>  //  std::stringstream

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -268,10 +268,10 @@ namespace sqlite_orm {
     namespace static_magic {
         
         template <typename T, typename F>
-        auto static_if(std::true_type, T t, F f) { return t; }
+        auto static_if(std::true_type, T t, F) { return t; }
         
         template <typename T, typename F>
-        auto static_if(std::false_type, T t, F f) { return f; }
+        auto static_if(std::false_type, T, F f) { return f; }
         
         template <bool B, typename T, typename F>
         auto static_if(T t, F f) { return static_if(std::integral_constant<bool, B>{}, t, f); }
@@ -400,6 +400,7 @@ namespace sqlite_orm {
 }
 #pragma once
 
+#include <cassert>
 #include <string>   //  std::string
 #include <tuple>    //  std::tuple, std::make_tuple
 #include <sstream>  //  std::stringstream
@@ -714,6 +715,7 @@ namespace sqlite_orm {
                     case decltype(argument)::nocase: return "NOCASE";
                     case decltype(argument)::rtrim: return "RTRIM";
                 }
+                assert(false);
             }
         };
         
@@ -3697,7 +3699,7 @@ namespace sqlite_orm {
          *  Generic way to get DISTINCT value from any type.
          */
         template<class T>
-        bool get_distinct(const T &t) {
+        bool get_distinct(const T &) {
             return false;
         }
         
@@ -4326,7 +4328,7 @@ namespace sqlite_orm {
         std::vector<char> extract(const char *row_value) {
             if(row_value){
                 auto len = ::strlen(row_value);
-                return this->go(row_value, static_cast<int>(len));
+                return this->go(row_value, len);
             }else{
                 return {};
             }
@@ -4340,7 +4342,7 @@ namespace sqlite_orm {
         
     protected:
         
-        std::vector<char> go(const char *bytes, int len) {
+        std::vector<char> go(const char *bytes, size_t len) {
             if(len){
                 std::vector<char> res;
                 res.reserve(len);
@@ -4388,7 +4390,7 @@ namespace sqlite_orm {
         std::vector<char> extract(const char *row_value) {
             if(row_value){
                 auto len = ::strlen(row_value);
-                return this->go(row_value, static_cast<int>(len));
+                return this->go(row_value, len);
             }else{
                 return {};
             }
@@ -4396,13 +4398,13 @@ namespace sqlite_orm {
         
         std::vector<char> extract(sqlite3_stmt *stmt, int columnIndex) {
             auto bytes = static_cast<const char *>(sqlite3_column_blob(stmt, columnIndex));
-            auto len = sqlite3_column_bytes(stmt, columnIndex);
+            auto len = static_cast<size_t>(sqlite3_column_bytes(stmt, columnIndex));
             return this->go(bytes, len);
         }
         
     protected:
         
-        std::vector<char> go(const char *bytes, int len) {
+        std::vector<char> go(const char *bytes, size_t len) {
             if(len){
                 std::vector<char> res;
                 res.reserve(len);
@@ -4538,6 +4540,7 @@ namespace sqlite_orm {
             case sync_schema_result::new_columns_added_and_old_columns_removed: return os << "old excess columns removed and new columns added";
             case sync_schema_result::dropped_and_recreated: return os << "old table dropped and recreated";
         }
+        return os;
     }
 }
 #pragma once
@@ -5340,8 +5343,8 @@ namespace sqlite_orm {
                     using member_pointer_t = typename column_type::member_pointer_t;
                     using getter_type = typename column_type::getter_type;
                     using setter_type = typename column_type::setter_type;
-
-					// GCC has bug that reported in https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64095 so static_if must have at lease one input
+                    // Make static_if have at least one input as a workaround for GCC bug:
+                    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64095
                     if(!res){
                         static_if<std::is_same<C, member_pointer_t>{}>([&res, &obj, &col](const C& c){
                             if(compare_any(col.member_pointer, c)){
@@ -5674,7 +5677,7 @@ namespace sqlite_orm {
                                 break;
                             }
                             dbTableInfo.erase(dbColumnInfoIt);
-                            storageTableInfo.erase(storageTableInfo.begin() + storageColumnInfoIndex);
+                            storageTableInfo.erase(storageTableInfo.begin() + static_cast<ptrdiff_t>(storageColumnInfoIndex));
                             --storageColumnInfoIndex;
                         }else{
                             
@@ -6838,7 +6841,7 @@ namespace sqlite_orm {
                 std::stringstream ss;
                 std::vector<std::string> columnNames;
                 using columns_type_t = typename std::decay<decltype(fk)>::type::columns_type;
-                constexpr const int columnsCount = std::tuple_size<columns_type_t>::value;
+                constexpr const size_t columnsCount = std::tuple_size<columns_type_t>::value;
                 columnNames.reserve(columnsCount);
                 tuple_helper::iterator<columnsCount - 1, Cs...>()(fk.columns, [&columnNames, this](auto &v){
                     columnNames.push_back(this->impl.column_name(v));
@@ -6854,7 +6857,7 @@ namespace sqlite_orm {
                 ss << ") REFERENCES ";
                 std::vector<std::string> referencesNames;
                 using references_type_t = typename std::decay<decltype(fk)>::type::references_type;
-                constexpr const int referencesCount = std::tuple_size<references_type_t>::value;
+                constexpr const size_t referencesCount = std::tuple_size<references_type_t>::value;
                 referencesNames.reserve(referencesCount);
                 {
                     using first_reference_t = typename std::tuple_element<0, references_type_t>::type;
@@ -6958,7 +6961,7 @@ namespace sqlite_orm {
             std::string escape(std::string text) {
                 for(size_t i = 0; i < text.length(); ) {
                     if(text[i] == '\''){
-                        text.insert(text.begin() + i, '\'');
+                        text.insert(text.begin() + static_cast<ptrdiff_t>(i), '\'');
                         i += 2;
                     }
                     else
@@ -6991,12 +6994,12 @@ namespace sqlite_orm {
             }
             
             template<class T>
-            std::string string_from_expression(const alias_holder<T> &holder, bool noTableName = false, bool /*escape*/ = false) {
+            std::string string_from_expression(const alias_holder<T> &, bool /*noTableName*/ = false, bool /*escape*/ = false) {
                 return T::get();
             }
             
             template<class T, class E>
-            std::string string_from_expression(const as_t<T, E> &als, bool noTableName = false, bool /*escape*/ = false) {
+            std::string string_from_expression(const as_t<T, E> &als, bool /*noTableName*/ = false, bool /*escape*/ = false) {
                 auto tableAliasString = alias_extractor<T>::get();
                 return this->string_from_expression(als.expression) + " AS " + tableAliasString;
             }
@@ -7187,7 +7190,7 @@ namespace sqlite_orm {
             }
             
             template<class T>
-            std::string string_from_expression(const aggregate_functions::count_asterisk_t<T> &f, bool /*noTableName*/ = false, bool /*escape*/ = false) {
+            std::string string_from_expression(const aggregate_functions::count_asterisk_t<T> &, bool /*noTableName*/ = false, bool /*escape*/ = false) {
                 return this->string_from_expression(aggregate_functions::count_asterisk_without_type{});
             }
             
@@ -7349,9 +7352,9 @@ namespace sqlite_orm {
                     args.emplace_back(std::move(expression));
                 });
                 ss << static_cast<std::string>(f) << "(";
-                auto lim = int(args.size());
+                const auto lim = static_cast<int>(args.size());
                 for(auto i = 0; i < lim; ++i) {
-                    ss << args[i];
+                    ss << args[static_cast<size_t>(i)];
                     if(i < lim - 1) {
                         ss << ", ";
                     }else{
@@ -7388,7 +7391,7 @@ namespace sqlite_orm {
             }
             
             template<class T, class F>
-            std::string string_from_expression(const column_pointer<T, F> &c, bool noTableName = false, bool escape = false) {
+            std::string string_from_expression(const column_pointer<T, F> &c, bool noTableName = false, bool /*escape*/ = false) {
                 std::stringstream ss;
                 if(!noTableName){
                     ss << "'" << this->impl.template find_table_name<T>() << "'.";
@@ -7409,7 +7412,7 @@ namespace sqlite_orm {
             }
             
             template<class T>
-            std::vector<std::string> get_column_names(const internal::asterisk_t<T> &ast) {
+            std::vector<std::string> get_column_names(const internal::asterisk_t<T> &) {
                 std::vector<std::string> res;
                 res.push_back("*");
                 return res;
@@ -7418,7 +7421,7 @@ namespace sqlite_orm {
             template<class ...Args>
             std::vector<std::string> get_column_names(const internal::columns_t<Args...> &cols) {
                 std::vector<std::string> columnNames;
-                columnNames.reserve(cols.count());
+                columnNames.reserve(static_cast<size_t>(cols.count()));
                 cols.for_each([&columnNames, this](auto &m) {
                     auto columnName = this->string_from_expression(m);
                     if(columnName.length()){
@@ -8303,7 +8306,7 @@ namespace sqlite_orm {
             }
             
             template<class T, class F>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const column_pointer<T, F> &c) {
+            std::set<std::pair<std::string, std::string>> parse_table_name(const column_pointer<T, F> &) {
                 std::set<std::pair<std::string, std::string>> res;
                 res.insert({this->impl.template find_table_name<T>(), ""});
                 return res;
@@ -8315,7 +8318,7 @@ namespace sqlite_orm {
             }
             
             template<class T>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const aggregate_functions::count_asterisk_t<T> &c) {
+            std::set<std::pair<std::string, std::string>> parse_table_name(const aggregate_functions::count_asterisk_t<T> &) {
                 auto tableName = this->impl.template find_table_name<T>();
                 if(!tableName.empty()){
                     return {std::make_pair(std::move(tableName), "")};
@@ -8329,7 +8332,7 @@ namespace sqlite_orm {
             }
             
             template<class T>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const asterisk_t<T> &ast) {
+            std::set<std::pair<std::string, std::string>> parse_table_name(const asterisk_t<T> &) {
                 auto tableName = this->impl.template find_table_name<T>();
                 return {std::make_pair(std::move(tableName), "")};
             }

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -28,7 +28,7 @@ void testCast() {
                                            make_column("score_str", &Student::scoreString)));
     storage.sync_schema();
     
-    storage.replace(Student{1, 10.1, "14.5"});
+    storage.replace(Student{1, 10.1f, "14.5"});
     
     {
         auto rows = storage.select(columns(cast<int>(&Student::scoreFloat), cast<int>(&Student::scoreString)));
@@ -656,7 +656,7 @@ void testExplicitInsert() {
         try {
             storage.insert(user4, columns(&User::name));
             throw std::runtime_error("Must not fire");
-        } catch (std::system_error e) {
+        } catch (const std::system_error&) {
             //        cout << e.what() << endl;
         }
     }
@@ -705,14 +705,14 @@ void testExplicitInsert() {
         try {
             storage.insert(visit3, columns(&Visit::id));
             throw std::runtime_error("Must not fire");
-        } catch (std::system_error e) {
+        } catch (const std::system_error&) {
             //        cout << e.what() << endl;
         }
         
         try {
             storage.insert(visit3, columns(&Visit::setId));
             throw std::runtime_error("Must not fire");
-        } catch (std::system_error e) {
+        } catch (const std::system_error&) {
             //        cout << e.what() << endl;
         }
     }
@@ -741,7 +741,7 @@ void testCustomCollate() {
     storage.create_collation("ototo", [](int, const void *lhs, int, const void *rhs){
         return strcmp((const char*)lhs, (const char*)rhs);
     });
-    storage.create_collation("alwaysequal", [](int, const void *lhs, int, const void *rhs){
+    storage.create_collation("alwaysequal", [](int, const void *, int, const void *){
         return 0;
     });
     auto rows = storage.select(&Item::name, where(is_equal(&Item::name, "Mercury").collate("ototo")));
@@ -754,12 +754,12 @@ void testCustomCollate() {
     storage.create_collation("ototo", {});
     try {
         rows = storage.select(&Item::name, where(is_equal(&Item::name, "Mercury").collate("ototo")));
-    } catch (std::system_error e) {
+    } catch (const std::system_error& e) {
         cout << e.what() << endl;
     }
     try {
         rows = storage.select(&Item::name, where(is_equal(&Item::name, "Mercury").collate("ototo2")));
-    } catch (std::system_error e) {
+    } catch (const std::system_error& e) {
         cout << e.what() << endl;
     }
     rows = storage.select(&Item::name, where(is_equal(&Item::name, "Mercury").collate("alwaysequal")),
@@ -767,7 +767,7 @@ void testCustomCollate() {
     
     rows = storage.select(&Item::name, where(is_equal(&Item::name, "Mercury").collate("alwaysequal")),
                           order_by(&Item::name).collate("alwaysequal"));
-    assert(rows.size() == storage.count<Item>());
+    assert(rows.size() == static_cast<size_t>(storage.count<Item>()));
 }
 
 void testVacuum() {
@@ -870,7 +870,7 @@ void testOperators() {
                                        c(&Object::nameLen) / c(&Object::number),
                                        c(&Object::nameLen) / 2));
     
-    for(auto i = 0; i < rows.size(); ++i) {
+    for(size_t i = 0; i < rows.size(); ++i) {
         auto &row = rows[i];
         auto &name = names[i];
         assert(std::get<0>(row) == name + suffix);
@@ -912,14 +912,14 @@ void testOperators() {
                                         &Object::nameLen % c(&Object::number),
                                         c(&Object::nameLen) % c(&Object::number),
                                         c(&Object::nameLen) % 5));
-    for(auto i = 0; i < rows2.size(); ++i) {
+    for(size_t i = 0; i < rows2.size(); ++i) {
         auto &row = rows2[i];
         auto &name = names[i];
-        assert(std::get<0>(row) == name.length() % number);
+        assert(std::get<0>(row) == static_cast<int>(name.length()) % number);
         assert(std::get<1>(row) == std::get<0>(row));
         assert(std::get<2>(row) == std::get<1>(row));
         assert(std::get<3>(row) == std::get<2>(row));
-        assert(std::get<4>(row) == name.length() % 5);
+        assert(std::get<4>(row) == static_cast<int>(name.length()) % 5);
     }
 }
 
@@ -1314,7 +1314,7 @@ void testSyncSchema() {
     }
 
     //  assert count first cause we will be asserting row by row next..
-    assert(storage.count<UserBefore>() == usersToInsert.size());
+    assert(static_cast<size_t>(storage.count<UserBefore>()) == usersToInsert.size());
 
     //  now we create new storage with partial schema..
     auto newStorage = make_storage(filename,
@@ -1338,7 +1338,7 @@ void testSyncSchema() {
 
     assert(usersFromDb.size() == usersToInsert.size());
 
-    for(auto i = 0; i < usersFromDb.size(); ++i) {
+    for(size_t i = 0; i < usersFromDb.size(); ++i) {
         auto &userFromDb = usersFromDb[i];
         auto &oldUser = usersToInsert[i];
         assert(userFromDb.id == oldUser.id);
@@ -1654,7 +1654,7 @@ void testInsert() {
     auto countBefore = storage.count<Object>();
     storage.insert_range(initList.begin(),
                          initList.end());
-    assert(storage.count<Object>() == countBefore + initList.size());
+    assert(storage.count<Object>() == countBefore + static_cast<int>(initList.size()));
 
 
     //  test empty container
@@ -1897,13 +1897,13 @@ void testBlob() {
     };
     using byte = char;
 
-    auto generateData = [](int size) -> byte* {
+    auto generateData = [](size_t size) -> byte* {
         auto data = (byte*)::malloc(size * sizeof(byte));
-        for (int i = 0; i < size; ++i) {
+        for (int i = 0; i < static_cast<int>(size); ++i) {
             if ((i+1) % 10 == 0) {
                 data[i] = 0;
             } else {
-                data[i] = (rand() % 100) + 1;
+                data[i] = static_cast<byte>((rand() % 100) + 1);
             }
         }
         return data;
@@ -1915,7 +1915,7 @@ void testBlob() {
     storage.sync_schema();
     storage.remove_all<BlobData>();
 
-    auto size = 100;
+    size_t size = 100;
     auto data = generateData(size);
 
     //  write data
@@ -1988,7 +1988,7 @@ void testDefaultValue() {
                                             make_column("Age", &User::age),
                                             make_column("Email", &User::email, default_value("example@email.com"))));
     storage2.sync_schema();
-    storage2.insert(User{0, "Tom", 15});
+    storage2.insert(User{0, "Tom", 15, ""});
 }
 
 //  after #18
@@ -2109,7 +2109,7 @@ void testSynchronous() {
     try{
         storage.pragma.synchronous(newValue);
         throw std::runtime_error("Must not fire");
-    }catch(std::system_error) {
+    }catch(const std::system_error&) {
         //  Safety level may not be changed inside a transaction
         assert(storage.pragma.synchronous() == value);
     }
@@ -2285,11 +2285,11 @@ void testRowId() {
                                        _rowid_<SimpleTable>(),
                                        &SimpleTable::letter,
                                        &SimpleTable::desc));
-    for(auto i = 0; i < rows.size(); ++i) {
+    for(size_t i = 0; i < rows.size(); ++i) {
         auto &row = rows[i];
         assert(std::get<0>(row) == std::get<1>(row));
         assert(std::get<1>(row) == std::get<2>(row));
-        assert(std::get<2>(row) == i + 1);
+        assert(std::get<2>(row) == static_cast<int>(i + 1));
         assert(std::get<2>(row) == std::get<3>(row));
         assert(std::get<3>(row) == std::get<4>(row));
         assert(std::get<4>(row) == std::get<5>(row));
@@ -2343,7 +2343,7 @@ void testWhere() {
     assert(users5.size() == 0);
 }
 
-int main(int argc, char **argv) {
+int main(int, char **) {
 
     cout << "version = " << make_storage("").libversion() << endl;
 


### PR DESCRIPTION
The project I'm using sqlite_orm for is built with fairly stringent
warnings (-Wall -Wextra -Wpointer-arith -Wconversion -Wsign-conversion
-Wno-maybe-uninitialized -Werror). This resolves warnings that came out
of that set, mostly related to:

- Sign conversion errors, especially regarding size_t <-> int.
  To preserve the existing API, all count() functions continue to return
  int, but this requires casts whenever you compare those to STL .size()
  calls.

- Unused args

- Catching exceptions by value

- Unreachable locations - I'm currently calling assert(false) to
  convince the compiler that we don't reach the end of some functions
  (and exit without returning a value).
  Let me know if something else is preferred - e.g. an UNREACHABLE macro
  that resolves to __builtin_unreachable() in GCC and Clang.