### PR TITLE
TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ before_script:
 # build examples, and run tests (ie make & make test)
 script:
   - cmake --build . --config Debug
-  - ctest --verbose --output-on-failure -C Debug
+  - ctest --verbose --output-on-failure -C Debug -j $(nproc)
 
 # generate and publish GCov coveralls results
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,13 @@ matrix:
       osx_image: xcode10.2
       language: cpp
       env:
-        - VCPKG_ALLOW_APPLE_CLANG: 1
+        - VCPKG_CXX: g++-6 # Compiler to build vcpkg
+        - SQLITE_ORM_OMITS_CODECVT: ON
+      addons:
+        homebrew:
+          packages:
+            - gcc@6
+          update: true
 
     - name: "OSX LLVM/Clang"
       os: osx
@@ -70,8 +76,18 @@ before_script:
   - mv -f -t ./vcpkg ~/.cache/vcpkg/* || echo "No cached files for vcpkg."
   - cd vcpkg
   - chmod +x bootstrap-vcpkg.sh
-  - if [[ ! "${CXX:-}" && "$TRAVIS_OS_NAME" == "osx" ]]; then ./bootstrap-vcpkg.sh --allowAppleClang ; else ./bootstrap-vcpkg.sh ; fi
-  - chmod +x vcpkg
+  - |
+    # Build vcpkg
+    ( set -eu
+      if [[ ${VCPKG_CC:-} ]]; then eval "CC=${VCPKG_CC}"; fi
+      if [[ ${VCPKG_CXX:-} ]]; then eval "CXX=${VCPKG_CXX}"; fi
+      if [[ ${TRAVIS_OS_NAME} == "osx" && ! ${VCPKG_CXX:-} ]]; then
+        ./bootstrap-vcpkg.sh --allowAppleClang
+      else
+        ./bootstrap-vcpkg.sh
+      fi
+      chmod +x vcpkg
+    )
   - ./vcpkg install gtest
   - cd ${TRAVIS_BUILD_DIR}
   - mkdir compile && cd compile

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,12 +37,10 @@ matrix:
       osx_image: xcode10.2
       language: cpp
       env:
-        - VCPKG_CXX: g++-6 # Compiler to build vcpkg
         - SQLITE_ORM_OMITS_CODECVT: ON
       addons:
         homebrew:
           packages:
-            - gcc@6
             - catch2
           update: true
 
@@ -84,52 +82,13 @@ before_install:
     fi
   # coveralls test coverage:
   - if [[ "$CXX" == "g++" ]]; then pip install --user cpp-coveralls ; fi
-  # vcpkg library manager
-  - |
-    VCPKG_DIR="${TRAVIS_BUILD_DIR}/third_party/vcpkg"
-    export PATH=$PATH:${VCPKG_DIR:?}
-  - git clone https://github.com/Microsoft/vcpkg.git ${VCPKG_DIR:?}
-  - mv -f -t ${VCPKG_DIR:?} ~/.cache/vcpkg/* || echo "No cached files for vcpkg."
-  - |
-    # Build vcpkg
-    cd ${VCPKG_DIR} # Outside `(...)` Travis OSX bug
-    ( set -euxo pipefail
-      VCPKG_SRC_HASH="${VCPKG_DIR}/vcpkg_src_hash" && touch ${VCPKG_SRC_HASH}
-      GENERATE_SRC_HASH='( git log --format=format:%H --max-count=1 -- toolsrc )'
-      if [[ ${VCPKG_CC:-} ]]; then eval "CC=${VCPKG_CC}"; fi
-      if [[ ${VCPKG_CXX:-} ]]; then eval "CXX=${VCPKG_CXX}"; fi
-      if [[ ! -x "$(command -v vcpkg)" ||
-        ( $(vcpkg update) == 'Warning: Different source'*'for vcpkg'* ) ||
-        ( $(eval $GENERATE_SRC_HASH) != $(< ${VCPKG_SRC_HASH}) ) ]]
-      then
-        if [[ ${TRAVIS_OS_NAME} == "osx" && ! ${VCPKG_CXX:-} ]]; then
-          bootstrap-vcpkg.sh --allowAppleClang
-        else
-          bootstrap-vcpkg.sh
-        fi
-        eval ${GENERATE_SRC_HASH} > ${VCPKG_SRC_HASH}
-      fi
-      chmod +x vcpkg
-    )
-
-install:
-  - if [[ ${TRAVIS_OS_NAME} == "linux" ]]; then vcpkg install catch2; fi
-  - |
-    # Update installed (cached) packages
-    ( set -eu
-      vcpkg update # print potential updates
-      if [[ $(vcpkg upgrade) != *'installed packages are up-to-date'* ]]
-      then
-        vcpkg upgrade --no-dry-run
-      fi
-    )
 
 # scripts to run before build
 before_script:
   - if [[ "$CXX" == *"clang"* ]]; then clang --version ; fi
   - cd ${TRAVIS_BUILD_DIR}
   - mkdir compile && cd compile
-  - cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE=../third_party/vcpkg/scripts/buildsystems/vcpkg.cmake -DSQLITE_ORM_OMITS_CODECVT="${SQLITE_ORM_OMITS_CODECVT:OFF}" ..
+  - cmake -DCMAKE_BUILD_TYPE=Debug -DSQLITE_ORM_OMITS_CODECVT="${SQLITE_ORM_OMITS_CODECVT:OFF}" ..
 
 # build examples, and run tests (ie make & make test)
 script:
@@ -139,13 +98,3 @@ script:
 # generate and publish GCov coveralls results
 after_success:
   - if [[ "$CXX" == "g++" ]]; then coveralls --root .. -e examples -e googletest -e sqlite3 -e tests -E ".*feature_tests.*" -E ".*CompilerId.*" --gcov-options '\-lp' ; fi
-
-before_cache:
-- |
-  # Select files for caching
-  mkdir -p ~/.cache/vcpkg
-  mv -u -t ~/.cache/vcpkg ${VCPKG_DIR}/vcpkg ${VCPKG_DIR}/installed ${VCPKG_DIR}/vcpkg_src_hash
-
-cache:
-  directories:
-  - ~/.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,10 @@ matrix:
         - CXX: g++-6
 
 before_install:
+  - |
+    if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then
+      export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH" # Use coreutils from homebrew.
+    fi
   # coveralls test coverage:
   - if [[ "$CXX" == "g++" ]]; then pip install --user cpp-coveralls ; fi
   # vcpkg library manager

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,18 @@ matrix:
         - CXX=/usr/local/opt/llvm/bin/clang++
         - VCPKG_ALLOW_APPLE_CLANG=1
         - SQLITE_ORM_OMITS_CODECVT=ON
+    - name: "osx gcc"
+      addons:
+        homebrew:
+          packages:
+            - gcc6
+      compiler: gcc
+      os: osx
+      osx_image: xcode10.1
+      env:
+        - CC=gcc-6
+        - CXX=g++-6
+        - SQLITE_ORM_OMITS_CODECVT=OFF
 
 before_install:
   # coveralls test coverage:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,18 @@ dist: xenial
 
 matrix:
   include:
-    - name: "gcc 7"
+    - name: "GCC-9"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-9
+      env:
+        - CC: gcc-9
+        - CXX: g++-9
+
+    - name: "GCC-7"
       addons:
         apt:
           sources:
@@ -15,13 +26,13 @@ matrix:
         - CC: gcc-7
         - CXX: g++-7
 
-    - name: "clang default"
+    - name: "LLVM/Clang (Travis default)"
       language: cpp
       compiler: clang
       env:
         - SQLITE_ORM_OMITS_CODECVT: ON
 
-    - name: AppleClang Xcode-10.2
+    - name: AppleClang-10.0.1
       os: osx
       osx_image: xcode10.2
       language: cpp
@@ -34,7 +45,7 @@ matrix:
             - gcc@6
           update: true
 
-    - name: "OSX LLVM/Clang"
+    - name: "OSX LLVM/Clang (latest)"
       os: osx
       osx_image: xcode10.2
       addons:
@@ -51,7 +62,7 @@ matrix:
         - CXX: /usr/local/opt/llvm/bin/clang++
         - SQLITE_ORM_OMITS_CODECVT: ON
 
-    - name: "osx gcc"
+    - name: "GCC-6"
       os: osx
       osx_image: xcode10.1
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ matrix:
             - llvm
             - catch2
             - ninja
+          update: true
       env:
         - CPPFLAGS: "-I/usr/local/opt/llvm/include"
         - LDFLAGS: "-L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib"
@@ -72,7 +73,7 @@ matrix:
 
     - name: "GCC-6"
       os: osx
-      osx_image: xcode10.1
+      osx_image: xcode10.2
       addons:
         homebrew:
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - g++-9
+            - ninja-build
       env:
         - CC: gcc-9
         - CXX: g++-9
@@ -22,6 +23,7 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - g++-7
+            - ninja-build
       env:
         - CC: gcc-7
         - CXX: g++-7
@@ -29,6 +31,10 @@ matrix:
     - name: "LLVM/Clang (Travis default)"
       language: cpp
       compiler: clang
+      addons:
+        apt:
+          packages:
+            - ninja-build
       env:
         - SQLITE_ORM_OMITS_CODECVT: ON
 
@@ -42,6 +48,7 @@ matrix:
         homebrew:
           packages:
             - catch2
+            - ninja
           update: true
 
     - name: "LLVM/Clang (latest)"
@@ -52,6 +59,7 @@ matrix:
           packages:
             - llvm
             - catch2
+            - ninja
       env:
         - CPPFLAGS: "-I/usr/local/opt/llvm/include"
         - LDFLAGS: "-L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib"
@@ -70,6 +78,7 @@ matrix:
           packages:
             - gcc@6
             - catch2
+            - ninja
           update: true
       env:
         - CC: gcc-6
@@ -98,11 +107,11 @@ before_script:
   - if [[ "$CXX" == *"clang"* ]]; then clang --version ; fi
   - cd ${TRAVIS_BUILD_DIR}
   - mkdir compile && cd compile
-  - cmake -DCMAKE_BUILD_TYPE=Debug -DSQLITE_ORM_OMITS_CODECVT="${SQLITE_ORM_OMITS_CODECVT:OFF}" ..
+  - cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DSQLITE_ORM_OMITS_CODECVT="${SQLITE_ORM_OMITS_CODECVT:OFF}" ..
 
 # build examples, and run tests (ie make & make test)
 script:
-  - cmake --build . --config Debug
+  - cmake --build . --config Debug -- -k 10
   - ctest --verbose --output-on-failure -C Debug -j $(nproc)
 
 # generate and publish GCov coveralls results

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ matrix:
             - gcc@6
           update: true
 
-    - name: "OSX LLVM/Clang (latest)"
+    - name: "LLVM/Clang (latest)"
       os: osx
       osx_image: xcode10.2
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,14 +63,14 @@ before_script:
   - chmod +x build.sh
   - cd third_party
   - git clone https://github.com/Microsoft/vcpkg.git vcpkg
+  - mv -f -t ./vcpkg ~/.cache/vcpkg/* || echo "No cached files for vcpkg."
   - cd vcpkg
   - chmod +x bootstrap-vcpkg.sh
-  - if [[ "$CXX" == *"clang"* && "$TRAVIS_OS_NAME" == "osx" ]]; then ./bootstrap-vcpkg.sh --allowAppleClang ; else ./bootstrap-vcpkg.sh ; fi
+  - if [[ ! "${CXX:-}" && "$TRAVIS_OS_NAME" == "osx" ]]; then ./bootstrap-vcpkg.sh --allowAppleClang ; else ./bootstrap-vcpkg.sh ; fi
   - chmod +x vcpkg
   - ./vcpkg install gtest
-  - cd ../..
-  - mkdir compile
-  - cd compile
+  - cd ${TRAVIS_BUILD_DIR}
+  - mkdir compile && cd compile
   - cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE=../third_party/vcpkg/scripts/buildsystems/vcpkg.cmake -DSQLITE_ORM_OMITS_CODECVT="$SQLITE_ORM_OMITS_CODECVT" ..
 
 # build examples, and run tests (ie make & make test)
@@ -81,3 +81,13 @@ script:
 # generate and publish GCov coveralls results
 after_success:
   - if [[ "$CXX" == "g++" ]]; then coveralls --root .. -e examples -e googletest -e sqlite3 -e tests -E ".*feature_tests.*" -E ".*CompilerId.*" --gcov-options '\-lp' ; fi
+
+before_cache:
+- |
+  # Select files for caching
+  mkdir -p ~/.cache/vcpkg
+  mv -u -t ~/.cache/vcpkg ${TRAVIS_BUILD_DIR}/third_party/vcpkg/installed
+
+cache:
+  directories:
+  - ~/.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,24 +82,32 @@ before_install:
   # coveralls test coverage:
   - if [[ "$CXX" == "g++" ]]; then pip install --user cpp-coveralls ; fi
   # vcpkg library manager
-  - cd third_party
-  - git clone https://github.com/Microsoft/vcpkg.git vcpkg
-  - mv -f -t ./vcpkg ~/.cache/vcpkg/* || echo "No cached files for vcpkg."
-  - cd vcpkg
-  - chmod +x bootstrap-vcpkg.sh
+  - |
+    VCPKG_DIR="${TRAVIS_BUILD_DIR}/third_party/vcpkg"
+    export PATH=$PATH:${VCPKG_DIR:?}
+  - git clone https://github.com/Microsoft/vcpkg.git ${VCPKG_DIR:?}
+  - mv -f -t ${VCPKG_DIR:?} ~/.cache/vcpkg/* || echo "No cached files for vcpkg."
   - |
     # Build vcpkg
-    ( set -eu
+    cd ${VCPKG_DIR} # Outside `(...)` Travis OSX bug
+    ( set -euxo pipefail
+      VCPKG_SRC_HASH="${VCPKG_DIR}/vcpkg_src_hash" && touch ${VCPKG_SRC_HASH}
+      GENERATE_SRC_HASH='( git log --format=format:%H --max-count=1 -- toolsrc )'
       if [[ ${VCPKG_CC:-} ]]; then eval "CC=${VCPKG_CC}"; fi
       if [[ ${VCPKG_CXX:-} ]]; then eval "CXX=${VCPKG_CXX}"; fi
-      if [[ ${TRAVIS_OS_NAME} == "osx" && ! ${VCPKG_CXX:-} ]]; then
-        ./bootstrap-vcpkg.sh --allowAppleClang
-      else
-        ./bootstrap-vcpkg.sh
+      if [[ ! -x "$(command -v vcpkg)" ||
+        ( $(vcpkg update) == 'Warning: Different source'*'for vcpkg'* ) ||
+        ( $(eval $GENERATE_SRC_HASH) != $(< ${VCPKG_SRC_HASH}) ) ]]
+      then
+        if [[ ${TRAVIS_OS_NAME} == "osx" && ! ${VCPKG_CXX:-} ]]; then
+          bootstrap-vcpkg.sh --allowAppleClang
+        else
+          bootstrap-vcpkg.sh
+        fi
+        eval ${GENERATE_SRC_HASH} > ${VCPKG_SRC_HASH}
       fi
       chmod +x vcpkg
     )
-    export PATH=$PATH:${TRAVIS_BUILD_DIR}/third_party/vcpkg
 
 install:
   - vcpkg install gtest
@@ -133,7 +141,7 @@ before_cache:
 - |
   # Select files for caching
   mkdir -p ~/.cache/vcpkg
-  mv -u -t ~/.cache/vcpkg ${TRAVIS_BUILD_DIR}/third_party/vcpkg/installed
+  mv -u -t ~/.cache/vcpkg ${VCPKG_DIR}/vcpkg ${VCPKG_DIR}/installed ${VCPKG_DIR}/vcpkg_src_hash
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,6 @@ before_install:
 # scripts to run before build
 before_script:
   - if [[ "$CXX" == *"clang"* ]]; then clang --version ; fi
-  - if [[ "$CXX" == *"clang"* && "$TRAVIS_OS_NAME" == "osx" ]]; then chmod +x prepare-osx-with-clang.sh ; ./prepare-osx-with-clang.sh ; fi 
   - chmod +x build.sh
   - cd third_party
   - git clone https://github.com/Microsoft/vcpkg.git vcpkg

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,11 +77,7 @@ matrix:
 before_install:
   # coveralls test coverage:
   - if [[ "$CXX" == "g++" ]]; then pip install --user cpp-coveralls ; fi
-
-# scripts to run before build
-before_script:
-  - if [[ "$CXX" == *"clang"* ]]; then clang --version ; fi
-  - chmod +x build.sh
+  # vcpkg library manager
   - cd third_party
   - git clone https://github.com/Microsoft/vcpkg.git vcpkg
   - mv -f -t ./vcpkg ~/.cache/vcpkg/* || echo "No cached files for vcpkg."
@@ -99,7 +95,23 @@ before_script:
       fi
       chmod +x vcpkg
     )
-  - ./vcpkg install gtest
+    export PATH=$PATH:${TRAVIS_BUILD_DIR}/third_party/vcpkg
+
+install:
+  - vcpkg install gtest
+  - |
+    # Update installed (cached) packages
+    ( set -eu
+      vcpkg update # print potential updates
+      if [[ $(vcpkg upgrade) != *'installed packages are up-to-date'* ]]
+      then
+        vcpkg upgrade --no-dry-run
+      fi
+    )
+
+# scripts to run before build
+before_script:
+  - if [[ "$CXX" == *"clang"* ]]; then clang --version ; fi
   - cd ${TRAVIS_BUILD_DIR}
   - mkdir compile && cd compile
   - cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE=../third_party/vcpkg/scripts/buildsystems/vcpkg.cmake -DSQLITE_ORM_OMITS_CODECVT="${SQLITE_ORM_OMITS_CODECVT:OFF}" ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,16 @@ before_install:
   # coveralls test coverage:
   - if [[ "$CXX" == "g++" ]]; then pip install --user cpp-coveralls ; fi
 
+install:
+  - |
+    # Catch2 test framework
+    if [[ ${TRAVIS_OS_NAME} == "linux" ]]; then
+      git clone --depth=1 --quiet https://github.com/catchorg/Catch2.git
+      cd Catch2
+      cmake -Bbuild -H. -DBUILD_TESTING=OFF
+      sudo env "PATH=$PATH" cmake --build ./build --target install
+    fi
+
 # scripts to run before build
 before_script:
   - if [[ "$CXX" == *"clang"* ]]; then clang --version ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,8 +89,6 @@ before_install:
     if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then
       export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH" # Use coreutils from homebrew.
     fi
-  # coveralls test coverage:
-  - if [[ "$CXX" == "g++" ]]; then pip install --user cpp-coveralls ; fi
 
 install:
   - |
@@ -113,7 +111,3 @@ before_script:
 script:
   - cmake --build . --config Debug -- -k 10
   - ctest --verbose --output-on-failure -C Debug -j $(nproc)
-
-# generate and publish GCov coveralls results
-after_success:
-  - if [[ "$CXX" == "g++" ]]; then coveralls --root .. -e examples -e googletest -e sqlite3 -e tests -E ".*feature_tests.*" -E ".*CompilerId.*" --gcov-options '\-lp' ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,7 +110,6 @@ before_install:
     )
 
 install:
-  - vcpkg install gtest
   - vcpkg install catch2
   - |
     # Update installed (cached) packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,14 @@ matrix:
       env:
         - SQLITE_ORM_OMITS_CODECVT: ON
 
+    - name: AppleClang Xcode-10.2
+      os: osx
+      osx_image: xcode10.2
+      language: cpp
+      env:
+        - VCPKG_ALLOW_APPLE_CLANG: 1
+        - SQLITE_ORM_OMITS_CODECVT: OFF
+
     - name: "OSX LLVM/Clang"
       os: osx
       osx_image: xcode10.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ matrix:
       env:
         - CC: gcc-7
         - CXX: g++-7
-        - SQLITE_ORM_OMITS_CODECVT: OFF
 
     - name: "clang default"
       language: cpp
@@ -28,7 +27,6 @@ matrix:
       language: cpp
       env:
         - VCPKG_ALLOW_APPLE_CLANG: 1
-        - SQLITE_ORM_OMITS_CODECVT: OFF
 
     - name: "OSX LLVM/Clang"
       os: osx
@@ -58,7 +56,6 @@ matrix:
       env:
         - CC: gcc-6
         - CXX: g++-6
-        - SQLITE_ORM_OMITS_CODECVT: OFF
 
 before_install:
   # coveralls test coverage:
@@ -78,7 +75,7 @@ before_script:
   - ./vcpkg install gtest
   - cd ${TRAVIS_BUILD_DIR}
   - mkdir compile && cd compile
-  - cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE=../third_party/vcpkg/scripts/buildsystems/vcpkg.cmake -DSQLITE_ORM_OMITS_CODECVT="$SQLITE_ORM_OMITS_CODECVT" ..
+  - cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE=../third_party/vcpkg/scripts/buildsystems/vcpkg.cmake -DSQLITE_ORM_OMITS_CODECVT="${SQLITE_ORM_OMITS_CODECVT:OFF}" ..
 
 # build examples, and run tests (ie make & make test)
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ matrix:
         homebrew:
           packages:
             - gcc@6
+            - catch2
           update: true
 
     - name: "LLVM/Clang (latest)"
@@ -52,6 +53,7 @@ matrix:
         homebrew:
           packages:
             - llvm
+            - catch2
       env:
         - CPPFLAGS: "-I/usr/local/opt/llvm/include"
         - LDFLAGS: "-L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib"
@@ -69,6 +71,7 @@ matrix:
         homebrew:
           packages:
             - gcc@6
+            - catch2
           update: true
       env:
         - CC: gcc-6
@@ -110,7 +113,7 @@ before_install:
     )
 
 install:
-  - vcpkg install catch2
+  - if [[ ${TRAVIS_OS_NAME} == "linux" ]]; then vcpkg install catch2; fi
   - |
     # Update installed (cached) packages
     ( set -eu

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,10 @@
-# Request for Ubuntu 16.04 Trusty VM
-sudo: true
+# Defaults
+os: linux
 dist: xenial
-
-# This is comment to easer chagne CXX and CC flags
-#language: cpp
-
-cache:
-  apt: true
-
-addons:
-    apt:
-      update: true
-      packages:
-      - cmake
-      - git
-    homebrew:
-      packages:
-      - cmake
-      - git
-      update: true
 
 matrix:
   include:
     - name: "gcc 7"
-      compiler: gcc
       addons:
         apt:
           sources:
@@ -31,45 +12,45 @@ matrix:
           packages:
             - g++-7
       env:
-        - CC=gcc-7
-        - CXX=g++-7
-        - SQLITE_ORM_OMITS_CODECVT=OFF
+        - CC: gcc-7
+        - CXX: g++-7
+        - SQLITE_ORM_OMITS_CODECVT: OFF
+
     - name: "clang default"
+      language: cpp
       compiler: clang
       env:
-        - CC=clang
-        - CXX=clang++
-        - SQLITE_ORM_OMITS_CODECVT=ON
-    - name: "osx clang"
+        - SQLITE_ORM_OMITS_CODECVT: ON
+
+    - name: "OSX LLVM/Clang"
+      os: osx
+      osx_image: xcode10.2
       addons:
         homebrew:
           packages:
             - llvm
-      compiler: clang
-      os: osx
-      osx_image: xcode10.2
       env:
-        - CPPFLAGS="-I/usr/local/opt/llvm/include"
-        - LDFLAGS="-L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib"
-        - CPATH=/usr/local/opt/llvm/include
-        - LIBRARY_PATH=/usr/local/opt/llvm/lib
-        - LD_LIBRARY_PATH=/usr/local/opt/llvm/lib
-        - CC=/usr/local/opt/llvm/bin/clang
-        - CXX=/usr/local/opt/llvm/bin/clang++
-        - VCPKG_ALLOW_APPLE_CLANG=1
-        - SQLITE_ORM_OMITS_CODECVT=ON
+        - CPPFLAGS: "-I/usr/local/opt/llvm/include"
+        - LDFLAGS: "-L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib"
+        - CPATH: /usr/local/opt/llvm/include
+        - LIBRARY_PATH: /usr/local/opt/llvm/lib
+        - LD_LIBRARY_PATH: /usr/local/opt/llvm/lib
+        - CC: /usr/local/opt/llvm/bin/clang
+        - CXX: /usr/local/opt/llvm/bin/clang++
+        - SQLITE_ORM_OMITS_CODECVT: ON
+
     - name: "osx gcc"
+      os: osx
+      osx_image: xcode10.1
       addons:
         homebrew:
           packages:
-            - gcc6
-      compiler: gcc
-      os: osx
-      osx_image: xcode10.1
+            - gcc@6
+          update: true
       env:
-        - CC=gcc-6
-        - CXX=g++-6
-        - SQLITE_ORM_OMITS_CODECVT=OFF
+        - CC: gcc-6
+        - CXX: g++-6
+        - SQLITE_ORM_OMITS_CODECVT: OFF
 
 before_install:
   # coveralls test coverage:

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,6 +111,7 @@ before_install:
 
 install:
   - vcpkg install gtest
+  - vcpkg install catch2
   - |
     # Update installed (cached) packages
     ( set -eu


### PR DESCRIPTION
Cleanup of the Travis configuration.

Functional changes:
- Install Catch2 - usable from [CMake](github.com/catchorg/Catch2/blob/master/docs/cmake-integration.md).
- Let CMake call Ninja instead of Make (per build job speedup: 30-120 seconds).
- ~~Allow setting a different compiler to build the vcpkg executable.~~
  ~~This makes it possible to test the project with older compilers (and AppleClang).~~
- ~~Cache the vcpkg executable (build job speedup: 2-4 minutes).~~
- ~~Cache gtest (build job speedup: 20-50 seconds).~~

Add more configurations:
- Linux: GCC-9
- OSX: AppleClang-10.0.1.
- ?
