### PR TITLE
Reduce builds on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,16 @@
 # build format
 version: "{build}"
 
+skip_commits:
+  files:
+  - .git*
+  - .travis.yml
+  - _config.yml
+  - LICENSE
+  - '*.md'
+  - '*.png'
+  - '*.sh'
+
 # scripts that run after cloning repository
 install:
   - git submodule update --init --recursive

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 # build format
 version: "{build}"
 
+skip_branch_with_pr: true
 skip_commits:
   files:
   - .git*


### PR DESCRIPTION
At the moment there is a significant backlog for AppVeyor.
This PR adds two methods to reduce the amount of irrelevant builds:
- ba6fbd3 This keeps AppVeyor from running for commits that only affect files irrelevant to the Windows build. Such as documentation and the TravisCI configuration.
- 482c986 Only build the merged commit for PR builds. To reduce the amount of duplicate builds.
  This affects PR's between branches within this repository. (i.e. only PR's created by @fnc12)
  Note that PR builds are cancelled when the PR is closed (or merged).
