### PR TITLE
AppVeyor: set architecture flag

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,12 +18,12 @@ platform:
 
 init:
   - echo %APPVEYOR_BUILD_WORKER_IMAGE% - %configuration% - %PLATFORM%
-  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2019" (set generator="Visual Studio 16 2019")
-  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" (set generator="Visual Studio 15 2017")
-  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" (set generator="Visual Studio 14 2015")
-  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2013" (set generator="Visual Studio 12 2013")
   - if "%PLATFORM%"=="x64" (set architecture=-A x64)
   - if "%PLATFORM%"=="x86" (set architecture=-A Win32)
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2019" (set vs="Visual Studio 16 2019" %architecture%)
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" (set vs="Visual Studio 15 2017" %architecture%)
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" (set vs="Visual Studio 14 2015" %architecture%)
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2013" (set vs="Visual Studio 12 2013" %architecture%)
 
 install:
   - C:\Tools\vcpkg\vcpkg integrate install
@@ -33,7 +33,7 @@ install:
 before_build:
   - mkdir compile
   - cd compile
-  - cmake -DSqliteOrm_BuildTests=ON .. -G %generator% %architecture%
+  - cmake -DSqliteOrm_BuildTests=ON .. -G %generator%
 
 # build examples, and run tests (ie make & make test)
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,12 +18,12 @@ platform:
 
 init:
   - echo %APPVEYOR_BUILD_WORKER_IMAGE% - %configuration% - %PLATFORM%
-  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" (set vs=Visual Studio 15 2017)
-  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" (set vs=Visual Studio 14 2015)
-  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2013" (set vs=Visual Studio 12 2013)
-  - if "%PLATFORM%"=="x64" (set generator="%vs% %PLATFORM%")
-  - if "%PLATFORM%"=="x86" (set generator="%vs% Win32")
-  - echo %generator%
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2019" (set generator="Visual Studio 16 2019")
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" (set generator="Visual Studio 15 2017")
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" (set generator="Visual Studio 14 2015")
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2013" (set generator="Visual Studio 12 2013")
+  - if "%PLATFORM%"=="x64" (set architecture=-A x64)
+  - if "%PLATFORM%"=="x86" (set architecture=-A Win32)
 
 install:
   - C:\Tools\vcpkg\vcpkg integrate install
@@ -33,7 +33,7 @@ install:
 before_build:
   - mkdir compile
   - cd compile
-  - cmake -DSqliteOrm_BuildTests=ON .. -G %generator%
+  - cmake -DSqliteOrm_BuildTests=ON .. -G %generator% %architecture%
 
 # build examples, and run tests (ie make & make test)
 build_script:


### PR DESCRIPTION
To be compatible with the Visual Studio 2019 generator, available since CMake v3.14.

This format is in use since CMake v3.1, so there should be no issues. _(Project minimum supported is v3.2.)_
