### PR TITLE
refactor get_pointer object creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .DS_store
 examples/simple_neural_network.cpp
+
+cmake-build-debug/
+
+.idea/

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -2439,18 +2439,18 @@ namespace sqlite_orm {
                 auto stepRes = sqlite3_step(stmt);
                 switch(stepRes){
                     case SQLITE_ROW:{
-                        T res;
+                        auto res = std::make_unique<T>();
                         index = 0;
                         impl.table.for_each_column([&index, &res, stmt] (auto c) {
                             using field_type = typename decltype(c)::field_type;
                             auto value = row_extractor<field_type>().extract(stmt, index++);
                             if(c.member_pointer){
-                                res.*c.member_pointer = std::move(value);
+                                (*res).*c.member_pointer = std::move(value);
                             }else{
-                                ((res).*(c.setter))(std::move(value));
+                                ((*res).*(c.setter))(std::move(value));
                             }
                         });
-                        return std::make_unique<T>(std::move(res));
+                        return res;
                     }break;
                     case SQLITE_DONE:{
                         return {};

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -10594,18 +10594,18 @@ namespace sqlite_orm {
                 auto stepRes = sqlite3_step(stmt);
                 switch(stepRes){
                     case SQLITE_ROW:{
-                        T res;
+                        auto res = std::make_unique<T>();
                         index = 0;
                         impl.table.for_each_column([&index, &res, stmt] (auto c) {
                             using field_type = typename decltype(c)::field_type;
                             auto value = row_extractor<field_type>().extract(stmt, index++);
                             if(c.member_pointer){
-                                res.*c.member_pointer = std::move(value);
+                                (*res).*c.member_pointer = std::move(value);
                             }else{
-                                ((res).*(c.setter))(std::move(value));
+                                ((*res).*(c.setter))(std::move(value));
                             }
                         });
-                        return std::make_unique<T>(std::move(res));
+                        return res;
                     }break;
                     case SQLITE_DONE:{
                         return {};


### PR DESCRIPTION
Refactor get_pointer to create the object as a smart pointer at the beginning instead of normal object so no move constructor is needed when creating the unique pointer later.
When used with Qt framework and QObject base class the copy/move constructors are deleted by default.