### PR TITLE
added clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,123 @@
+---
+Language:        Cpp
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortLambdasOnASingleLine: Empty
+AllowAllArgumentsOnNextLine: false
+AllowAllConstructorInitializersOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: AfterColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: false
+ForEachMacros:   
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories: 
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: All
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    false
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: Never
+SpaceBeforeRangeBasedForLoopColon: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+StatementMacros: 
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseTab:          Never
+...
+

--- a/dev/aggregate_functions.h
+++ b/dev/aggregate_functions.h
@@ -1,27 +1,27 @@
 #pragma once
 
 namespace sqlite_orm {
-    
+
     namespace aggregate_functions {
-        
+
         template<class T>
         struct avg_t {
             T t;
-            
+
             operator std::string() const {
                 return "AVG";
             }
         };
-        
+
         template<class T>
         struct count_t {
             T t;
-            
+
             operator std::string() const {
                 return "COUNT";
             }
         };
-        
+
         /**
          *  T is use to specify type explicitly for queries like
          *  SELECT COUNT(*) FROM table_name;
@@ -30,119 +30,119 @@ namespace sqlite_orm {
         template<class T>
         struct count_asterisk_t {
             using type = T;
-            
+
             operator std::string() const {
                 return "COUNT";
             }
         };
-        
+
         struct count_asterisk_without_type {
             operator std::string() const {
                 return "COUNT";
             }
         };
-        
+
         template<class T>
         struct sum_t {
             T t;
-            
+
             operator std::string() const {
                 return "SUM";
             }
         };
-        
+
         template<class T>
         struct total_t {
             T t;
-            
+
             operator std::string() const {
                 return "TOTAL";
             }
         };
-        
+
         template<class T>
         struct max_t {
             T t;
-            
+
             operator std::string() const {
                 return "MAX";
             }
         };
-        
+
         template<class T>
         struct min_t {
             T t;
-            
+
             operator std::string() const {
                 return "MIN";
             }
         };
-        
+
         template<class T>
         struct group_concat_single_t {
             T t;
-            
+
             operator std::string() const {
                 return "GROUP_CONCAT";
             }
         };
-        
+
         template<class T>
         struct group_concat_double_t {
             T t;
             std::string y;
-            
+
             operator std::string() const {
                 return "GROUP_CONCAT";
             }
         };
-        
+
     }
-    
+
     template<class T>
     aggregate_functions::avg_t<T> avg(T t) {
         return {t};
     }
-    
+
     template<class T>
     aggregate_functions::count_t<T> count(T t) {
         return {t};
     }
-    
+
     inline aggregate_functions::count_asterisk_without_type count() {
         return {};
     }
-    
+
     template<class T>
     aggregate_functions::count_asterisk_t<T> count() {
         return {};
     }
-    
+
     template<class T>
     aggregate_functions::sum_t<T> sum(T t) {
         return {t};
     }
-    
+
     template<class T>
     aggregate_functions::max_t<T> max(T t) {
         return {t};
     }
-    
+
     template<class T>
     aggregate_functions::min_t<T> min(T t) {
         return {t};
     }
-    
+
     template<class T>
     aggregate_functions::total_t<T> total(T t) {
         return {t};
     }
-    
+
     template<class T>
     aggregate_functions::group_concat_single_t<T> group_concat(T t) {
         return {t};
     }
-    
+
     template<class T, class Y>
     aggregate_functions::group_concat_double_t<T> group_concat(T t, Y y) {
         return {t, y};

--- a/dev/alias.h
+++ b/dev/alias.h
@@ -2,18 +2,18 @@
 
 #include <type_traits>  //  std::enable_if, std::is_base_of, std::is_member_pointer
 #include <sstream>  //  std::stringstream
-#include <string>   //  std::string
+#include <string>  //  std::string
 
 namespace sqlite_orm {
-    
+
     /**
      *  This is base class for every class which is used as a custom table alias.
      *  For more information please look through self_join.cpp example
      */
     struct alias_tag {};
-    
+
     namespace internal {
-        
+
         /**
          *  This is a common built-in class used for custom single character table aliases.
          *  Also you can use language aliases `alias_a`, `alias_b` etc. instead
@@ -21,12 +21,12 @@ namespace sqlite_orm {
         template<class T, char A>
         struct table_alias : alias_tag {
             using type = T;
-            
+
             static char get() {
                 return A;
             }
         };
-        
+
         /**
          *  Column expression with table alias attached like 'C.ID'. This is not a column alias
          */
@@ -34,17 +34,17 @@ namespace sqlite_orm {
         struct alias_column_t {
             using alias_type = T;
             using column_type = C;
-            
+
             column_type column;
-            
-            alias_column_t() {};
-            
-            alias_column_t(column_type column_): column(column_) {}
+
+            alias_column_t(){};
+
+            alias_column_t(column_type column_) : column(column_) {}
         };
-        
+
         template<class T, class SFINAE = void>
         struct alias_extractor;
-        
+
         template<class T>
         struct alias_extractor<T, typename std::enable_if<std::is_base_of<alias_tag, T>::value>::type> {
             static std::string get() {
@@ -53,72 +53,99 @@ namespace sqlite_orm {
                 return ss.str();
             }
         };
-        
+
         template<class T>
         struct alias_extractor<T, typename std::enable_if<!std::is_base_of<alias_tag, T>::value>::type> {
             static std::string get() {
                 return {};
             }
         };
-        
+
         template<class T, class E>
         struct as_t {
             using alias_type = T;
             using expression_type = E;
-            
+
             expression_type expression;
         };
-        
+
         template<class T>
         struct alias_holder {
             using type = T;
         };
     }
-    
+
     /**
      *  @return column with table alias attached. Place it instead of a column statement in case you need to specify a
      *  column with table alias prefix like 'a.column'. For more information please look through self_join.cpp example
      */
     template<class T, class C>
     internal::alias_column_t<T, C> alias_column(C c) {
-        static_assert(std::is_member_pointer<C>::value, "alias_column argument must be a member pointer mapped to a storage");
+        static_assert(std::is_member_pointer<C>::value,
+                      "alias_column argument must be a member pointer mapped to a storage");
         return {c};
     }
-    
+
     template<class T, class E>
     internal::as_t<T, E> as(E expression) {
         return {std::move(expression)};
     }
-    
+
     template<class T>
     internal::alias_holder<T> get() {
         return {};
     }
-    
-    template<class T> using alias_a = internal::table_alias<T, 'a'>;
-    template<class T> using alias_b = internal::table_alias<T, 'b'>;
-    template<class T> using alias_c = internal::table_alias<T, 'c'>;
-    template<class T> using alias_d = internal::table_alias<T, 'd'>;
-    template<class T> using alias_e = internal::table_alias<T, 'e'>;
-    template<class T> using alias_f = internal::table_alias<T, 'f'>;
-    template<class T> using alias_g = internal::table_alias<T, 'g'>;
-    template<class T> using alias_h = internal::table_alias<T, 'h'>;
-    template<class T> using alias_i = internal::table_alias<T, 'i'>;
-    template<class T> using alias_j = internal::table_alias<T, 'j'>;
-    template<class T> using alias_k = internal::table_alias<T, 'k'>;
-    template<class T> using alias_l = internal::table_alias<T, 'l'>;
-    template<class T> using alias_m = internal::table_alias<T, 'm'>;
-    template<class T> using alias_n = internal::table_alias<T, 'n'>;
-    template<class T> using alias_o = internal::table_alias<T, 'o'>;
-    template<class T> using alias_p = internal::table_alias<T, 'p'>;
-    template<class T> using alias_q = internal::table_alias<T, 'q'>;
-    template<class T> using alias_r = internal::table_alias<T, 'r'>;
-    template<class T> using alias_s = internal::table_alias<T, 's'>;
-    template<class T> using alias_t = internal::table_alias<T, 't'>;
-    template<class T> using alias_u = internal::table_alias<T, 'u'>;
-    template<class T> using alias_v = internal::table_alias<T, 'v'>;
-    template<class T> using alias_w = internal::table_alias<T, 'w'>;
-    template<class T> using alias_x = internal::table_alias<T, 'x'>;
-    template<class T> using alias_y = internal::table_alias<T, 'y'>;
-    template<class T> using alias_z = internal::table_alias<T, 'z'>;
+
+    template<class T>
+    using alias_a = internal::table_alias<T, 'a'>;
+    template<class T>
+    using alias_b = internal::table_alias<T, 'b'>;
+    template<class T>
+    using alias_c = internal::table_alias<T, 'c'>;
+    template<class T>
+    using alias_d = internal::table_alias<T, 'd'>;
+    template<class T>
+    using alias_e = internal::table_alias<T, 'e'>;
+    template<class T>
+    using alias_f = internal::table_alias<T, 'f'>;
+    template<class T>
+    using alias_g = internal::table_alias<T, 'g'>;
+    template<class T>
+    using alias_h = internal::table_alias<T, 'h'>;
+    template<class T>
+    using alias_i = internal::table_alias<T, 'i'>;
+    template<class T>
+    using alias_j = internal::table_alias<T, 'j'>;
+    template<class T>
+    using alias_k = internal::table_alias<T, 'k'>;
+    template<class T>
+    using alias_l = internal::table_alias<T, 'l'>;
+    template<class T>
+    using alias_m = internal::table_alias<T, 'm'>;
+    template<class T>
+    using alias_n = internal::table_alias<T, 'n'>;
+    template<class T>
+    using alias_o = internal::table_alias<T, 'o'>;
+    template<class T>
+    using alias_p = internal::table_alias<T, 'p'>;
+    template<class T>
+    using alias_q = internal::table_alias<T, 'q'>;
+    template<class T>
+    using alias_r = internal::table_alias<T, 'r'>;
+    template<class T>
+    using alias_s = internal::table_alias<T, 's'>;
+    template<class T>
+    using alias_t = internal::table_alias<T, 't'>;
+    template<class T>
+    using alias_u = internal::table_alias<T, 'u'>;
+    template<class T>
+    using alias_v = internal::table_alias<T, 'v'>;
+    template<class T>
+    using alias_w = internal::table_alias<T, 'w'>;
+    template<class T>
+    using alias_x = internal::table_alias<T, 'x'>;
+    template<class T>
+    using alias_y = internal::table_alias<T, 'y'>;
+    template<class T>
+    using alias_z = internal::table_alias<T, 'z'>;
 }

--- a/dev/arithmetic_tag.h
+++ b/dev/arithmetic_tag.h
@@ -1,30 +1,23 @@
 #pragma once
 
 namespace sqlite_orm {
-    
+
     /**
      *  Helper classes used by statement_binder and row_extractor.
      */
-    struct int_or_smaller_tag{};
-    struct bigint_tag{};
-    struct real_tag{};
-    
+    struct int_or_smaller_tag {};
+    struct bigint_tag {};
+    struct real_tag {};
+
     template<class V>
-    struct arithmetic_tag
-    {
-        using type = std::conditional_t<
-        std::is_integral<V>::value,
-        // Integer class
-        std::conditional_t<
-        sizeof(V) <= sizeof(int),
-        int_or_smaller_tag,
-        bigint_tag
-        >,
-        // Floating-point class
-        real_tag
-        >;
+    struct arithmetic_tag {
+        using type = std::conditional_t<std::is_integral<V>::value,
+                                        // Integer class
+                                        std::conditional_t<sizeof(V) <= sizeof(int), int_or_smaller_tag, bigint_tag>,
+                                        // Floating-point class
+                                        real_tag>;
     };
-    
+
     template<class V>
     using arithmetic_tag_t = typename arithmetic_tag<V>::type;
 }

--- a/dev/ast_iterator.h
+++ b/dev/ast_iterator.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <vector>   //  std::vector
+#include <vector>  //  std::vector
 
 #include "conditions.h"
 #include "select_constraints.h"
@@ -10,9 +10,9 @@
 #include "prepared_statement.h"
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         /**
          *  ast_iterator accepts an any expression and a callable object
          *  which will be called for any node of provided expression.
@@ -25,7 +25,7 @@ namespace sqlite_orm {
         template<class T, class SFINAE = void>
         struct ast_iterator {
             using node_type = T;
-            
+
             /**
              *  L is a callable type. Mostly is templated lambda
              */
@@ -34,7 +34,7 @@ namespace sqlite_orm {
                 l(t);
             }
         };
-        
+
         /**
          *  Simplified API
          */
@@ -43,115 +43,117 @@ namespace sqlite_orm {
             ast_iterator<T> iterator;
             iterator(t, l);
         }
-        
+
         template<class C>
         struct ast_iterator<conditions::where_t<C>, void> {
             using node_type = conditions::where_t<C>;
-         
+
             template<class L>
             void operator()(const node_type &where, const L &l) const {
                 iterate_ast(where.c, l);
             }
         };
-        
+
         template<class T>
-        struct ast_iterator<T, typename std::enable_if<is_base_of_template<T, conditions::binary_condition>::value>::type> {
+        struct ast_iterator<
+            T,
+            typename std::enable_if<is_base_of_template<T, conditions::binary_condition>::value>::type> {
             using node_type = T;
-            
+
             template<class L>
             void operator()(const node_type &binaryCondition, const L &l) const {
                 iterate_ast(binaryCondition.l, l);
                 iterate_ast(binaryCondition.r, l);
             }
         };
-        
-        template<class L, class R, class ...Ds>
+
+        template<class L, class R, class... Ds>
         struct ast_iterator<binary_operator<L, R, Ds...>, void> {
             using node_type = binary_operator<L, R, Ds...>;
-            
+
             template<class C>
             void operator()(const node_type &binaryOperator, const C &l) const {
                 iterate_ast(binaryOperator.lhs, l);
                 iterate_ast(binaryOperator.rhs, l);
             }
         };
-        
-        template<class ...Args>
+
+        template<class... Args>
         struct ast_iterator<columns_t<Args...>, void> {
             using node_type = columns_t<Args...>;
-            
+
             template<class L>
             void operator()(const node_type &cols, const L &l) const {
                 iterate_ast(cols.columns, l);
             }
         };
-        
+
         template<class L, class A>
         struct ast_iterator<conditions::in_t<L, A>, void> {
             using node_type = conditions::in_t<L, A>;
-            
+
             template<class C>
             void operator()(const node_type &in, const C &l) const {
                 iterate_ast(in.l, l);
                 iterate_ast(in.arg, l);
             }
         };
-        
+
         template<class T>
         struct ast_iterator<std::vector<T>, void> {
             using node_type = std::vector<T>;
-            
+
             template<class L>
             void operator()(const node_type &vec, const L &l) const {
-                for(auto &i : vec) {
+                for(auto &i: vec) {
                     iterate_ast(i, l);
                 }
             }
         };
-        
+
         template<>
         struct ast_iterator<std::vector<char>, void> {
             using node_type = std::vector<char>;
-            
+
             template<class L>
             void operator()(const node_type &vec, const L &l) const {
                 l(vec);
             }
         };
-        
+
         template<class T>
         struct ast_iterator<T, typename std::enable_if<is_base_of_template<T, compound_operator>::value>::type> {
             using node_type = T;
-            
+
             template<class L>
             void operator()(const node_type &c, const L &l) const {
                 iterate_ast(c.left, l);
                 iterate_ast(c.right, l);
             }
         };
-        
-        template<class T, class ...Args>
+
+        template<class T, class... Args>
         struct ast_iterator<select_t<T, Args...>, void> {
             using node_type = select_t<T, Args...>;
-            
+
             template<class L>
             void operator()(const node_type &sel, const L &l) const {
                 iterate_ast(sel.col, l);
                 iterate_ast(sel.conditions, l);
             }
         };
-        
-        template<class T, class ...Args>
+
+        template<class T, class... Args>
         struct ast_iterator<get_all_t<T, Args...>, void> {
             using node_type = get_all_t<T, Args...>;
-            
+
             template<class L>
             void operator()(const node_type &get, const L &l) const {
                 iterate_ast(get.conditions, l);
             }
         };
 
-        template<class T, class ...Args>
+        template<class T, class... Args>
         struct ast_iterator<get_all_pointer_t<T, Args...>, void> {
             using node_type = get_all_pointer_t<T, Args...>;
 
@@ -161,77 +163,77 @@ namespace sqlite_orm {
             }
         };
 
-        template<class ...Args>
+        template<class... Args>
         struct ast_iterator<std::tuple<Args...>, void> {
             using node_type = std::tuple<Args...>;
-            
+
             template<class L>
             void operator()(const node_type &tuple, const L &l) const {
-                iterate_tuple(tuple, [&l](auto &v){
+                iterate_tuple(tuple, [&l](auto &v) {
                     iterate_ast(v, l);
                 });
             }
         };
-        
+
         template<class T>
         struct ast_iterator<conditions::having_t<T>, void> {
             using node_type = conditions::having_t<T>;
-            
+
             template<class L>
             void operator()(const node_type &hav, const L &l) const {
                 iterate_ast(hav.t, l);
             }
         };
-        
+
         template<class T, class E>
         struct ast_iterator<conditions::cast_t<T, E>, void> {
             using node_type = conditions::cast_t<T, E>;
-            
+
             template<class L>
             void operator()(const node_type &c, const L &l) const {
                 iterate_ast(c.expression, l);
             }
         };
-        
+
         template<class T>
         struct ast_iterator<conditions::exists_t<T>, void> {
             using node_type = conditions::exists_t<T>;
-            
+
             template<class L>
             void operator()(const node_type &e, const L &l) const {
                 iterate_ast(e.t, l);
             }
         };
-        
+
         template<class A, class T, class E>
         struct ast_iterator<conditions::like_t<A, T, E>, void> {
             using node_type = conditions::like_t<A, T, E>;
-            
+
             template<class L>
             void operator()(const node_type &lk, const L &l) const {
                 iterate_ast(lk.arg, l);
                 iterate_ast(lk.pattern, l);
-                lk.arg3.apply([&l](auto &value){
+                lk.arg3.apply([&l](auto &value) {
                     iterate_ast(value, l);
                 });
             }
         };
-        
+
         template<class A, class T>
         struct ast_iterator<conditions::glob_t<A, T>, void> {
             using node_type = conditions::glob_t<A, T>;
-            
+
             template<class L>
             void operator()(const node_type &lk, const L &l) const {
                 iterate_ast(lk.arg, l);
                 iterate_ast(lk.pattern, l);
             }
         };
-        
+
         template<class A, class T>
         struct ast_iterator<conditions::between_t<A, T>, void> {
             using node_type = conditions::between_t<A, T>;
-            
+
             template<class L>
             void operator()(const node_type &b, const L &l) const {
                 iterate_ast(b.expr, l);
@@ -239,110 +241,110 @@ namespace sqlite_orm {
                 iterate_ast(b.b2, l);
             }
         };
-        
+
         template<class T>
         struct ast_iterator<conditions::named_collate<T>, void> {
             using node_type = conditions::named_collate<T>;
-            
+
             template<class L>
             void operator()(const node_type &col, const L &l) const {
                 iterate_ast(col.expr, l);
             }
         };
-        
+
         template<class C>
         struct ast_iterator<conditions::negated_condition_t<C>, void> {
             using node_type = conditions::negated_condition_t<C>;
-            
+
             template<class L>
             void operator()(const node_type &neg, const L &l) const {
                 iterate_ast(neg.c, l);
             }
         };
-        
-        template<class R, class S, class ...Args>
+
+        template<class R, class S, class... Args>
         struct ast_iterator<core_functions::core_function_t<R, S, Args...>, void> {
             using node_type = core_functions::core_function_t<R, S, Args...>;
-            
+
             template<class L>
             void operator()(const node_type &f, const L &l) const {
                 iterate_ast(f.args, l);
             }
         };
-        
+
         template<class T, class O>
         struct ast_iterator<conditions::left_join_t<T, O>, void> {
             using node_type = conditions::left_join_t<T, O>;
-            
+
             template<class L>
             void operator()(const node_type &j, const L &l) const {
                 iterate_ast(j.constraint, l);
             }
         };
-        
+
         template<class T>
         struct ast_iterator<conditions::on_t<T>, void> {
             using node_type = conditions::on_t<T>;
-            
+
             template<class L>
             void operator()(const node_type &o, const L &l) const {
                 iterate_ast(o.arg, l);
             }
         };
-        
+
         template<class T, class O>
         struct ast_iterator<conditions::join_t<T, O>, void> {
             using node_type = conditions::join_t<T, O>;
-            
+
             template<class L>
             void operator()(const node_type &j, const L &l) const {
                 iterate_ast(j.constraint, l);
             }
         };
-        
+
         template<class T, class O>
         struct ast_iterator<conditions::left_outer_join_t<T, O>, void> {
             using node_type = conditions::left_outer_join_t<T, O>;
-            
+
             template<class L>
             void operator()(const node_type &j, const L &l) const {
                 iterate_ast(j.constraint, l);
             }
         };
-        
+
         template<class T, class O>
         struct ast_iterator<conditions::inner_join_t<T, O>, void> {
             using node_type = conditions::inner_join_t<T, O>;
-            
+
             template<class L>
             void operator()(const node_type &j, const L &l) const {
                 iterate_ast(j.constraint, l);
             }
         };
-        
-        template<class R, class T, class E, class ...Args>
+
+        template<class R, class T, class E, class... Args>
         struct ast_iterator<simple_case_t<R, T, E, Args...>, void> {
             using node_type = simple_case_t<R, T, E, Args...>;
-            
+
             template<class L>
             void operator()(const node_type &c, const L &l) const {
-                c.case_expression.apply([&l](auto &c){
+                c.case_expression.apply([&l](auto &c) {
                     iterate_ast(c, l);
                 });
-                iterate_tuple(c.args, [&l](auto &pair){
+                iterate_tuple(c.args, [&l](auto &pair) {
                     iterate_ast(pair.first, l);
                     iterate_ast(pair.second, l);
                 });
-                c.else_expression.apply([&l](auto &el){
+                c.else_expression.apply([&l](auto &el) {
                     iterate_ast(el, l);
                 });
             }
         };
-        
+
         template<class T, class E>
         struct ast_iterator<as_t<T, E>, void> {
             using node_type = as_t<T, E>;
-            
+
             template<class L>
             void operator()(const node_type &a, const L &l) const {
                 iterate_ast(a.expression, l);

--- a/dev/backup.h
+++ b/dev/backup.h
@@ -1,16 +1,16 @@
 #pragma once
 
 #include <sqlite3.h>
-#include <string>   //  std::string
+#include <string>  //  std::string
 #include <memory>
 
 #include "error_code.h"
 #include "connection_holder.h"
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         /**
          *  A backup class. Don't construct it as is, call storage.make_backup_from or storage.make_backup_to instead.
          *  An instance of this class represents a wrapper around sqlite3_backup pointer. Use this class
@@ -23,54 +23,47 @@ namespace sqlite_orm {
                      connection_ref from_,
                      const std::string &zSourceName,
                      std::unique_ptr<connection_holder> holder_) :
-            handle(sqlite3_backup_init(to_.get(), zDestName.c_str(), from_.get(), zSourceName.c_str())),
-            holder(move(holder_)),
-            to(to_),
-            from(from_)
-            {
-                if(!this->handle){
+                handle(sqlite3_backup_init(to_.get(), zDestName.c_str(), from_.get(), zSourceName.c_str())),
+                holder(move(holder_)), to(to_), from(from_) {
+                if(!this->handle) {
                     throw std::system_error(std::make_error_code(orm_error_code::failed_to_init_a_backup));
                 }
             }
-            
+
             backup_t(backup_t &&other) :
-            handle(other.handle),
-            holder(move(other.holder)),
-            to(other.to),
-            from(other.from)
-            {
+                handle(other.handle), holder(move(other.holder)), to(other.to), from(other.from) {
                 other.handle = nullptr;
             }
-            
+
             ~backup_t() {
-                if(this->handle){
+                if(this->handle) {
                     (void)sqlite3_backup_finish(this->handle);
                     this->handle = nullptr;
                 }
             }
-            
+
             /**
              *  Calls sqlite3_backup_step with pages argument
              */
             int step(int pages) {
                 return sqlite3_backup_step(this->handle, pages);
             }
-            
+
             /**
              *  Returns sqlite3_backup_remaining result
              */
             int remaining() const {
                 return sqlite3_backup_remaining(this->handle);
             }
-            
+
             /**
              *  Returns sqlite3_backup_pagecount result
              */
             int pagecount() const {
                 return sqlite3_backup_pagecount(this->handle);
             }
-            
-        protected:
+
+          protected:
             sqlite3_backup *handle = nullptr;
             std::unique_ptr<connection_holder> holder;
             connection_ref to;

--- a/dev/collate_argument.h
+++ b/dev/collate_argument.h
@@ -1,14 +1,14 @@
 #pragma once
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         enum class collate_argument {
             binary,
             nocase,
             rtrim,
         };
     }
-    
+
 }

--- a/dev/column.h
+++ b/dev/column.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <tuple>    //  std::tuple
-#include <string>   //  std::string
-#include <memory>   //  std::unique_ptr
+#include <tuple>  //  std::tuple
+#include <string>  //  std::string
+#include <memory>  //  std::unique_ptr
 #include <type_traits>  //  std::true_type, std::false_type, std::is_same, std::enable_if, std::is_member_pointer, std::is_member_function_pointer
 
 #include "type_is_nullable.h"
@@ -11,24 +11,24 @@
 #include "constraints.h"
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         struct column_base {
-            
+
             /**
              *  Column name. Specified during construction in `make_column`.
              */
             const std::string name;
         };
-        
+
         /**
          *  This class stores single column info. column_t is a pair of [column_name:member_pointer] mapped to a storage
          *  O is a mapped class, e.g. User
          *  T is a mapped class'es field type, e.g. &User::name
          *  Op... is a constraints pack, e.g. primary_key_t, autoincrement_t etc
          */
-        template<class O, class T, class G/* = const T& (O::*)() const*/, class S/* = void (O::*)(T)*/, class ...Op>
+        template<class O, class T, class G /* = const T& (O::*)() const*/, class S /* = void (O::*)(T)*/, class... Op>
         struct column_t : column_base {
             using object_type = O;
             using field_type = T;
@@ -36,282 +36,296 @@ namespace sqlite_orm {
             using member_pointer_t = field_type object_type::*;
             using getter_type = G;
             using setter_type = S;
-            
+
             /**
              *  Member pointer used to read/write member
              */
-            member_pointer_t member_pointer/* = nullptr*/;
-            
+            member_pointer_t member_pointer /* = nullptr*/;
+
             /**
              *  Getter member function pointer to get a value. If member_pointer is null than
              *  `getter` and `setter` must be not null
              */
-            getter_type getter/* = nullptr*/;
-            
+            getter_type getter /* = nullptr*/;
+
             /**
              *  Setter member function
              */
-            setter_type setter/* = nullptr*/;
-            
+            setter_type setter /* = nullptr*/;
+
             /**
              *  Constraints tuple
              */
             constraints_type constraints;
-            
-            column_t(std::string name, member_pointer_t member_pointer_, getter_type getter_, setter_type setter_, constraints_type constraints_):
-            column_base{std::move(name)}, member_pointer(member_pointer_), getter(getter_), setter(setter_), constraints(std::move(constraints_))
-            {}
-            
+
+            column_t(std::string name,
+                     member_pointer_t member_pointer_,
+                     getter_type getter_,
+                     setter_type setter_,
+                     constraints_type constraints_) :
+                column_base{std::move(name)},
+                member_pointer(member_pointer_), getter(getter_), setter(setter_),
+                constraints(std::move(constraints_)) {}
+
             /**
              *  Simplified interface for `NOT NULL` constraint
              */
             bool not_null() const {
                 return !type_is_nullable<field_type>::value;
             }
-            
+
             template<class Opt>
             constexpr bool has() const {
                 return tuple_helper::tuple_contains_type<Opt, constraints_type>::value;
             }
-            
-            template<class O1, class O2, class ...Opts>
-            constexpr bool has_every() const  {
+
+            template<class O1, class O2, class... Opts>
+            constexpr bool has_every() const {
                 if(has<O1>() && has<O2>()) {
                     return true;
-                }else{
+                } else {
                     return has_every<Opts...>();
                 }
             }
-            
+
             template<class O1>
             constexpr bool has_every() const {
                 return has<O1>();
             }
-            
+
             /**
              *  Simplified interface for `DEFAULT` constraint
              *  @return string representation of default value if it exists otherwise nullptr
              */
             std::unique_ptr<std::string> default_value() const {
                 std::unique_ptr<std::string> res;
-                iterate_tuple(this->constraints, [&res](auto &v){
+                iterate_tuple(this->constraints, [&res](auto &v) {
                     auto dft = internal::default_value_extractor()(v);
-                    if(dft){
+                    if(dft) {
                         res = std::move(dft);
                     }
                 });
                 return res;
             }
         };
-        
+
         /**
          *  Column traits. Common case.
          */
         template<class T>
         struct is_column : public std::false_type {};
-        
+
         /**
          *  Column traits. Specialized case case.
          */
-        template<class O, class T, class ...Op>
+        template<class O, class T, class... Op>
         struct is_column<column_t<O, T, Op...>> : public std::true_type {};
-        
+
         template<class T, class SFINAE = void>
         struct is_field_member_pointer : std::false_type {};
-        
+
         template<class T>
-        struct is_field_member_pointer<T, typename std::enable_if<std::is_member_pointer<T>::value && !std::is_member_function_pointer<T>::value>::type> : std::true_type {};
-        
+        struct is_field_member_pointer<T,
+                                       typename std::enable_if<std::is_member_pointer<T>::value &&
+                                                               !std::is_member_function_pointer<T>::value>::type>
+            : std::true_type {};
+
         /**
          *  Getters aliases
          */
         template<class O, class T>
         using getter_by_value_const = T (O::*)() const;
-        
+
         template<class O, class T>
         using getter_by_value = T (O::*)();
-        
+
         template<class O, class T>
-        using getter_by_ref_const = T& (O::*)() const;
-        
+        using getter_by_ref_const = T &(O::*)() const;
+
         template<class O, class T>
-        using getter_by_ref = T& (O::*)();
-        
+        using getter_by_ref = T &(O::*)();
+
         template<class O, class T>
-        using getter_by_const_ref_const = const T& (O::*)() const;
-        
+        using getter_by_const_ref_const = const T &(O::*)() const;
+
         template<class O, class T>
-        using getter_by_const_ref = const T& (O::*)();
-        
+        using getter_by_const_ref = const T &(O::*)();
+
         /**
          *  Setters aliases
          */
         template<class O, class T>
         using setter_by_value = void (O::*)(T);
-        
+
         template<class O, class T>
-        using setter_by_ref = void (O::*)(T&);
-        
+        using setter_by_ref = void (O::*)(T &);
+
         template<class O, class T>
-        using setter_by_const_ref = void (O::*)(const T&);
-        
+        using setter_by_const_ref = void (O::*)(const T &);
+
         template<class T>
         struct is_getter : std::false_type {};
-        
+
         template<class O, class T>
         struct is_getter<getter_by_value_const<O, T>> : std::true_type {};
-        
+
         template<class O, class T>
         struct is_getter<getter_by_value<O, T>> : std::true_type {};
-        
+
         template<class O, class T>
         struct is_getter<getter_by_ref_const<O, T>> : std::true_type {};
-        
+
         template<class O, class T>
         struct is_getter<getter_by_ref<O, T>> : std::true_type {};
-        
+
         template<class O, class T>
         struct is_getter<getter_by_const_ref_const<O, T>> : std::true_type {};
-        
+
         template<class O, class T>
         struct is_getter<getter_by_const_ref<O, T>> : std::true_type {};
-        
+
         template<class T>
         struct is_setter : std::false_type {};
-        
+
         template<class O, class T>
         struct is_setter<setter_by_value<O, T>> : std::true_type {};
-        
+
         template<class O, class T>
         struct is_setter<setter_by_ref<O, T>> : std::true_type {};
-        
+
         template<class O, class T>
         struct is_setter<setter_by_const_ref<O, T>> : std::true_type {};
-        
+
         template<class T>
         struct getter_traits;
-        
+
         template<class O, class T>
         struct getter_traits<getter_by_value_const<O, T>> {
             using object_type = O;
             using field_type = T;
-            
+
             static constexpr const bool returns_lvalue = false;
         };
-        
+
         template<class O, class T>
         struct getter_traits<getter_by_value<O, T>> {
             using object_type = O;
             using field_type = T;
-            
+
             static constexpr const bool returns_lvalue = false;
         };
-        
+
         template<class O, class T>
         struct getter_traits<getter_by_ref_const<O, T>> {
             using object_type = O;
             using field_type = T;
-            
+
             static constexpr const bool returns_lvalue = true;
         };
-        
+
         template<class O, class T>
         struct getter_traits<getter_by_ref<O, T>> {
             using object_type = O;
             using field_type = T;
-            
+
             static constexpr const bool returns_lvalue = true;
         };
-        
+
         template<class O, class T>
         struct getter_traits<getter_by_const_ref_const<O, T>> {
             using object_type = O;
             using field_type = T;
-            
+
             static constexpr const bool returns_lvalue = true;
         };
-        
+
         template<class O, class T>
         struct getter_traits<getter_by_const_ref<O, T>> {
             using object_type = O;
             using field_type = T;
-            
+
             static constexpr const bool returns_lvalue = true;
         };
-        
+
         template<class T>
         struct setter_traits;
-        
+
         template<class O, class T>
         struct setter_traits<setter_by_value<O, T>> {
             using object_type = O;
             using field_type = T;
         };
-        
+
         template<class O, class T>
         struct setter_traits<setter_by_ref<O, T>> {
             using object_type = O;
             using field_type = T;
         };
-        
+
         template<class O, class T>
         struct setter_traits<setter_by_const_ref<O, T>> {
             using object_type = O;
             using field_type = T;
         };
     }
-    
+
     /**
      *  Column builder function. You should use it to create columns instead of constructor
      */
-    template<class O, class T,
-    typename = typename std::enable_if<!std::is_member_function_pointer<T O::*>::value>::type,
-    class ...Op>
-    internal::column_t<O, T, const T& (O::*)() const, void (O::*)(T), Op...> make_column(const std::string &name, T O::*m, Op ...constraints){
-        static_assert(constraints::constraints_size<Op...>::value == std::tuple_size<std::tuple<Op...>>::value, "Incorrect constraints pack");
+    template<class O,
+             class T,
+             typename = typename std::enable_if<!std::is_member_function_pointer<T O::*>::value>::type,
+             class... Op>
+    internal::column_t<O, T, const T &(O::*)() const, void (O::*)(T), Op...>
+    make_column(const std::string &name, T O::*m, Op... constraints) {
+        static_assert(constraints::constraints_size<Op...>::value == std::tuple_size<std::tuple<Op...>>::value,
+                      "Incorrect constraints pack");
         return {name, m, nullptr, nullptr, std::make_tuple(constraints...)};
     }
-    
+
     /**
      *  Column builder function with setter and getter. You should use it to create columns instead of constructor
      */
-    template<class G, class S,
-    typename = typename std::enable_if<internal::is_getter<G>::value>::type,
-    typename = typename std::enable_if<internal::is_setter<S>::value>::type,
-    class ...Op>
-    internal::column_t<
-    typename internal::setter_traits<S>::object_type,
-    typename internal::setter_traits<S>::field_type,
-    G, S, Op...> make_column(const std::string &name,
-                             S setter,
-                             G getter,
-                             Op ...constraints)
-    {
-        static_assert(std::is_same<typename internal::setter_traits<S>::field_type, typename internal::getter_traits<G>::field_type>::value,
+    template<class G,
+             class S,
+             typename = typename std::enable_if<internal::is_getter<G>::value>::type,
+             typename = typename std::enable_if<internal::is_setter<S>::value>::type,
+             class... Op>
+    internal::column_t<typename internal::setter_traits<S>::object_type,
+                       typename internal::setter_traits<S>::field_type,
+                       G,
+                       S,
+                       Op...>
+    make_column(const std::string &name, S setter, G getter, Op... constraints) {
+        static_assert(std::is_same<typename internal::setter_traits<S>::field_type,
+                                   typename internal::getter_traits<G>::field_type>::value,
                       "Getter and setter must get and set same data type");
-        static_assert(constraints::constraints_size<Op...>::value == std::tuple_size<std::tuple<Op...>>::value, "Incorrect constraints pack");
+        static_assert(constraints::constraints_size<Op...>::value == std::tuple_size<std::tuple<Op...>>::value,
+                      "Incorrect constraints pack");
         return {name, nullptr, getter, setter, std::make_tuple(constraints...)};
     }
-    
+
     /**
-     *  Column builder function with getter and setter (reverse order). You should use it to create columns instead of constructor
+     *  Column builder function with getter and setter (reverse order). You should use it to create columns instead of
+     * constructor
      */
-    template<class G, class S,
-    typename = typename std::enable_if<internal::is_getter<G>::value>::type,
-    typename = typename std::enable_if<internal::is_setter<S>::value>::type,
-    class ...Op>
-    internal::column_t<
-    typename internal::setter_traits<S>::object_type,
-    typename internal::setter_traits<S>::field_type,
-    G, S, Op...> make_column(const std::string &name,
-                             G getter,
-                             S setter,
-                             Op ...constraints)
-    {
-        static_assert(std::is_same<typename internal::setter_traits<S>::field_type, typename internal::getter_traits<G>::field_type>::value,
+    template<class G,
+             class S,
+             typename = typename std::enable_if<internal::is_getter<G>::value>::type,
+             typename = typename std::enable_if<internal::is_setter<S>::value>::type,
+             class... Op>
+    internal::column_t<typename internal::setter_traits<S>::object_type,
+                       typename internal::setter_traits<S>::field_type,
+                       G,
+                       S,
+                       Op...>
+    make_column(const std::string &name, G getter, S setter, Op... constraints) {
+        static_assert(std::is_same<typename internal::setter_traits<S>::field_type,
+                                   typename internal::getter_traits<G>::field_type>::value,
                       "Getter and setter must get and set same data type");
-        static_assert(constraints::constraints_size<Op...>::value == std::tuple_size<std::tuple<Op...>>::value, "Incorrect constraints pack");
+        static_assert(constraints::constraints_size<Op...>::value == std::tuple_size<std::tuple<Op...>>::value,
+                      "Incorrect constraints pack");
         return {name, nullptr, getter, setter, std::make_tuple(constraints...)};
     }
-    
+
 }

--- a/dev/column_result.h
+++ b/dev/column_result.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <type_traits>  //  std::enable_if, std::is_same, std::decay
-#include <tuple>    //  std::tuple
+#include <tuple>  //  std::tuple
 
 #include "core_functions.h"
 #include "aggregate_functions.h"
@@ -13,9 +13,9 @@
 #include "storage_traits.h"
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         /**
          *  This is a proxy class used to define what type must have result type depending on select
          *  arguments (member pointer, aggregate functions, etc). Below you can see specializations
@@ -27,12 +27,15 @@ namespace sqlite_orm {
          */
         template<class St, class T, class SFINAE = void>
         struct column_result_t;
-        
+
         template<class St, class O, class F>
-        struct column_result_t<St, F O::*, typename std::enable_if<std::is_member_pointer<F O::*>::value && !std::is_member_function_pointer<F O::*>::value>::type> {
+        struct column_result_t<St,
+                               F O::*,
+                               typename std::enable_if<std::is_member_pointer<F O::*>::value &&
+                                                       !std::is_member_function_pointer<F O::*>::value>::type> {
             using type = F;
         };
-        
+
         /**
          *  Common case for all getter types. Getter types are defined in column.h file
          */
@@ -40,7 +43,7 @@ namespace sqlite_orm {
         struct column_result_t<St, T, typename std::enable_if<is_getter<T>::value>::type> {
             using type = typename getter_traits<T>::field_type;
         };
-        
+
         /**
          *  Common case for all setter types. Setter types are defined in column.h file
          */
@@ -48,158 +51,162 @@ namespace sqlite_orm {
         struct column_result_t<St, T, typename std::enable_if<is_setter<T>::value>::type> {
             using type = typename setter_traits<T>::field_type;
         };
-        
+
         template<class St, class T>
-        struct column_result_t<St, T, typename std::enable_if<is_base_of_template<T, core_functions::core_function_t>::value>::type> {
+        struct column_result_t<
+            St,
+            T,
+            typename std::enable_if<is_base_of_template<T, core_functions::core_function_t>::value>::type> {
             using type = typename T::return_type;
         };
-        
+
         template<class St, class T>
         struct column_result_t<St, aggregate_functions::avg_t<T>, void> {
             using type = double;
         };
-        
+
         template<class St, class T>
         struct column_result_t<St, aggregate_functions::count_t<T>, void> {
             using type = int;
         };
-        
+
         template<class St, class T>
         struct column_result_t<St, aggregate_functions::count_asterisk_t<T>, void> {
             using type = int;
         };
-        
+
         template<class St, class T>
         struct column_result_t<St, aggregate_functions::sum_t<T>, void> {
             using type = std::unique_ptr<double>;
         };
-        
+
         template<class St, class T>
         struct column_result_t<St, aggregate_functions::total_t<T>, void> {
             using type = double;
         };
-        
+
         template<class St, class T>
         struct column_result_t<St, aggregate_functions::group_concat_single_t<T>, void> {
             using type = std::string;
         };
-        
+
         template<class St, class T>
         struct column_result_t<St, aggregate_functions::group_concat_double_t<T>, void> {
             using type = std::string;
         };
-        
+
         template<class St, class T>
         struct column_result_t<St, aggregate_functions::max_t<T>, void> {
             using type = std::unique_ptr<typename column_result_t<St, T>::type>;
         };
-        
+
         template<class St, class T>
         struct column_result_t<St, aggregate_functions::min_t<T>, void> {
             using type = std::unique_ptr<typename column_result_t<St, T>::type>;
         };
-        
+
         template<class St>
         struct column_result_t<St, aggregate_functions::count_asterisk_without_type, void> {
             using type = int;
         };
-        
+
         template<class St, class T>
         struct column_result_t<St, distinct_t<T>, void> {
             using type = typename column_result_t<St, T>::type;
         };
-        
+
         template<class St, class T>
         struct column_result_t<St, all_t<T>, void> {
             using type = typename column_result_t<St, T>::type;
         };
-        
+
         template<class St, class L, class R>
         struct column_result_t<St, conc_t<L, R>, void> {
             using type = std::string;
         };
-        
+
         template<class St, class L, class R>
         struct column_result_t<St, add_t<L, R>, void> {
             using type = double;
         };
-        
+
         template<class St, class L, class R>
         struct column_result_t<St, sub_t<L, R>, void> {
             using type = double;
         };
-        
+
         template<class St, class L, class R>
         struct column_result_t<St, mul_t<L, R>, void> {
             using type = double;
         };
-        
+
         template<class St, class L, class R>
         struct column_result_t<St, internal::div_t<L, R>, void> {
             using type = double;
         };
-        
+
         template<class St, class L, class R>
         struct column_result_t<St, mod_t<L, R>, void> {
             using type = double;
         };
-        
+
         template<class St>
         struct column_result_t<St, rowid_t, void> {
             using type = int64;
         };
-        
+
         template<class St>
         struct column_result_t<St, oid_t, void> {
             using type = int64;
         };
-        
+
         template<class St>
         struct column_result_t<St, _rowid_t, void> {
             using type = int64;
         };
-        
+
         template<class St, class T>
         struct column_result_t<St, table_rowid_t<T>, void> {
             using type = int64;
         };
-        
+
         template<class St, class T>
         struct column_result_t<St, table_oid_t<T>, void> {
             using type = int64;
         };
-        
+
         template<class St, class T>
         struct column_result_t<St, table__rowid_t<T>, void> {
             using type = int64;
         };
-        
+
         template<class St, class T, class C>
         struct column_result_t<St, alias_column_t<T, C>, void> {
             using type = typename column_result_t<St, C>::type;
         };
-        
+
         template<class St, class T, class F>
         struct column_result_t<St, column_pointer<T, F>> : column_result_t<St, F, void> {};
-        
-        template<class St, class ...Args>
+
+        template<class St, class... Args>
         struct column_result_t<St, columns_t<Args...>, void> {
             using type = std::tuple<typename column_result_t<St, typename std::decay<Args>::type>::type...>;
         };
-        
-        template<class St, class T, class ...Args>
+
+        template<class St, class T, class... Args>
         struct column_result_t<St, select_t<T, Args...>> : column_result_t<St, T, void> {};
-        
+
         template<class St, class T>
         struct column_result_t<St, T, typename std::enable_if<is_base_of_template<T, compound_operator>::value>::type> {
             using left_type = typename T::left_type;
             using right_type = typename T::right_type;
             using left_result = typename column_result_t<St, left_type>::type;
             using right_result = typename column_result_t<St, right_type>::type;
-            static_assert(std::is_same<left_result, right_result>::value, "Compound subselect queries must return same types");
+            static_assert(std::is_same<left_result, right_result>::value,
+                          "Compound subselect queries must return same types");
             using type = left_result;
         };
-        
+
         /**
          *  Result for the most simple queries like `SELECT 1`
          */
@@ -207,43 +214,43 @@ namespace sqlite_orm {
         struct column_result_t<St, T, typename std::enable_if<std::is_arithmetic<T>::value>::type> {
             using type = T;
         };
-        
+
         /**
          *  Result for the most simple queries like `SELECT 'ototo'`
          */
         template<class St>
-        struct column_result_t<St, const char*, void> {
+        struct column_result_t<St, const char *, void> {
             using type = std::string;
         };
-        
+
         template<class St, class T, class E>
         struct column_result_t<St, as_t<T, E>, void> : column_result_t<St, typename std::decay<E>::type, void> {};
-        
+
         template<class St, class T>
         struct column_result_t<St, asterisk_t<T>, void> {
             using type = typename storage_traits::storage_mapped_columns<St, T>::type;
         };
-        
+
         template<class St, class T, class E>
         struct column_result_t<St, conditions::cast_t<T, E>, void> {
             using type = T;
         };
-        
-        template<class St, class R, class T, class E, class ...Args>
+
+        template<class St, class R, class T, class E, class... Args>
         struct column_result_t<St, simple_case_t<R, T, E, Args...>, void> {
             using type = R;
         };
-        
+
         template<class St, class A, class T, class E>
         struct column_result_t<St, conditions::like_t<A, T, E>, void> {
             using type = bool;
         };
-        
+
         template<class St, class A, class T>
         struct column_result_t<St, conditions::glob_t<A, T>, void> {
             using type = bool;
         };
-        
+
         template<class St, class C>
         struct column_result_t<St, conditions::negated_condition_t<C>, void> {
             using type = bool;

--- a/dev/conditions.h
+++ b/dev/conditions.h
@@ -1,17 +1,17 @@
 #pragma once
 
-#include <string>   //  std::string
+#include <string>  //  std::string
 #include <type_traits>  //  std::enable_if, std::is_same
-#include <vector>   //  std::vector
+#include <vector>  //  std::vector
 
 #include "collate_argument.h"
 #include "constraints.h"
 #include "optional_container.h"
 
 namespace sqlite_orm {
-    
+
     namespace conditions {
-        
+
         /**
          *  Stores LIMIT/OFFSET info
          */
@@ -20,37 +20,35 @@ namespace sqlite_orm {
             bool has_offset = false;
             bool offset_is_implicit = false;
             int off = 0;
-            
+
             limit_t() = default;
-            
-            limit_t(decltype(lim) lim_): lim(lim_) {}
-            
+
+            limit_t(decltype(lim) lim_) : lim(lim_) {}
+
             limit_t(decltype(lim) lim_,
                     decltype(has_offset) has_offset_,
                     decltype(offset_is_implicit) offset_is_implicit_,
-                    decltype(off) off_):
-            lim(lim_),
-            has_offset(has_offset_),
-            offset_is_implicit(offset_is_implicit_),
-            off(off_){}
-            
-            operator std::string () const {
+                    decltype(off) off_) :
+                lim(lim_),
+                has_offset(has_offset_), offset_is_implicit(offset_is_implicit_), off(off_) {}
+
+            operator std::string() const {
                 return "LIMIT";
             }
         };
-        
+
         /**
          *  Stores OFFSET only info
          */
         struct offset_t {
             int off;
         };
-        
+
         /**
          *  Inherit from this class if target class can be chained with other conditions with '&&' and '||' operators
          */
         struct condition_t {};
-        
+
         /**
          *  Collated something
          */
@@ -58,48 +56,48 @@ namespace sqlite_orm {
         struct collate_t : public condition_t {
             T expr;
             internal::collate_argument argument;
-            
-            collate_t(T expr_, internal::collate_argument argument_): expr(expr_), argument(argument_) {}
-            
-            operator std::string () const {
+
+            collate_t(T expr_, internal::collate_argument argument_) : expr(expr_), argument(argument_) {}
+
+            operator std::string() const {
                 return constraints::collate_t{this->argument};
             }
         };
-        
+
         struct named_collate_base {
             std::string name;
-            
-            operator std::string () const {
+
+            operator std::string() const {
                 return "COLLATE " + this->name;
             }
         };
-        
+
         /**
          *  Collated something with custom collate function
          */
         template<class T>
         struct named_collate : named_collate_base {
             T expr;
-            
-            named_collate(T expr_, std::string name_): named_collate_base{std::move(name_)}, expr(std::move(expr_)) {}
+
+            named_collate(T expr_, std::string name_) : named_collate_base{std::move(name_)}, expr(std::move(expr_)) {}
         };
-        
+
         struct negated_condition_string {
-            operator std::string () const {
+            operator std::string() const {
                 return "NOT";
             }
         };
-        
+
         /**
          *  Result of not operator
          */
         template<class C>
         struct negated_condition_t : condition_t, negated_condition_string {
             C c;
-            
-            negated_condition_t(C c_): c(std::move(c_)) {}
+
+            negated_condition_t(C c_) : c(std::move(c_)) {}
         };
-        
+
         /**
          *  Base class for binary conditions
          */
@@ -107,320 +105,319 @@ namespace sqlite_orm {
         struct binary_condition : public condition_t {
             L l;
             R r;
-            
+
             binary_condition() = default;
-            
-            binary_condition(L l_, R r_): l(std::move(l_)), r(std::move(r_)) {}
+
+            binary_condition(L l_, R r_) : l(std::move(l_)), r(std::move(r_)) {}
         };
-        
+
         struct and_condition_string {
-            operator std::string () const {
+            operator std::string() const {
                 return "AND";
             }
         };
-        
+
         /**
          *  Result of and operator
          */
         template<class L, class R>
         struct and_condition_t : binary_condition<L, R>, and_condition_string {
             using super = binary_condition<L, R>;
-            
+
             using super::super;
         };
-        
+
         struct or_condition_string {
-            operator std::string () const {
+            operator std::string() const {
                 return "OR";
             }
         };
-        
+
         /**
          *  Result of or operator
          */
         template<class L, class R>
         struct or_condition_t : binary_condition<L, R>, or_condition_string {
             using super = binary_condition<L, R>;
-            
+
             using super::super;
         };
-        
+
         struct is_equal_string {
-            operator std::string () const {
+            operator std::string() const {
                 return "=";
             }
         };
-        
+
         /**
          *  = and == operators object
          */
         template<class L, class R>
         struct is_equal_t : binary_condition<L, R>, is_equal_string {
             using self = is_equal_t<L, R>;
-            
+
             using binary_condition<L, R>::binary_condition;
-            
+
             negated_condition_t<self> operator!() const {
                 return {*this};
             }
-            
+
             collate_t<self> collate_binary() const {
                 return {*this, internal::collate_argument::binary};
             }
-            
+
             collate_t<self> collate_nocase() const {
                 return {*this, internal::collate_argument::nocase};
             }
-            
+
             collate_t<self> collate_rtrim() const {
                 return {*this, internal::collate_argument::rtrim};
             }
-            
+
             named_collate<self> collate(std::string name) const {
                 return {*this, std::move(name)};
             }
-            
         };
-        
+
         struct is_not_equal_string {
-            operator std::string () const {
+            operator std::string() const {
                 return "!=";
             }
         };
-        
+
         /**
          *  != operator object
          */
         template<class L, class R>
         struct is_not_equal_t : binary_condition<L, R>, is_not_equal_string {
             using self = is_not_equal_t<L, R>;
-            
+
             using binary_condition<L, R>::binary_condition;
-            
+
             negated_condition_t<self> operator!() const {
                 return {*this};
             }
-            
+
             collate_t<self> collate_binary() const {
                 return {*this, internal::collate_argument::binary};
             }
-            
+
             collate_t<self> collate_nocase() const {
                 return {*this, internal::collate_argument::nocase};
             }
-            
+
             collate_t<self> collate_rtrim() const {
                 return {*this, internal::collate_argument::rtrim};
             }
         };
-        
+
         struct greater_than_string {
-            operator std::string () const {
+            operator std::string() const {
                 return ">";
             }
         };
-        
+
         /**
          *  > operator object.
          */
         template<class L, class R>
         struct greater_than_t : binary_condition<L, R>, greater_than_string {
             using self = greater_than_t<L, R>;
-            
+
             using binary_condition<L, R>::binary_condition;
-            
+
             negated_condition_t<self> operator!() const {
                 return {*this};
             }
-            
+
             collate_t<self> collate_binary() const {
                 return {*this, internal::collate_argument::binary};
             }
-            
+
             collate_t<self> collate_nocase() const {
                 return {*this, internal::collate_argument::nocase};
             }
-            
+
             collate_t<self> collate_rtrim() const {
                 return {*this, internal::collate_argument::rtrim};
             }
         };
-        
+
         struct greater_or_equal_string {
-            operator std::string () const {
+            operator std::string() const {
                 return ">=";
             }
         };
-        
+
         /**
          *  >= operator object.
          */
         template<class L, class R>
         struct greater_or_equal_t : binary_condition<L, R>, greater_or_equal_string {
             using self = greater_or_equal_t<L, R>;
-            
+
             using binary_condition<L, R>::binary_condition;
-            
+
             negated_condition_t<self> operator!() const {
                 return {*this};
             }
-            
+
             collate_t<self> collate_binary() const {
                 return {*this, internal::collate_argument::binary};
             }
-            
+
             collate_t<self> collate_nocase() const {
                 return {*this, internal::collate_argument::nocase};
             }
-            
+
             collate_t<self> collate_rtrim() const {
                 return {*this, internal::collate_argument::rtrim};
             }
         };
-        
+
         struct lesser_than_string {
-            operator std::string () const {
+            operator std::string() const {
                 return "<";
             }
         };
-        
+
         /**
          *  < operator object.
          */
         template<class L, class R>
         struct lesser_than_t : binary_condition<L, R>, lesser_than_string {
             using self = lesser_than_t<L, R>;
-            
+
             using binary_condition<L, R>::binary_condition;
-            
+
             negated_condition_t<self> operator!() const {
                 return {*this};
             }
-            
+
             collate_t<self> collate_binary() const {
                 return {*this, internal::collate_argument::binary};
             }
-            
+
             collate_t<self> collate_nocase() const {
                 return {*this, internal::collate_argument::nocase};
             }
-            
+
             collate_t<self> collate_rtrim() const {
                 return {*this, internal::collate_argument::rtrim};
             }
         };
-        
+
         struct lesser_or_equal_string {
-            operator std::string () const {
+            operator std::string() const {
                 return "<=";
             }
         };
-        
+
         /**
          *  <= operator object.
          */
         template<class L, class R>
         struct lesser_or_equal_t : binary_condition<L, R>, lesser_or_equal_string {
             using self = lesser_or_equal_t<L, R>;
-            
+
             using binary_condition<L, R>::binary_condition;
-            
+
             negated_condition_t<lesser_or_equal_t<L, R>> operator!() const {
                 return {*this};
             }
-            
+
             collate_t<self> collate_binary() const {
                 return {*this, internal::collate_argument::binary};
             }
-            
+
             collate_t<self> collate_nocase() const {
                 return {*this, internal::collate_argument::nocase};
             }
-            
+
             collate_t<self> collate_rtrim() const {
                 return {*this, internal::collate_argument::rtrim};
             }
         };
-        
+
         struct in_base {
             bool negative = false;  //  used in not_in
-            
-            operator std::string () const {
-                if(!this->negative){
+
+            operator std::string() const {
+                if(!this->negative) {
                     return "IN";
-                }else{
+                } else {
                     return "NOT IN";
                 }
             }
         };
-        
+
         /**
          *  IN operator object.
          */
         template<class L, class A>
         struct in_t : condition_t, in_base {
             using self = in_t<L, A>;
-            
-            L l;    //  left expression
-            A arg;       //  in arg
-            
-            in_t(L l_, A arg_, bool negative): in_base{negative}, l(l_), arg(std::move(arg_)) {}
-            
+
+            L l;  //  left expression
+            A arg;  //  in arg
+
+            in_t(L l_, A arg_, bool negative) : in_base{negative}, l(l_), arg(std::move(arg_)) {}
+
             negated_condition_t<self> operator!() const {
                 return {*this};
             }
         };
-        
+
         struct is_null_string {
-            operator std::string () const {
+            operator std::string() const {
                 return "IS NULL";
             }
         };
-        
+
         /**
          *  IS NULL operator object.
          */
         template<class T>
         struct is_null_t : is_null_string {
             using self = is_null_t<T>;
-            
+
             T t;
-            
+
             is_null_t(T t_) : t(std::move(t_)) {}
-            
+
             negated_condition_t<self> operator!() const {
                 return {*this};
             }
         };
-        
+
         struct is_not_null_string {
-            operator std::string () const {
+            operator std::string() const {
                 return "IS NOT NULL";
             }
         };
-        
+
         /**
          *  IS NOT NULL operator object.
          */
         template<class T>
         struct is_not_null_t : is_not_null_string {
             using self = is_not_null_t<T>;
-            
+
             T t;
-            
+
             is_not_null_t(T t_) : t(std::move(t_)) {}
-            
+
             negated_condition_t<self> operator!() const {
                 return {*this};
             }
         };
-        
+
         struct where_string {
-            operator std::string () const {
+            operator std::string() const {
                 return "WHERE";
             }
         };
-        
+
         /**
          *  WHERE argument holder.
          *  C is conditions type. Can be any condition like: is_equal_t, is_null_t, exists_t etc
@@ -428,147 +425,148 @@ namespace sqlite_orm {
         template<class C>
         struct where_t : where_string {
             C c;
-            
+
             where_t(C c_) : c(std::move(c_)) {}
         };
-        
+
         struct order_by_base {
-            int asc_desc = 0;   //  1: asc, -1: desc
+            int asc_desc = 0;  //  1: asc, -1: desc
             std::string _collate_argument;
         };
-        
+
         struct order_by_string {
             operator std::string() const {
                 return "ORDER BY";
             }
         };
-        
+
         /**
          *  ORDER BY argument holder.
          */
         template<class O>
         struct order_by_t : order_by_base, order_by_string {
             using self = order_by_t<O>;
-            
+
             O o;
-            
-            order_by_t(O o_): o(std::move(o_)) {}
-            
+
+            order_by_t(O o_) : o(std::move(o_)) {}
+
             self asc() {
                 auto res = *this;
                 res.asc_desc = 1;
                 return res;
             }
-            
+
             self desc() {
                 auto res = *this;
                 res.asc_desc = -1;
                 return res;
             }
-            
+
             self collate_binary() const {
                 auto res = *this;
-                res._collate_argument = constraints::collate_t::string_from_collate_argument(internal::collate_argument::binary);
+                res._collate_argument =
+                    constraints::collate_t::string_from_collate_argument(internal::collate_argument::binary);
                 return res;
             }
-            
+
             self collate_nocase() const {
                 auto res = *this;
-                res._collate_argument = constraints::collate_t::string_from_collate_argument(internal::collate_argument::nocase);
+                res._collate_argument =
+                    constraints::collate_t::string_from_collate_argument(internal::collate_argument::nocase);
                 return res;
             }
-            
+
             self collate_rtrim() const {
                 auto res = *this;
-                res._collate_argument = constraints::collate_t::string_from_collate_argument(internal::collate_argument::rtrim);
+                res._collate_argument =
+                    constraints::collate_t::string_from_collate_argument(internal::collate_argument::rtrim);
                 return res;
             }
-            
+
             self collate(std::string name) const {
                 auto res = *this;
                 res._collate_argument = std::move(name);
                 return res;
             }
         };
-        
+
         /**
          *  ORDER BY pack holder.
          */
-        template<class ...Args>
+        template<class... Args>
         struct multi_order_by_t : order_by_string {
             using args_type = std::tuple<Args...>;
-            
+
             args_type args;
-            
+
             multi_order_by_t(args_type &&args_) : args(std::move(args_)) {}
         };
-        
+
         /**
          *  S - storage class
          */
         template<class S>
         struct dynamic_order_by_t : order_by_string {
             using storage_type = S;
-            
+
             struct entry_t : order_by_base {
                 std::string name;
-                
+
                 entry_t(decltype(name) name_, int asc_desc, std::string collate_argument) :
-                order_by_base{asc_desc, move(collate_argument)},
-                name(move(name_))
-                {}
+                    order_by_base{asc_desc, move(collate_argument)}, name(move(name_)) {}
             };
-            
+
             using const_iterator = typename std::vector<entry_t>::const_iterator;
-            
-            dynamic_order_by_t(const storage_type &storage_): storage(storage_) {}
-            
+
+            dynamic_order_by_t(const storage_type &storage_) : storage(storage_) {}
+
             template<class O>
             void push_back(order_by_t<O> order_by) {
                 auto columnName = this->storage.string_from_expression(order_by.o, true);
                 entries.emplace_back(move(columnName), order_by.asc_desc, move(order_by._collate_argument));
             }
-            
+
             const_iterator begin() const {
                 return this->entries.begin();
             }
-            
+
             const_iterator end() const {
                 return this->entries.end();
             }
-            
+
             void clear() {
                 this->entries.clear();
             }
-            
-        protected:
+
+          protected:
             std::vector<entry_t> entries;
             const storage_type &storage;
         };
-        
+
         struct group_by_string {
             operator std::string() const {
                 return "GROUP BY";
             }
         };
-        
+
         /**
          *  GROUP BY pack holder.
          */
-        template<class ...Args>
+        template<class... Args>
         struct group_by_t : group_by_string {
             using args_type = std::tuple<Args...>;
             args_type args;
-            
-            group_by_t(args_type &&args_): args(std::move(args_)) {}
+
+            group_by_t(args_type &&args_) : args(std::move(args_)) {}
         };
-        
+
         struct between_string {
             operator std::string() const {
                 return "BETWEEN";
             }
         };
-        
+
         /**
          *  BETWEEN operator object.
          */
@@ -577,16 +575,16 @@ namespace sqlite_orm {
             A expr;
             T b1;
             T b2;
-            
-            between_t(A expr_, T b1_, T b2_): expr(std::move(expr_)), b1(std::move(b1_)), b2(std::move(b2_)) {}
+
+            between_t(A expr_, T b1_, T b2_) : expr(std::move(expr_)), b1(std::move(b1_)), b2(std::move(b2_)) {}
         };
-        
+
         struct like_string {
             operator std::string() const {
                 return "LIKE";
             }
         };
-        
+
         /**
          *  LIKE operator object.
          */
@@ -596,54 +594,53 @@ namespace sqlite_orm {
             using arg_t = A;
             using pattern_t = T;
             using escape_t = E;
-            
+
             arg_t arg;
             pattern_t pattern;
             internal::optional_container<escape_t> arg3;  //  not escape cause escape exists as a function here
-            
-            like_t(arg_t arg_, pattern_t pattern_, internal::optional_container<escape_t> escape):
-            arg(std::move(arg_)), pattern(std::move(pattern_)), arg3(std::move(escape)) {}
-            
+
+            like_t(arg_t arg_, pattern_t pattern_, internal::optional_container<escape_t> escape) :
+                arg(std::move(arg_)), pattern(std::move(pattern_)), arg3(std::move(escape)) {}
+
             template<class C>
             like_t<A, T, C> escape(C c) const {
                 internal::optional_container<C> arg3{std::move(c)};
                 return {std::move(this->arg), std::move(this->pattern), std::move(arg3)};
             }
-            
+
             negated_condition_t<self> operator!() const {
                 return {*this};
             }
         };
-        
+
         struct glob_string {
             operator std::string() const {
                 return "GLOB";
             }
         };
-        
+
         template<class A, class T>
         struct glob_t : condition_t, glob_string {
             using self = glob_t<A, T>;
             using arg_t = A;
             using pattern_t = T;
-            
+
             arg_t arg;
             pattern_t pattern;
-            
-            glob_t(arg_t arg_, pattern_t pattern_):
-            arg(std::move(arg_)), pattern(std::move(pattern_)) {}
-            
+
+            glob_t(arg_t arg_, pattern_t pattern_) : arg(std::move(arg_)), pattern(std::move(pattern_)) {}
+
             negated_condition_t<self> operator!() const {
                 return {*this};
             }
         };
-        
+
         struct cross_join_string {
             operator std::string() const {
                 return "CROSS JOIN";
             }
         };
-        
+
         /**
          *  CROSS JOIN holder.
          *  T is joined type which represents any mapped table.
@@ -652,13 +649,13 @@ namespace sqlite_orm {
         struct cross_join_t : cross_join_string {
             using type = T;
         };
-        
+
         struct natural_join_string {
             operator std::string() const {
                 return "NATURAL JOIN";
             }
         };
-        
+
         /**
          *  NATURAL JOIN holder.
          *  T is joined type which represents any mapped table.
@@ -667,13 +664,13 @@ namespace sqlite_orm {
         struct natural_join_t : natural_join_string {
             using type = T;
         };
-        
+
         struct left_join_string {
             operator std::string() const {
                 return "LEFT JOIN";
             }
         };
-        
+
         /**
          *  LEFT JOIN holder.
          *  T is joined type which represents any mapped table.
@@ -683,18 +680,18 @@ namespace sqlite_orm {
         struct left_join_t : left_join_string {
             using type = T;
             using on_type = O;
-            
+
             on_type constraint;
-            
+
             left_join_t(on_type constraint_) : constraint(std::move(constraint_)) {}
         };
-        
+
         struct join_string {
             operator std::string() const {
                 return "JOIN";
             }
         };
-        
+
         /**
          *  Simple JOIN holder.
          *  T is joined type which represents any mapped table.
@@ -704,18 +701,18 @@ namespace sqlite_orm {
         struct join_t : join_string {
             using type = T;
             using on_type = O;
-            
+
             on_type constraint;
-            
+
             join_t(on_type constraint_) : constraint(std::move(constraint_)) {}
         };
-        
+
         struct left_outer_join_string {
             operator std::string() const {
                 return "LEFT OUTER JOIN";
             }
         };
-        
+
         /**
          *  LEFT OUTER JOIN holder.
          *  T is joined type which represents any mapped table.
@@ -725,18 +722,18 @@ namespace sqlite_orm {
         struct left_outer_join_t : left_outer_join_string {
             using type = T;
             using on_type = O;
-            
+
             on_type constraint;
-            
+
             left_outer_join_t(on_type constraint_) : constraint(std::move(constraint_)) {}
         };
-        
+
         struct on_string {
             operator std::string() const {
                 return "ON";
             }
         };
-        
+
         /**
          *  on(...) argument holder used for JOIN, LEFT JOIN, LEFT OUTER JOIN and INNER JOIN
          *  T is on type argument.
@@ -744,30 +741,30 @@ namespace sqlite_orm {
         template<class T>
         struct on_t : on_string {
             using arg_type = T;
-            
+
             arg_type arg;
-            
+
             on_t(arg_type arg_) : arg(std::move(arg_)) {}
         };
-        
+
         /**
          *  USING argument holder.
          */
         template<class F, class O>
         struct using_t {
             F O::*column = nullptr;
-            
+
             operator std::string() const {
                 return "USING";
             }
         };
-        
+
         struct inner_join_string {
             operator std::string() const {
                 return "INNER JOIN";
             }
         };
-        
+
         /**
          *  INNER JOIN holder.
          *  T is joined type which represents any mapped table.
@@ -777,38 +774,38 @@ namespace sqlite_orm {
         struct inner_join_t : inner_join_string {
             using type = T;
             using on_type = O;
-            
+
             on_type constraint;
-            
+
             inner_join_t(on_type constraint_) : constraint(std::move(constraint_)) {}
         };
-        
+
         struct exists_string {
             operator std::string() const {
                 return "EXISTS";
             }
         };
-        
+
         template<class T>
         struct exists_t : condition_t, exists_string {
             using type = T;
             using self = exists_t<type>;
-            
+
             type t;
-            
+
             exists_t(T t_) : t(std::move(t_)) {}
-            
+
             negated_condition_t<self> operator!() const {
                 return {*this};
             }
         };
-        
+
         struct having_string {
             operator std::string() const {
                 return "HAVING";
             }
         };
-        
+
         /**
          *  HAVING holder.
          *  T is having argument type.
@@ -816,30 +813,30 @@ namespace sqlite_orm {
         template<class T>
         struct having_t : having_string {
             using type = T;
-            
+
             type t;
-            
+
             having_t(type t_) : t(std::move(t_)) {}
         };
-    
+
         struct cast_string {
             operator std::string() const {
                 return "CAST";
             }
         };
-        
+
         template<class T, class E>
         struct cast_t : cast_string {
             using to_type = T;
             using expression_type = E;
-            
+
             expression_type expression;
-            
+
             cast_t(expression_type expression_) : expression(std::move(expression_)) {}
         };
-        
+
     }
-    
+
     /**
      *  Cute operators for columns
      */
@@ -847,381 +844,379 @@ namespace sqlite_orm {
     conditions::lesser_than_t<T, R> operator<(internal::expression_t<T> expr, R r) {
         return {expr.t, r};
     }
-    
+
     template<class L, class T>
     conditions::lesser_than_t<L, T> operator<(L l, internal::expression_t<T> expr) {
         return {l, expr.t};
     }
-    
+
     template<class T, class R>
     conditions::lesser_or_equal_t<T, R> operator<=(internal::expression_t<T> expr, R r) {
         return {expr.t, r};
     }
-    
+
     template<class L, class T>
     conditions::lesser_or_equal_t<L, T> operator<=(L l, internal::expression_t<T> expr) {
         return {l, expr.t};
     }
-    
+
     template<class T, class R>
     conditions::greater_than_t<T, R> operator>(internal::expression_t<T> expr, R r) {
         return {expr.t, r};
     }
-    
+
     template<class L, class T>
     conditions::greater_than_t<L, T> operator>(L l, internal::expression_t<T> expr) {
         return {l, expr.t};
     }
-    
+
     template<class T, class R>
     conditions::greater_or_equal_t<T, R> operator>=(internal::expression_t<T> expr, R r) {
         return {expr.t, r};
     }
-    
+
     template<class L, class T>
     conditions::greater_or_equal_t<L, T> operator>=(L l, internal::expression_t<T> expr) {
         return {l, expr.t};
     }
-    
+
     template<class T, class R>
     conditions::is_equal_t<T, R> operator==(internal::expression_t<T> expr, R r) {
         return {expr.t, r};
     }
-    
+
     template<class L, class T>
     conditions::is_equal_t<L, T> operator==(L l, internal::expression_t<T> expr) {
         return {l, expr.t};
     }
-    
+
     template<class T, class R>
     conditions::is_not_equal_t<T, R> operator!=(internal::expression_t<T> expr, R r) {
         return {expr.t, r};
     }
-    
+
     template<class L, class T>
     conditions::is_not_equal_t<L, T> operator!=(L l, internal::expression_t<T> expr) {
         return {l, expr.t};
     }
-    
+
     template<class T, class R>
     internal::conc_t<T, R> operator||(internal::expression_t<T> expr, R r) {
         return {expr.t, r};
     }
-    
+
     template<class L, class T>
     internal::conc_t<L, T> operator||(L l, internal::expression_t<T> expr) {
         return {l, expr.t};
     }
-    
+
     template<class L, class R>
     internal::conc_t<L, R> operator||(internal::expression_t<L> l, internal::expression_t<R> r) {
         return {l.t, r.t};
     }
-    
+
     template<class T, class R>
     internal::add_t<T, R> operator+(internal::expression_t<T> expr, R r) {
         return {expr.t, r};
     }
-    
+
     template<class L, class T>
     internal::add_t<L, T> operator+(L l, internal::expression_t<T> expr) {
         return {l, expr.t};
     }
-    
+
     template<class L, class R>
     internal::add_t<L, R> operator+(internal::expression_t<L> l, internal::expression_t<R> r) {
         return {l.t, r.t};
     }
-    
+
     template<class T, class R>
     internal::sub_t<T, R> operator-(internal::expression_t<T> expr, R r) {
         return {expr.t, r};
     }
-    
+
     template<class L, class T>
     internal::sub_t<L, T> operator-(L l, internal::expression_t<T> expr) {
         return {l, expr.t};
     }
-    
+
     template<class L, class R>
     internal::sub_t<L, R> operator-(internal::expression_t<L> l, internal::expression_t<R> r) {
         return {l.t, r.t};
     }
-    
+
     template<class T, class R>
     internal::mul_t<T, R> operator*(internal::expression_t<T> expr, R r) {
         return {expr.t, r};
     }
-    
+
     template<class L, class T>
     internal::mul_t<L, T> operator*(L l, internal::expression_t<T> expr) {
         return {l, expr.t};
     }
-    
+
     template<class L, class R>
     internal::mul_t<L, R> operator*(internal::expression_t<L> l, internal::expression_t<R> r) {
         return {l.t, r.t};
     }
-    
+
     template<class T, class R>
     internal::div_t<T, R> operator/(internal::expression_t<T> expr, R r) {
         return {expr.t, r};
     }
-    
+
     template<class L, class T>
     internal::div_t<L, T> operator/(L l, internal::expression_t<T> expr) {
         return {l, expr.t};
     }
-    
+
     template<class L, class R>
     internal::div_t<L, R> operator/(internal::expression_t<L> l, internal::expression_t<R> r) {
         return {l.t, r.t};
     }
-    
+
     template<class T, class R>
     internal::mod_t<T, R> operator%(internal::expression_t<T> expr, R r) {
         return {expr.t, r};
     }
-    
+
     template<class L, class T>
     internal::mod_t<L, T> operator%(L l, internal::expression_t<T> expr) {
         return {l, expr.t};
     }
-    
+
     template<class L, class R>
     internal::mod_t<L, R> operator%(internal::expression_t<L> l, internal::expression_t<R> r) {
         return {l.t, r.t};
     }
-    
+
     template<class F, class O>
     conditions::using_t<F, O> using_(F O::*p) {
         return {p};
     }
-    
+
     template<class T>
     conditions::on_t<T> on(T t) {
         return {t};
     }
-    
+
     template<class T>
     conditions::cross_join_t<T> cross_join() {
         return {};
     }
-    
+
     template<class T>
     conditions::natural_join_t<T> natural_join() {
         return {};
     }
-    
+
     template<class T, class O>
     conditions::left_join_t<T, O> left_join(O o) {
         return {o};
     }
-    
+
     template<class T, class O>
     conditions::join_t<T, O> join(O o) {
         return {o};
     }
-    
+
     template<class T, class O>
     conditions::left_outer_join_t<T, O> left_outer_join(O o) {
         return {o};
     }
-    
+
     template<class T, class O>
     conditions::inner_join_t<T, O> inner_join(O o) {
         return {o};
     }
-    
+
     inline conditions::offset_t offset(int off) {
         return {off};
     }
-    
+
     inline conditions::limit_t limit(int lim) {
         return {lim};
     }
-    
+
     inline conditions::limit_t limit(int off, int lim) {
         return {lim, true, true, off};
     }
-    
+
     inline conditions::limit_t limit(int lim, conditions::offset_t offt) {
-        return {lim, true, false, offt.off };
+        return {lim, true, false, offt.off};
     }
-    
-    template<
-    class L,
-    class R,
-    typename = typename std::enable_if<std::is_base_of<conditions::condition_t, L>::value || std::is_base_of<conditions::condition_t, R>::value>::type
-    >
-    conditions::and_condition_t<L, R> operator &&(const L &l, const R &r) {
+
+    template<class L,
+             class R,
+             typename = typename std::enable_if<std::is_base_of<conditions::condition_t, L>::value ||
+                                                std::is_base_of<conditions::condition_t, R>::value>::type>
+    conditions::and_condition_t<L, R> operator&&(const L &l, const R &r) {
         return {l, r};
     }
-    
-    template<
-    class L,
-    class R,
-    typename = typename std::enable_if<std::is_base_of<conditions::condition_t, L>::value || std::is_base_of<conditions::condition_t, R>::value>::type
-    >
-    conditions::or_condition_t<L, R> operator ||(const L &l, const R &r) {
+
+    template<class L,
+             class R,
+             typename = typename std::enable_if<std::is_base_of<conditions::condition_t, L>::value ||
+                                                std::is_base_of<conditions::condition_t, R>::value>::type>
+    conditions::or_condition_t<L, R> operator||(const L &l, const R &r) {
         return {l, r};
     }
-    
+
     template<class T>
     conditions::is_not_null_t<T> is_not_null(T t) {
         return {t};
     }
-    
+
     template<class T>
     conditions::is_null_t<T> is_null(T t) {
         return {t};
     }
-    
+
     template<class L, class E>
     conditions::in_t<L, std::vector<E>> in(L l, std::vector<E> values) {
         return {std::move(l), std::move(values), false};
     }
-    
+
     template<class L, class E>
     conditions::in_t<L, std::vector<E>> in(L l, std::initializer_list<E> values) {
         return {std::move(l), std::move(values), false};
     }
-    
+
     template<class L, class A>
     conditions::in_t<L, A> in(L l, A arg) {
         return {std::move(l), std::move(arg), false};
     }
-    
+
     template<class L, class E>
     conditions::in_t<L, std::vector<E>> not_in(L l, std::vector<E> values) {
         return {std::move(l), std::move(values), true};
     }
-    
+
     template<class L, class E>
     conditions::in_t<L, std::vector<E>> not_in(L l, std::initializer_list<E> values) {
         return {std::move(l), std::move(values), true};
     }
-    
+
     template<class L, class A>
     conditions::in_t<L, A> not_in(L l, A arg) {
         return {std::move(l), std::move(arg), true};
     }
-    
+
     template<class L, class R>
     conditions::is_equal_t<L, R> is_equal(L l, R r) {
         return {l, r};
     }
-    
+
     template<class L, class R>
     conditions::is_equal_t<L, R> eq(L l, R r) {
         return {l, r};
     }
-    
+
     template<class L, class R>
     conditions::is_not_equal_t<L, R> is_not_equal(L l, R r) {
         return {l, r};
     }
-    
+
     template<class L, class R>
     conditions::is_not_equal_t<L, R> ne(L l, R r) {
         return {l, r};
     }
-    
+
     template<class L, class R>
     conditions::greater_than_t<L, R> greater_than(L l, R r) {
         return {l, r};
     }
-    
+
     template<class L, class R>
     conditions::greater_than_t<L, R> gt(L l, R r) {
         return {l, r};
     }
-    
+
     template<class L, class R>
     conditions::greater_or_equal_t<L, R> greater_or_equal(L l, R r) {
         return {l, r};
     }
-    
+
     template<class L, class R>
     conditions::greater_or_equal_t<L, R> ge(L l, R r) {
         return {l, r};
     }
-    
+
     template<class L, class R>
     conditions::lesser_than_t<L, R> lesser_than(L l, R r) {
         return {l, r};
     }
-    
+
     template<class L, class R>
     conditions::lesser_than_t<L, R> lt(L l, R r) {
         return {l, r};
     }
-    
+
     template<class L, class R>
     conditions::lesser_or_equal_t<L, R> lesser_or_equal(L l, R r) {
         return {l, r};
     }
-    
+
     template<class L, class R>
     conditions::lesser_or_equal_t<L, R> le(L l, R r) {
         return {l, r};
     }
-    
+
     template<class C>
     conditions::where_t<C> where(C c) {
         return {c};
     }
-    
+
     template<class O>
     conditions::order_by_t<O> order_by(O o) {
         return {o};
     }
-    
-    template<class ...Args>
-    conditions::multi_order_by_t<Args...> multi_order_by(Args&& ...args) {
+
+    template<class... Args>
+    conditions::multi_order_by_t<Args...> multi_order_by(Args &&... args) {
         return {std::make_tuple(std::forward<Args>(args)...)};
     }
-    
+
     template<class S>
     conditions::dynamic_order_by_t<S> dynamic_order_by(const S &storage) {
         return {storage};
     }
-    
-    template<class ...Args>
-    conditions::group_by_t<Args...> group_by(Args&& ...args) {
+
+    template<class... Args>
+    conditions::group_by_t<Args...> group_by(Args &&... args) {
         return {std::make_tuple(std::forward<Args>(args)...)};
     }
-    
+
     template<class A, class T>
     conditions::between_t<A, T> between(A expr, T b1, T b2) {
         return {expr, b1, b2};
     }
-    
+
     template<class A, class T>
     conditions::like_t<A, T, void> like(A a, T t) {
         return {std::move(a), std::move(t), {}};
     }
-    
+
     template<class A, class T>
     conditions::glob_t<A, T> glob(A a, T t) {
         return {std::move(a), std::move(t)};
     }
-    
+
     template<class A, class T, class E>
     conditions::like_t<A, T, E> like(A a, T t, E e) {
         return {std::move(a), std::move(t), {std::move(e)}};
     }
-    
+
     template<class T>
     conditions::exists_t<T> exists(T t) {
         return {std::move(t)};
     }
-    
+
     template<class T>
     conditions::having_t<T> having(T t) {
         return {t};
     }
-    
+
     template<class T, class E>
     conditions::cast_t<T, E> cast(E e) {
         return {e};

--- a/dev/connection_holder.h
+++ b/dev/connection_holder.h
@@ -1,84 +1,78 @@
 #pragma once
 
 #include <sqlite3.h>
-#include <string>   //  std::string
-#include <system_error> //  std::system_error
+#include <string>  //  std::string
+#include <system_error>  //  std::system_error
 
 #include "error_code.h"
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         struct connection_holder {
-            
-            connection_holder(std::string filename_) :
-            filename(move(filename_))
-            {}
-            
+
+            connection_holder(std::string filename_) : filename(move(filename_)) {}
+
             void retain() {
                 ++this->_retain_count;
                 if(1 == this->_retain_count) {
                     auto rc = sqlite3_open(this->filename.c_str(), &this->db);
-                    if(rc != SQLITE_OK){
-                        throw std::system_error(std::error_code(sqlite3_errcode(this->db), get_sqlite_error_category()), sqlite3_errmsg(this->db));
+                    if(rc != SQLITE_OK) {
+                        throw std::system_error(std::error_code(sqlite3_errcode(this->db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(this->db));
                     }
                 }
             }
-            
+
             void release() {
                 --this->_retain_count;
-                if(0 == this->_retain_count){
+                if(0 == this->_retain_count) {
                     auto rc = sqlite3_close(this->db);
-                    if(rc != SQLITE_OK){
-                        throw std::system_error(std::error_code(sqlite3_errcode(this->db), get_sqlite_error_category()), sqlite3_errmsg(this->db));
+                    if(rc != SQLITE_OK) {
+                        throw std::system_error(std::error_code(sqlite3_errcode(this->db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(this->db));
                     }
                 }
             }
-            
+
             sqlite3 *get() const {
                 return this->db;
             }
-            
+
             int retain_count() const {
                 return this->_retain_count;
             }
-            
+
             const std::string filename;
-            
-        protected:
+
+          protected:
             sqlite3 *db = nullptr;
             int _retain_count = 0;
         };
-        
+
         struct connection_ref {
-            connection_ref(connection_holder &holder_) :
-            holder(holder_)
-            {
+            connection_ref(connection_holder &holder_) : holder(holder_) {
                 this->holder.retain();
             }
-            
-            connection_ref(const connection_ref &other) :
-            holder(other.holder)
-            {
+
+            connection_ref(const connection_ref &other) : holder(other.holder) {
                 this->holder.retain();
             }
-            
-            connection_ref(connection_ref &&other) :
-            holder(other.holder)
-            {
+
+            connection_ref(connection_ref &&other) : holder(other.holder) {
                 this->holder.retain();
             }
-            
+
             ~connection_ref() {
                 this->holder.release();
             }
-            
+
             sqlite3 *get() const {
                 return this->holder.get();
             }
-            
-        protected:
+
+          protected:
             connection_holder &holder;
         };
     }

--- a/dev/constraints.h
+++ b/dev/constraints.h
@@ -1,37 +1,37 @@
 #pragma once
 
-#include <string>   //  std::string
-#include <tuple>    //  std::tuple, std::make_tuple
+#include <string>  //  std::string
+#include <tuple>  //  std::tuple, std::make_tuple
 #include <sstream>  //  std::stringstream
 #include <type_traits>  //  std::is_base_of, std::false_type, std::true_type
 #include <ostream>  //  std::ostream
 
 namespace sqlite_orm {
-    
+
     namespace constraints {
-        
+
         /**
          *  AUTOINCREMENT constraint class.
          */
         struct autoincrement_t {
-            
+
             operator std::string() const {
                 return "AUTOINCREMENT";
             }
         };
-        
+
         struct primary_key_base {
             enum class order_by {
                 unspecified,
                 ascending,
                 descending,
             };
-            
+
             order_by asc_option = order_by::unspecified;
-            
+
             operator std::string() const {
                 std::string res = "PRIMARY KEY";
-                switch(this->asc_option){
+                switch(this->asc_option) {
                     case order_by::ascending:
                         res += " ASC";
                         break;
@@ -44,45 +44,46 @@ namespace sqlite_orm {
                 return res;
             }
         };
-        
+
         /**
          *  PRIMARY KEY constraint class.
-         *  Cs is parameter pack which contains columns (member pointers and/or function pointers). Can be empty when used withen `make_column` function.
+         *  Cs is parameter pack which contains columns (member pointers and/or function pointers). Can be empty when
+         * used withen `make_column` function.
          */
-        template<class ...Cs>
+        template<class... Cs>
         struct primary_key_t : primary_key_base {
             using order_by = primary_key_base::order_by;
-            
+
             std::tuple<Cs...> columns;
-            
-            primary_key_t(decltype(columns) c):columns(std::move(c)){}
-            
-            using field_type = void;    //  for column iteration. Better be deleted
+
+            primary_key_t(decltype(columns) c) : columns(std::move(c)) {}
+
+            using field_type = void;  //  for column iteration. Better be deleted
             using constraints_type = std::tuple<>;
-            
+
             primary_key_t<Cs...> asc() const {
                 auto res = *this;
                 res.asc_option = order_by::ascending;
                 return res;
             }
-            
+
             primary_key_t<Cs...> desc() const {
                 auto res = *this;
                 res.asc_option = order_by::descending;
                 return res;
             }
         };
-        
+
         /**
          *  UNIQUE constraint class.
          */
         struct unique_t {
-            
+
             operator std::string() const {
                 return "UNIQUE";
             }
         };
-        
+
         /**
          *  DEFAULT constraint class.
          *  T is a value type.
@@ -90,47 +91,47 @@ namespace sqlite_orm {
         template<class T>
         struct default_t {
             using value_type = T;
-            
+
             value_type value;
-            
+
             operator std::string() const {
                 std::stringstream ss;
                 ss << "DEFAULT ";
                 auto needQuotes = std::is_base_of<text_printer, type_printer<T>>::value;
-                if(needQuotes){
+                if(needQuotes) {
                     ss << "'";
                 }
                 ss << this->value;
-                if(needQuotes){
+                if(needQuotes) {
                     ss << "'";
                 }
                 return ss.str();
             }
         };
-        
+
 #if SQLITE_VERSION_NUMBER >= 3006019
-        
+
         /**
          *  FOREIGN KEY constraint class.
          *  Cs are columns which has foreign key
          *  Rs are column which C references to
          *  Available in SQLite 3.6.19 or higher
          */
-        
+
         template<class A, class B>
         struct foreign_key_t;
-        
+
         enum class foreign_key_action {
-            none,   //  not specified
+            none,  //  not specified
             no_action,
             restrict_,
             set_null,
             set_default,
             cascade,
         };
-        
+
         inline std::ostream &operator<<(std::ostream &os, foreign_key_action action) {
-            switch(action){
+            switch(action) {
                 case decltype(action)::no_action:
                     os << "NO ACTION";
                     break;
@@ -151,119 +152,111 @@ namespace sqlite_orm {
             }
             return os;
         }
-        
+
         struct on_update_delete_base {
             const bool update;  //  true if update and false if delete
-            
+
             operator std::string() const {
-                if(this->update){
+                if(this->update) {
                     return "ON UPDATE";
-                }else{
+                } else {
                     return "ON DELETE";
                 }
             }
         };
-        
+
         /**
          *  F - foreign key class
          */
         template<class F>
         struct on_update_delete_t : on_update_delete_base {
             using foreign_key_type = F;
-            
+
             const foreign_key_type &fk;
-            
+
             on_update_delete_t(decltype(fk) fk_, decltype(update) update, foreign_key_action action_) :
-            on_update_delete_base{update},
-            fk(fk_),
-            _action(action_)
-            {}
-            
+                on_update_delete_base{update}, fk(fk_), _action(action_) {}
+
             foreign_key_action _action = foreign_key_action::none;
-            
+
             foreign_key_type no_action() const {
                 auto res = this->fk;
-                if(update){
+                if(update) {
                     res.on_update._action = foreign_key_action::no_action;
-                }else{
+                } else {
                     res.on_delete._action = foreign_key_action::no_action;
                 }
                 return res;
             }
-            
+
             foreign_key_type restrict_() const {
                 auto res = this->fk;
-                if(update){
+                if(update) {
                     res.on_update._action = foreign_key_action::restrict_;
-                }else{
+                } else {
                     res.on_delete._action = foreign_key_action::restrict_;
                 }
                 return res;
             }
-            
+
             foreign_key_type set_null() const {
                 auto res = this->fk;
-                if(update){
+                if(update) {
                     res.on_update._action = foreign_key_action::set_null;
-                }else{
+                } else {
                     res.on_delete._action = foreign_key_action::set_null;
                 }
                 return res;
             }
-            
+
             foreign_key_type set_default() const {
                 auto res = this->fk;
-                if(update){
+                if(update) {
                     res.on_update._action = foreign_key_action::set_default;
-                }else{
+                } else {
                     res.on_delete._action = foreign_key_action::set_default;
                 }
                 return res;
             }
-            
+
             foreign_key_type cascade() const {
                 auto res = this->fk;
-                if(update){
+                if(update) {
                     res.on_update._action = foreign_key_action::cascade;
-                }else{
+                } else {
                     res.on_delete._action = foreign_key_action::cascade;
                 }
                 return res;
             }
-            
+
             operator bool() const {
                 return this->_action != decltype(this->_action)::none;
             }
         };
-        
-        template<class ...Cs, class ...Rs>
+
+        template<class... Cs, class... Rs>
         struct foreign_key_t<std::tuple<Cs...>, std::tuple<Rs...>> {
             using columns_type = std::tuple<Cs...>;
             using references_type = std::tuple<Rs...>;
             using self = foreign_key_t<columns_type, references_type>;
-            
+
             columns_type columns;
             references_type references;
-            
+
             on_update_delete_t<self> on_update;
             on_update_delete_t<self> on_delete;
-            
-            static_assert(std::tuple_size<columns_type>::value == std::tuple_size<references_type>::value, "Columns size must be equal to references tuple");
-            
-            foreign_key_t(columns_type columns_, references_type references_):
-            columns(std::move(columns_)),
-            references(std::move(references_)),
-            on_update(*this, true, foreign_key_action::none),
-            on_delete(*this, false, foreign_key_action::none)
-            {}
-            
-            foreign_key_t(const self &other):
-            columns(other.columns),
-            references(other.references),
-            on_update(*this, true, other.on_update._action),
-            on_delete(*this, false, other.on_delete._action)
-            {}
-            
+
+            static_assert(std::tuple_size<columns_type>::value == std::tuple_size<references_type>::value,
+                          "Columns size must be equal to references tuple");
+
+            foreign_key_t(columns_type columns_, references_type references_) :
+                columns(std::move(columns_)), references(std::move(references_)),
+                on_update(*this, true, foreign_key_action::none), on_delete(*this, false, foreign_key_action::none) {}
+
+            foreign_key_t(const self &other) :
+                columns(other.columns), references(other.references), on_update(*this, true, other.on_update._action),
+                on_delete(*this, false, other.on_delete._action) {}
+
             self &operator=(const self &other) {
                 this->columns = other.columns;
                 this->references = other.references;
@@ -271,165 +264,168 @@ namespace sqlite_orm {
                 this->on_delete = {*this, false, other.on_delete._action};
                 return *this;
             }
-            
-            using field_type = void;    //  for column iteration. Better be deleted
+
+            using field_type = void;  //  for column iteration. Better be deleted
             using constraints_type = std::tuple<>;
-            
+
             template<class L>
             void for_each_column(const L &) {}
-            
-            template<class ...Opts>
-            constexpr bool has_every() const  {
+
+            template<class... Opts>
+            constexpr bool has_every() const {
                 return false;
             }
         };
-        
+
         /**
          *  Cs can be a class member pointer, a getter function member pointer or setter
          *  func member pointer
          *  Available in SQLite 3.6.19 or higher
          */
-        template<class ...Cs>
+        template<class... Cs>
         struct foreign_key_intermediate_t {
             using tuple_type = std::tuple<Cs...>;
-            
+
             tuple_type columns;
-            
-            foreign_key_intermediate_t(tuple_type columns_): columns(std::move(columns_)) {}
-            
-            template<class ...Rs>
-            foreign_key_t<std::tuple<Cs...>, std::tuple<Rs...>> references(Rs ...references) {
+
+            foreign_key_intermediate_t(tuple_type columns_) : columns(std::move(columns_)) {}
+
+            template<class... Rs>
+            foreign_key_t<std::tuple<Cs...>, std::tuple<Rs...>> references(Rs... references) {
                 return {std::move(this->columns), std::make_tuple(std::forward<Rs>(references)...)};
             }
         };
 #endif
-        
+
         struct collate_t {
             internal::collate_argument argument = internal::collate_argument::binary;
-            
-            collate_t(internal::collate_argument argument_): argument(argument_) {}
-            
+
+            collate_t(internal::collate_argument argument_) : argument(argument_) {}
+
             operator std::string() const {
                 std::string res = "COLLATE " + this->string_from_collate_argument(this->argument);
                 return res;
             }
-            
-            static std::string string_from_collate_argument(internal::collate_argument argument){
-                switch(argument){
-                    case decltype(argument)::binary: return "BINARY";
-                    case decltype(argument)::nocase: return "NOCASE";
-                    case decltype(argument)::rtrim: return "RTRIM";
+
+            static std::string string_from_collate_argument(internal::collate_argument argument) {
+                switch(argument) {
+                    case decltype(argument)::binary:
+                        return "BINARY";
+                    case decltype(argument)::nocase:
+                        return "NOCASE";
+                    case decltype(argument)::rtrim:
+                        return "RTRIM";
                 }
                 throw std::system_error(std::make_error_code(orm_error_code::invalid_collate_argument_enum));
             }
         };
-        
+
         template<class T>
         struct is_constraint : std::false_type {};
-        
+
         template<>
         struct is_constraint<autoincrement_t> : std::true_type {};
-        
-        template<class ...Cs>
+
+        template<class... Cs>
         struct is_constraint<primary_key_t<Cs...>> : std::true_type {};
-        
+
         template<>
         struct is_constraint<unique_t> : std::true_type {};
-        
+
         template<class T>
         struct is_constraint<default_t<T>> : std::true_type {};
-        
+
         template<class C, class R>
         struct is_constraint<foreign_key_t<C, R>> : std::true_type {};
-        
+
         template<>
         struct is_constraint<collate_t> : std::true_type {};
-        
-        template<class ...Args>
+
+        template<class... Args>
         struct constraints_size;
-        
+
         template<>
         struct constraints_size<> {
             static constexpr const int value = 0;
         };
-        
-        template<class H, class ...Args>
+
+        template<class H, class... Args>
         struct constraints_size<H, Args...> {
             static constexpr const int value = is_constraint<H>::value + constraints_size<Args...>::value;
         };
     }
-    
+
 #if SQLITE_VERSION_NUMBER >= 3006019
-    
+
     /**
      *  FOREIGN KEY constraint construction function that takes member pointer as argument
      *  Available in SQLite 3.6.19 or higher
      */
-    template<class ...Cs>
-    constraints::foreign_key_intermediate_t<Cs...> foreign_key(Cs ...columns) {
+    template<class... Cs>
+    constraints::foreign_key_intermediate_t<Cs...> foreign_key(Cs... columns) {
         return {std::make_tuple(std::forward<Cs>(columns)...)};
     }
 #endif
-    
+
     /**
      *  UNIQUE constraint builder function.
      */
     inline constraints::unique_t unique() {
         return {};
     }
-    
+
     inline constraints::autoincrement_t autoincrement() {
         return {};
     }
-    
-    template<class ...Cs>
-    inline constraints::primary_key_t<Cs...> primary_key(Cs ...cs) {
+
+    template<class... Cs>
+    inline constraints::primary_key_t<Cs...> primary_key(Cs... cs) {
         using ret_type = constraints::primary_key_t<Cs...>;
         return ret_type(std::make_tuple(cs...));
     }
-    
+
     template<class T>
     constraints::default_t<T> default_value(T t) {
         return {std::move(t)};
     }
-    
+
     inline constraints::collate_t collate_nocase() {
         return {internal::collate_argument::nocase};
     }
-    
+
     inline constraints::collate_t collate_binary() {
         return {internal::collate_argument::binary};
     }
-    
+
     inline constraints::collate_t collate_rtrim() {
         return {internal::collate_argument::rtrim};
     }
-    
+
     namespace internal {
-        
+
         /**
          *  FOREIGN KEY traits. Common case
          */
         template<class T>
         struct is_foreign_key : std::false_type {};
-        
+
         /**
          *  FOREIGN KEY traits. Specialized case
          */
         template<class C, class R>
         struct is_foreign_key<constraints::foreign_key_t<C, R>> : std::true_type {};
-        
+
         /**
          *  PRIMARY KEY traits. Common case
          */
         template<class T>
         struct is_primary_key : public std::false_type {};
-        
+
         /**
          *  PRIMARY KEY traits. Specialized case
          */
-        template<class ...Cs>
+        template<class... Cs>
         struct is_primary_key<constraints::primary_key_t<Cs...>> : public std::true_type {};
     }
-    
+
 }

--- a/dev/core_functions.h
+++ b/dev/core_functions.h
@@ -1,191 +1,191 @@
 #pragma once
 
-#include <string>   //  std::string
-#include <tuple>    //  std::make_tuple, std::tuple_size
+#include <string>  //  std::string
+#include <tuple>  //  std::make_tuple, std::tuple_size
 #include <type_traits>  //  std::forward, std::is_base_of, std::enable_if
-#include <memory>   //  std::unique_ptr
-#include <vector>   //  std::vector
+#include <memory>  //  std::unique_ptr
+#include <vector>  //  std::vector
 
 #include "conditions.h"
 #include "operators.h"
 #include "is_base_of_template.h"
 
 namespace sqlite_orm {
-    
+
     namespace core_functions {
-        
+
         /**
          *  Base class for operator overloading
          *  R - return type
          *  S - class with operator std::string
          *  Args - function arguments types
          */
-        template<class R, class S, class ...Args>
+        template<class R, class S, class... Args>
         struct core_function_t : S, internal::arithmetic_t {
             using return_type = R;
             using string_type = S;
             using args_type = std::tuple<Args...>;
-            
+
             static constexpr const size_t args_size = std::tuple_size<args_type>::value;
-            
+
             args_type args;
-            
+
             core_function_t(args_type &&args_) : args(std::move(args_)) {}
         };
-        
+
         struct length_string {
             operator std::string() const {
                 return "LENGTH";
             }
         };
-        
+
         struct abs_string {
             operator std::string() const {
                 return "ABS";
             }
         };
-        
+
         struct lower_string {
             operator std::string() const {
                 return "LOWER";
             }
         };
-        
+
         struct upper_string {
             operator std::string() const {
                 return "UPPER";
             }
         };
-        
+
         struct changes_string {
             operator std::string() const {
                 return "CHANGES";
             }
         };
-        
+
         struct trim_string {
             operator std::string() const {
                 return "TRIM";
             }
         };
-        
+
         struct ltrim_string {
             operator std::string() const {
                 return "LTRIM";
             }
         };
-        
+
         struct rtrim_string {
             operator std::string() const {
                 return "RTRIM";
             }
         };
-        
+
 #if SQLITE_VERSION_NUMBER >= 3007016
-        
+
         struct char_string {
             operator std::string() const {
                 return "CHAR";
             }
         };
-        
+
         struct random_string {
             operator std::string() const {
                 return "RANDOM";
             }
         };
-        
+
 #endif
-        
+
         struct coalesce_string {
             operator std::string() const {
                 return "COALESCE";
             }
         };
-        
+
         struct date_string {
             operator std::string() const {
                 return "DATE";
             }
         };
-        
+
         struct datetime_string {
             operator std::string() const {
                 return "DATETIME";
             }
         };
-        
+
         struct julianday_string {
             operator std::string() const {
                 return "JULIANDAY";
             }
         };
-        
+
         struct zeroblob_string {
             operator std::string() const {
                 return "ZEROBLOB";
             }
         };
-        
+
         struct substr_string {
             operator std::string() const {
                 return "SUBSTR";
             }
         };
     }
-    
+
     /**
      *  Cute operators for core functions
      */
-    
-    template<
-    class F,
-    class R,
-    typename = typename std::enable_if<internal::is_base_of_template<F, core_functions::core_function_t>::value>::type>
+
+    template<class F,
+             class R,
+             typename = typename std::enable_if<
+                 internal::is_base_of_template<F, core_functions::core_function_t>::value>::type>
     conditions::lesser_than_t<F, R> operator<(F f, R r) {
         return {std::move(f), std::move(r)};
     }
-    
-    template<
-    class F,
-    class R,
-    typename = typename std::enable_if<internal::is_base_of_template<F, core_functions::core_function_t>::value>::type>
+
+    template<class F,
+             class R,
+             typename = typename std::enable_if<
+                 internal::is_base_of_template<F, core_functions::core_function_t>::value>::type>
     conditions::lesser_or_equal_t<F, R> operator<=(F f, R r) {
         return {std::move(f), std::move(r)};
     }
-    
-    template<
-    class F,
-    class R,
-    typename = typename std::enable_if<internal::is_base_of_template<F, core_functions::core_function_t>::value>::type>
+
+    template<class F,
+             class R,
+             typename = typename std::enable_if<
+                 internal::is_base_of_template<F, core_functions::core_function_t>::value>::type>
     conditions::greater_than_t<F, R> operator>(F f, R r) {
         return {std::move(f), std::move(r)};
     }
-    
-    template<
-    class F,
-    class R,
-    typename = typename std::enable_if<internal::is_base_of_template<F, core_functions::core_function_t>::value>::type>
+
+    template<class F,
+             class R,
+             typename = typename std::enable_if<
+                 internal::is_base_of_template<F, core_functions::core_function_t>::value>::type>
     conditions::greater_or_equal_t<F, R> operator>=(F f, R r) {
         return {std::move(f), std::move(r)};
     }
-    
-    template<
-    class F,
-    class R,
-    typename = typename std::enable_if<internal::is_base_of_template<F, core_functions::core_function_t>::value>::type>
+
+    template<class F,
+             class R,
+             typename = typename std::enable_if<
+                 internal::is_base_of_template<F, core_functions::core_function_t>::value>::type>
     conditions::is_equal_t<F, R> operator==(F f, R r) {
         return {std::move(f), std::move(r)};
     }
-    
-    template<
-    class F,
-    class R,
-    typename = typename std::enable_if<internal::is_base_of_template<F, core_functions::core_function_t>::value>::type>
+
+    template<class F,
+             class R,
+             typename = typename std::enable_if<
+                 internal::is_base_of_template<F, core_functions::core_function_t>::value>::type>
     conditions::is_not_equal_t<F, R> operator!=(F f, R r) {
         return {std::move(f), std::move(r)};
     }
-    
+
     /**
      *  LENGTH(x) function https://sqlite.org/lang_corefunc.html#length
      */
@@ -194,7 +194,7 @@ namespace sqlite_orm {
         std::tuple<T> args{std::forward<T>(t)};
         return {std::move(args)};
     }
-    
+
     /**
      *  ABS(x) function https://sqlite.org/lang_corefunc.html#abs
      */
@@ -203,7 +203,7 @@ namespace sqlite_orm {
         std::tuple<T> args{std::forward<T>(t)};
         return {std::move(args)};
     }
-    
+
     /**
      *  LOWER(x) function https://sqlite.org/lang_corefunc.html#lower
      */
@@ -212,7 +212,7 @@ namespace sqlite_orm {
         std::tuple<T> args{std::forward<T>(t)};
         return {std::move(args)};
     }
-    
+
     /**
      *  UPPER(x) function https://sqlite.org/lang_corefunc.html#upper
      */
@@ -221,14 +221,14 @@ namespace sqlite_orm {
         std::tuple<T> args{std::forward<T>(t)};
         return {std::move(args)};
     }
-    
+
     /**
      *  CHANGES() function https://sqlite.org/lang_corefunc.html#changes
      */
     inline core_functions::core_function_t<int, core_functions::changes_string> changes() {
         return {{}};
     }
-    
+
     /**
      *  TRIM(X) function https://sqlite.org/lang_corefunc.html#trim
      */
@@ -237,7 +237,7 @@ namespace sqlite_orm {
         std::tuple<T> args{std::forward<T>(t)};
         return {std::move(args)};
     }
-    
+
     /**
      *  TRIM(X,Y) function https://sqlite.org/lang_corefunc.html#trim
      */
@@ -246,7 +246,7 @@ namespace sqlite_orm {
         std::tuple<X, Y> args{std::forward<X>(x), std::forward<Y>(y)};
         return {std::move(args)};
     }
-    
+
     /**
      *  LTRIM(X) function https://sqlite.org/lang_corefunc.html#ltrim
      */
@@ -255,7 +255,7 @@ namespace sqlite_orm {
         std::tuple<X> args{std::forward<X>(x)};
         return {std::move(args)};
     }
-    
+
     /**
      *  LTRIM(X,Y) function https://sqlite.org/lang_corefunc.html#ltrim
      */
@@ -264,7 +264,7 @@ namespace sqlite_orm {
         std::tuple<X, Y> args{std::forward<X>(x), std::forward<Y>(y)};
         return {std::move(args)};
     }
-    
+
     /**
      *  RTRIM(X) function https://sqlite.org/lang_corefunc.html#rtrim
      */
@@ -273,7 +273,7 @@ namespace sqlite_orm {
         std::tuple<X> args{std::forward<X>(x)};
         return {std::move(args)};
     }
-    
+
     /**
      *  RTRIM(X,Y) function https://sqlite.org/lang_corefunc.html#rtrim
      */
@@ -282,61 +282,61 @@ namespace sqlite_orm {
         std::tuple<X, Y> args{std::forward<X>(x), std::forward<Y>(y)};
         return {std::move(args)};
     }
-    
+
 #if SQLITE_VERSION_NUMBER >= 3007016
-    
+
     /**
      *  CHAR(X1,X2,...,XN) function https://sqlite.org/lang_corefunc.html#char
      */
-    template<class ...Args>
-    core_functions::core_function_t<std::string, core_functions::char_string, Args...> char_(Args&& ...args) {
+    template<class... Args>
+    core_functions::core_function_t<std::string, core_functions::char_string, Args...> char_(Args &&... args) {
         return {std::make_tuple(std::forward<Args>(args)...)};
     }
-    
+
     /**
      *  RANDOM() function https://www.sqlite.org/lang_corefunc.html#random
      */
     inline core_functions::core_function_t<int, core_functions::random_string> random() {
         return {{}};
     }
-    
+
 #endif
-    
+
     /**
      *  COALESCE(X,Y,...) function https://www.sqlite.org/lang_corefunc.html#coalesce
      */
-    template<class R, class ...Args>
-    core_functions::core_function_t<R, core_functions::coalesce_string, Args...> coalesce(Args&& ...args) {
+    template<class R, class... Args>
+    core_functions::core_function_t<R, core_functions::coalesce_string, Args...> coalesce(Args &&... args) {
         return {std::make_tuple(std::forward<Args>(args)...)};
     }
-    
+
     /**
      *  DATE(timestring, modifier, modifier, ...) function https://www.sqlite.org/lang_datefunc.html
      */
-    template<class ...Args>
-    core_functions::core_function_t<std::string, core_functions::date_string, Args...> date(Args &&...args) {
+    template<class... Args>
+    core_functions::core_function_t<std::string, core_functions::date_string, Args...> date(Args &&... args) {
         std::tuple<Args...> t{std::forward<Args>(args)...};
         return {std::move(t)};
     }
-    
+
     /**
      *  DATETIME(timestring, modifier, modifier, ...) function https://www.sqlite.org/lang_datefunc.html
      */
-    template<class ...Args>
-    core_functions::core_function_t<std::string, core_functions::datetime_string, Args...> datetime(Args &&...args) {
+    template<class... Args>
+    core_functions::core_function_t<std::string, core_functions::datetime_string, Args...> datetime(Args &&... args) {
         std::tuple<Args...> t{std::forward<Args>(args)...};
         return {std::move(t)};
     }
-    
+
     /**
      *  JULIANDAY(timestring, modifier, modifier, ...) function https://www.sqlite.org/lang_datefunc.html
      */
-    template<class ...Args>
-    core_functions::core_function_t<double, core_functions::julianday_string, Args...> julianday(Args &&...args) {
+    template<class... Args>
+    core_functions::core_function_t<double, core_functions::julianday_string, Args...> julianday(Args &&... args) {
         std::tuple<Args...> t{std::forward<Args>(args)...};
         return {std::move(t)};
     }
-    
+
     /**
      *  ZEROBLOB(N) function https://www.sqlite.org/lang_corefunc.html#zeroblob
      */
@@ -345,7 +345,7 @@ namespace sqlite_orm {
         std::tuple<N> args{std::forward<N>(n)};
         return {std::move(args)};
     }
-    
+
     /**
      *  SUBSTR(X,Y) function https://www.sqlite.org/lang_corefunc.html#substr
      */
@@ -354,7 +354,7 @@ namespace sqlite_orm {
         std::tuple<X, Y> args{std::forward<X>(x), std::forward<Y>(y)};
         return {std::move(args)};
     }
-    
+
     /**
      *  SUBSTR(X,Y,Z) function https://www.sqlite.org/lang_corefunc.html#substr
      */
@@ -363,43 +363,48 @@ namespace sqlite_orm {
         std::tuple<X, Y, Z> args{std::forward<X>(x), std::forward<Y>(y), std::forward<Z>(z)};
         return {std::move(args)};
     }
-    
-    template<
-    class L,
-    class R,
-    typename = typename std::enable_if<(std::is_base_of<internal::arithmetic_t, L>::value + std::is_base_of<internal::arithmetic_t, R>::value > 0)>::type>
+
+    template<class L,
+             class R,
+             typename = typename std::enable_if<(std::is_base_of<internal::arithmetic_t, L>::value +
+                                                     std::is_base_of<internal::arithmetic_t, R>::value >
+                                                 0)>::type>
     internal::add_t<L, R> operator+(L l, R r) {
         return {std::move(l), std::move(r)};
     }
-    
-    template<
-    class L,
-    class R,
-    typename = typename std::enable_if<(std::is_base_of<internal::arithmetic_t, L>::value + std::is_base_of<internal::arithmetic_t, R>::value > 0)>::type>
+
+    template<class L,
+             class R,
+             typename = typename std::enable_if<(std::is_base_of<internal::arithmetic_t, L>::value +
+                                                     std::is_base_of<internal::arithmetic_t, R>::value >
+                                                 0)>::type>
     internal::sub_t<L, R> operator-(L l, R r) {
         return {std::move(l), std::move(r)};
     }
-    
-    template<
-    class L,
-    class R,
-    typename = typename std::enable_if<(std::is_base_of<internal::arithmetic_t, L>::value + std::is_base_of<internal::arithmetic_t, R>::value > 0)>::type>
+
+    template<class L,
+             class R,
+             typename = typename std::enable_if<(std::is_base_of<internal::arithmetic_t, L>::value +
+                                                     std::is_base_of<internal::arithmetic_t, R>::value >
+                                                 0)>::type>
     internal::mul_t<L, R> operator*(L l, R r) {
         return {std::move(l), std::move(r)};
     }
-    
-    template<
-    class L,
-    class R,
-    typename = typename std::enable_if<(std::is_base_of<internal::arithmetic_t, L>::value + std::is_base_of<internal::arithmetic_t, R>::value > 0)>::type>
+
+    template<class L,
+             class R,
+             typename = typename std::enable_if<(std::is_base_of<internal::arithmetic_t, L>::value +
+                                                     std::is_base_of<internal::arithmetic_t, R>::value >
+                                                 0)>::type>
     internal::div_t<L, R> operator/(L l, R r) {
         return {std::move(l), std::move(r)};
     }
-    
-    template<
-    class L,
-    class R,
-    typename = typename std::enable_if<(std::is_base_of<internal::arithmetic_t, L>::value + std::is_base_of<internal::arithmetic_t, R>::value > 0)>::type>
+
+    template<class L,
+             class R,
+             typename = typename std::enable_if<(std::is_base_of<internal::arithmetic_t, L>::value +
+                                                     std::is_base_of<internal::arithmetic_t, R>::value >
+                                                 0)>::type>
     internal::mod_t<L, R> operator%(L l, R r) {
         return {std::move(l), std::move(r)};
     }

--- a/dev/database_connection.h
+++ b/dev/database_connection.h
@@ -1,33 +1,34 @@
 #pragma once
 
-#include <string>   //  std::string
+#include <string>  //  std::string
 #include <sqlite3.h>
-#include <system_error> //  std::error_code, std::system_error
+#include <system_error>  //  std::error_code, std::system_error
 
 #include "error_code.h"
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         struct database_connection {
-            
+
             database_connection(const std::string &filename) {
                 auto rc = sqlite3_open(filename.c_str(), &this->db);
-                if(rc != SQLITE_OK){
-                    throw std::system_error(std::error_code(sqlite3_errcode(this->db), get_sqlite_error_category()), sqlite3_errmsg(this->db));
+                if(rc != SQLITE_OK) {
+                    throw std::system_error(std::error_code(sqlite3_errcode(this->db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(this->db));
                 }
             }
-            
+
             ~database_connection() {
                 sqlite3_close(this->db);
             }
-            
-            sqlite3* get_db() {
+
+            sqlite3 *get_db() {
                 return this->db;
             }
-            
-        protected:
+
+          protected:
             sqlite3 *db = nullptr;
         };
     }

--- a/dev/default_value_extractor.h
+++ b/dev/default_value_extractor.h
@@ -1,34 +1,34 @@
 #pragma once
 
-#include <memory>   //  std::unique_ptr
-#include <string>   //  std::string
+#include <memory>  //  std::unique_ptr
+#include <string>  //  std::string
 #include <sstream>  //  std::stringstream
 
 #include "constraints.h"
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         /**
          *  This class is used in tuple interation to know whether tuple constains `default_value_t`
          *  constraint class and what it's value if it is
          */
         struct default_value_extractor {
-            
+
             template<class A>
-            std::unique_ptr<std::string> operator() (const A &) {
+            std::unique_ptr<std::string> operator()(const A &) {
                 return {};
             }
-            
+
             template<class T>
-            std::unique_ptr<std::string> operator() (const constraints::default_t<T> &t) {
+            std::unique_ptr<std::string> operator()(const constraints::default_t<T> &t) {
                 std::stringstream ss;
                 ss << t.value;
                 return std::make_unique<std::string>(ss.str());
             }
         };
-        
+
     }
-    
+
 }

--- a/dev/error_code.h
+++ b/dev/error_code.h
@@ -1,12 +1,12 @@
 #pragma once
 
 #include <system_error>  // std::error_code, std::system_error
-#include <string>   //  std::string
+#include <string>  //  std::string
 #include <sqlite3.h>
 #include <stdexcept>
 
 namespace sqlite_orm {
-    
+
     enum class orm_error_code {
         not_found = 1,
         type_is_not_mapped_to_storage,
@@ -21,20 +21,19 @@ namespace sqlite_orm {
         invalid_collate_argument_enum,
         failed_to_init_a_backup,
     };
-    
+
 }
 
 namespace sqlite_orm {
-    
+
     class orm_error_category : public std::error_category {
-    public:
-        
+      public:
         const char *name() const noexcept override final {
             return "ORM error";
         }
-        
+
         std::string message(int c) const override final {
-            switch (static_cast<orm_error_code>(c)) {
+            switch(static_cast<orm_error_code>(c)) {
                 case orm_error_code::not_found:
                     return "Not found";
                 case orm_error_code::type_is_not_mapped_to_storage:
@@ -62,35 +61,33 @@ namespace sqlite_orm {
             }
         }
     };
-    
+
     class sqlite_error_category : public std::error_category {
-    public:
-        
+      public:
         const char *name() const noexcept override final {
             return "SQLite error";
         }
-        
+
         std::string message(int c) const override final {
             return sqlite3_errstr(c);
         }
     };
-    
-    inline const orm_error_category& get_orm_error_category() {
+
+    inline const orm_error_category &get_orm_error_category() {
         static orm_error_category res;
         return res;
     }
-    
-    inline const sqlite_error_category& get_sqlite_error_category() {
+
+    inline const sqlite_error_category &get_sqlite_error_category() {
         static sqlite_error_category res;
         return res;
     }
 }
 
-namespace std
-{
-    template <>
-    struct is_error_code_enum<sqlite_orm::orm_error_code> : std::true_type{};
-    
+namespace std {
+    template<>
+    struct is_error_code_enum<sqlite_orm::orm_error_code> : std::true_type {};
+
     inline std::error_code make_error_code(sqlite_orm::orm_error_code errorCode) {
         return std::error_code(static_cast<int>(errorCode), sqlite_orm::get_orm_error_category());
     }

--- a/dev/field_printer.h
+++ b/dev/field_printer.h
@@ -1,13 +1,13 @@
 #pragma once
 
-#include <string>   //  std::string
+#include <string>  //  std::string
 #include <sstream>  //  std::stringstream
-#include <vector>   //  std::vector
+#include <vector>  //  std::vector
 #include <cstddef>  //  std::nullptr_t
-#include <memory>   //  std::shared_ptr, std::unique_ptr
+#include <memory>  //  std::shared_ptr, std::unique_ptr
 
 namespace sqlite_orm {
-    
+
     /**
      *  Is used to print members mapped to objects in storage_t::dump member function.
      *  Other developers can create own specialization to map custom types
@@ -20,7 +20,7 @@ namespace sqlite_orm {
             return stream.str();
         }
     };
-    
+
     /**
      *  Upgrade to integer is required when using unsigned char(uint8_t)
      */
@@ -32,7 +32,7 @@ namespace sqlite_orm {
             return stream.str();
         }
     };
-    
+
     /**
      *  Upgrade to integer is required when using signed char(int8_t)
      */
@@ -44,7 +44,7 @@ namespace sqlite_orm {
             return stream.str();
         }
     };
-    
+
     /**
      *  char is neigher signer char nor unsigned char so it has its own specialization
      */
@@ -56,50 +56,50 @@ namespace sqlite_orm {
             return stream.str();
         }
     };
-    
+
     template<>
     struct field_printer<std::string> {
         std::string operator()(const std::string &t) const {
             return t;
         }
     };
-    
+
     template<>
     struct field_printer<std::vector<char>> {
         std::string operator()(const std::vector<char> &t) const {
             std::stringstream ss;
             ss << std::hex;
-            for(auto c : t) {
+            for(auto c: t) {
                 ss << c;
             }
             return ss.str();
         }
     };
-    
+
     template<>
     struct field_printer<std::nullptr_t> {
         std::string operator()(const std::nullptr_t &) const {
             return "null";
         }
     };
-    
+
     template<class T>
     struct field_printer<std::shared_ptr<T>> {
         std::string operator()(const std::shared_ptr<T> &t) const {
-            if(t){
+            if(t) {
                 return field_printer<T>()(*t);
-            }else{
+            } else {
                 return field_printer<std::nullptr_t>()(nullptr);
             }
         }
     };
-    
+
     template<class T>
     struct field_printer<std::unique_ptr<T>> {
         std::string operator()(const std::unique_ptr<T> &t) const {
-            if(t){
+            if(t) {
                 return field_printer<T>()(*t);
-            }else{
+            } else {
                 return field_printer<std::nullptr_t>()(nullptr);
             }
         }

--- a/dev/field_value_holder.h
+++ b/dev/field_value_holder.h
@@ -6,21 +6,21 @@
 
 namespace sqlite_orm {
     namespace internal {
-        
+
         template<class T, class SFINAE = void>
         struct field_value_holder;
-        
+
         template<class T>
         struct field_value_holder<T, typename std::enable_if<getter_traits<T>::returns_lvalue>::type> {
             using type = typename getter_traits<T>::field_type;
-            
+
             const type &value;
         };
-        
+
         template<class T>
         struct field_value_holder<T, typename std::enable_if<!getter_traits<T>::returns_lvalue>::type> {
             using type = typename getter_traits<T>::field_type;
-            
+
             type value;
         };
     }

--- a/dev/finish_macros.h
+++ b/dev/finish_macros.h
@@ -1,12 +1,12 @@
 #pragma once
 
 #if defined(_MSC_VER)
-# if defined(__RESTORE_MIN__)
+#if defined(__RESTORE_MIN__)
 __pragma(pop_macro("min"))
-# undef __RESTORE_MIN__
-# endif
-# if defined(__RESTORE_MAX__)
-__pragma(pop_macro("max"))
-# undef __RESTORE_MAX__
-# endif
-#endif // defined(_MSC_VER)
+#undef __RESTORE_MIN__
+#endif
+#if defined(__RESTORE_MAX__)
+    __pragma(pop_macro("max"))
+#undef __RESTORE_MAX__
+#endif
+#endif  // defined(_MSC_VER)

--- a/dev/index.h
+++ b/dev/index.h
@@ -1,34 +1,34 @@
 #pragma once
 
-#include <tuple>    //  std::tuple, std::make_tuple
-#include <string>   //  std::string
+#include <tuple>  //  std::tuple, std::make_tuple
+#include <string>  //  std::string
 #include <utility>  //  std::forward
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
-        template<class ...Cols>
+
+        template<class... Cols>
         struct index_t {
             using columns_type = std::tuple<Cols...>;
             using object_type = void;
-            
+
             std::string name;
             bool unique;
             columns_type columns;
-            
+
             template<class L>
             void for_each_column_with_constraints(const L &) {}
         };
     }
-    
-    template<class ...Cols>
-    internal::index_t<Cols...> make_index(const std::string &name, Cols ...cols) {
+
+    template<class... Cols>
+    internal::index_t<Cols...> make_index(const std::string &name, Cols... cols) {
         return {name, false, std::make_tuple(std::forward<Cols>(cols)...)};
     }
-    
-    template<class ...Cols>
-    internal::index_t<Cols...> make_unique_index(const std::string &name, Cols ...cols) {
+
+    template<class... Cols>
+    internal::index_t<Cols...> make_unique_index(const std::string &name, Cols... cols) {
         return {name, true, std::make_tuple(std::forward<Cols>(cols)...)};
     }
 }

--- a/dev/is_base_of_template.h
+++ b/dev/is_base_of_template.h
@@ -3,37 +3,37 @@
 #include <type_traits>  //  std::true_type, std::false_type, std::declval
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         /*
          * This is because of bug in MSVC, for more information, please visit
          * https://stackoverflow.com/questions/34672441/stdis-base-of-for-template-classes/34672753#34672753
          */
 #if defined(_MSC_VER)
-        template <template <typename...> class Base, typename Derived>
+        template<template<typename...> class Base, typename Derived>
         struct is_base_of_template_impl {
             template<typename... Ts>
-            static constexpr std::true_type test(const Base<Ts...>*);
-            
+            static constexpr std::true_type test(const Base<Ts...> *);
+
             static constexpr std::false_type test(...);
-            
-            using type = decltype(test(std::declval<Derived*>()));
+
+            using type = decltype(test(std::declval<Derived *>()));
         };
-        
-        template <typename Derived, template <typename...> class Base>
+
+        template<typename Derived, template<typename...> class Base>
         using is_base_of_template = typename is_base_of_template_impl<Base, Derived>::type;
-        
+
 #else
-        template <template <typename...> class C, typename...Ts>
-        std::true_type is_base_of_template_impl(const C<Ts...>*);
-        
-        template <template <typename...> class C>
+        template<template<typename...> class C, typename... Ts>
+        std::true_type is_base_of_template_impl(const C<Ts...> *);
+
+        template<template<typename...> class C>
         std::false_type is_base_of_template_impl(...);
-        
-        template <typename T, template <typename...> class C>
-        using is_base_of_template = decltype(is_base_of_template_impl<C>(std::declval<T*>()));
-        
+
+        template<typename T, template<typename...> class C>
+        using is_base_of_template = decltype(is_base_of_template_impl<C>(std::declval<T *>()));
+
 #endif
     }
 }

--- a/dev/is_std_ptr.h
+++ b/dev/is_std_ptr.h
@@ -1,23 +1,23 @@
 #pragma once
 
 namespace sqlite_orm {
-    
+
     /**
      *  Specialization for optional type (std::shared_ptr / std::unique_ptr).
      */
-    template <typename T>
+    template<typename T>
     struct is_std_ptr : std::false_type {};
-    
-    template <typename T>
+
+    template<typename T>
     struct is_std_ptr<std::shared_ptr<T>> : std::true_type {
-        static std::shared_ptr<T> make(const T& v) {
+        static std::shared_ptr<T> make(const T &v) {
             return std::make_shared<T>(v);
         }
     };
-    
-    template <typename T>
+
+    template<typename T>
     struct is_std_ptr<std::unique_ptr<T>> : std::true_type {
-        static std::unique_ptr<T> make(const T& v) {
+        static std::unique_ptr<T> make(const T &v) {
             return std::make_unique<T>(v);
         }
     };

--- a/dev/iterator.h
+++ b/dev/iterator.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <memory>   //  std::shared_ptr, std::unique_ptr, std::make_shared
+#include <memory>  //  std::shared_ptr, std::unique_ptr, std::make_shared
 #include <sqlite3.h>
 #include <type_traits>  //  std::decay
 #include <utility>  //  std::move
 #include <cstddef>  //  std::ptrdiff_t
-#include <iterator> //  std::input_iterator_tag
-#include <system_error> //  std::system_error
+#include <iterator>  //  std::input_iterator_tag
+#include <system_error>  //  std::system_error
 #include <ios>  //  std::make_error_code
 
 #include "row_extractor.h"
@@ -14,16 +14,15 @@
 #include "error_code.h"
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         template<class V>
         struct iterator_t {
             using view_type = V;
             using value_type = typename view_type::mapped_type;
-            
-        protected:
-            
+
+          protected:
             /**
              *  The double-indirection is so that copies of the iterator
              *  share the same sqlite3_stmt from a sqlite3_prepare_v2()
@@ -32,105 +31,107 @@ namespace sqlite_orm {
              */
             std::shared_ptr<sqlite3_stmt *> stmt;
             view_type &view;
-            
+
             /**
              *  shared_ptr is used over unique_ptr here
              *  so that the iterator can be copyable.
              */
             std::shared_ptr<value_type> current;
-            
+
             void extract_value(std::unique_ptr<value_type> &temp) {
                 temp = std::make_unique<value_type>();
                 auto &storage = this->view.storage;
                 auto &impl = storage.template get_impl<value_type>();
                 auto index = 0;
-                impl.table.for_each_column([&index, &temp, this] (auto &c) {
+                impl.table.for_each_column([&index, &temp, this](auto &c) {
                     using field_type = typename std::decay<decltype(c)>::type::field_type;
                     auto value = row_extractor<field_type>().extract(*this->stmt, index++);
-                    if(c.member_pointer){
+                    if(c.member_pointer) {
                         auto member_pointer = c.member_pointer;
                         (*temp).*member_pointer = std::move(value);
-                    }else{
+                    } else {
                         ((*temp).*(c.setter))(std::move(value));
                     }
                 });
             }
-            
-        public:
+
+          public:
             using difference_type = std::ptrdiff_t;
             using pointer = value_type *;
             using reference = value_type &;
             using iterator_category = std::input_iterator_tag;
-            
-            iterator_t(sqlite3_stmt *stmt_, view_type &view_): stmt(std::make_shared<sqlite3_stmt *>(stmt_)), view(view_) {
+
+            iterator_t(sqlite3_stmt *stmt_, view_type &view_) :
+                stmt(std::make_shared<sqlite3_stmt *>(stmt_)), view(view_) {
                 this->operator++();
             }
-            
+
             iterator_t(const iterator_t &) = default;
-            
-            iterator_t(iterator_t&&) = default;
-            
-            iterator_t& operator=(iterator_t &&) = default;
-            
-            iterator_t& operator=(const iterator_t &) = default;
-            
+
+            iterator_t(iterator_t &&) = default;
+
+            iterator_t &operator=(iterator_t &&) = default;
+
+            iterator_t &operator=(const iterator_t &) = default;
+
             ~iterator_t() {
-                if(this->stmt){
+                if(this->stmt) {
                     statement_finalizer f{*this->stmt};
                 }
             }
-            
+
             value_type &operator*() {
                 if(!this->stmt) {
                     throw std::system_error(std::make_error_code(orm_error_code::trying_to_dereference_null_iterator));
                 }
-                if(!this->current){
+                if(!this->current) {
                     std::unique_ptr<value_type> value;
                     this->extract_value(value);
                     this->current = move(value);
                 }
                 return *this->current;
             }
-            
+
             value_type *operator->() {
                 return &(this->operator*());
             }
-            
+
             void operator++() {
-                if(this->stmt && *this->stmt){
+                if(this->stmt && *this->stmt) {
                     auto ret = sqlite3_step(*this->stmt);
-                    switch(ret){
+                    switch(ret) {
                         case SQLITE_ROW:
                             this->current = nullptr;
                             break;
-                        case SQLITE_DONE:{
+                        case SQLITE_DONE: {
                             statement_finalizer f{*this->stmt};
                             *this->stmt = nullptr;
-                        }break;
-                        default:{
+                        } break;
+                        default: {
                             auto db = this->view.connection.get();
-                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                    sqlite3_errmsg(db));
                         }
                     }
                 }
             }
-            
+
             void operator++(int) {
                 this->operator++();
             }
-            
+
             bool operator==(const iterator_t &other) const {
-                if(this->stmt && other.stmt){
+                if(this->stmt && other.stmt) {
                     return *this->stmt == *other.stmt;
-                }else{
-                    if(!this->stmt && !other.stmt){
+                } else {
+                    if(!this->stmt && !other.stmt) {
                         return true;
-                    }else{
+                    } else {
                         return false;
                     }
                 }
             }
-            
+
             bool operator!=(const iterator_t &other) const {
                 return !(*this == other);
             }

--- a/dev/join_iterator.h
+++ b/dev/join_iterator.h
@@ -3,103 +3,102 @@
 #include "conditions.h"
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
-        template<class ...Args>
+
+        template<class... Args>
         struct join_iterator {
-            
+
             template<class L>
             void operator()(const L &) {
                 //..
             }
         };
-        
+
         template<>
         struct join_iterator<> {
-            
+
             template<class L>
             void operator()(const L &) {
                 //..
             }
         };
-        
-        template<class H, class ...Tail>
-        struct join_iterator<H, Tail...> : public join_iterator<Tail...>{
+
+        template<class H, class... Tail>
+        struct join_iterator<H, Tail...> : public join_iterator<Tail...> {
             using super = join_iterator<Tail...>;
-            
+
             template<class L>
             void operator()(const L &l) {
                 this->super::operator()(l);
             }
-            
         };
-        
-        template<class T, class ...Tail>
-        struct join_iterator<conditions::cross_join_t<T>, Tail...> : public join_iterator<Tail...>{
+
+        template<class T, class... Tail>
+        struct join_iterator<conditions::cross_join_t<T>, Tail...> : public join_iterator<Tail...> {
             using super = join_iterator<Tail...>;
             using join_type = conditions::cross_join_t<T>;
-            
+
             template<class L>
             void operator()(const L &l) {
                 l(*this);
                 this->super::operator()(l);
             }
         };
-        
-        template<class T, class ...Tail>
-        struct join_iterator<conditions::natural_join_t<T>, Tail...> : public join_iterator<Tail...>{
+
+        template<class T, class... Tail>
+        struct join_iterator<conditions::natural_join_t<T>, Tail...> : public join_iterator<Tail...> {
             using super = join_iterator<Tail...>;
             using join_type = conditions::natural_join_t<T>;
-            
+
             template<class L>
             void operator()(const L &l) {
                 l(*this);
                 this->super::operator()(l);
             }
         };
-        
-        template<class T, class O, class ...Tail>
+
+        template<class T, class O, class... Tail>
         struct join_iterator<conditions::left_join_t<T, O>, Tail...> : public join_iterator<Tail...> {
             using super = join_iterator<Tail...>;
             using join_type = conditions::left_join_t<T, O>;
-            
+
             template<class L>
             void operator()(const L &l) {
                 l(*this);
                 this->super::operator()(l);
             }
         };
-        
-        template<class T, class O, class ...Tail>
+
+        template<class T, class O, class... Tail>
         struct join_iterator<conditions::join_t<T, O>, Tail...> : public join_iterator<Tail...> {
             using super = join_iterator<Tail...>;
             using join_type = conditions::join_t<T, O>;
-            
+
             template<class L>
             void operator()(const L &l) {
                 l(*this);
                 this->super::operator()(l);
             }
         };
-        
-        template<class T, class O, class ...Tail>
+
+        template<class T, class O, class... Tail>
         struct join_iterator<conditions::left_outer_join_t<T, O>, Tail...> : public join_iterator<Tail...> {
             using super = join_iterator<Tail...>;
             using join_type = conditions::left_outer_join_t<T, O>;
-            
+
             template<class L>
             void operator()(const L &l) {
                 l(*this);
                 this->super::operator()(l);
             }
         };
-        
-        template<class T, class O, class ...Tail>
+
+        template<class T, class O, class... Tail>
         struct join_iterator<conditions::inner_join_t<T, O>, Tail...> : public join_iterator<Tail...> {
             using super = join_iterator<Tail...>;
             using join_type = conditions::inner_join_t<T, O>;
-            
+
             template<class L>
             void operator()(const L &l) {
                 l(*this);

--- a/dev/journal_mode.h
+++ b/dev/journal_mode.h
@@ -1,19 +1,19 @@
 #pragma once
 
-#include <string>   //  std::string
-#include <memory>   //  std::unique_ptr
-#include <array>    //  std::array
-#include <algorithm>    //  std::transform
-#include <locale>   // std::toupper
+#include <string>  //  std::string
+#include <memory>  //  std::unique_ptr
+#include <array>  //  std::array
+#include <algorithm>  //  std::transform
+#include <locale>  // std::toupper
 
 namespace sqlite_orm {
-    
-    /**
-     *  Caps case cause of 1) delete keyword; 2) https://www.sqlite.org/pragma.html#pragma_journal_mode original spelling
-     */
-    #ifdef DELETE
-        #undef DELETE
-    #endif
+
+/**
+ *  Caps case cause of 1) delete keyword; 2) https://www.sqlite.org/pragma.html#pragma_journal_mode original spelling
+ */
+#ifdef DELETE
+#undef DELETE
+#endif
     enum class journal_mode : signed char {
         DELETE = 0,
         TRUNCATE = 1,
@@ -21,11 +21,11 @@ namespace sqlite_orm {
         MEMORY = 3,
         WAL = 4,
         OFF = 5,
-        };
-    
+    };
+
     namespace internal {
-        
-        inline const std::string& to_string(journal_mode j) {
+
+        inline const std::string &to_string(journal_mode j) {
             static std::string res[] = {
                 "DELETE",
                 "TRUNCATE",
@@ -36,7 +36,7 @@ namespace sqlite_orm {
             };
             return res[static_cast<int>(j)];
         }
-        
+
         inline std::unique_ptr<journal_mode> journal_mode_from_string(const std::string &str) {
             std::string upper_str;
             std::transform(str.begin(), str.end(), std::back_inserter(upper_str), ::toupper);
@@ -48,8 +48,8 @@ namespace sqlite_orm {
                 journal_mode::WAL,
                 journal_mode::OFF,
             };
-            for(auto j : all) {
-                if(to_string(j) == upper_str){
+            for(auto j: all) {
+                if(to_string(j) == upper_str) {
                     return std::make_unique<journal_mode>(j);
                 }
             }

--- a/dev/limit_accesor.h
+++ b/dev/limit_accesor.h
@@ -2,133 +2,131 @@
 
 #include <sqlite3.h>
 #include <map>  //  std::map
-#include <functional>   //  std::function
-#include <memory>   //  std::shared_ptr
+#include <functional>  //  std::function
+#include <memory>  //  std::shared_ptr
 
 #include "connection_holder.h"
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         struct limit_accesor {
             using get_connection_t = std::function<connection_ref()>;
-            
-            limit_accesor(get_connection_t get_connection_):
-            get_connection(std::move(get_connection_))
-            {}
-            
+
+            limit_accesor(get_connection_t get_connection_) : get_connection(std::move(get_connection_)) {}
+
             int length() {
                 return this->get(SQLITE_LIMIT_LENGTH);
             }
-            
+
             void length(int newValue) {
                 this->set(SQLITE_LIMIT_LENGTH, newValue);
             }
-            
+
             int sql_length() {
                 return this->get(SQLITE_LIMIT_SQL_LENGTH);
             }
-            
+
             void sql_length(int newValue) {
                 this->set(SQLITE_LIMIT_SQL_LENGTH, newValue);
             }
-            
+
             int column() {
                 return this->get(SQLITE_LIMIT_COLUMN);
             }
-            
+
             void column(int newValue) {
                 this->set(SQLITE_LIMIT_COLUMN, newValue);
             }
-            
+
             int expr_depth() {
                 return this->get(SQLITE_LIMIT_EXPR_DEPTH);
             }
-            
+
             void expr_depth(int newValue) {
                 this->set(SQLITE_LIMIT_EXPR_DEPTH, newValue);
             }
-            
+
             int compound_select() {
                 return this->get(SQLITE_LIMIT_COMPOUND_SELECT);
             }
-            
+
             void compound_select(int newValue) {
                 this->set(SQLITE_LIMIT_COMPOUND_SELECT, newValue);
             }
-            
+
             int vdbe_op() {
                 return this->get(SQLITE_LIMIT_VDBE_OP);
             }
-            
+
             void vdbe_op(int newValue) {
                 this->set(SQLITE_LIMIT_VDBE_OP, newValue);
             }
-            
+
             int function_arg() {
                 return this->get(SQLITE_LIMIT_FUNCTION_ARG);
             }
-            
+
             void function_arg(int newValue) {
                 this->set(SQLITE_LIMIT_FUNCTION_ARG, newValue);
             }
-            
+
             int attached() {
                 return this->get(SQLITE_LIMIT_ATTACHED);
             }
-            
+
             void attached(int newValue) {
                 this->set(SQLITE_LIMIT_ATTACHED, newValue);
             }
-            
+
             int like_pattern_length() {
                 return this->get(SQLITE_LIMIT_LIKE_PATTERN_LENGTH);
             }
-            
+
             void like_pattern_length(int newValue) {
                 this->set(SQLITE_LIMIT_LIKE_PATTERN_LENGTH, newValue);
             }
-            
+
             int variable_number() {
                 return this->get(SQLITE_LIMIT_VARIABLE_NUMBER);
             }
-            
+
             void variable_number(int newValue) {
                 this->set(SQLITE_LIMIT_VARIABLE_NUMBER, newValue);
             }
-            
+
             int trigger_depth() {
                 return this->get(SQLITE_LIMIT_TRIGGER_DEPTH);
             }
-            
+
             void trigger_depth(int newValue) {
                 this->set(SQLITE_LIMIT_TRIGGER_DEPTH, newValue);
             }
-            
+
             int worker_threads() {
                 return this->get(SQLITE_LIMIT_WORKER_THREADS);
             }
-            
+
             void worker_threads(int newValue) {
                 this->set(SQLITE_LIMIT_WORKER_THREADS, newValue);
             }
-            
-        protected:
+
+          protected:
             get_connection_t get_connection;
-            
+
             friend struct storage_base;
-            
+
             /**
              *  Stores limit set between connections.
              */
             std::map<int, int> limits;
-            
+
             int get(int id) {
                 auto connection = this->get_connection();
                 return sqlite3_limit(connection.get(), id, -1);
             }
-            
+
             void set(int id, int newValue) {
                 this->limits[id] = newValue;
                 auto connection = this->get_connection();

--- a/dev/mapped_type_proxy.h
+++ b/dev/mapped_type_proxy.h
@@ -3,9 +3,9 @@
 #include "alias.h"
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         /**
          *  If T is alias than mapped_type_proxy<T>::type is alias::type
          *  otherwise T is T.
@@ -14,7 +14,7 @@ namespace sqlite_orm {
         struct mapped_type_proxy {
             using type = T;
         };
-        
+
         template<class T>
         struct mapped_type_proxy<T, typename std::enable_if<std::is_base_of<alias_tag, T>::value>::type> {
             using type = typename T::type;

--- a/dev/operators.h
+++ b/dev/operators.h
@@ -3,158 +3,160 @@
 #include <type_traits>  //  std::false_type, std::true_type
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         /**
          *  Inherit this class to support arithmetic types overloading
          */
         struct arithmetic_t {};
-        
-        template<class L, class R, class ...Ds>
+
+        template<class L, class R, class... Ds>
         struct binary_operator : Ds... {
             using left_type = L;
             using right_type = R;
-            
+
             left_type lhs;
             right_type rhs;
-            
+
             binary_operator(left_type lhs_, right_type rhs_) : lhs(std::move(lhs_)), rhs(std::move(rhs_)) {}
         };
-        
+
         struct conc_string {
-            operator std::string () const {
+            operator std::string() const {
                 return "||";
             }
         };
-        
+
         /**
          *  Result of concatenation || operator
          */
         template<class L, class R>
         using conc_t = binary_operator<L, R, conc_string>;
-        
+
         struct add_string {
-            operator std::string () const {
+            operator std::string() const {
                 return "+";
             }
         };
-        
+
         /**
          *  Result of addition + operator
          */
         template<class L, class R>
         using add_t = binary_operator<L, R, add_string, arithmetic_t>;
-        
+
         struct sub_string {
-            operator std::string () const {
+            operator std::string() const {
                 return "-";
             }
         };
-        
+
         /**
          *  Result of substitute - operator
          */
         template<class L, class R>
         using sub_t = binary_operator<L, R, sub_string, arithmetic_t>;
-        
+
         struct mul_string {
-            operator std::string () const {
+            operator std::string() const {
                 return "*";
             }
         };
-        
+
         /**
          *  Result of multiply * operator
          */
         template<class L, class R>
         using mul_t = binary_operator<L, R, mul_string, arithmetic_t>;
-        
+
         struct div_string {
-            operator std::string () const {
+            operator std::string() const {
                 return "/";
             }
         };
-        
+
         /**
          *  Result of divide / operator
          */
         template<class L, class R>
         using div_t = binary_operator<L, R, div_string, arithmetic_t>;
-        
+
         struct mod_string {
-            operator std::string () const {
+            operator std::string() const {
                 return "%";
             }
         };
-        
+
         /**
          *  Result of mod % operator
          */
         template<class L, class R>
         using mod_t = binary_operator<L, R, mod_string, arithmetic_t>;
-        
+
         struct assign_string {
-            operator std::string () const {
+            operator std::string() const {
                 return "=";
             }
         };
-        
+
         /**
          *  Result of assign = operator
          */
         template<class L, class R>
         using assign_t = binary_operator<L, R, assign_string>;
-        
+
         /**
          *  Assign operator traits. Common case
          */
         template<class T>
         struct is_assign_t : public std::false_type {};
-        
+
         /**
          *  Assign operator traits. Specialized case
          */
         template<class L, class R>
         struct is_assign_t<assign_t<L, R>> : public std::true_type {};
-        
+
         /**
          *  Is not an operator but a result of c(...) function. Has operator= overloaded which returns assign_t
          */
         template<class T>
         struct expression_t {
             T t;
-            
-            expression_t(T t_): t(std::move(t_)) {}
-            
+
+            expression_t(T t_) : t(std::move(t_)) {}
+
             template<class R>
             assign_t<T, R> operator=(R r) const {
                 return {this->t, std::move(r)};
             }
-            
+
             assign_t<T, std::nullptr_t> operator=(std::nullptr_t) const {
                 return {this->t, nullptr};
             }
         };
-        
+
     }
-    
+
     /**
-     *  Public interface for syntax sugar for columns. Example: `where(c(&User::id) == 5)` or `storage.update(set(c(&User::name) = "Dua Lipa"));
+     *  Public interface for syntax sugar for columns. Example: `where(c(&User::id) == 5)` or
+     * `storage.update(set(c(&User::name) = "Dua Lipa"));
      */
     template<class T>
     internal::expression_t<T> c(T t) {
         return {std::move(t)};
     }
-    
+
     /**
-     *  Public interface for || concatenation operator. Example: `select(conc(&User::name, "@gmail.com"));` => SELECT name || '@gmail.com' FROM users
+     *  Public interface for || concatenation operator. Example: `select(conc(&User::name, "@gmail.com"));` => SELECT
+     * name || '@gmail.com' FROM users
      */
     template<class L, class R>
     internal::conc_t<L, R> conc(L l, R r) {
         return {std::move(l), std::move(r)};
     }
-    
+
     /**
      *  Public interface for + operator. Example: `select(add(&User::age, 100));` => SELECT age + 100 FROM users
      */
@@ -162,7 +164,7 @@ namespace sqlite_orm {
     internal::add_t<L, R> add(L l, R r) {
         return {std::move(l), std::move(r)};
     }
-    
+
     /**
      *  Public interface for - operator. Example: `select(add(&User::age, 1));` => SELECT age - 1 FROM users
      */
@@ -170,25 +172,25 @@ namespace sqlite_orm {
     internal::sub_t<L, R> sub(L l, R r) {
         return {std::move(l), std::move(r)};
     }
-    
+
     template<class L, class R>
     internal::mul_t<L, R> mul(L l, R r) {
         return {std::move(l), std::move(r)};
     }
-    
+
     template<class L, class R>
     internal::div_t<L, R> div(L l, R r) {
         return {std::move(l), std::move(r)};
     }
-    
+
     template<class L, class R>
     internal::mod_t<L, R> mod(L l, R r) {
         return {std::move(l), std::move(r)};
     }
-    
+
     template<class L, class R>
     internal::assign_t<L, R> assign(L l, R r) {
         return {std::move(l), std::move(r)};
     }
-    
+
 }

--- a/dev/optional_container.h
+++ b/dev/optional_container.h
@@ -1,9 +1,9 @@
 #pragma once
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         /**
          *  This is a cute class which allows storing something or nothing
          *  depending on template argument. Useful for optional class members
@@ -11,19 +11,19 @@ namespace sqlite_orm {
         template<class T>
         struct optional_container {
             using type = T;
-            
+
             type field;
-            
+
             template<class L>
             void apply(const L &l) const {
                 l(this->field);
             }
         };
-        
+
         template<>
-        struct optional_container<void>{
+        struct optional_container<void> {
             using type = void;
-            
+
             template<class L>
             void apply(const L &) const {
                 //..

--- a/dev/pragma.h
+++ b/dev/pragma.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <string>   //  std::string
+#include <string>  //  std::string
 #include <sqlite3.h>
-#include <functional>   //  std::function
-#include <memory> // std::shared_ptr
+#include <functional>  //  std::function
+#include <memory>  // std::shared_ptr
 
 #include "error_code.h"
 #include "row_extractor.h"
@@ -11,82 +11,86 @@
 #include "connection_holder.h"
 
 namespace sqlite_orm {
-    
+
     namespace internal {
         struct storage_base;
     }
-    
+
     struct pragma_t {
         using get_connection_t = std::function<internal::connection_ref()>;
-        
-        pragma_t(get_connection_t get_connection_):
-        get_connection(std::move(get_connection_))
-        {}
-        
+
+        pragma_t(get_connection_t get_connection_) : get_connection(std::move(get_connection_)) {}
+
         sqlite_orm::journal_mode journal_mode() {
             return this->get_pragma<sqlite_orm::journal_mode>("journal_mode");
         }
-        
+
         void journal_mode(sqlite_orm::journal_mode value) {
             this->_journal_mode = -1;
             this->set_pragma("journal_mode", value);
             this->_journal_mode = static_cast<decltype(this->_journal_mode)>(value);
         }
-        
+
         int synchronous() {
             return this->get_pragma<int>("synchronous");
         }
-        
+
         void synchronous(int value) {
             this->_synchronous = -1;
             this->set_pragma("synchronous", value);
             this->_synchronous = value;
         }
-        
+
         int user_version() {
             return this->get_pragma<int>("user_version");
         }
-        
+
         void user_version(int value) {
             this->set_pragma("user_version", value);
         }
-        
+
         int auto_vacuum() {
             return this->get_pragma<int>("auto_vacuum");
         }
-        
+
         void auto_vacuum(int value) {
             this->set_pragma("auto_vacuum", value);
         }
-        
-    protected:
+
+      protected:
         friend struct storage_base;
-        
-    public:
+
+      public:
         int _synchronous = -1;
-        signed char _journal_mode = -1; //  if != -1 stores static_cast<sqlite_orm::journal_mode>(journal_mode)
+        signed char _journal_mode = -1;  //  if != -1 stores static_cast<sqlite_orm::journal_mode>(journal_mode)
         get_connection_t get_connection;
-        
+
         template<class T>
         T get_pragma(const std::string &name) {
             auto connection = this->get_connection();
             auto query = "PRAGMA " + name;
             T res;
             auto db = connection.get();
-            auto rc = sqlite3_exec(db, query.c_str(), [](void *data, int argc, char **argv, char **) -> int {
-                                       auto &res = *(T*)data;
-                                       if(argc){
-                                           res = row_extractor<T>().extract(argv[0]);
-                                       }
-                                       return 0;
-                                   }, &res, nullptr);
-            if(rc == SQLITE_OK){
+            auto rc = sqlite3_exec(
+                db,
+                query.c_str(),
+                [](void *data, int argc, char **argv, char **) -> int {
+                    auto &res = *(T *)data;
+                    if(argc) {
+                        res = row_extractor<T>().extract(argv[0]);
+                    }
+                    return 0;
+                },
+                &res,
+                nullptr);
+            if(rc == SQLITE_OK) {
                 return res;
-            }else{
-                throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+            } else {
+                throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                        sqlite3_errmsg(db));
             }
         }
-        
+
         /**
          *  Yevgeniy Zakharov: I wanted to refactore this function with statements and value bindings
          *  but it turns out that bindings in pragma statements are not supported.
@@ -94,7 +98,7 @@ namespace sqlite_orm {
         template<class T>
         void set_pragma(const std::string &name, const T &value, sqlite3 *db = nullptr) {
             auto con = this->get_connection();
-            if(!db){
+            if(!db) {
                 db = con.get();
             }
             std::stringstream ss;
@@ -102,13 +106,14 @@ namespace sqlite_orm {
             auto query = ss.str();
             auto rc = sqlite3_exec(db, query.c_str(), nullptr, nullptr, nullptr);
             if(rc != SQLITE_OK) {
-                throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                        sqlite3_errmsg(db));
             }
         }
-        
+
         void set_pragma(const std::string &name, const sqlite_orm::journal_mode &value, sqlite3 *db = nullptr) {
             auto con = this->get_connection();
-            if(!db){
+            if(!db) {
                 db = con.get();
             }
             std::stringstream ss;
@@ -116,7 +121,8 @@ namespace sqlite_orm {
             auto query = ss.str();
             auto rc = sqlite3_exec(db, query.c_str(), nullptr, nullptr, nullptr);
             if(rc != SQLITE_OK) {
-                throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                        sqlite3_errmsg(db));
             }
         }
     };

--- a/dev/prepared_statement.h
+++ b/dev/prepared_statement.h
@@ -1,103 +1,101 @@
 #pragma once
 
 #include <sqlite3.h>
-#include <iterator> //  std::iterator_traits
-#include <string>   //  std::string
+#include <iterator>  //  std::iterator_traits
+#include <string>  //  std::string
 #include <type_traits>  //  std::true_type, std::false_type
 
 #include "connection_holder.h"
 #include "select_constraints.h"
 
 namespace sqlite_orm {
-    
+
     template<class T>
     struct by_val {
         using type = T;
-        
+
         type obj;
     };
-    
+
     namespace internal {
-        
+
         template<class T>
         struct is_by_val : std::false_type {};
-        
+
         template<class T>
         struct is_by_val<by_val<T>> : std::true_type {};
-        
+
         struct prepared_statement_base {
             sqlite3_stmt *stmt = nullptr;
             connection_ref con;
-            
+
             ~prepared_statement_base() {
-                if(this->stmt){
+                if(this->stmt) {
                     sqlite3_finalize(this->stmt);
                     this->stmt = nullptr;
                 }
             }
-            
+
             std::string sql() const {
-                if(this->stmt){
-                    if(auto res = sqlite3_sql(this->stmt)){
+                if(this->stmt) {
+                    if(auto res = sqlite3_sql(this->stmt)) {
                         return res;
-                    }else{
+                    } else {
                         return {};
                     }
-                }else{
+                } else {
                     return {};
                 }
             }
-            
+
             std::string expanded_sql() const {
-                if(this->stmt){
-                    if(auto res = sqlite3_expanded_sql(this->stmt)){
+                if(this->stmt) {
+                    if(auto res = sqlite3_expanded_sql(this->stmt)) {
                         std::string result = res;
                         sqlite3_free(res);
                         return result;
-                    }else{
+                    } else {
                         return {};
                     }
-                }else{
+                } else {
                     return {};
                 }
             }
 #if SQLITE_VERSION_NUMBER >= 3027000
             std::string normalized_sql() const {
-                if(this->stmt){
-                    if(auto res = sqlite3_normalized_sql(this->stmt)){
+                if(this->stmt) {
+                    if(auto res = sqlite3_normalized_sql(this->stmt)) {
                         return res;
-                    }else{
+                    } else {
                         return {};
                     }
-                }else{
+                } else {
                     return {};
                 }
             }
 #endif
         };
-        
+
         template<class T>
         struct prepared_statement_t : prepared_statement_base {
             using expression_type = T;
-            
+
             expression_type t;
-            
+
             prepared_statement_t(T t_, sqlite3_stmt *stmt, connection_ref con_) :
-            prepared_statement_base{stmt, std::move(con_)},
-            t(std::move(t_))
-            {}
+                prepared_statement_base{stmt, std::move(con_)}, t(std::move(t_)) {}
         };
-        
-        template<class T, class ...Args>
+
+        template<class T, class... Args>
         struct get_all_t {
             using type = T;
-            
+
             using conditions_type = std::tuple<Args...>;
-            
+
             conditions_type conditions;
         };
 
-        template<class T, class ...Args>
+        template<class T, class... Args>
         struct get_all_pointer_t {
             using type = T;
 
@@ -105,252 +103,253 @@ namespace sqlite_orm {
 
             conditions_type conditions;
         };
-        
-        template<class T, class ...Wargs>
+
+        template<class T, class... Wargs>
         struct update_all_t;
-        
-        template<class ...Args, class ...Wargs>
+
+        template<class... Args, class... Wargs>
         struct update_all_t<set_t<Args...>, Wargs...> {
             using set_type = set_t<Args...>;
             using conditions_type = std::tuple<Wargs...>;
-            
+
             set_type set;
             conditions_type conditions;
         };
-        
-        template<class T, class ...Args>
+
+        template<class T, class... Args>
         struct remove_all_t {
             using type = T;
-            
+
             using conditions_type = std::tuple<Args...>;
-            
+
             conditions_type conditions;
         };
-        
-        template<class T, class ...Ids>
+
+        template<class T, class... Ids>
         struct get_t {
             using type = T;
-            
+
             using ids_type = std::tuple<Ids...>;
-            
+
             ids_type ids;
         };
-        
-        template<class T, class ...Ids>
+
+        template<class T, class... Ids>
         struct get_pointer_t {
             using type = T;
-            
+
             using ids_type = std::tuple<Ids...>;
-            
+
             ids_type ids;
         };
-        
+
         template<class T, bool by_ref>
         struct update_t;
-        
+
         template<class T>
-        struct update_t<T, true>{
+        struct update_t<T, true> {
             using type = T;
-            
+
             const type &obj;
-            
+
             update_t(decltype(obj) obj_) : obj(obj_) {}
         };
-        
+
         template<class T>
-        struct update_t<T, false>{
+        struct update_t<T, false> {
             using type = T;
-            
+
             type obj;
         };
-        
-        template<class T, class ...Ids>
+
+        template<class T, class... Ids>
         struct remove_t {
             using type = T;
-            
+
             using ids_type = std::tuple<Ids...>;
-            
+
             ids_type ids;
         };
-        
+
         template<class T, bool by_ref>
         struct insert_t;
-        
+
         template<class T>
         struct insert_t<T, true> {
             using type = T;
-            
+
             const type &obj;
-            
+
             insert_t(decltype(obj) obj_) : obj(obj_) {}
         };
-        
+
         template<class T>
         struct insert_t<T, false> {
             using type = T;
-            
+
             type obj;
         };
-        
-        template<class T, bool by_ref, class ...Cols>
+
+        template<class T, bool by_ref, class... Cols>
         struct insert_explicit;
-        
-        template<class T, class ...Cols>
+
+        template<class T, class... Cols>
         struct insert_explicit<T, true, Cols...> {
             using type = T;
             using columns_type = columns_t<Cols...>;
-            
+
             const type &obj;
             columns_type columns;
-            
+
             insert_explicit(decltype(obj) obj_, decltype(columns) columns_) : obj(obj_), columns(std::move(columns_)) {}
         };
-        
-        template<class T, class ...Cols>
+
+        template<class T, class... Cols>
         struct insert_explicit<T, false, Cols...> {
             using type = T;
             using columns_type = columns_t<Cols...>;
-            
+
             type obj;
             columns_type columns;
-            
+
             insert_explicit(decltype(obj) obj_, decltype(columns) columns_) : obj(obj_), columns(std::move(columns_)) {}
         };
-        
+
         template<class T, bool by_ref>
         struct replace_t;
-        
+
         template<class T>
         struct replace_t<T, true> {
             using type = T;
-            
+
             const type &obj;
-            
+
             replace_t(decltype(obj) obj_) : obj(obj_) {}
         };
-        
+
         template<class T>
         struct replace_t<T, false> {
             using type = T;
-            
+
             type obj;
         };
-        
+
         template<class It>
         struct insert_range_t {
             using iterator_type = It;
             using object_type = typename std::iterator_traits<iterator_type>::value_type;
-            
+
             iterator_type from;
             iterator_type to;
         };
-        
+
         template<class It>
         struct replace_range_t {
             using iterator_type = It;
             using object_type = typename std::iterator_traits<iterator_type>::value_type;
-            
+
             iterator_type from;
             iterator_type to;
         };
     }
-    
+
     template<class It>
     internal::replace_range_t<It> replace_range(It from, It to) {
         return {std::move(from), std::move(to)};
     }
-    
+
     template<class It>
     internal::insert_range_t<It> insert_range(It from, It to) {
         return {std::move(from), std::move(to)};
     }
-    
+
     template<class T>
     internal::replace_t<T, true> replace(const T &obj) {
         static_assert(!internal::is_by_val<T>::value, "by_val is not allowed here");
         return {obj};
     }
-    
+
     template<class B>
     internal::replace_t<typename B::type, false> replace(typename B::type obj) {
         static_assert(internal::is_by_val<B>::value, "by_val expected");
         return {std::move(obj)};
     }
-    
+
     template<class T>
     internal::insert_t<T, true> insert(const T &obj) {
         static_assert(!internal::is_by_val<T>::value, "by_val is not allowed here");
         return {obj};
     }
-    
+
     template<class B>
     internal::insert_t<typename B::type, false> insert(typename B::type obj) {
         static_assert(internal::is_by_val<B>::value, "by_val expected");
         return {std::move(obj)};
     }
-    
-    template<class T, class ...Cols>
+
+    template<class T, class... Cols>
     internal::insert_explicit<T, true, Cols...> insert(const T &obj, internal::columns_t<Cols...> cols) {
         static_assert(!internal::is_by_val<T>::value, "by_val is not allowed here");
         return {obj, std::move(cols)};
     }
-    
-    template<class B, class ...Cols>
-    internal::insert_explicit<typename B::type, false, Cols...> insert(typename B::type obj, internal::columns_t<Cols...> cols) {
+
+    template<class B, class... Cols>
+    internal::insert_explicit<typename B::type, false, Cols...> insert(typename B::type obj,
+                                                                       internal::columns_t<Cols...> cols) {
         static_assert(internal::is_by_val<B>::value, "by_val expected");
         return {std::move(obj), std::move(cols)};
     }
-    
-    template<class T, class ...Ids>
-    internal::remove_t<T, Ids...> remove(Ids ...ids) {
+
+    template<class T, class... Ids>
+    internal::remove_t<T, Ids...> remove(Ids... ids) {
         std::tuple<Ids...> idsTuple{std::forward<Ids>(ids)...};
         return {move(idsTuple)};
     }
-    
+
     template<class T>
     internal::update_t<T, true> update(const T &obj) {
         static_assert(!internal::is_by_val<T>::value, "by_val is not allowed here");
         return {obj};
     }
-    
+
     template<class B>
     internal::update_t<typename B::type, false> update(typename B::type obj) {
         static_assert(internal::is_by_val<B>::value, "by_val expected");
         return {std::move(obj)};
     }
-    
-    template<class T, class ...Ids>
-    internal::get_t<T, Ids...> get(Ids ...ids) {
+
+    template<class T, class... Ids>
+    internal::get_t<T, Ids...> get(Ids... ids) {
         std::tuple<Ids...> idsTuple{std::forward<Ids>(ids)...};
         return {move(idsTuple)};
     }
-    
-    template<class T, class ...Ids>
-    internal::get_pointer_t<T, Ids...> get_pointer(Ids ...ids) {
+
+    template<class T, class... Ids>
+    internal::get_pointer_t<T, Ids...> get_pointer(Ids... ids) {
         std::tuple<Ids...> idsTuple{std::forward<Ids>(ids)...};
         return {move(idsTuple)};
     }
-    
-    template<class T, class ...Args>
-    internal::remove_all_t<T, Args...> remove_all(Args ...args) {
-        std::tuple<Args...> conditions{std::forward<Args>(args)...};
-        return {move(conditions)};
-    }
-    
-    template<class T, class ...Args>
-    internal::get_all_t<T, Args...> get_all(Args ...args) {
+
+    template<class T, class... Args>
+    internal::remove_all_t<T, Args...> remove_all(Args... args) {
         std::tuple<Args...> conditions{std::forward<Args>(args)...};
         return {move(conditions)};
     }
 
-    template<class T, class ...Args>
-    internal::get_all_pointer_t<T, Args...> get_all_pointer(Args ...args) {
+    template<class T, class... Args>
+    internal::get_all_t<T, Args...> get_all(Args... args) {
         std::tuple<Args...> conditions{std::forward<Args>(args)...};
         return {move(conditions)};
     }
-    
-    template<class ...Args, class ...Wargs>
-    internal::update_all_t<internal::set_t<Args...>, Wargs...> update_all(internal::set_t<Args...> set, Wargs ...wh) {
+
+    template<class T, class... Args>
+    internal::get_all_pointer_t<T, Args...> get_all_pointer(Args... args) {
+        std::tuple<Args...> conditions{std::forward<Args>(args)...};
+        return {move(conditions)};
+    }
+
+    template<class... Args, class... Wargs>
+    internal::update_all_t<internal::set_t<Args...>, Wargs...> update_all(internal::set_t<Args...> set, Wargs... wh) {
         std::tuple<Wargs...> conditions{std::forward<Wargs>(wh)...};
         return {std::move(set), move(conditions)};
     }

--- a/dev/row_extractor.h
+++ b/dev/row_extractor.h
@@ -3,104 +3,95 @@
 #include <sqlite3.h>
 #include <type_traits>  //  std::enable_if_t, std::is_arithmetic, std::is_same, std::enable_if
 #include <cstdlib>  //  atof, atoi, atoll
-#include <string>   //  std::string, std::wstring
+#include <string>  //  std::string, std::wstring
 #ifndef SQLITE_ORM_OMITS_CODECVT
 #include <codecvt>  //  std::wstring_convert, std::codecvt_utf8_utf16
 #endif  //  SQLITE_ORM_OMITS_CODECVT
-#include <vector>   //  std::vector
+#include <vector>  //  std::vector
 #include <cstring>  //  strlen
-#include <algorithm>    //  std::copy
-#include <iterator> //  std::back_inserter
-#include <tuple>    //  std::tuple, std::tuple_size, std::tuple_element
+#include <algorithm>  //  std::copy
+#include <iterator>  //  std::back_inserter
+#include <tuple>  //  std::tuple, std::tuple_size, std::tuple_element
 
 #include "arithmetic_tag.h"
 #include "journal_mode.h"
 #include "error_code.h"
 
 namespace sqlite_orm {
-    
+
     /**
      *  Helper class used to cast values from argv to V class
      *  which depends from column type.
      *
      */
     template<class V, typename Enable = void>
-    struct row_extractor
-    {
+    struct row_extractor {
         //  used in sqlite3_exec (select)
         V extract(const char *row_value);
-        
+
         //  used in sqlite_column (iteration, get_all)
         V extract(sqlite3_stmt *stmt, int columnIndex);
     };
-    
+
     /**
      *  Specialization for arithmetic types.
      */
     template<class V>
-    struct row_extractor<
-    V,
-    std::enable_if_t<std::is_arithmetic<V>::value>
-    >
-    {
+    struct row_extractor<V, std::enable_if_t<std::is_arithmetic<V>::value>> {
         V extract(const char *row_value) {
             return extract(row_value, tag());
         }
-        
+
         V extract(sqlite3_stmt *stmt, int columnIndex) {
             return extract(stmt, columnIndex, tag());
         }
-        
-    private:
+
+      private:
         using tag = arithmetic_tag_t<V>;
-        
-        V extract(const char *row_value, const int_or_smaller_tag&) {
+
+        V extract(const char *row_value, const int_or_smaller_tag &) {
             return static_cast<V>(atoi(row_value));
         }
-        
-        V extract(sqlite3_stmt *stmt, int columnIndex, const int_or_smaller_tag&) {
+
+        V extract(sqlite3_stmt *stmt, int columnIndex, const int_or_smaller_tag &) {
             return static_cast<V>(sqlite3_column_int(stmt, columnIndex));
         }
-        
-        V extract(const char *row_value, const bigint_tag&) {
+
+        V extract(const char *row_value, const bigint_tag &) {
             return static_cast<V>(atoll(row_value));
         }
-        
-        V extract(sqlite3_stmt *stmt, int columnIndex, const bigint_tag&) {
+
+        V extract(sqlite3_stmt *stmt, int columnIndex, const bigint_tag &) {
             return static_cast<V>(sqlite3_column_int64(stmt, columnIndex));
         }
-        
-        V extract(const char *row_value, const real_tag&) {
+
+        V extract(const char *row_value, const real_tag &) {
             return static_cast<V>(atof(row_value));
         }
-        
-        V extract(sqlite3_stmt *stmt, int columnIndex, const real_tag&) {
+
+        V extract(sqlite3_stmt *stmt, int columnIndex, const real_tag &) {
             return static_cast<V>(sqlite3_column_double(stmt, columnIndex));
         }
     };
-    
+
     /**
      *  Specialization for std::string.
      */
     template<class V>
-    struct row_extractor<
-    V,
-    std::enable_if_t<std::is_same<V, std::string>::value>
-    >
-    {
+    struct row_extractor<V, std::enable_if_t<std::is_same<V, std::string>::value>> {
         std::string extract(const char *row_value) {
-            if(row_value){
+            if(row_value) {
                 return row_value;
-            }else{
+            } else {
                 return {};
             }
         }
-        
+
         std::string extract(sqlite3_stmt *stmt, int columnIndex) {
-            auto cStr = (const char*)sqlite3_column_text(stmt, columnIndex);
-            if(cStr){
+            auto cStr = (const char *)sqlite3_column_text(stmt, columnIndex);
+            if(cStr) {
                 return cStr;
-            }else{
+            } else {
                 return {};
             }
         }
@@ -110,26 +101,22 @@ namespace sqlite_orm {
      *  Specialization for std::wstring.
      */
     template<class V>
-    struct row_extractor<
-    V,
-    std::enable_if_t<std::is_same<V, std::wstring>::value>
-    >
-    {
+    struct row_extractor<V, std::enable_if_t<std::is_same<V, std::wstring>::value>> {
         std::wstring extract(const char *row_value) {
-            if(row_value){
+            if(row_value) {
                 std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
                 return converter.from_bytes(row_value);
-            }else{
+            } else {
                 return {};
             }
         }
-        
+
         std::wstring extract(sqlite3_stmt *stmt, int columnIndex) {
-            auto cStr = (const char*)sqlite3_column_text(stmt, columnIndex);
-            if(cStr){
+            auto cStr = (const char *)sqlite3_column_text(stmt, columnIndex);
+            if(cStr) {
                 std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
                 return converter.from_bytes(cStr);
-            }else{
+            } else {
                 return {};
             }
         }
@@ -139,169 +126,150 @@ namespace sqlite_orm {
      *  Specialization for std::vector<char>.
      */
     template<class V>
-    struct row_extractor<
-    V,
-    std::enable_if_t<std::is_same<V, std::vector<char>>::value>
-    >
-    {
+    struct row_extractor<V, std::enable_if_t<std::is_same<V, std::vector<char>>::value>> {
         std::vector<char> extract(const char *row_value) {
-            if(row_value){
+            if(row_value) {
                 auto len = ::strlen(row_value);
                 return this->go(row_value, len);
-            }else{
+            } else {
                 return {};
             }
         }
-        
+
         std::vector<char> extract(sqlite3_stmt *stmt, int columnIndex) {
             auto bytes = static_cast<const char *>(sqlite3_column_blob(stmt, columnIndex));
             auto len = sqlite3_column_bytes(stmt, columnIndex);
             return this->go(bytes, len);
         }
-        
-    protected:
-        
+
+      protected:
         std::vector<char> go(const char *bytes, size_t len) {
-            if(len){
+            if(len) {
                 std::vector<char> res;
                 res.reserve(len);
-                std::copy(bytes,
-                          bytes + len,
-                          std::back_inserter(res));
+                std::copy(bytes, bytes + len, std::back_inserter(res));
                 return res;
-            }else{
+            } else {
                 return {};
             }
         }
     };
-    
+
     template<class V>
-    struct row_extractor<
-    V,
-    std::enable_if_t<is_std_ptr<V>::value>
-    >
-    {
+    struct row_extractor<V, std::enable_if_t<is_std_ptr<V>::value>> {
         using value_type = typename V::element_type;
-        
+
         V extract(const char *row_value) {
-            if(row_value){
+            if(row_value) {
                 return is_std_ptr<V>::make(row_extractor<value_type>().extract(row_value));
-            }else{
+            } else {
                 return {};
             }
         }
-        
+
         V extract(sqlite3_stmt *stmt, int columnIndex) {
             auto type = sqlite3_column_type(stmt, columnIndex);
-            if(type != SQLITE_NULL){
+            if(type != SQLITE_NULL) {
                 return is_std_ptr<V>::make(row_extractor<value_type>().extract(stmt, columnIndex));
-            }else{
+            } else {
                 return {};
             }
         }
     };
-    
+
     /**
      *  Specialization for std::vector<char>.
      */
     template<>
     struct row_extractor<std::vector<char>> {
         std::vector<char> extract(const char *row_value) {
-            if(row_value){
+            if(row_value) {
                 auto len = ::strlen(row_value);
                 return this->go(row_value, len);
-            }else{
+            } else {
                 return {};
             }
         }
-        
+
         std::vector<char> extract(sqlite3_stmt *stmt, int columnIndex) {
             auto bytes = static_cast<const char *>(sqlite3_column_blob(stmt, columnIndex));
             auto len = static_cast<size_t>(sqlite3_column_bytes(stmt, columnIndex));
             return this->go(bytes, len);
         }
-        
-    protected:
-        
+
+      protected:
         std::vector<char> go(const char *bytes, size_t len) {
-            if(len){
+            if(len) {
                 std::vector<char> res;
                 res.reserve(len);
-                std::copy(bytes,
-                          bytes + len,
-                          std::back_inserter(res));
+                std::copy(bytes, bytes + len, std::back_inserter(res));
                 return res;
-            }else{
+            } else {
                 return {};
             }
         }
     };
-    
-    template<class ...Args>
+
+    template<class... Args>
     struct row_extractor<std::tuple<Args...>> {
-        
+
         std::tuple<Args...> extract(char **argv) {
             std::tuple<Args...> res;
             this->extract<std::tuple_size<decltype(res)>::value>(res, argv);
             return res;
         }
-        
+
         std::tuple<Args...> extract(sqlite3_stmt *stmt, int /*columnIndex*/) {
             std::tuple<Args...> res;
             this->extract<std::tuple_size<decltype(res)>::value>(res, stmt);
             return res;
         }
-        
-    protected:
-        
+
+      protected:
         template<size_t I, typename std::enable_if<I != 0>::type * = nullptr>
         void extract(std::tuple<Args...> &t, sqlite3_stmt *stmt) {
             using tuple_type = typename std::tuple_element<I - 1, typename std::tuple<Args...>>::type;
             std::get<I - 1>(t) = row_extractor<tuple_type>().extract(stmt, I - 1);
             this->extract<I - 1>(t, stmt);
         }
-        
+
         template<size_t I, typename std::enable_if<I == 0>::type * = nullptr>
         void extract(std::tuple<Args...> &, sqlite3_stmt *) {
             //..
         }
-        
+
         template<size_t I, typename std::enable_if<I != 0>::type * = nullptr>
         void extract(std::tuple<Args...> &t, char **argv) {
             using tuple_type = typename std::tuple_element<I - 1, typename std::tuple<Args...>>::type;
             std::get<I - 1>(t) = row_extractor<tuple_type>().extract(argv[I - 1]);
             this->extract<I - 1>(t, argv);
         }
-        
+
         template<size_t I, typename std::enable_if<I == 0>::type * = nullptr>
         void extract(std::tuple<Args...> &, char **) {
             //..
         }
     };
-    
+
     /**
      *  Specialization for journal_mode.
      */
     template<class V>
-    struct row_extractor<
-    V,
-    std::enable_if_t<std::is_same<V, journal_mode>::value>
-    >
-    {
+    struct row_extractor<V, std::enable_if_t<std::is_same<V, journal_mode>::value>> {
         journal_mode extract(const char *row_value) {
-            if(row_value){
-                if(auto res = internal::journal_mode_from_string(row_value)){
+            if(row_value) {
+                if(auto res = internal::journal_mode_from_string(row_value)) {
                     return std::move(*res);
-                }else{
+                } else {
                     throw std::system_error(std::make_error_code(orm_error_code::incorrect_journal_mode_string));
                 }
-            }else{
+            } else {
                 throw std::system_error(std::make_error_code(orm_error_code::incorrect_journal_mode_string));
             }
         }
-        
+
         journal_mode extract(sqlite3_stmt *stmt, int columnIndex) {
-            auto cStr = (const char*)sqlite3_column_text(stmt, columnIndex);
+            auto cStr = (const char *)sqlite3_column_text(stmt, columnIndex);
             return this->extract(cStr);
         }
     };

--- a/dev/rowid.h
+++ b/dev/rowid.h
@@ -1,34 +1,34 @@
 #pragma once
 
-#include <string>   //  std::string
+#include <string>  //  std::string
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         struct rowid_t {
             operator std::string() const {
                 return "rowid";
             }
         };
-        
+
         struct oid_t {
             operator std::string() const {
                 return "oid";
             }
         };
-        
+
         struct _rowid_t {
             operator std::string() const {
                 return "_rowid_";
             }
         };
-        
+
         template<class T>
         struct table_rowid_t : public rowid_t {
             using type = T;
         };
-        
+
         template<class T>
         struct table_oid_t : public oid_t {
             using type = T;
@@ -37,31 +37,31 @@ namespace sqlite_orm {
         struct table__rowid_t : public _rowid_t {
             using type = T;
         };
-        
+
     }
-    
+
     inline internal::rowid_t rowid() {
         return {};
     }
-    
+
     inline internal::oid_t oid() {
         return {};
     }
-    
+
     inline internal::_rowid_t _rowid_() {
         return {};
     }
-    
+
     template<class T>
     internal::table_rowid_t<T> rowid() {
         return {};
     }
-    
+
     template<class T>
     internal::table_oid_t<T> oid() {
         return {};
     }
-    
+
     template<class T>
     internal::table__rowid_t<T> _rowid_() {
         return {};

--- a/dev/select_constraints.h
+++ b/dev/select_constraints.h
@@ -1,82 +1,83 @@
 #pragma once
 
-#include <string>   //  std::string
+#include <string>  //  std::string
 #include <utility>  //  std::declval
-#include <tuple>    //  std::tuple, std::get, std::tuple_size
+#include <tuple>  //  std::tuple, std::get, std::tuple_size
 
 #include "is_base_of_template.h"
 #include "tuple_helper.h"
 #include "optional_container.h"
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         /**
          *  DISCTINCT generic container.
          */
         template<class T>
         struct distinct_t {
             T t;
-            
+
             operator std::string() const {
                 return "DISTINCT";
             }
         };
-        
+
         /**
          *  ALL generic container.
          */
         template<class T>
         struct all_t {
             T t;
-            
+
             operator std::string() const {
                 return "ALL";
             }
         };
-        
-        template<class ...Args>
+
+        template<class... Args>
         struct columns_t {
             using columns_type = std::tuple<Args...>;
-            
+
             columns_type columns;
             bool distinct = false;
-            
+
             static constexpr const int count = std::tuple_size<columns_type>::value;
         };
-        
-        template<class ...Args>
+
+        template<class... Args>
         struct set_t {
-            
+
             operator std::string() const {
                 return "SET";
             }
-            
+
             template<class F>
             void for_each(F) const {
                 //..
             }
         };
-        
-        template<class L, class ...Args>
+
+        template<class L, class... Args>
         struct set_t<L, Args...> : public set_t<Args...> {
-            static_assert(is_assign_t<typename std::remove_reference<L>::type>::value, "set_t argument must be assign_t");
-            
+            static_assert(is_assign_t<typename std::remove_reference<L>::type>::value,
+                          "set_t argument must be assign_t");
+
             L l;
-            
+
             using super = set_t<Args...>;
             using self = set_t<L, Args...>;
-            
-            set_t(L l_, Args&& ...args) : super(std::forward<Args>(args)...), l(std::forward<L>(l_)) {}
-            
+
+            set_t(L l_, Args &&... args) : super(std::forward<Args>(args)...), l(std::forward<L>(l_)) {}
+
             template<class F>
             void for_each(F f) const {
                 f(l);
                 this->super::for_each(f);
             }
         };
-        
+
         /**
          *  This class is used to store explicit mapped type T and its column descriptor (member pointer/getter/setter).
          *  Is useful when mapped type is derived from other type and base class has members mapped to a storage.
@@ -85,23 +86,23 @@ namespace sqlite_orm {
         struct column_pointer {
             using type = T;
             using field_type = F;
-            
+
             field_type field;
         };
-        
+
         /**
          *  Subselect object type.
          */
-        template<class T, class ...Args>
+        template<class T, class... Args>
         struct select_t {
             using return_type = T;
             using conditions_type = std::tuple<Args...>;
-            
+
             return_type col;
             conditions_type conditions;
             bool highest_level = false;
         };
-        
+
         /**
          *  Base for UNION, UNION ALL, EXCEPT and INTERSECT
          */
@@ -109,28 +110,28 @@ namespace sqlite_orm {
         struct compound_operator {
             using left_type = L;
             using right_type = R;
-            
+
             left_type left;
             right_type right;
-            
-            compound_operator(left_type l, right_type r): left(std::move(l)), right(std::move(r)) {
+
+            compound_operator(left_type l, right_type r) : left(std::move(l)), right(std::move(r)) {
                 this->left.highest_level = true;
                 this->right.highest_level = true;
             }
         };
-        
+
         struct union_base {
             bool all = false;
-            
+
             operator std::string() const {
-                if(!this->all){
+                if(!this->all) {
                     return "UNION";
-                }else{
+                } else {
                     return "UNION ALL";
                 }
             }
         };
-        
+
         /**
          *  UNION object type.
          */
@@ -138,12 +139,13 @@ namespace sqlite_orm {
         struct union_t : public compound_operator<L, R>, union_base {
             using left_type = typename compound_operator<L, R>::left_type;
             using right_type = typename compound_operator<L, R>::right_type;
-            
-            union_t(left_type l, right_type r, decltype(all) all): compound_operator<L, R>(std::move(l), std::move(r)), union_base{all} {}
-            
-            union_t(left_type l, right_type r): union_t(std::move(l), std::move(r), false) {}
+
+            union_t(left_type l, right_type r, decltype(all) all) :
+                compound_operator<L, R>(std::move(l), std::move(r)), union_base{all} {}
+
+            union_t(left_type l, right_type r) : union_t(std::move(l), std::move(r), false) {}
         };
-        
+
         /**
          *  EXCEPT object type.
          */
@@ -152,14 +154,14 @@ namespace sqlite_orm {
             using super = compound_operator<L, R>;
             using left_type = typename super::left_type;
             using right_type = typename super::right_type;
-            
+
             using super::super;
-            
+
             operator std::string() const {
                 return "EXCEPT";
             }
         };
-        
+
         /**
          *  INTERSECT object type.
          */
@@ -168,14 +170,14 @@ namespace sqlite_orm {
             using super = compound_operator<L, R>;
             using left_type = typename super::left_type;
             using right_type = typename super::right_type;
-            
+
             using super::super;
-            
+
             operator std::string() const {
                 return "INTERSECT";
             }
         };
-        
+
         /**
          *  Generic way to get DISTINCT value from any type.
          */
@@ -183,52 +185,52 @@ namespace sqlite_orm {
         bool get_distinct(const T &) {
             return false;
         }
-        
-        template<class ...Args>
+
+        template<class... Args>
         bool get_distinct(const columns_t<Args...> &cols) {
             return cols.distinct;
         }
-        
+
         template<class T>
         struct asterisk_t {
             using type = T;
         };
-        
+
         template<class T>
         struct then_t {
             using expression_type = T;
-            
+
             expression_type expression;
         };
-        
-        template<class R, class T, class E, class ...Args>
+
+        template<class R, class T, class E, class... Args>
         struct simple_case_t {
             using return_type = R;
             using case_expression_type = T;
             using args_type = std::tuple<Args...>;
             using else_expression_type = E;
-            
+
             optional_container<case_expression_type> case_expression;
             args_type args;
             optional_container<else_expression_type> else_expression;
         };
-        
+
         /**
          *  T is a case expression type
          *  E is else type (void is ELSE is omitted)
          *  Args... is a pack of WHEN expressions
          */
-        template<class R, class T, class E, class ...Args>
+        template<class R, class T, class E, class... Args>
         struct simple_case_builder {
             using return_type = R;
             using case_expression_type = T;
             using args_type = std::tuple<Args...>;
             using else_expression_type = E;
-            
+
             optional_container<case_expression_type> case_expression;
             args_type args;
             optional_container<else_expression_type> else_expression;
-            
+
             template<class W, class Th>
             simple_case_builder<R, T, E, Args..., std::pair<W, Th>> when(W w, then_t<Th> t) {
                 using result_args_type = std::tuple<Args..., std::pair<W, Th>>;
@@ -238,63 +240,63 @@ namespace sqlite_orm {
                 std::get<std::tuple_size<result_args_type>::value - 1>(result_args) = std::move(newPair);
                 return {std::move(this->case_expression), std::move(result_args), std::move(this->else_expression)};
             }
-            
+
             simple_case_t<R, T, E, Args...> end() {
                 return {std::move(this->case_expression), std::move(args), std::move(this->else_expression)};
             }
-            
+
             template<class El>
             simple_case_builder<R, T, El, Args...> else_(El el) {
                 return {{std::move(this->case_expression)}, std::move(args), {std::move(el)}};
             }
         };
     }
-    
+
     template<class T>
     internal::then_t<T> then(T t) {
         return {std::move(t)};
     }
-    
+
     template<class R, class T>
     internal::simple_case_builder<R, T, void> case_(T t) {
         return {{std::move(t)}};
     }
-    
+
     template<class R>
     internal::simple_case_builder<R, void, void> case_() {
         return {};
     }
-    
+
     template<class T>
     internal::distinct_t<T> distinct(T t) {
         return {std::move(t)};
     }
-    
+
     template<class T>
     internal::all_t<T> all(T t) {
         return {std::move(t)};
     }
-    
-    template<class ...Args>
+
+    template<class... Args>
     internal::columns_t<Args...> distinct(internal::columns_t<Args...> cols) {
         cols.distinct = true;
         return cols;
     }
-    
+
     /**
      *  SET keyword used in UPDATE ... SET queries.
      *  Args must have `assign_t` type. E.g. set(assign(&User::id, 5)) or set(c(&User::id) = 5)
      */
-    template<class ...Args>
-    internal::set_t<Args...> set(Args&& ...args) {
+    template<class... Args>
+    internal::set_t<Args...> set(Args &&... args) {
         return {std::forward<Args>(args)...};
     }
-    
-    template<class ...Args>
-    internal::columns_t<Args...> columns(Args&& ...args) {
+
+    template<class... Args>
+    internal::columns_t<Args...> columns(Args &&... args) {
         return {std::make_tuple<Args...>(std::forward<Args>(args)...)};
     }
-    
+
     /**
      *  Use it like this:
      *  struct MyType : BaseType { ... };
@@ -304,15 +306,15 @@ namespace sqlite_orm {
     internal::column_pointer<T, F> column(F f) {
         return {f};
     }
-    
+
     /**
      *  Public function for subselect query. Is useful in UNION queries.
      */
-    template<class T, class ...Args>
-    internal::select_t<T, Args...> select(T t, Args ...args) {
+    template<class T, class... Args>
+    internal::select_t<T, Args...> select(T t, Args... args) {
         return {std::move(t), std::make_tuple<Args...>(std::forward<Args>(args)...)};
     }
-    
+
     /**
      *  Public function for UNION operator.
      *  lhs and rhs are subselect objects.
@@ -322,7 +324,7 @@ namespace sqlite_orm {
     internal::union_t<L, R> union_(L lhs, R rhs) {
         return {std::move(lhs), std::move(rhs)};
     }
-    
+
     /**
      *  Public function for EXCEPT operator.
      *  lhs and rhs are subselect objects.
@@ -332,12 +334,12 @@ namespace sqlite_orm {
     internal::except_t<L, R> except(L lhs, R rhs) {
         return {std::move(lhs), std::move(rhs)};
     }
-    
+
     template<class L, class R>
     internal::intersect_t<L, R> intersect(L lhs, R rhs) {
         return {std::move(lhs), std::move(rhs)};
     }
-    
+
     /**
      *  Public function for UNION ALL operator.
      *  lhs and rhs are subselect objects.
@@ -347,7 +349,7 @@ namespace sqlite_orm {
     internal::union_t<L, R> union_all(L lhs, R rhs) {
         return {std::move(lhs), std::move(rhs), true};
     }
-    
+
     template<class T>
     internal::asterisk_t<T> asterisk() {
         return {};

--- a/dev/sqlite_type.h
+++ b/dev/sqlite_type.h
@@ -1,16 +1,16 @@
 #pragma once
 
 #include <map>  //  std::map
-#include <string>   //  std::string
-#include <regex>    //  std::regex, std::regex_match
-#include <memory>   //  std::make_unique, std::unique_ptr
-#include <vector>   //  std::vector
-#include <cctype>   //  std::toupper
+#include <string>  //  std::string
+#include <regex>  //  std::regex, std::regex_match
+#include <memory>  //  std::make_unique, std::unique_ptr
+#include <vector>  //  std::vector
+#include <cctype>  //  std::toupper
 
 namespace sqlite_orm {
     using int64 = sqlite_int64;
     using uint64 = sqlite_uint64;
-    
+
     //  numeric and real are the same for c++
     enum class sqlite_type {
         INTEGER,
@@ -18,64 +18,68 @@ namespace sqlite_orm {
         BLOB,
         REAL,
     };
-    
+
     /**
      *  @param str case doesn't matter - it is uppercased before comparing.
      */
     inline std::unique_ptr<sqlite_type> to_sqlite_type(const std::string &str) {
-        auto asciiStringToUpper = [](std::string &s){
-            std::transform(s.begin(),
-                           s.end(),
-                           s.begin(),
-                           [](char c){
-                               return std::toupper(c);
-                           });
+        auto asciiStringToUpper = [](std::string &s) {
+            std::transform(s.begin(), s.end(), s.begin(), [](char c) {
+                return std::toupper(c);
+            });
         };
         auto upperStr = str;
         asciiStringToUpper(upperStr);
-        
+
         static std::map<sqlite_type, std::vector<std::regex>> typeMap = {
-            { sqlite_type::INTEGER, {
-                std::regex("INT"),
-                std::regex("INT.*"),
-                std::regex("TINYINT"),
-                std::regex("SMALLINT"),
-                std::regex("MEDIUMINT"),
-                std::regex("BIGINT"),
-                std::regex("UNSIGNED BIG INT"),
-                std::regex("INT2"),
-                std::regex("INT8"),
-            } }, { sqlite_type::TEXT, {
-                std::regex("CHARACTER\\([[:digit:]]+\\)"),
-                std::regex("VARCHAR\\([[:digit:]]+\\)"),
-                std::regex("VARYING CHARACTER\\([[:digit:]]+\\)"),
-                std::regex("NCHAR\\([[:digit:]]+\\)"),
-                std::regex("NATIVE CHARACTER\\([[:digit:]]+\\)"),
-                std::regex("NVARCHAR\\([[:digit:]]+\\)"),
-                std::regex("CLOB"),
-                std::regex("TEXT"),
-            } }, { sqlite_type::BLOB, {
-                std::regex("BLOB"),
-            } }, { sqlite_type::REAL, {
-                std::regex("REAL"),
-                std::regex("DOUBLE"),
-                std::regex("DOUBLE PRECISION"),
-                std::regex("FLOAT"),
-                std::regex("NUMERIC"),
-                std::regex("DECIMAL\\([[:digit:]]+,[[:digit:]]+\\)"),
-                std::regex("BOOLEAN"),
-                std::regex("DATE"),
-                std::regex("DATETIME"),
-            } },
+            {sqlite_type::INTEGER,
+             {
+                 std::regex("INT"),
+                 std::regex("INT.*"),
+                 std::regex("TINYINT"),
+                 std::regex("SMALLINT"),
+                 std::regex("MEDIUMINT"),
+                 std::regex("BIGINT"),
+                 std::regex("UNSIGNED BIG INT"),
+                 std::regex("INT2"),
+                 std::regex("INT8"),
+             }},
+            {sqlite_type::TEXT,
+             {
+                 std::regex("CHARACTER\\([[:digit:]]+\\)"),
+                 std::regex("VARCHAR\\([[:digit:]]+\\)"),
+                 std::regex("VARYING CHARACTER\\([[:digit:]]+\\)"),
+                 std::regex("NCHAR\\([[:digit:]]+\\)"),
+                 std::regex("NATIVE CHARACTER\\([[:digit:]]+\\)"),
+                 std::regex("NVARCHAR\\([[:digit:]]+\\)"),
+                 std::regex("CLOB"),
+                 std::regex("TEXT"),
+             }},
+            {sqlite_type::BLOB,
+             {
+                 std::regex("BLOB"),
+             }},
+            {sqlite_type::REAL,
+             {
+                 std::regex("REAL"),
+                 std::regex("DOUBLE"),
+                 std::regex("DOUBLE PRECISION"),
+                 std::regex("FLOAT"),
+                 std::regex("NUMERIC"),
+                 std::regex("DECIMAL\\([[:digit:]]+,[[:digit:]]+\\)"),
+                 std::regex("BOOLEAN"),
+                 std::regex("DATE"),
+                 std::regex("DATETIME"),
+             }},
         };
-        for(auto &p : typeMap) {
-            for(auto &r : p.second) {
-                if(std::regex_match(upperStr, r)){
+        for(auto &p: typeMap) {
+            for(auto &r: p.second) {
+                if(std::regex_match(upperStr, r)) {
                     return std::make_unique<sqlite_type>(p.first);
                 }
             }
         }
-        
+
         return {};
     }
 }

--- a/dev/start_macros.h
+++ b/dev/start_macros.h
@@ -1,17 +1,16 @@
 #pragma once
 
 #if defined(_MSC_VER)
-# if defined(min)
+#if defined(min)
 __pragma(push_macro("min"))
-# undef min
-# define __RESTORE_MIN__
-# endif
-# if defined(max)
-__pragma(push_macro("max"))
-# undef max
-# define __RESTORE_MAX__
-# endif
-#endif // defined(_MSC_VER)
+#undef min
+#define __RESTORE_MIN__
+#endif
+#if defined(max)
+    __pragma(push_macro("max"))
+#undef max
+#define __RESTORE_MAX__
+#endif
+#endif  // defined(_MSC_VER)
 
 #include <ciso646>  //  due to #166
-

--- a/dev/statement_binder.h
+++ b/dev/statement_binder.h
@@ -2,24 +2,24 @@
 
 #include <sqlite3.h>
 #include <type_traits>  //  std::enable_if_t, std::is_arithmetic, std::is_same, std::true_type, std::false_type
-#include <string>   //  std::string, std::wstring
+#include <string>  //  std::string, std::wstring
 #ifndef SQLITE_ORM_OMITS_CODECVT
 #include <codecvt>  //  std::wstring_convert, std::codecvt_utf8_utf16
 #endif  //  SQLITE_ORM_OMITS_CODECVT
-#include <vector>   //  std::vector
+#include <vector>  //  std::vector
 #include <cstddef>  //  std::nullptr_t
 #include <utility>  //  std::declval
 
 #include "is_std_ptr.h"
 
 namespace sqlite_orm {
-    
+
     /**
      *  Helper class used for binding fields to sqlite3 statements.
      */
     template<class V, typename Enable = void>
     struct statement_binder : std::false_type {};
-    
+
     /**
      *  Specialization for arithmetic types.
      */
@@ -28,49 +28,52 @@ namespace sqlite_orm {
         int bind(sqlite3_stmt *stmt, int index, const V &value) {
             return bind(stmt, index, value, tag());
         }
-        
-    private:
+
+      private:
         using tag = arithmetic_tag_t<V>;
-        
-        int bind(sqlite3_stmt *stmt, int index, const V &value, const int_or_smaller_tag&) {
+
+        int bind(sqlite3_stmt *stmt, int index, const V &value, const int_or_smaller_tag &) {
             return sqlite3_bind_int(stmt, index, static_cast<int>(value));
         }
-        
-        int bind(sqlite3_stmt *stmt, int index, const V &value, const bigint_tag&) {
+
+        int bind(sqlite3_stmt *stmt, int index, const V &value, const bigint_tag &) {
             return sqlite3_bind_int64(stmt, index, static_cast<sqlite3_int64>(value));
         }
-        
-        int bind(sqlite3_stmt *stmt, int index, const V &value, const real_tag&) {
+
+        int bind(sqlite3_stmt *stmt, int index, const V &value, const real_tag &) {
             return sqlite3_bind_double(stmt, index, static_cast<double>(value));
         }
     };
-    
-    
+
     /**
      *  Specialization for std::string and C-string.
      */
     template<class V>
-    struct statement_binder<V, std::enable_if_t<std::is_same<V, std::string>::value || std::is_same<V, const char*>::value>> {
+    struct statement_binder<
+        V,
+        std::enable_if_t<std::is_same<V, std::string>::value || std::is_same<V, const char *>::value>> {
         int bind(sqlite3_stmt *stmt, int index, const V &value) {
             return sqlite3_bind_text(stmt, index, string_data(value), -1, SQLITE_TRANSIENT);
         }
-        
-    private:
-        const char* string_data(const std::string& s) const {
+
+      private:
+        const char *string_data(const std::string &s) const {
             return s.c_str();
         }
-        
-        const char* string_data(const char* s) const{
+
+        const char *string_data(const char *s) const {
             return s;
         }
     };
-    
+
 #ifndef SQLITE_ORM_OMITS_CODECVT
     /**
      *  Specialization for std::wstring and C-wstring.
      */
     template<class V>
-    struct statement_binder<V, std::enable_if_t<std::is_same<V, std::wstring>::value || std::is_same<V, const wchar_t*>::value>> {
+    struct statement_binder<
+        V,
+        std::enable_if_t<std::is_same<V, std::wstring>::value || std::is_same<V, const wchar_t *>::value>> {
         int bind(sqlite3_stmt *stmt, int index, const V &value) {
             std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
             std::string utf8Str = converter.to_bytes(value);
@@ -78,7 +81,7 @@ namespace sqlite_orm {
         }
     };
 #endif  //  SQLITE_ORM_OMITS_CODECVT
-    
+
     /**
      *  Specialization for std::nullptr_t.
      */
@@ -88,66 +91,67 @@ namespace sqlite_orm {
             return sqlite3_bind_null(stmt, index);
         }
     };
-    
+
     template<class V>
     struct statement_binder<V, std::enable_if_t<is_std_ptr<V>::value>> {
         using value_type = typename V::element_type;
-        
+
         int bind(sqlite3_stmt *stmt, int index, const V &value) {
-            if(value){
+            if(value) {
                 return statement_binder<value_type>().bind(stmt, index, *value);
-            }else{
+            } else {
                 return statement_binder<std::nullptr_t>().bind(stmt, index, nullptr);
             }
         }
     };
-    
+
     /**
      *  Specialization for optional type (std::vector<char>).
      */
     template<>
     struct statement_binder<std::vector<char>, void> {
         int bind(sqlite3_stmt *stmt, int index, const std::vector<char> &value) {
-            if (value.size()) {
-                return sqlite3_bind_blob(stmt, index, (const void *)&value.front(), int(value.size()), SQLITE_TRANSIENT);
-            }else{
+            if(value.size()) {
+                return sqlite3_bind_blob(stmt,
+                                         index,
+                                         (const void *)&value.front(),
+                                         int(value.size()),
+                                         SQLITE_TRANSIENT);
+            } else {
                 return sqlite3_bind_blob(stmt, index, "", 0, SQLITE_TRANSIENT);
             }
         }
     };
-    
+
     namespace internal {
-        
+
         template<class T>
         using is_bindable = std::integral_constant<bool, !std::is_base_of<std::false_type, statement_binder<T>>::value>;
-        
+
         struct conditional_binder_base {
             sqlite3_stmt *stmt = nullptr;
             int &index;
-            
-            conditional_binder_base(decltype(stmt) stmt_, decltype(index) index_):
-            stmt(stmt_),
-            index(index_)
-            {}
+
+            conditional_binder_base(decltype(stmt) stmt_, decltype(index) index_) : stmt(stmt_), index(index_) {}
         };
-        
+
         template<class T, class C>
         struct conditional_binder;
-        
+
         template<class T>
         struct conditional_binder<T, std::true_type> : conditional_binder_base {
-            
+
             using conditional_binder_base::conditional_binder_base;
-            
+
             int operator()(const T &t) const {
                 return statement_binder<T>().bind(this->stmt, this->index++, t);
             }
         };
-        
+
         template<class T>
         struct conditional_binder<T, std::false_type> : conditional_binder_base {
             using conditional_binder_base::conditional_binder_base;
-            
+
             int operator()(const T &) const {
                 return SQLITE_OK;
             }

--- a/dev/statement_finalizer.h
+++ b/dev/statement_finalizer.h
@@ -3,15 +3,15 @@
 #include <sqlite3.h>
 
 namespace sqlite_orm {
-    
+
     /**
      *  Guard class which finalizes `sqlite3_stmt` in dtor
      */
     struct statement_finalizer {
         sqlite3_stmt *stmt = nullptr;
-        
-        statement_finalizer(decltype(stmt) stmt_): stmt(stmt_) {}
-        
+
+        statement_finalizer(decltype(stmt) stmt_) : stmt(stmt_) {}
+
         inline ~statement_finalizer() {
             sqlite3_finalize(this->stmt);
         }

--- a/dev/static_magic.h
+++ b/dev/static_magic.h
@@ -3,21 +3,30 @@
 #include <type_traits>  //  std::false_type, std::true_type, std::integral_constant
 
 namespace sqlite_orm {
-    
-    //  got from here https://stackoverflow.com/questions/37617677/implementing-a-compile-time-static-if-logic-for-different-string-types-in-a-co
+
+    //  got from here
+    //  https://stackoverflow.com/questions/37617677/implementing-a-compile-time-static-if-logic-for-different-string-types-in-a-co
     namespace internal {
-        
-        template <typename T, typename F>
-        auto static_if(std::true_type, T t, F) { return t; }
-        
-        template <typename T, typename F>
-        auto static_if(std::false_type, T, F f) { return f; }
-        
-        template <bool B, typename T, typename F>
-        auto static_if(T t, F f) { return static_if(std::integral_constant<bool, B>{}, t, f); }
-        
-        template <bool B, typename T>
-        auto static_if(T t) { return static_if(std::integral_constant<bool, B>{}, t, [](auto&&...){}); }
+
+        template<typename T, typename F>
+        auto static_if(std::true_type, T t, F) {
+            return t;
+        }
+
+        template<typename T, typename F>
+        auto static_if(std::false_type, T, F f) {
+            return f;
+        }
+
+        template<bool B, typename T, typename F>
+        auto static_if(T t, F f) {
+            return static_if(std::integral_constant<bool, B>{}, t, f);
+        }
+
+        template<bool B, typename T>
+        auto static_if(T t) {
+            return static_if(std::integral_constant<bool, B>{}, t, [](auto &&...) {});
+        }
     }
-    
+
 }

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -1,19 +1,19 @@
 #pragma once
 
-#include <memory>   //  std::unique/shared_ptr, std::make_unique/shared
-#include <string>   //  std::string
+#include <memory>  //  std::unique/shared_ptr, std::make_unique/shared
+#include <string>  //  std::string
 #include <sqlite3.h>
 #include <type_traits>  //  std::remove_reference, std::is_base_of, std::decay, std::false_type, std::true_type
 #include <cstddef>  //  std::ptrdiff_t
-#include <iterator> //  std::input_iterator_tag, std::iterator_traits, std::distance
-#include <functional>   //  std::function
+#include <iterator>  //  std::input_iterator_tag, std::iterator_traits, std::distance
+#include <functional>  //  std::function
 #include <sstream>  //  std::stringstream
 #include <map>  //  std::map
-#include <vector>   //  std::vector
-#include <tuple>    //  std::tuple_size, std::tuple, std::make_tuple
+#include <vector>  //  std::vector
+#include <tuple>  //  std::tuple_size, std::tuple, std::make_tuple
 #include <utility>  //  std::forward, std::pair
 #include <set>  //  std::set
-#include <algorithm>    //  std::find
+#include <algorithm>  //  std::find
 
 #include "alias.h"
 #include "row_extractor.h"
@@ -44,57 +44,53 @@
 #include "prepared_statement.h"
 
 namespace sqlite_orm {
-    
+
     namespace conditions {
-        
+
         template<class S>
         struct dynamic_order_by_t;
     }
-    
+
     namespace internal {
-        
+
         /**
-         *  Storage class itself. Create an instanse to use it as an interfacto to sqlite db by calling `make_storage` function.
+         *  Storage class itself. Create an instanse to use it as an interfacto to sqlite db by calling `make_storage`
+         * function.
          */
-        template<class ...Ts>
+        template<class... Ts>
         struct storage_t : storage_base {
             using self = storage_t<Ts...>;
             using impl_type = storage_impl<Ts...>;
             using storage_base::serialize_column_schema;
-            
+
             /**
              *  @param filename database filename.
              *  @param impl_ storage_impl head
              */
-            storage_t(const std::string &filename, impl_type impl_):
-            storage_base{filename, foreign_keys_count(impl_)},
-            impl(std::move(impl_))
-            {}
-            
-            storage_t(const storage_t &other):
-            storage_base(other),
-            impl(other.impl)
-            {}
-            
-        protected:
+            storage_t(const std::string &filename, impl_type impl_) :
+                storage_base{filename, foreign_keys_count(impl_)}, impl(std::move(impl_)) {}
+
+            storage_t(const storage_t &other) : storage_base(other), impl(other.impl) {}
+
+          protected:
             impl_type impl;
-            
-            template<class T, class S, class ...Args>
+
+            template<class T, class S, class... Args>
             friend struct view_t;
-            
+
             template<class S>
             friend struct conditions::dynamic_order_by_t;
-            
+
             template<class V>
             friend struct iterator_t;
-            
-            template<class ...Cs>
+
+            template<class... Cs>
             std::string serialize_column_schema(const constraints::primary_key_t<Cs...> &fk) {
                 std::stringstream ss;
                 ss << static_cast<std::string>(fk) << " (";
                 std::vector<std::string> columnNames;
                 columnNames.reserve(std::tuple_size<decltype(fk.columns)>::value);
-                iterate_tuple(fk.columns, [&columnNames, this](auto &c){
+                iterate_tuple(fk.columns, [&columnNames, this](auto &c) {
                     columnNames.push_back(this->impl.column_name(c));
                 });
                 for(size_t i = 0; i < columnNames.size(); ++i) {
@@ -106,23 +102,24 @@ namespace sqlite_orm {
                 ss << ") ";
                 return ss.str();
             }
-            
+
 #if SQLITE_VERSION_NUMBER >= 3006019
-            
-            template<class ...Cs, class ...Rs>
-            std::string serialize_column_schema(const constraints::foreign_key_t<std::tuple<Cs...>, std::tuple<Rs...>> &fk) {
+
+            template<class... Cs, class... Rs>
+            std::string
+            serialize_column_schema(const constraints::foreign_key_t<std::tuple<Cs...>, std::tuple<Rs...>> &fk) {
                 std::stringstream ss;
                 std::vector<std::string> columnNames;
                 using columns_type_t = typename std::decay<decltype(fk)>::type::columns_type;
                 constexpr const size_t columnsCount = std::tuple_size<columns_type_t>::value;
                 columnNames.reserve(columnsCount);
-                iterate_tuple(fk.columns, [&columnNames, this](auto &v){
+                iterate_tuple(fk.columns, [&columnNames, this](auto &v) {
                     columnNames.push_back(this->impl.column_name(v));
                 });
                 ss << "FOREIGN KEY( ";
                 for(size_t i = 0; i < columnNames.size(); ++i) {
                     ss << columnNames[i];
-                    if(i < columnNames.size() - 1){
+                    if(i < columnNames.size() - 1) {
                         ss << ",";
                     }
                     ss << " ";
@@ -138,35 +135,35 @@ namespace sqlite_orm {
                     auto refTableName = this->impl.template find_table_name<first_reference_mapped_type>();
                     ss << refTableName << " ";
                 }
-                iterate_tuple(fk.references, [&referencesNames, this](auto &v){
+                iterate_tuple(fk.references, [&referencesNames, this](auto &v) {
                     referencesNames.push_back(this->impl.column_name(v));
                 });
                 ss << "( ";
-                for(size_t i = 0; i < referencesNames.size(); ++i){
+                for(size_t i = 0; i < referencesNames.size(); ++i) {
                     ss << referencesNames[i];
-                    if(i < referencesNames.size() - 1){
+                    if(i < referencesNames.size() - 1) {
                         ss << ",";
                     }
                     ss << " ";
                 }
                 ss << ") ";
-                if(fk.on_update){
+                if(fk.on_update) {
                     ss << static_cast<std::string>(fk.on_update) << " " << fk.on_update._action << " ";
                 }
-                if(fk.on_delete){
+                if(fk.on_delete) {
                     ss << static_cast<std::string>(fk.on_delete) << " " << fk.on_delete._action << " ";
                 }
                 return ss.str();
             }
 #endif
-            
+
             template<class I>
             void create_table(sqlite3 *db, const std::string &tableName, I *impl) {
                 std::stringstream ss;
                 ss << "CREATE TABLE '" << tableName << "' ( ";
                 auto columnsCount = impl->table.columns_count;
                 auto index = 0;
-                impl->table.for_each_column_with_constraints([columnsCount, &index, &ss, this] (auto &c) {
+                impl->table.for_each_column_with_constraints([columnsCount, &index, &ss, this](auto &c) {
                     ss << this->serialize_column_schema(c);
                     if(index < columnsCount - 1) {
                         ss << ", ";
@@ -179,186 +176,192 @@ namespace sqlite_orm {
                 }
                 auto query = ss.str();
                 sqlite3_stmt *stmt;
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if (sqlite3_step(stmt) == SQLITE_DONE) {
+                    if(sqlite3_step(stmt) == SQLITE_DONE) {
                         //  done..
-                    }else{
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    } else {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
-                }else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             template<class I>
             void backup_table(sqlite3 *db, I *impl) {
-                
+
                 //  here we copy source table to another with a name with '_backup' suffix, but in case table with such
                 //  a name already exists we append suffix 1, then 2, etc until we find a free name..
                 auto backupTableName = impl->table.name + "_backup";
-                if(impl->table_exists(backupTableName, db)){
+                if(impl->table_exists(backupTableName, db)) {
                     int suffix = 1;
-                    do{
+                    do {
                         std::stringstream stream;
                         stream << suffix;
                         auto anotherBackupTableName = backupTableName + stream.str();
-                        if(!impl->table_exists(anotherBackupTableName, db)){
+                        if(!impl->table_exists(anotherBackupTableName, db)) {
                             backupTableName = anotherBackupTableName;
                             break;
                         }
                         ++suffix;
-                    }while(true);
+                    } while(true);
                 }
-                
+
                 this->create_table(db, backupTableName, impl);
-                
+
                 impl->copy_table(db, backupTableName);
-                
+
                 this->drop_table_internal(impl->table.name, db);
-                
+
                 impl->rename_table(db, backupTableName, impl->table.name);
             }
-            
+
             template<class O>
             void assert_mapped_type() const {
                 using mapped_types_tuples = std::tuple<typename Ts::object_type...>;
                 static_assert(tuple_helper::has_type<O, mapped_types_tuples>::value, "type is not mapped to a storage");
             }
-            
+
             template<class O>
-            auto& get_impl() const {
+            auto &get_impl() const {
                 return this->impl.template get_impl<O>();
             }
-            
+
             template<class T>
-            typename std::enable_if<is_bindable<T>::value, std::string>::type string_from_expression(const T &, bool) const {
+            typename std::enable_if<is_bindable<T>::value, std::string>::type string_from_expression(const T &,
+                                                                                                     bool) const {
                 return "?";
             }
-            
+
             std::string string_from_expression(std::nullptr_t, bool /*noTableName*/) const {
                 return "?";
             }
-            
+
             template<class T>
             std::string string_from_expression(const alias_holder<T> &, bool /*noTableName*/) const {
                 return T::get();
             }
-            
-            template<class R, class S, class ...Args>
-            std::string string_from_expression(const core_functions::core_function_t<R, S, Args...> &c, bool noTableName) const {
+
+            template<class R, class S, class... Args>
+            std::string string_from_expression(const core_functions::core_function_t<R, S, Args...> &c,
+                                               bool noTableName) const {
                 std::stringstream ss;
                 ss << static_cast<std::string>(c) << "(";
                 std::vector<std::string> args;
                 using args_type = typename std::decay<decltype(c)>::type::args_type;
                 args.reserve(std::tuple_size<args_type>::value);
-                iterate_tuple(c.args, [&args, this, noTableName](auto &v){
+                iterate_tuple(c.args, [&args, this, noTableName](auto &v) {
                     args.push_back(this->string_from_expression(v, noTableName));
                 });
-                for(size_t i = 0; i < args.size(); ++i){
+                for(size_t i = 0; i < args.size(); ++i) {
                     ss << args[i];
-                    if(i < args.size() - 1){
+                    if(i < args.size() - 1) {
                         ss << ", ";
                     }
                 }
                 ss << ")";
                 return ss.str();
             }
-            
+
             template<class T, class E>
             std::string string_from_expression(const as_t<T, E> &als, bool noTableName) const {
                 auto tableAliasString = alias_extractor<T>::get();
                 return this->string_from_expression(als.expression, noTableName) + " AS " + tableAliasString;
             }
-            
+
             template<class T, class C>
             std::string string_from_expression(const alias_column_t<T, C> &als, bool noTableName) const {
                 std::stringstream ss;
-                if(!noTableName){
+                if(!noTableName) {
                     ss << "'" << T::get() << "'.";
                 }
                 ss << this->string_from_expression(als.column, true);
                 return ss.str();
             }
-            
+
             std::string string_from_expression(const std::string &, bool /*noTableName*/) const {
                 return "?";
             }
-            
+
             std::string string_from_expression(const char *, bool /*noTableName*/) const {
                 return "?";
             }
-            
+
             template<class F, class O>
             std::string string_from_expression(F O::*m, bool noTableName) const {
                 std::stringstream ss;
-                if(!noTableName){
+                if(!noTableName) {
                     ss << "'" << this->impl.template find_table_name<O>() << "'.";
                 }
                 ss << "\"" << this->impl.column_name(m) << "\"";
                 return ss.str();
             }
-            
+
             std::string string_from_expression(const rowid_t &rid, bool /*noTableName*/) const {
                 return static_cast<std::string>(rid);
             }
-            
+
             std::string string_from_expression(const oid_t &rid, bool /*noTableName*/) const {
                 return static_cast<std::string>(rid);
             }
-            
+
             std::string string_from_expression(const _rowid_t &rid, bool /*noTableName*/) const {
                 return static_cast<std::string>(rid);
             }
-            
+
             template<class O>
             std::string string_from_expression(const table_rowid_t<O> &rid, bool noTableName) const {
                 std::stringstream ss;
-                if(!noTableName){
+                if(!noTableName) {
                     ss << "'" << this->impl.template find_table_name<O>() << "'.";
                 }
                 ss << static_cast<std::string>(rid);
                 return ss.str();
             }
-            
+
             template<class O>
             std::string string_from_expression(const table_oid_t<O> &rid, bool noTableName) const {
                 std::stringstream ss;
-                if(!noTableName){
+                if(!noTableName) {
                     ss << "'" << this->impl.template find_table_name<O>() << "'.";
                 }
                 ss << static_cast<std::string>(rid);
                 return ss.str();
             }
-            
+
             template<class O>
             std::string string_from_expression(const table__rowid_t<O> &rid, bool noTableName) const {
                 std::stringstream ss;
-                if(!noTableName){
+                if(!noTableName) {
                     ss << "'" << this->impl.template find_table_name<O>() << "'.";
                 }
                 ss << static_cast<std::string>(rid);
                 return ss.str();
             }
-            
+
             template<class T>
-            std::string string_from_expression(const aggregate_functions::group_concat_double_t<T> &f, bool noTableName) const {
+            std::string string_from_expression(const aggregate_functions::group_concat_double_t<T> &f,
+                                               bool noTableName) const {
                 std::stringstream ss;
                 auto expr = this->string_from_expression(f.t, noTableName);
                 auto expr2 = this->string_from_expression(f.y, noTableName);
                 ss << static_cast<std::string>(f) << "(" << expr << ", " << expr2 << ")";
                 return ss.str();
             }
-            
+
             template<class T>
-            std::string string_from_expression(const aggregate_functions::group_concat_single_t<T> &f, bool noTableName) const {
+            std::string string_from_expression(const aggregate_functions::group_concat_single_t<T> &f,
+                                               bool noTableName) const {
                 std::stringstream ss;
                 auto expr = this->string_from_expression(f.t, noTableName);
                 ss << static_cast<std::string>(f) << "(" << expr << ")";
                 return ss.str();
             }
-            
-            template<class L, class R, class ...Ds>
+
+            template<class L, class R, class... Ds>
             std::string string_from_expression(const binary_operator<L, R, Ds...> &f, bool noTableName) const {
                 std::stringstream ss;
                 auto lhs = this->string_from_expression(f.lhs, noTableName);
@@ -366,7 +369,7 @@ namespace sqlite_orm {
                 ss << "(" << lhs << " " << static_cast<std::string>(f) << " " << rhs << ")";
                 return ss.str();
             }
-            
+
             template<class T>
             std::string string_from_expression(const aggregate_functions::min_t<T> &f, bool noTableName) const {
                 std::stringstream ss;
@@ -374,7 +377,7 @@ namespace sqlite_orm {
                 ss << static_cast<std::string>(f) << "(" << expr << ")";
                 return ss.str();
             }
-            
+
             template<class T>
             std::string string_from_expression(const aggregate_functions::max_t<T> &f, bool noTableName) const {
                 std::stringstream ss;
@@ -382,7 +385,7 @@ namespace sqlite_orm {
                 ss << static_cast<std::string>(f) << "(" << expr << ")";
                 return ss.str();
             }
-            
+
             template<class T>
             std::string string_from_expression(const aggregate_functions::total_t<T> &f, bool noTableName) const {
                 std::stringstream ss;
@@ -390,7 +393,7 @@ namespace sqlite_orm {
                 ss << static_cast<std::string>(f) << "(" << expr << ")";
                 return ss.str();
             }
-            
+
             template<class T>
             std::string string_from_expression(const aggregate_functions::sum_t<T> &f, bool noTableName) const {
                 std::stringstream ss;
@@ -398,18 +401,20 @@ namespace sqlite_orm {
                 ss << static_cast<std::string>(f) << "(" << expr << ")";
                 return ss.str();
             }
-            
+
             template<class T>
-            std::string string_from_expression(const aggregate_functions::count_asterisk_t<T> &, bool noTableName) const {
+            std::string string_from_expression(const aggregate_functions::count_asterisk_t<T> &,
+                                               bool noTableName) const {
                 return this->string_from_expression(aggregate_functions::count_asterisk_without_type{}, noTableName);
             }
-            
-            std::string string_from_expression(const aggregate_functions::count_asterisk_without_type &f, bool /*noTableName*/) const {
+
+            std::string string_from_expression(const aggregate_functions::count_asterisk_without_type &f,
+                                               bool /*noTableName*/) const {
                 std::stringstream ss;
                 ss << static_cast<std::string>(f) << "(*)";
                 return ss.str();
             }
-            
+
             template<class T>
             std::string string_from_expression(const aggregate_functions::count_t<T> &f, bool noTableName) const {
                 std::stringstream ss;
@@ -417,7 +422,7 @@ namespace sqlite_orm {
                 ss << static_cast<std::string>(f) << "(" << expr << ")";
                 return ss.str();
             }
-            
+
             template<class T>
             std::string string_from_expression(const aggregate_functions::avg_t<T> &a, bool noTableName) const {
                 std::stringstream ss;
@@ -425,7 +430,7 @@ namespace sqlite_orm {
                 ss << static_cast<std::string>(a) << "(" << expr << ") ";
                 return ss.str();
             }
-            
+
             template<class T>
             std::string string_from_expression(const distinct_t<T> &f, bool noTableName) const {
                 std::stringstream ss;
@@ -433,7 +438,7 @@ namespace sqlite_orm {
                 ss << static_cast<std::string>(f) << "(" << expr << ") ";
                 return ss.str();
             }
-            
+
             template<class T>
             std::string string_from_expression(const all_t<T> &f, bool noTableName) const {
                 std::stringstream ss;
@@ -441,58 +446,58 @@ namespace sqlite_orm {
                 ss << static_cast<std::string>(f) << "(" << expr << ") ";
                 return ss.str();
             }
-            
+
             template<class T, class F>
             std::string string_from_expression(const column_pointer<T, F> &c, bool noTableName) const {
                 std::stringstream ss;
-                if(!noTableName){
+                if(!noTableName) {
                     ss << "'" << this->impl.template find_table_name<T>() << "'.";
                 }
                 auto &impl = this->get_impl<T>();
                 ss << "\"" << impl.column_name_simple(c.field) << "\"";
                 return ss.str();
             }
-            
+
             template<class T>
             std::vector<std::string> get_column_names(const T &t) const {
                 auto columnName = this->string_from_expression(t, false);
-                if(columnName.length()){
+                if(columnName.length()) {
                     return {columnName};
-                }else{
+                } else {
                     throw std::system_error(std::make_error_code(orm_error_code::column_not_found));
                 }
             }
-            
+
             template<class T>
             std::vector<std::string> get_column_names(const internal::asterisk_t<T> &) const {
                 std::vector<std::string> res;
                 res.push_back("*");
                 return res;
             }
-            
-            template<class ...Args>
+
+            template<class... Args>
             std::vector<std::string> get_column_names(const internal::columns_t<Args...> &cols) const {
                 std::vector<std::string> columnNames;
                 columnNames.reserve(static_cast<size_t>(cols.count));
-                iterate_tuple(cols.columns, [&columnNames, this](auto &m){
+                iterate_tuple(cols.columns, [&columnNames, this](auto &m) {
                     auto columnName = this->string_from_expression(m, false);
-                    if(columnName.length()){
+                    if(columnName.length()) {
                         columnNames.push_back(columnName);
-                    }else{
+                    } else {
                         throw std::system_error(std::make_error_code(orm_error_code::column_not_found));
                     }
                 });
                 return columnNames;
             }
-            
+
             /**
              *  Takes select_t object and returns SELECT query string
              */
-            template<class T, class ...Args>
+            template<class T, class... Args>
             std::string string_from_expression(const internal::select_t<T, Args...> &sel, bool /*noTableName*/) const {
                 std::stringstream ss;
-                if(!is_base_of_template<T, compound_operator>::value){
-                    if(!sel.highest_level){
+                if(!is_base_of_template<T, compound_operator>::value) {
+                    if(!sel.highest_level) {
                         ss << "( ";
                     }
                     ss << "SELECT ";
@@ -509,21 +514,23 @@ namespace sqlite_orm {
                     ss << " ";
                 }
                 auto tableNamesSet = this->parse_table_name(sel.col);
-                internal::join_iterator<Args...>()([&tableNamesSet, this](const auto &c){
+                internal::join_iterator<Args...>()([&tableNamesSet, this](const auto &c) {
                     using original_join_type = typename std::decay<decltype(c)>::type::join_type::type;
                     using cross_join_type = typename internal::mapped_type_proxy<original_join_type>::type;
                     auto crossJoinedTableName = this->impl.template find_table_name<cross_join_type>();
                     auto tableAliasString = alias_extractor<original_join_type>::get();
-                    std::pair<std::string, std::string> tableNameWithAlias(std::move(crossJoinedTableName), std::move(tableAliasString));
+                    std::pair<std::string, std::string> tableNameWithAlias(std::move(crossJoinedTableName),
+                                                                           std::move(tableAliasString));
                     tableNamesSet.erase(tableNameWithAlias);
                 });
-                if(!tableNamesSet.empty()){
+                if(!tableNamesSet.empty()) {
                     ss << "FROM ";
-                    std::vector<std::pair<std::string, std::string>> tableNames(tableNamesSet.begin(), tableNamesSet.end());
+                    std::vector<std::pair<std::string, std::string>> tableNames(tableNamesSet.begin(),
+                                                                                tableNamesSet.end());
                     for(size_t i = 0; i < tableNames.size(); ++i) {
                         auto &tableNamePair = tableNames[i];
                         ss << "'" << tableNamePair.first << "' ";
-                        if(!tableNamePair.second.empty()){
+                        if(!tableNamePair.second.empty()) {
                             ss << tableNamePair.second << " ";
                         }
                         if(int(i) < int(tableNames.size()) - 1) {
@@ -532,33 +539,29 @@ namespace sqlite_orm {
                         ss << " ";
                     }
                 }
-                iterate_tuple(sel.conditions, [&ss, this](auto &v){
+                iterate_tuple(sel.conditions, [&ss, this](auto &v) {
                     this->process_single_condition(ss, v);
                 });
-                if(!is_base_of_template<T, compound_operator>::value){
-                    if(!sel.highest_level){
+                if(!is_base_of_template<T, compound_operator>::value) {
+                    if(!sel.highest_level) {
                         ss << ") ";
                     }
                 }
                 return ss.str();
             }
-            
-            template<class T, class ...Args>
+
+            template<class T, class... Args>
             std::string string_from_expression(const get_all_t<T, Args...> &get, bool /*noTableName*/) const {
                 std::stringstream ss;
                 ss << "SELECT ";
                 auto &impl = this->get_impl<T>();
                 auto columnNames = impl.table.column_names();
                 for(size_t i = 0; i < columnNames.size(); ++i) {
-                    ss
-                    << "\"" << impl.table.name << "\"."
-                    << "\""
-                    << columnNames[i]
-                    << "\""
-                    ;
+                    ss << "\"" << impl.table.name << "\"."
+                       << "\"" << columnNames[i] << "\"";
                     if(i < columnNames.size() - 1) {
                         ss << ", ";
-                    }else{
+                    } else {
                         ss << " ";
                     }
                 }
@@ -567,22 +570,18 @@ namespace sqlite_orm {
                 return ss.str();
             }
 
-            template<class T, class ...Args>
+            template<class T, class... Args>
             std::string string_from_expression(const get_all_pointer_t<T, Args...> &get, bool /*noTableName*/) const {
                 std::stringstream ss;
                 ss << "SELECT ";
                 auto &impl = this->get_impl<T>();
                 auto columnNames = impl.table.column_names();
                 for(size_t i = 0; i < columnNames.size(); ++i) {
-                    ss
-                            << "\"" << impl.table.name << "\"."
-                            << "\""
-                            << columnNames[i]
-                            << "\""
-                            ;
+                    ss << "\"" << impl.table.name << "\"."
+                       << "\"" << columnNames[i] << "\"";
                     if(i < columnNames.size() - 1) {
                         ss << ", ";
-                    }else{
+                    } else {
                         ss << " ";
                     }
                 }
@@ -590,9 +589,10 @@ namespace sqlite_orm {
                 this->process_conditions(ss, get.conditions);
                 return ss.str();
             }
-            
-            template<class ...Args, class ...Wargs>
-            std::string string_from_expression(const update_all_t<set_t<Args...>, Wargs...> &upd, bool /*noTableName*/) const {
+
+            template<class... Args, class... Wargs>
+            std::string string_from_expression(const update_all_t<set_t<Args...>, Wargs...> &upd,
+                                               bool /*noTableName*/) const {
                 std::stringstream ss;
                 ss << "UPDATE ";
                 std::set<std::pair<std::string, std::string>> tableNamesSet;
@@ -600,12 +600,12 @@ namespace sqlite_orm {
                     auto tableName = this->parse_table_name(asgn.lhs);
                     tableNamesSet.insert(tableName.begin(), tableName.end());
                 });
-                if(!tableNamesSet.empty()){
-                    if(tableNamesSet.size() == 1){
+                if(!tableNamesSet.empty()) {
+                    if(tableNamesSet.size() == 1) {
                         ss << " '" << tableNamesSet.begin()->first << "' ";
                         ss << static_cast<std::string>(upd.set) << " ";
                         std::vector<std::string> setPairs;
-                        upd.set.for_each([this, &setPairs](auto &asgn){
+                        upd.set.for_each([this, &setPairs](auto &asgn) {
                             std::stringstream sss;
                             sss << this->string_from_expression(asgn.lhs, true);
                             sss << " " << static_cast<std::string>(asgn) << " ";
@@ -621,15 +621,15 @@ namespace sqlite_orm {
                         }
                         this->process_conditions(ss, upd.conditions);
                         return ss.str();
-                    }else{
+                    } else {
                         throw std::system_error(std::make_error_code(orm_error_code::too_many_tables_specified));
                     }
-                }else{
+                } else {
                     throw std::system_error(std::make_error_code(orm_error_code::incorrect_set_fields_specified));
                 }
             }
-            
-            template<class T, class ...Args>
+
+            template<class T, class... Args>
             std::string string_from_expression(const remove_all_t<T, Args...> &rem, bool /*noTableName*/) const {
                 auto &impl = this->get_impl<T>();
                 std::stringstream ss;
@@ -637,8 +637,8 @@ namespace sqlite_orm {
                 this->process_conditions(ss, rem.conditions);
                 return ss.str();
             }
-            
-            template<class T, class ...Ids>
+
+            template<class T, class... Ids>
             std::string string_from_expression(const get_t<T, Ids...> &g, bool /*noTableName*/) const {
                 auto &impl = this->get_impl<T>();
                 std::stringstream ss;
@@ -653,21 +653,22 @@ namespace sqlite_orm {
                 }
                 ss << "FROM '" << impl.table.name << "' WHERE ";
                 auto primaryKeyColumnNames = impl.table.primary_key_column_names();
-                if(!primaryKeyColumnNames.empty()){
+                if(!primaryKeyColumnNames.empty()) {
                     for(size_t i = 0; i < primaryKeyColumnNames.size(); ++i) {
-                        ss << "\"" << primaryKeyColumnNames[i] << "\"" << " = ? ";
+                        ss << "\"" << primaryKeyColumnNames[i] << "\""
+                           << " = ? ";
                         if(i < primaryKeyColumnNames.size() - 1) {
                             ss << "AND ";
                         }
                         ss << ' ';
                     }
                     return ss.str();
-                }else{
+                } else {
                     throw std::system_error(std::make_error_code(orm_error_code::table_has_no_primary_key_column));
                 }
             }
-            
-            template<class T, class ...Ids>
+
+            template<class T, class... Ids>
             std::string string_from_expression(const get_pointer_t<T, Ids...> &g, bool /*noTableName*/) const {
                 auto &impl = this->get_impl<T>();
                 std::stringstream ss;
@@ -682,20 +683,21 @@ namespace sqlite_orm {
                 }
                 ss << "FROM '" << impl.table.name << "' WHERE ";
                 auto primaryKeyColumnNames = impl.table.primary_key_column_names();
-                if(!primaryKeyColumnNames.empty()){
+                if(!primaryKeyColumnNames.empty()) {
                     for(size_t i = 0; i < primaryKeyColumnNames.size(); ++i) {
-                        ss << "\"" << primaryKeyColumnNames[i] << "\"" << " = ? ";
+                        ss << "\"" << primaryKeyColumnNames[i] << "\""
+                           << " = ? ";
                         if(i < primaryKeyColumnNames.size() - 1) {
                             ss << "AND ";
                         }
                         ss << ' ';
                     }
                     return ss.str();
-                }else{
+                } else {
                     throw std::system_error(std::make_error_code(orm_error_code::table_has_no_primary_key_column));
                 }
             }
-            
+
             template<class T, bool by_ref>
             std::string string_from_expression(const update_t<T, by_ref> &upd, bool /*noTableName*/) const {
                 auto &impl = this->get_impl<T>();
@@ -708,7 +710,8 @@ namespace sqlite_orm {
                     }
                 });
                 for(size_t i = 0; i < setColumnNames.size(); ++i) {
-                    ss << "\"" << setColumnNames[i] << "\"" << " = ?";
+                    ss << "\"" << setColumnNames[i] << "\""
+                       << " = ?";
                     if(i < setColumnNames.size() - 1) {
                         ss << ",";
                     }
@@ -717,7 +720,8 @@ namespace sqlite_orm {
                 ss << "WHERE ";
                 auto primaryKeyColumnNames = impl.table.primary_key_column_names();
                 for(size_t i = 0; i < primaryKeyColumnNames.size(); ++i) {
-                    ss << "\"" << primaryKeyColumnNames[i] << "\"" << " = ?";
+                    ss << "\"" << primaryKeyColumnNames[i] << "\""
+                       << " = ?";
                     if(i < primaryKeyColumnNames.size() - 1) {
                         ss << " AND";
                     }
@@ -725,8 +729,8 @@ namespace sqlite_orm {
                 }
                 return ss.str();
             }
-            
-            template<class T, class ...Ids>
+
+            template<class T, class... Ids>
             std::string string_from_expression(const remove_t<T, Ids...> &rem, bool /*noTableName*/) const {
                 auto &impl = this->get_impl<T>();
                 std::stringstream ss;
@@ -734,16 +738,18 @@ namespace sqlite_orm {
                 ss << "WHERE ";
                 auto primaryKeyColumnNames = impl.table.primary_key_column_names();
                 for(size_t i = 0; i < primaryKeyColumnNames.size(); ++i) {
-                    ss << "\"" << primaryKeyColumnNames[i] << "\"" << " = ? ";
+                    ss << "\"" << primaryKeyColumnNames[i] << "\""
+                       << " = ? ";
                     if(i < primaryKeyColumnNames.size() - 1) {
                         ss << "AND ";
                     }
                 }
                 return ss.str();
             }
-            
-            template<class T, bool by_ref, class ...Cols>
-            std::string string_from_expression(const insert_explicit<T, by_ref, Cols...> &ins, bool /*noTableName*/) const {
+
+            template<class T, bool by_ref, class... Cols>
+            std::string string_from_expression(const insert_explicit<T, by_ref, Cols...> &ins,
+                                               bool /*noTableName*/) const {
                 constexpr const size_t colsCount = std::tuple_size<std::tuple<Cols...>>::value;
                 static_assert(colsCount > 0, "Use insert or replace with 1 argument instead");
                 this->assert_mapped_type<T>();
@@ -752,37 +758,37 @@ namespace sqlite_orm {
                 ss << "INSERT INTO '" << impl.table.name << "' ";
                 std::vector<std::string> columnNames;
                 columnNames.reserve(colsCount);
-                iterate_tuple(ins.columns.columns, [&columnNames, this](auto &m){
+                iterate_tuple(ins.columns.columns, [&columnNames, this](auto &m) {
                     auto columnName = this->string_from_expression(m, true);
-                    if(!columnName.empty()){
+                    if(!columnName.empty()) {
                         columnNames.push_back(columnName);
-                    }else{
+                    } else {
                         throw std::system_error(std::make_error_code(orm_error_code::column_not_found));
                     }
                 });
                 ss << "(";
-                for(size_t i = 0; i < columnNames.size(); ++i){
+                for(size_t i = 0; i < columnNames.size(); ++i) {
                     ss << columnNames[i];
-                    if(i < columnNames.size() - 1){
+                    if(i < columnNames.size() - 1) {
                         ss << ",";
-                    }else{
+                    } else {
                         ss << ")";
                     }
                     ss << " ";
                 }
                 ss << "VALUES (";
-                for(size_t i = 0; i < columnNames.size(); ++i){
+                for(size_t i = 0; i < columnNames.size(); ++i) {
                     ss << "?";
-                    if(i < columnNames.size() - 1){
+                    if(i < columnNames.size() - 1) {
                         ss << ",";
-                    }else{
+                    } else {
                         ss << ")";
                     }
                     ss << " ";
                 }
                 return ss.str();
             }
-            
+
             template<class T, bool by_ref>
             std::string string_from_expression(const insert_t<T, by_ref> &ins, bool /*noTableName*/) const {
                 auto &impl = this->get_impl<T>();
@@ -790,48 +796,46 @@ namespace sqlite_orm {
                 ss << "INSERT INTO '" << impl.table.name << "' ";
                 std::vector<std::string> columnNames;
                 auto compositeKeyColumnNames = impl.table.composite_key_columns_names();
-                
-                impl.table.for_each_column([&impl, &columnNames, &compositeKeyColumnNames] (auto &c) {
+
+                impl.table.for_each_column([&impl, &columnNames, &compositeKeyColumnNames](auto &c) {
                     if(impl.table._without_rowid || !c.template has<constraints::primary_key_t<>>()) {
-                        auto it = std::find(compositeKeyColumnNames.begin(),
-                                            compositeKeyColumnNames.end(),
-                                            c.name);
-                        if(it == compositeKeyColumnNames.end()){
+                        auto it = std::find(compositeKeyColumnNames.begin(), compositeKeyColumnNames.end(), c.name);
+                        if(it == compositeKeyColumnNames.end()) {
                             columnNames.emplace_back(c.name);
                         }
                     }
                 });
-                
+
                 auto columnNamesCount = columnNames.size();
-                if(columnNamesCount){
+                if(columnNamesCount) {
                     ss << "( ";
                     for(size_t i = 0; i < columnNamesCount; ++i) {
                         ss << "\"" << columnNames[i] << "\"";
                         if(i < columnNamesCount - 1) {
                             ss << ",";
-                        }else{
+                        } else {
                             ss << ")";
                         }
                         ss << " ";
                     }
-                }else{
+                } else {
                     ss << "DEFAULT ";
                 }
                 ss << "VALUES ";
-                if(columnNamesCount){
+                if(columnNamesCount) {
                     ss << "( ";
                     for(size_t i = 0; i < columnNamesCount; ++i) {
                         ss << "?";
                         if(i < columnNamesCount - 1) {
                             ss << ", ";
-                        }else{
+                        } else {
                             ss << ")";
                         }
                     }
                 }
                 return ss.str();
             }
-            
+
             template<class T, bool by_ref>
             std::string string_from_expression(const replace_t<T, by_ref> &rep, bool /*noTableName*/) const {
                 auto &impl = this->get_impl<T>();
@@ -843,7 +847,7 @@ namespace sqlite_orm {
                     ss << "\"" << columnNames[i] << "\"";
                     if(i < columnNamesCount - 1) {
                         ss << ",";
-                    }else{
+                    } else {
                         ss << ")";
                     }
                     ss << " ";
@@ -853,13 +857,13 @@ namespace sqlite_orm {
                     ss << "?";
                     if(i < columnNamesCount - 1) {
                         ss << ", ";
-                    }else{
+                    } else {
                         ss << ")";
                     }
                 }
                 return ss.str();
             }
-            
+
             template<class It>
             std::string string_from_expression(const replace_range_t<It> &rep, bool /*noTableName*/) const {
                 using expression_type = typename std::decay<decltype(rep)>::type;
@@ -873,19 +877,19 @@ namespace sqlite_orm {
                     ss << "\"" << columnNames[i] << "\"";
                     if(i < columnNamesCount - 1) {
                         ss << ", ";
-                    }else{
+                    } else {
                         ss << ") ";
                     }
                 }
                 ss << "VALUES ";
-                auto valuesString = [columnNamesCount]{
+                auto valuesString = [columnNamesCount] {
                     std::stringstream ss;
                     ss << "(";
                     for(size_t i = 0; i < columnNamesCount; ++i) {
                         ss << "?";
                         if(i < columnNamesCount - 1) {
                             ss << ", ";
-                        }else{
+                        } else {
                             ss << ")";
                         }
                     }
@@ -901,41 +905,41 @@ namespace sqlite_orm {
                 }
                 return ss.str();
             }
-            
+
             template<class It>
             std::string string_from_expression(const insert_range_t<It> &ins, bool /*noTableName*/) const {
                 using expression_type = typename std::decay<decltype(ins)>::type;
                 using object_type = typename expression_type::object_type;
                 auto &impl = this->get_impl<object_type>();
-                
+
                 std::stringstream ss;
                 ss << "INSERT INTO '" << impl.table.name << "' (";
                 std::vector<std::string> columnNames;
-                impl.table.for_each_column([&columnNames] (auto &c) {
+                impl.table.for_each_column([&columnNames](auto &c) {
                     if(!c.template has<constraints::primary_key_t<>>()) {
                         columnNames.emplace_back(c.name);
                     }
                 });
-                
+
                 auto columnNamesCount = columnNames.size();
                 for(size_t i = 0; i < columnNamesCount; ++i) {
                     ss << "\"" << columnNames[i] << "\"";
                     if(i < columnNamesCount - 1) {
                         ss << ",";
-                    }else{
+                    } else {
                         ss << ")";
                     }
                     ss << " ";
                 }
                 ss << "VALUES ";
-                auto valuesString = [columnNamesCount]{
+                auto valuesString = [columnNamesCount] {
                     std::stringstream ss;
                     ss << "(";
                     for(size_t i = 0; i < columnNamesCount; ++i) {
                         ss << "?";
                         if(i < columnNamesCount - 1) {
                             ss << ", ";
-                        }else{
+                        } else {
                             ss << ")";
                         }
                     }
@@ -951,57 +955,59 @@ namespace sqlite_orm {
                 }
                 return ss.str();
             }
-            
+
             template<class T, class E>
             std::string string_from_expression(const conditions::cast_t<T, E> &c, bool noTableName) const {
                 std::stringstream ss;
                 ss << static_cast<std::string>(c) << " (";
-                ss << this->string_from_expression(c.expression, noTableName) << " AS " << type_printer<T>().print() << ")";
+                ss << this->string_from_expression(c.expression, noTableName) << " AS " << type_printer<T>().print()
+                   << ")";
                 return ss.str();
             }
-            
+
             template<class T>
-            typename std::enable_if<is_base_of_template<T, compound_operator>::value, std::string>::type string_from_expression(const T &op, bool noTableName) const
-            {
+            typename std::enable_if<is_base_of_template<T, compound_operator>::value, std::string>::type
+            string_from_expression(const T &op, bool noTableName) const {
                 std::stringstream ss;
                 ss << this->string_from_expression(op.left, noTableName) << " ";
                 ss << static_cast<std::string>(op) << " ";
                 ss << this->string_from_expression(op.right, noTableName);
                 return ss.str();
             }
-            
-            template<class R, class T, class E, class ...Args>
-            std::string string_from_expression(const internal::simple_case_t<R, T, E, Args...> &c, bool noTableName) const {
+
+            template<class R, class T, class E, class... Args>
+            std::string string_from_expression(const internal::simple_case_t<R, T, E, Args...> &c,
+                                               bool noTableName) const {
                 std::stringstream ss;
                 ss << "CASE ";
-                c.case_expression.apply([&ss, this, noTableName](auto &c){
+                c.case_expression.apply([&ss, this, noTableName](auto &c) {
                     ss << this->string_from_expression(c, noTableName) << " ";
                 });
-                iterate_tuple(c.args, [&ss, this, noTableName](auto &pair){
+                iterate_tuple(c.args, [&ss, this, noTableName](auto &pair) {
                     ss << "WHEN " << this->string_from_expression(pair.first, noTableName) << " ";
                     ss << "THEN " << this->string_from_expression(pair.second, noTableName) << " ";
                 });
-                c.else_expression.apply([&ss, this, noTableName](auto &el){
+                c.else_expression.apply([&ss, this, noTableName](auto &el) {
                     ss << "ELSE " << this->string_from_expression(el, noTableName) << " ";
                 });
                 ss << "END";
                 return ss.str();
             }
-             
+
             template<class T>
             std::string string_from_expression(const conditions::is_null_t<T> &c, bool noTableName) const {
                 std::stringstream ss;
                 ss << this->string_from_expression(c.t, noTableName) << " " << static_cast<std::string>(c) << " ";
                 return ss.str();
             }
-            
+
             template<class T>
             std::string string_from_expression(const conditions::is_not_null_t<T> &c, bool noTableName) const {
                 std::stringstream ss;
                 ss << this->string_from_expression(c.t, noTableName) << " " << static_cast<std::string>(c) << " ";
                 return ss.str();
             }
-            
+
             template<class C>
             std::string string_from_expression(const conditions::negated_condition_t<C> &c, bool noTableName) const {
                 std::stringstream ss;
@@ -1010,7 +1016,7 @@ namespace sqlite_orm {
                 ss << " (" << cString << " ) ";
                 return ss.str();
             }
-            
+
             template<class L, class R>
             std::string string_from_expression(const conditions::is_equal_t<L, R> &c, bool noTableName) const {
                 auto leftString = this->string_from_expression(c.l, noTableName);
@@ -1019,28 +1025,29 @@ namespace sqlite_orm {
                 ss << leftString << " " << static_cast<std::string>(c) << " " << rightString;
                 return ss.str();
             }
-            
+
             template<class C>
-            typename std::enable_if<is_base_of_template<C, conditions::binary_condition>::value, std::string>::type string_from_expression(const C &c, bool noTableName) const {
+            typename std::enable_if<is_base_of_template<C, conditions::binary_condition>::value, std::string>::type
+            string_from_expression(const C &c, bool noTableName) const {
                 auto leftString = this->string_from_expression(c.l, noTableName);
                 auto rightString = this->string_from_expression(c.r, noTableName);
                 std::stringstream ss;
                 ss << "(" << leftString << " " << static_cast<std::string>(c) << " " << rightString << ")";
                 return ss.str();
             }
-            
+
             template<class T>
             std::string string_from_expression(const conditions::named_collate<T> &col, bool noTableName) const {
                 auto res = this->string_from_expression(col.expr, noTableName);
                 return res + " " + static_cast<std::string>(col);
             }
-            
+
             template<class T>
             std::string string_from_expression(const conditions::collate_t<T> &col, bool noTableName) const {
                 auto res = this->string_from_expression(col.expr, noTableName);
                 return res + " " + static_cast<std::string>(col);
             }
-            
+
             template<class L, class A>
             std::string string_from_expression(const conditions::in_t<L, A> &inCondition, bool noTableName) const {
                 std::stringstream ss;
@@ -1049,9 +1056,10 @@ namespace sqlite_orm {
                 ss << this->string_from_expression(inCondition.arg, noTableName);
                 return ss.str();
             }
-            
+
             template<class L, class E>
-            std::string string_from_expression(const conditions::in_t<L, std::vector<E>> &inCondition, bool noTableName) const {
+            std::string string_from_expression(const conditions::in_t<L, std::vector<E>> &inCondition,
+                                               bool noTableName) const {
                 std::stringstream ss;
                 auto leftString = this->string_from_expression(inCondition.l, noTableName);
                 ss << leftString << " " << static_cast<std::string>(inCondition) << " ( ";
@@ -1065,19 +1073,19 @@ namespace sqlite_orm {
                 ss << " )";
                 return ss.str();
             }
-            
+
             template<class A, class T, class E>
             std::string string_from_expression(const conditions::like_t<A, T, E> &l, bool noTableName) const {
                 std::stringstream ss;
                 ss << this->string_from_expression(l.arg, noTableName) << " ";
                 ss << static_cast<std::string>(l) << " ";
                 ss << this->string_from_expression(l.pattern, noTableName);
-                l.arg3.apply([&ss, this, noTableName](auto &value){
+                l.arg3.apply([&ss, this, noTableName](auto &value) {
                     ss << " ESCAPE " << this->string_from_expression(value, noTableName);
                 });
                 return ss.str();
             }
-            
+
             template<class A, class T>
             std::string string_from_expression(const conditions::glob_t<A, T> &l, bool noTableName) const {
                 std::stringstream ss;
@@ -1086,7 +1094,7 @@ namespace sqlite_orm {
                 ss << this->string_from_expression(l.pattern, noTableName);
                 return ss.str();
             }
-            
+
             template<class A, class T>
             std::string string_from_expression(const conditions::between_t<A, T> &bw, bool noTableName) const {
                 std::stringstream ss;
@@ -1097,7 +1105,7 @@ namespace sqlite_orm {
                 ss << this->string_from_expression(bw.b2, noTableName);
                 return ss.str();
             }
-            
+
             template<class T>
             std::string string_from_expression(const conditions::exists_t<T> &e, bool noTableName) const {
                 std::stringstream ss;
@@ -1105,16 +1113,16 @@ namespace sqlite_orm {
                 ss << this->string_from_expression(e.t, noTableName);
                 return ss.str();
             }
-            
+
             template<class O>
             std::string process_order_by(const conditions::order_by_t<O> &orderBy) const {
                 std::stringstream ss;
                 auto columnName = this->string_from_expression(orderBy.o, false);
                 ss << columnName << " ";
-                if(orderBy._collate_argument.length()){
+                if(orderBy._collate_argument.length()) {
                     ss << "COLLATE " << orderBy._collate_argument << " ";
                 }
-                switch(orderBy.asc_desc){
+                switch(orderBy.asc_desc) {
                     case 1:
                         ss << "ASC";
                         break;
@@ -1124,92 +1132,93 @@ namespace sqlite_orm {
                 }
                 return ss.str();
             }
-            
+
             template<class T>
             void process_join_constraint(std::stringstream &ss, const conditions::on_t<T> &t) const {
                 ss << static_cast<std::string>(t) << " " << this->string_from_expression(t.arg, false);
             }
-            
+
             template<class F, class O>
             void process_join_constraint(std::stringstream &ss, const conditions::using_t<F, O> &u) const {
                 ss << static_cast<std::string>(u) << " (" << this->string_from_expression(u.column, true) << " )";
             }
-            
+
             void process_single_condition(std::stringstream &ss, const conditions::limit_t &limt) const {
                 ss << static_cast<std::string>(limt) << " ";
                 if(limt.has_offset) {
-                    if(limt.offset_is_implicit){
+                    if(limt.offset_is_implicit) {
                         ss << limt.off << ", " << limt.lim;
-                    }else{
+                    } else {
                         ss << limt.lim << " OFFSET " << limt.off;
                     }
-                }else{
+                } else {
                     ss << limt.lim;
                 }
             }
-            
+
             template<class O>
             void process_single_condition(std::stringstream &ss, const conditions::cross_join_t<O> &c) const {
                 ss << static_cast<std::string>(c) << " ";
                 ss << " '" << this->impl.template find_table_name<O>() << "'";
             }
-            
+
             template<class O>
             void process_single_condition(std::stringstream &ss, const conditions::natural_join_t<O> &c) const {
                 ss << static_cast<std::string>(c) << " ";
                 ss << " '" << this->impl.template find_table_name<O>() << "'";
             }
-            
+
             template<class T, class O>
             void process_single_condition(std::stringstream &ss, const conditions::inner_join_t<T, O> &l) const {
                 ss << static_cast<std::string>(l) << " ";
                 auto aliasString = alias_extractor<T>::get();
                 ss << " '" << this->impl.template find_table_name<typename mapped_type_proxy<T>::type>() << "' ";
-                if(aliasString.length()){
+                if(aliasString.length()) {
                     ss << "'" << aliasString << "' ";
                 }
                 this->process_join_constraint(ss, l.constraint);
             }
-            
+
             template<class T, class O>
             void process_single_condition(std::stringstream &ss, const conditions::left_outer_join_t<T, O> &l) const {
                 ss << static_cast<std::string>(l) << " ";
                 ss << " '" << this->impl.template find_table_name<T>() << "' ";
                 this->process_join_constraint(ss, l.constraint);
             }
-            
+
             template<class T, class O>
             void process_single_condition(std::stringstream &ss, const conditions::left_join_t<T, O> &l) const {
                 ss << static_cast<std::string>(l) << " ";
                 ss << " '" << this->impl.template find_table_name<T>() << "' ";
                 this->process_join_constraint(ss, l.constraint);
             }
-            
+
             template<class T, class O>
             void process_single_condition(std::stringstream &ss, const conditions::join_t<T, O> &l) const {
                 ss << static_cast<std::string>(l) << " ";
                 ss << " '" << this->impl.template find_table_name<T>() << "' ";
                 this->process_join_constraint(ss, l.constraint);
             }
-            
+
             template<class C>
             void process_single_condition(std::stringstream &ss, const conditions::where_t<C> &w) const {
                 ss << static_cast<std::string>(w) << " ";
                 auto whereString = this->string_from_expression(w.c, false);
                 ss << "( " << whereString << ") ";
             }
-            
+
             template<class O>
             void process_single_condition(std::stringstream &ss, const conditions::order_by_t<O> &orderBy) const {
                 ss << static_cast<std::string>(orderBy) << " ";
                 auto orderByString = this->process_order_by(orderBy);
                 ss << orderByString << " ";
             }
-            
-            template<class ...Args>
-            void process_single_condition(std::stringstream &ss, const conditions::multi_order_by_t<Args...> &orderBy) const {
+
+            template<class... Args>
+            void process_single_condition(std::stringstream &ss,
+                                          const conditions::multi_order_by_t<Args...> &orderBy) const {
                 std::vector<std::string> expressions;
-                iterate_tuple(orderBy.args, [&expressions, this](auto &v){
+                iterate_tuple(orderBy.args, [&expressions, this](auto &v) {
                     auto expression = this->process_order_by(v);
                     expressions.push_back(std::move(expression));
                 });
@@ -1222,16 +1231,17 @@ namespace sqlite_orm {
                 }
                 ss << " ";
             }
-            
+
             template<class S>
-            void process_single_condition(std::stringstream &ss, const conditions::dynamic_order_by_t<S> &orderBy) const {
+            void process_single_condition(std::stringstream &ss,
+                                          const conditions::dynamic_order_by_t<S> &orderBy) const {
                 ss << this->storage_base::process_order_by(orderBy) << " ";
             }
-            
-            template<class ...Args>
+
+            template<class... Args>
             void process_single_condition(std::stringstream &ss, const conditions::group_by_t<Args...> &groupBy) const {
                 std::vector<std::string> expressions;
-                iterate_tuple(groupBy.args, [&expressions, this](auto &v){
+                iterate_tuple(groupBy.args, [&expressions, this](auto &v) {
                     auto expression = this->string_from_expression(v, false);
                     expressions.push_back(expression);
                 });
@@ -1244,49 +1254,48 @@ namespace sqlite_orm {
                 }
                 ss << " ";
             }
-            
+
             template<class T>
             void process_single_condition(std::stringstream &ss, const conditions::having_t<T> &hav) const {
                 ss << static_cast<std::string>(hav) << " ";
                 ss << this->string_from_expression(hav.t, false) << " ";
             }
-            
-            template<class ...Args>
+
+            template<class... Args>
             void process_conditions(std::stringstream &ss, const std::tuple<Args...> &args) const {
-                iterate_tuple(args, [this, &ss](auto &v){
+                iterate_tuple(args, [this, &ss](auto &v) {
                     this->process_single_condition(ss, v);
                 });
             }
-            
-        public:
-            
-            template<class T, class ...Args>
-            view_t<T, self, Args...> iterate(Args&& ...args) {
+
+          public:
+            template<class T, class... Args>
+            view_t<T, self, Args...> iterate(Args &&... args) {
                 this->assert_mapped_type<T>();
-                
+
                 auto con = this->get_connection();
                 return {*this, std::move(con), std::forward<Args>(args)...};
             }
-            
-            template<class O, class ...Args>
-            void remove_all(Args&& ...args) {
+
+            template<class O, class... Args>
+            void remove_all(Args &&... args) {
                 this->assert_mapped_type<O>();
                 auto statement = this->prepare(sqlite_orm::remove_all<O>(std::forward<Args>(args)...));
                 this->execute(statement);
             }
-            
+
             /**
              *  Delete routine.
              *  O is an object's type. Must be specified explicitly.
              *  @param ids ids of object to be removed.
              */
-            template<class O, class ...Ids>
-            void remove(Ids ...ids) {
+            template<class O, class... Ids>
+            void remove(Ids... ids) {
                 this->assert_mapped_type<O>();
                 auto statement = this->prepare(sqlite_orm::remove<O>(std::forward<Ids>(ids)...));
                 this->execute(statement);
             }
-            
+
             /**
              *  Update routine. Sets all non primary key fields where primary key is equal.
              *  O is an object type. May be not specified explicitly cause it can be deduced by
@@ -1299,90 +1308,99 @@ namespace sqlite_orm {
                 auto statement = this->prepare(sqlite_orm::update(o));
                 this->execute(statement);
             }
-            
-            template<class ...Args, class ...Wargs>
-            void update_all(internal::set_t<Args...> set, Wargs ...wh) {
+
+            template<class... Args, class... Wargs>
+            void update_all(internal::set_t<Args...> set, Wargs... wh) {
                 auto statement = this->prepare(sqlite_orm::update_all(std::move(set), std::forward<Wargs>(wh)...));
                 this->execute(statement);
             }
-            
-        protected:
-            
+
+          protected:
             template<class T>
             std::set<std::pair<std::string, std::string>> parse_table_name(const T &) const {
                 return {};
             }
-            
+
             template<class F, class O>
             std::set<std::pair<std::string, std::string>> parse_table_name(F O::*, std::string alias = {}) const {
                 return {std::make_pair(this->impl.template find_table_name<O>(), std::move(alias))};
             }
-            
+
             template<class T>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const aggregate_functions::min_t<T> &f) const {
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const aggregate_functions::min_t<T> &f) const {
                 return this->parse_table_name(f.t);
             }
-            
+
             template<class T>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const aggregate_functions::max_t<T> &f) const {
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const aggregate_functions::max_t<T> &f) const {
                 return this->parse_table_name(f.t);
             }
-            
+
             template<class T>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const aggregate_functions::sum_t<T> &f) const {
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const aggregate_functions::sum_t<T> &f) const {
                 return this->parse_table_name(f.t);
             }
-            
+
             template<class T>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const aggregate_functions::total_t<T> &f) const {
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const aggregate_functions::total_t<T> &f) const {
                 return this->parse_table_name(f.t);
             }
-            
+
             template<class T>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const aggregate_functions::group_concat_double_t<T> &f) const {
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const aggregate_functions::group_concat_double_t<T> &f) const {
                 auto res = this->parse_table_name(f.t);
                 auto secondSet = this->parse_table_name(f.y);
                 res.insert(secondSet.begin(), secondSet.end());
                 return res;
             }
-            
+
             template<class T>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const aggregate_functions::group_concat_single_t<T> &f) const {
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const aggregate_functions::group_concat_single_t<T> &f) const {
                 return this->parse_table_name(f.t);
             }
-            
+
             template<class T>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const aggregate_functions::count_t<T> &f) const {
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const aggregate_functions::count_t<T> &f) const {
                 return this->parse_table_name(f.t);
             }
-            
+
             template<class T>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const aggregate_functions::avg_t<T> &a) const {
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const aggregate_functions::avg_t<T> &a) const {
                 return this->parse_table_name(a.t);
             }
-            
-            template<class R, class S, class ...Args>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const core_functions::core_function_t<R, S, Args...> &f) const {
+
+            template<class R, class S, class... Args>
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const core_functions::core_function_t<R, S, Args...> &f) const {
                 std::set<std::pair<std::string, std::string>> res;
-                iterate_tuple(f.args, [&res, this](auto &v){
+                iterate_tuple(f.args, [&res, this](auto &v) {
                     auto tableNames = this->parse_table_name(v);
                     res.insert(tableNames.begin(), tableNames.end());
                 });
                 return res;
             }
-            
+
             template<class T>
             std::set<std::pair<std::string, std::string>> parse_table_name(const distinct_t<T> &f) const {
                 return this->parse_table_name(f.t);
             }
-            
+
             template<class T>
             std::set<std::pair<std::string, std::string>> parse_table_name(const all_t<T> &f) const {
                 return this->parse_table_name(f.t);
             }
-            
-            template<class L, class R, class ...Ds>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const binary_operator<L, R, Ds...> &f) const {
+
+            template<class L, class R, class... Ds>
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const binary_operator<L, R, Ds...> &f) const {
                 std::set<std::pair<std::string, std::string>> res;
                 auto leftSet = this->parse_table_name(f.lhs);
                 res.insert(leftSet.begin(), leftSet.end());
@@ -1390,66 +1408,70 @@ namespace sqlite_orm {
                 res.insert(rightSet.begin(), rightSet.end());
                 return res;
             }
-            
+
             template<class T, class F>
             std::set<std::pair<std::string, std::string>> parse_table_name(const column_pointer<T, F> &) const {
                 std::set<std::pair<std::string, std::string>> res;
                 res.insert({this->impl.template find_table_name<T>(), ""});
                 return res;
             }
-            
+
             template<class T, class C>
             std::set<std::pair<std::string, std::string>> parse_table_name(const alias_column_t<T, C> &a) const {
                 return this->parse_table_name(a.column, alias_extractor<T>::get());
             }
-            
+
             template<class T>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const aggregate_functions::count_asterisk_t<T> &) const {
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const aggregate_functions::count_asterisk_t<T> &) const {
                 auto tableName = this->impl.template find_table_name<T>();
-                if(!tableName.empty()){
+                if(!tableName.empty()) {
                     return {std::make_pair(std::move(tableName), "")};
-                }else{
+                } else {
                     return {};
                 }
             }
-            
-            std::set<std::pair<std::string, std::string>> parse_table_name(const aggregate_functions::count_asterisk_without_type &) const {
+
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const aggregate_functions::count_asterisk_without_type &) const {
                 return {};
             }
-            
+
             template<class T>
             std::set<std::pair<std::string, std::string>> parse_table_name(const asterisk_t<T> &) const {
                 auto tableName = this->impl.template find_table_name<T>();
                 return {std::make_pair(std::move(tableName), "")};
             }
-            
+
             template<class T, class E>
             std::set<std::pair<std::string, std::string>> parse_table_name(const conditions::cast_t<T, E> &c) const {
                 return this->parse_table_name(c.expression);
             }
-            
-            template<class R, class T, class E, class ...Args>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const simple_case_t<R, T, E, Args...> &c) const {
+
+            template<class R, class T, class E, class... Args>
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const simple_case_t<R, T, E, Args...> &c) const {
                 std::set<std::pair<std::string, std::string>> res;
-                c.case_expression.apply([this, &res](auto &c){
+                c.case_expression.apply([this, &res](auto &c) {
                     auto caseExpressionSet = this->parse_table_name(c);
                     res.insert(caseExpressionSet.begin(), caseExpressionSet.end());
                 });
-                iterate_tuple(c.args, [this, &res](auto &pair){
+                iterate_tuple(c.args, [this, &res](auto &pair) {
                     auto leftSet = this->parse_table_name(pair.first);
                     res.insert(leftSet.begin(), leftSet.end());
                     auto rightSet = this->parse_table_name(pair.second);
                     res.insert(rightSet.begin(), rightSet.end());
                 });
-                c.else_expression.apply([this, &res](auto &el){
+                c.else_expression.apply([this, &res](auto &el) {
                     auto tableNames = this->parse_table_name(el);
                     res.insert(tableNames.begin(), tableNames.end());
                 });
                 return res;
             }
-            
+
             template<class L, class R>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const conditions::and_condition_t<L, R> &c) const {
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const conditions::and_condition_t<L, R> &c) const {
                 std::set<std::pair<std::string, std::string>> res;
                 auto leftTableNames = this->parse_table_name(c.l);
                 res.insert(leftTableNames.begin(), leftTableNames.end());
@@ -1457,9 +1479,10 @@ namespace sqlite_orm {
                 res.insert(rightTableNames.begin(), rightTableNames.end());
                 return res;
             }
-            
+
             template<class L, class R>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const conditions::or_condition_t<L, R> &c) const {
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const conditions::or_condition_t<L, R> &c) const {
                 std::set<std::pair<std::string, std::string>> res;
                 auto leftTableNames = this->parse_table_name(c.l);
                 res.insert(leftTableNames.begin(), leftTableNames.end());
@@ -1467,9 +1490,10 @@ namespace sqlite_orm {
                 res.insert(rightTableNames.begin(), rightTableNames.end());
                 return res;
             }
-            
+
             template<class L, class R>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const conditions::is_equal_t<L, R> &c) const {
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const conditions::is_equal_t<L, R> &c) const {
                 std::set<std::pair<std::string, std::string>> res;
                 auto leftTableNames = this->parse_table_name(c.l);
                 res.insert(leftTableNames.begin(), leftTableNames.end());
@@ -1477,9 +1501,10 @@ namespace sqlite_orm {
                 res.insert(rightTableNames.begin(), rightTableNames.end());
                 return res;
             }
-            
+
             template<class L, class R>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const conditions::is_not_equal_t<L, R> &c) const {
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const conditions::is_not_equal_t<L, R> &c) const {
                 std::set<std::pair<std::string, std::string>> res;
                 auto leftTableNames = this->parse_table_name(c.l);
                 res.insert(leftTableNames.begin(), leftTableNames.end());
@@ -1487,9 +1512,10 @@ namespace sqlite_orm {
                 res.insert(rightTableNames.begin(), rightTableNames.end());
                 return res;
             }
-            
+
             template<class L, class R>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const conditions::greater_than_t<L, R> &c) const {
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const conditions::greater_than_t<L, R> &c) const {
                 std::set<std::pair<std::string, std::string>> res;
                 auto leftTableNames = this->parse_table_name(c.l);
                 res.insert(leftTableNames.begin(), leftTableNames.end());
@@ -1497,9 +1523,10 @@ namespace sqlite_orm {
                 res.insert(rightTableNames.begin(), rightTableNames.end());
                 return res;
             }
-            
+
             template<class L, class R>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const conditions::greater_or_equal_t<L, R> &c) const {
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const conditions::greater_or_equal_t<L, R> &c) const {
                 std::set<std::pair<std::string, std::string>> res;
                 auto leftTableNames = this->parse_table_name(c.l);
                 res.insert(leftTableNames.begin(), leftTableNames.end());
@@ -1507,9 +1534,10 @@ namespace sqlite_orm {
                 res.insert(rightTableNames.begin(), rightTableNames.end());
                 return res;
             }
-            
+
             template<class L, class R>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const conditions::lesser_than_t<L, R> &c) const {
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const conditions::lesser_than_t<L, R> &c) const {
                 std::set<std::pair<std::string, std::string>> res;
                 auto leftTableNames = this->parse_table_name(c.l);
                 res.insert(leftTableNames.begin(), leftTableNames.end());
@@ -1517,9 +1545,10 @@ namespace sqlite_orm {
                 res.insert(rightTableNames.begin(), rightTableNames.end());
                 return res;
             }
-            
+
             template<class L, class R>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const conditions::lesser_or_equal_t<L, R> &c) const {
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const conditions::lesser_or_equal_t<L, R> &c) const {
                 std::set<std::pair<std::string, std::string>> res;
                 auto leftTableNames = this->parse_table_name(c.l);
                 res.insert(leftTableNames.begin(), leftTableNames.end());
@@ -1527,7 +1556,7 @@ namespace sqlite_orm {
                 res.insert(rightTableNames.begin(), rightTableNames.end());
                 return res;
             }
-            
+
             template<class A, class T, class E>
             std::set<std::pair<std::string, std::string>> parse_table_name(const conditions::like_t<A, T, E> &l) const {
                 std::set<std::pair<std::string, std::string>> res;
@@ -1535,13 +1564,13 @@ namespace sqlite_orm {
                 res.insert(argTableNames.begin(), argTableNames.end());
                 auto patternTableNames = this->parse_table_name(l.pattern);
                 res.insert(patternTableNames.begin(), patternTableNames.end());
-                l.arg3.apply([&res, this](auto &value){
+                l.arg3.apply([&res, this](auto &value) {
                     auto escapeTableNames = this->parse_table_name(value);
                     res.insert(escapeTableNames.begin(), escapeTableNames.end());
                 });
                 return res;
             }
-            
+
             template<class A, class T>
             std::set<std::pair<std::string, std::string>> parse_table_name(const conditions::glob_t<A, T> &l) const {
                 std::set<std::pair<std::string, std::string>> res;
@@ -1551,52 +1580,53 @@ namespace sqlite_orm {
                 res.insert(patternTableNames.begin(), patternTableNames.end());
                 return res;
             }
-            
+
             template<class C>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const conditions::negated_condition_t<C> &c) const {
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const conditions::negated_condition_t<C> &c) const {
                 return this->parse_table_name(c.c);
             }
-            
+
             template<class T, class E>
             std::set<std::pair<std::string, std::string>> parse_table_name(const as_t<T, E> &a) const {
                 return this->parse_table_name(a.expression);
             }
-            
-            template<class ...Args>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const internal::columns_t<Args...> &cols) const {
+
+            template<class... Args>
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const internal::columns_t<Args...> &cols) const {
                 std::set<std::pair<std::string, std::string>> res;
-                iterate_tuple(cols.columns, [&res, this](auto &m){
+                iterate_tuple(cols.columns, [&res, this](auto &m) {
                     auto tableName = this->parse_table_name(m);
                     res.insert(tableName.begin(), tableName.end());
                 });
                 return res;
             }
-            
-            template<class F, class O, class ...Args>
-            std::string group_concat_internal(F O::*m, std::unique_ptr<std::string> y, Args&& ...args) {
+
+            template<class F, class O, class... Args>
+            std::string group_concat_internal(F O::*m, std::unique_ptr<std::string> y, Args &&... args) {
                 this->assert_mapped_type<O>();
                 std::vector<std::string> rows;
-                if(y){
+                if(y) {
                     rows = this->select(sqlite_orm::group_concat(m, move(*y)), std::forward<Args>(args)...);
-                }else{
+                } else {
                     rows = this->select(sqlite_orm::group_concat(m), std::forward<Args>(args)...);
                 }
-                if(!rows.empty()){
+                if(!rows.empty()) {
                     return move(rows.front());
-                }else{
+                } else {
                     return {};
                 }
             }
-            
-        public:
-            
+
+          public:
             /**
              *  Select * with no conditions routine.
              *  O is an object type to be extracted. Must be specified explicitly.
              *  @return All objects of type O stored in database at the moment.
              */
-            template<class O, class C = std::vector<O>, class ...Args>
-            C get_all(Args&& ...args) {
+            template<class O, class C = std::vector<O>, class... Args>
+            C get_all(Args &&... args) {
                 this->assert_mapped_type<O>();
                 auto statement = this->prepare(sqlite_orm::get_all<O>(std::forward<Args>(args)...));
                 return this->execute(statement);
@@ -1607,8 +1637,8 @@ namespace sqlite_orm {
              *  O is an object type to be extracted. Must be specified explicitly.
              *  @return All objects of type O as std::unique_ptr<O> stored in database at the moment.
              */
-            template<class O, class C = std::vector<std::unique_ptr<O>>, class ...Args>
-            C get_all_pointer(Args&& ...args) {
+            template<class O, class C = std::vector<std::unique_ptr<O>>, class... Args>
+            C get_all_pointer(Args &&... args) {
                 this->assert_mapped_type<O>();
                 auto statement = this->prepare(sqlite_orm::get_all_pointer<O>(std::forward<Args>(args)...));
                 return this->execute(statement);
@@ -1616,25 +1646,25 @@ namespace sqlite_orm {
 
             /**
              *  Select * by id routine.
-             *  throws std::system_error(orm_error_code::not_found, orm_error_category) if object not found with given id.
-             *  throws std::system_error with orm_error_category in case of db error.
-             *  O is an object type to be extracted. Must be specified explicitly.
-             *  @return Object of type O where id is equal parameter passed or throws `std::system_error(orm_error_code::not_found, orm_error_category)`
-             *  if there is no object with such id.
+             *  throws std::system_error(orm_error_code::not_found, orm_error_category) if object not found with given
+             * id. throws std::system_error with orm_error_category in case of db error. O is an object type to be
+             * extracted. Must be specified explicitly.
+             *  @return Object of type O where id is equal parameter passed or throws
+             * `std::system_error(orm_error_code::not_found, orm_error_category)` if there is no object with such id.
              */
-            template<class O, class ...Ids>
-            O get(Ids ...ids) {
+            template<class O, class... Ids>
+            O get(Ids... ids) {
                 this->assert_mapped_type<O>();
                 auto statement = this->prepare(sqlite_orm::get<O>(std::forward<Ids>(ids)...));
                 return this->execute(statement);
             }
-            
+
             /**
-             *  The same as `get` function but doesn't throw an exception if noting found but returns std::unique_ptr with null value.
-             *  throws std::system_error in case of db error.
+             *  The same as `get` function but doesn't throw an exception if noting found but returns std::unique_ptr
+             * with null value. throws std::system_error in case of db error.
              */
-            template<class O, class ...Ids>
-            std::unique_ptr<O> get_pointer(Ids ...ids) {
+            template<class O, class... Ids>
+            std::unique_ptr<O> get_pointer(Ids... ids) {
                 this->assert_mapped_type<O>();
                 auto statement = this->prepare(sqlite_orm::get_pointer<O>(std::forward<Ids>(ids)...));
                 return this->execute(statement);
@@ -1653,8 +1683,8 @@ namespace sqlite_orm {
              * shared_ptr, exactly like we're doing here.
              * (Conversely, you _can't_ go from shared back to unique.)
              */
-            template<class O, class ...Ids>
-            std::shared_ptr<O> get_no_throw(Ids ...ids) {
+            template<class O, class... Ids>
+            std::shared_ptr<O> get_no_throw(Ids... ids) {
                 return std::shared_ptr<O>(get_pointer<O>(std::forward<Ids>(ids)...));
             }
 
@@ -1662,171 +1692,174 @@ namespace sqlite_orm {
              *  SELECT COUNT(*) https://www.sqlite.org/lang_aggfunc.html#count
              *  @return Number of O object in table.
              */
-            template<class O, class ...Args, class R = typename mapped_type_proxy<O>::type>
-            int count(Args&& ...args) {
+            template<class O, class... Args, class R = typename mapped_type_proxy<O>::type>
+            int count(Args &&... args) {
                 this->assert_mapped_type<R>();
                 auto rows = this->select(sqlite_orm::count<R>(), std::forward<Args>(args)...);
-                if(!rows.empty()){
+                if(!rows.empty()) {
                     return rows.front();
-                }else{
+                } else {
                     return 0;
                 }
             }
-            
+
             /**
              *  SELECT COUNT(X) https://www.sqlite.org/lang_aggfunc.html#count
              *  @param m member pointer to class mapped to the storage.
              */
-            template<class F, class O, class ...Args>
-            int count(F O::*m, Args&& ...args) {
+            template<class F, class O, class... Args>
+            int count(F O::*m, Args &&... args) {
                 this->assert_mapped_type<O>();
                 auto rows = this->select(sqlite_orm::count(m), std::forward<Args>(args)...);
-                if(!rows.empty()){
+                if(!rows.empty()) {
                     return rows.front();
-                }else{
+                } else {
                     return 0;
                 }
             }
-            
+
             /**
              *  AVG(X) query.   https://www.sqlite.org/lang_aggfunc.html#avg
              *  @param m is a class member pointer (the same you passed into make_column).
              *  @return average value from db.
              */
-            template<class F, class O, class ...Args>
-            double avg(F O::*m, Args&& ...args) {
+            template<class F, class O, class... Args>
+            double avg(F O::*m, Args &&... args) {
                 this->assert_mapped_type<O>();
                 auto rows = this->select(sqlite_orm::avg(m), std::forward<Args>(args)...);
-                if(!rows.empty()){
+                if(!rows.empty()) {
                     return rows.front();
-                }else{
+                } else {
                     return 0;
                 }
             }
-            
+
             template<class F, class O>
             std::string group_concat(F O::*m) {
                 return this->group_concat_internal(m, {});
             }
-            
+
             /**
              *  GROUP_CONCAT(X) query.  https://www.sqlite.org/lang_aggfunc.html#groupconcat
              *  @param m is a class member pointer (the same you passed into make_column).
              *  @return group_concat query result.
              */
-            template<class F, class O, class ...Args,
-            class Tuple = std::tuple<Args...>,
-            typename sfinae = typename std::enable_if<std::tuple_size<Tuple>::value >= 1>::type
-            >
-            std::string group_concat(F O::*m, Args&& ...args) {
+            template<class F,
+                     class O,
+                     class... Args,
+                     class Tuple = std::tuple<Args...>,
+                     typename sfinae = typename std::enable_if<std::tuple_size<Tuple>::value >= 1>::type>
+            std::string group_concat(F O::*m, Args &&... args) {
                 return this->group_concat_internal(m, {}, std::forward<Args>(args)...);
             }
-            
+
             /**
              *  GROUP_CONCAT(X, Y) query.   https://www.sqlite.org/lang_aggfunc.html#groupconcat
              *  @param m is a class member pointer (the same you passed into make_column).
              *  @return group_concat query result.
              */
-            template<class F, class O, class ...Args>
-            std::string group_concat(F O::*m, std::string y, Args&& ...args) {
-                return this->group_concat_internal(m, std::make_unique<std::string>(move(y)), std::forward<Args>(args)...);
+            template<class F, class O, class... Args>
+            std::string group_concat(F O::*m, std::string y, Args &&... args) {
+                return this->group_concat_internal(m,
+                                                   std::make_unique<std::string>(move(y)),
+                                                   std::forward<Args>(args)...);
             }
-            
-            template<class F, class O, class ...Args>
-            std::string group_concat(F O::*m, const char *y, Args&& ...args) {
+
+            template<class F, class O, class... Args>
+            std::string group_concat(F O::*m, const char *y, Args &&... args) {
                 std::unique_ptr<std::string> str;
-                if(y){
+                if(y) {
                     str = std::make_unique<std::string>(y);
-                }else{
+                } else {
                     str = std::make_unique<std::string>();
                 }
                 return this->group_concat_internal(m, move(str), std::forward<Args>(args)...);
             }
-            
+
             /**
              *  MAX(x) query.
              *  @param m is a class member pointer (the same you passed into make_column).
              *  @return std::unique_ptr with max value or null if sqlite engine returned null.
              */
-            template<class F, class O, class ...Args, class Ret = typename column_result_t<self, F O::*>::type>
-            std::unique_ptr<Ret> max(F O::*m, Args&& ...args) {
+            template<class F, class O, class... Args, class Ret = typename column_result_t<self, F O::*>::type>
+            std::unique_ptr<Ret> max(F O::*m, Args &&... args) {
                 this->assert_mapped_type<O>();
                 auto rows = this->select(sqlite_orm::max(m), std::forward<Args>(args)...);
-                if(!rows.empty()){
+                if(!rows.empty()) {
                     return std::move(rows.front());
-                }else{
+                } else {
                     return {};
                 }
             }
-            
+
             /**
              *  MIN(x) query.
              *  @param m is a class member pointer (the same you passed into make_column).
              *  @return std::unique_ptr with min value or null if sqlite engine returned null.
              */
-            template<class F, class O, class ...Args, class Ret = typename column_result_t<self, F O::*>::type>
-            std::unique_ptr<Ret> min(F O::*m, Args&& ...args) {
+            template<class F, class O, class... Args, class Ret = typename column_result_t<self, F O::*>::type>
+            std::unique_ptr<Ret> min(F O::*m, Args &&... args) {
                 this->assert_mapped_type<O>();
                 auto rows = this->select(sqlite_orm::min(m), std::forward<Args>(args)...);
-                if(!rows.empty()){
+                if(!rows.empty()) {
                     return std::move(rows.front());
-                }else{
+                } else {
                     return {};
                 }
             }
-            
+
             /**
              *  SUM(x) query.
              *  @param m is a class member pointer (the same you passed into make_column).
              *  @return std::unique_ptr with sum value or null if sqlite engine returned null.
              */
-            template<class F, class O, class ...Args, class Ret = typename column_result_t<self, F O::*>::type>
-            std::unique_ptr<Ret> sum(F O::*m, Args&& ...args) {
+            template<class F, class O, class... Args, class Ret = typename column_result_t<self, F O::*>::type>
+            std::unique_ptr<Ret> sum(F O::*m, Args &&... args) {
                 this->assert_mapped_type<O>();
-                std::vector<std::unique_ptr<double>> rows = this->select(sqlite_orm::sum(m), std::forward<Args>(args)...);
-                if(!rows.empty()){
-                    if(rows.front()){
+                std::vector<std::unique_ptr<double>> rows =
+                    this->select(sqlite_orm::sum(m), std::forward<Args>(args)...);
+                if(!rows.empty()) {
+                    if(rows.front()) {
                         return std::make_unique<Ret>(std::move(*rows.front()));
-                    }else{
+                    } else {
                         return {};
                     }
-                }else{
+                } else {
                     return {};
                 }
             }
-            
+
             /**
              *  TOTAL(x) query.
              *  @param m is a class member pointer (the same you passed into make_column).
-             *  @return total value (the same as SUM but not nullable. More details here https://www.sqlite.org/lang_aggfunc.html)
+             *  @return total value (the same as SUM but not nullable. More details here
+             * https://www.sqlite.org/lang_aggfunc.html)
              */
-            template<class F, class O, class ...Args>
-            double total(F O::*m, Args&& ...args) {
+            template<class F, class O, class... Args>
+            double total(F O::*m, Args &&... args) {
                 this->assert_mapped_type<O>();
                 auto rows = this->select(sqlite_orm::total(m), std::forward<Args>(args)...);
-                if(!rows.empty()){
+                if(!rows.empty()) {
                     return std::move(rows.front());
-                }else{
+                } else {
                     return {};
                 }
             }
-            
+
             /**
              *  Select a single column into std::vector<T> or multiple columns into std::vector<std::tuple<...>>.
              *  For a single column use `auto rows = storage.select(&User::id, where(...));
              *  For multicolumns use `auto rows = storage.select(columns(&User::id, &User::name), where(...));
              */
-            template<
-            class T,
-            class ...Args,
-            class R = typename column_result_t<self, T>::type>
-            std::vector<R> select(T m, Args ...args) {
-                static_assert(!is_base_of_template<T, compound_operator>::value || std::tuple_size<std::tuple<Args...>>::value == 0,
+            template<class T, class... Args, class R = typename column_result_t<self, T>::type>
+            std::vector<R> select(T m, Args... args) {
+                static_assert(!is_base_of_template<T, compound_operator>::value ||
+                                  std::tuple_size<std::tuple<Args...>>::value == 0,
                               "Cannot use args with a compound operator");
                 auto statement = this->prepare(sqlite_orm::select(std::move(m), std::forward<Args>(args)...));
                 return this->execute(statement);
             }
-            
+
             /**
              *  Returns a string representation of object of a class mapped to the storage.
              *  Type of string has json-like style.
@@ -1836,7 +1869,7 @@ namespace sqlite_orm {
                 this->assert_mapped_type<O>();
                 return this->impl.dump(o);
             }
-            
+
             /**
              *  This is REPLACE (INSERT OR REPLACE) function.
              *  Also if you need to insert value with knows id you should
@@ -1849,7 +1882,7 @@ namespace sqlite_orm {
                 auto statement = this->prepare(sqlite_orm::replace(o));
                 this->execute(statement);
             }
-            
+
             template<class It>
             void replace_range(It from, It to) {
                 using O = typename std::iterator_traits<It>::value_type;
@@ -1857,12 +1890,12 @@ namespace sqlite_orm {
                 if(from == to) {
                     return;
                 }
-                
+
                 auto statement = this->prepare(sqlite_orm::replace_range(from, to));
                 this->execute(statement);
             }
-            
-            template<class O, class ...Cols>
+
+            template<class O, class... Cols>
             int insert(const O &o, columns_t<Cols...> cols) {
                 constexpr const size_t colsCount = std::tuple_size<std::tuple<Cols...>>::value;
                 static_assert(colsCount > 0, "Use insert or replace with 1 argument instead");
@@ -1870,7 +1903,7 @@ namespace sqlite_orm {
                 auto statement = this->prepare(sqlite_orm::insert(o, std::move(cols)));
                 return int(this->execute(statement));
             }
-            
+
             /**
              *  Insert routine. Inserts object with all non primary key fields in passed object. Id of passed
              *  object doesn't matter.
@@ -1882,7 +1915,7 @@ namespace sqlite_orm {
                 auto statement = this->prepare(sqlite_orm::insert(o));
                 return int(this->execute(statement));
             }
-            
+
             template<class It>
             void insert_range(It from, It to) {
                 using O = typename std::iterator_traits<It>::value_type;
@@ -1890,27 +1923,27 @@ namespace sqlite_orm {
                 if(from == to) {
                     return;
                 }
-                
+
                 auto statement = this->prepare(sqlite_orm::insert_range(from, to));
                 this->execute(statement);
             }
-            
-        protected:
-            
-            template<class ...Tss, class ...Cols>
+
+          protected:
+            template<class... Tss, class... Cols>
             sync_schema_result sync_table(storage_impl<internal::index_t<Cols...>, Tss...> *impl, sqlite3 *db, bool) {
                 auto res = sync_schema_result::already_in_sync;
                 std::stringstream ss;
                 ss << "CREATE ";
-                if(impl->table.unique){
+                if(impl->table.unique) {
                     ss << "UNIQUE ";
                 }
                 using columns_type = typename decltype(impl->table)::columns_type;
                 using head_t = typename std::tuple_element<0, columns_type>::type;
                 using indexed_type = typename internal::table_type<head_t>::type;
-                ss << "INDEX IF NOT EXISTS '" << impl->table.name << "' ON '" << this->impl.template find_table_name<indexed_type>() << "' ( ";
+                ss << "INDEX IF NOT EXISTS '" << impl->table.name << "' ON '"
+                   << this->impl.template find_table_name<indexed_type>() << "' ( ";
                 std::vector<std::string> columnNames;
-                iterate_tuple(impl->table.columns, [&columnNames, this](auto &v){
+                iterate_tuple(impl->table.columns, [&columnNames, this](auto &v) {
                     columnNames.push_back(this->impl.column_name(v));
                 });
                 for(size_t i = 0; i < columnNames.size(); ++i) {
@@ -1924,56 +1957,56 @@ namespace sqlite_orm {
                 auto query = ss.str();
                 auto rc = sqlite3_exec(db, query.c_str(), nullptr, nullptr, nullptr);
                 if(rc != SQLITE_OK) {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
                 return res;
             }
-            
-            template<class ...Tss, class ...Cs>
+
+            template<class... Tss, class... Cs>
             sync_schema_result sync_table(storage_impl<table_t<Cs...>, Tss...> *impl, sqlite3 *db, bool preserve) {
                 auto res = sync_schema_result::already_in_sync;
-                
+
                 auto schema_stat = impl->schema_status(db, preserve);
                 if(schema_stat != decltype(schema_stat)::already_in_sync) {
                     if(schema_stat == decltype(schema_stat)::new_table_created) {
                         this->create_table(db, impl->table.name, impl);
                         res = decltype(res)::new_table_created;
-                    }else{
-                        if(schema_stat == sync_schema_result::old_columns_removed
-                           || schema_stat == sync_schema_result::new_columns_added
-                           || schema_stat == sync_schema_result::new_columns_added_and_old_columns_removed)
-                        {
-                            
+                    } else {
+                        if(schema_stat == sync_schema_result::old_columns_removed ||
+                           schema_stat == sync_schema_result::new_columns_added ||
+                           schema_stat == sync_schema_result::new_columns_added_and_old_columns_removed) {
+
                             //  get table info provided in `make_table` call..
                             auto storageTableInfo = impl->table.get_table_info();
-                            
+
                             //  now get current table info from db using `PRAGMA table_info` query..
                             auto dbTableInfo = impl->get_table_info(impl->table.name, db);
-                            
+
                             //  this vector will contain pointers to columns that gotta be added..
-                            std::vector<table_info*> columnsToAdd;
-                            
+                            std::vector<table_info *> columnsToAdd;
+
                             impl->get_remove_add_columns(columnsToAdd, storageTableInfo, dbTableInfo);
-                            
+
                             if(schema_stat == sync_schema_result::old_columns_removed) {
-                                
+
                                 //  extra table columns than storage columns
                                 this->backup_table(db, impl);
                                 res = decltype(res)::old_columns_removed;
                             }
-                            
+
                             if(schema_stat == sync_schema_result::new_columns_added) {
-                                for(auto columnPointer : columnsToAdd) {
+                                for(auto columnPointer: columnsToAdd) {
                                     impl->add_column(*columnPointer, db);
                                 }
                                 res = decltype(res)::new_columns_added;
                             }
-                            
+
                             if(schema_stat == sync_schema_result::new_columns_added_and_old_columns_removed) {
-                                
-                                //remove extra columns
+
+                                // remove extra columns
                                 this->backup_table(db, impl);
-                                for(auto columnPointer : columnsToAdd) {
+                                for(auto columnPointer: columnsToAdd) {
                                     impl->add_column(*columnPointer, db);
                                 }
                                 res = decltype(res)::new_columns_added_and_old_columns_removed;
@@ -1987,9 +2020,8 @@ namespace sqlite_orm {
                 }
                 return res;
             }
-            
-        public:
-            
+
+          public:
             /**
              *  This is a cute function used to replace migration up/down functionality.
              *  It performs check storage schema with actual db schema and:
@@ -1997,31 +2029,37 @@ namespace sqlite_orm {
              *  * every table from storage is compared with it's db analog and
              *      * if table doesn't exist it is being created
              *      * if table exists its colums are being compared with table_info from db and
-             *          * if there are columns in db that do not exist in storage (excess) table will be dropped and recreated
-             *          * if there are columns in storage that do not exist in db they will be added using `ALTER TABLE ... ADD COLUMN ...' command
-             *          * if there is any column existing in both db and storage but differs by any of properties/constraints (type, pk, notnull, dflt_value) table will be dropped and recreated
-             *  Be aware that `sync_schema` doesn't guarantee that data will not be dropped. It guarantees only that it will make db schema the same
-             *  as you specified in `make_storage` function call. A good point is that if you have no db file at all it will be created and
-             *  all tables also will be created with exact tables and columns you specified in `make_storage`, `make_table` and `make_column` call.
-             *  The best practice is to call this function right after storage creation.
-             *  @param preserve affects on function behaviour in case it is needed to remove a column. If it is `false` so table will be dropped
-             *  if there is column to remove, if `true` -  table is being copied into another table, dropped and copied table is renamed with source table name.
-             *  Warning: sync_schema doesn't check foreign keys cause it is unable to do so in sqlite3. If you know how to get foreign key info
-             *  please submit an issue https://github.com/fnc12/sqlite_orm/issues
-             *  @return std::map with std::string key equal table name and `sync_schema_result` as value. `sync_schema_result` is a enum value that stores
-             *  table state after syncing a schema. `sync_schema_result` can be printed out on std::ostream with `operator<<`.
+             *          * if there are columns in db that do not exist in storage (excess) table will be dropped and
+             * recreated
+             *          * if there are columns in storage that do not exist in db they will be added using `ALTER TABLE
+             * ... ADD COLUMN ...' command
+             *          * if there is any column existing in both db and storage but differs by any of
+             * properties/constraints (type, pk, notnull, dflt_value) table will be dropped and recreated Be aware that
+             * `sync_schema` doesn't guarantee that data will not be dropped. It guarantees only that it will make db
+             * schema the same as you specified in `make_storage` function call. A good point is that if you have no db
+             * file at all it will be created and all tables also will be created with exact tables and columns you
+             * specified in `make_storage`, `make_table` and `make_column` call. The best practice is to call this
+             * function right after storage creation.
+             *  @param preserve affects on function behaviour in case it is needed to remove a column. If it is `false`
+             * so table will be dropped if there is column to remove, if `true` -  table is being copied into another
+             * table, dropped and copied table is renamed with source table name. Warning: sync_schema doesn't check
+             * foreign keys cause it is unable to do so in sqlite3. If you know how to get foreign key info please
+             * submit an issue https://github.com/fnc12/sqlite_orm/issues
+             *  @return std::map with std::string key equal table name and `sync_schema_result` as value.
+             * `sync_schema_result` is a enum value that stores table state after syncing a schema. `sync_schema_result`
+             * can be printed out on std::ostream with `operator<<`.
              */
             std::map<std::string, sync_schema_result> sync_schema(bool preserve = false) {
                 auto con = this->get_connection();
                 std::map<std::string, sync_schema_result> result;
                 auto db = con.get();
-                this->impl.for_each([&result, db, preserve, this](auto impl){
+                this->impl.for_each([&result, db, preserve, this](auto impl) {
                     auto res = this->sync_table(impl, db, preserve);
                     result.insert({impl->table.name, res});
                 });
                 return result;
             }
-            
+
             /**
              *  This function returns the same map that `sync_schema` returns but it
              *  doesn't perform `sync_schema` actually - just simulates it in case you want to know
@@ -2031,12 +2069,12 @@ namespace sqlite_orm {
                 auto con = this->get_connection();
                 std::map<std::string, sync_schema_result> result;
                 auto db = con.get();
-                this->impl.for_each([&result, db, preserve](auto impl){
+                this->impl.for_each([&result, db, preserve](auto impl) {
                     result.insert({impl->table.name, impl->schema_status(db, preserve)});
                 });
                 return result;
             }
-            
+
             /**
              *  Checks whether table exists in db. Doesn't check storage itself - works only with actual database.
              *  Note: table can be not mapped to a storage
@@ -2046,191 +2084,206 @@ namespace sqlite_orm {
                 auto con = this->get_connection();
                 return this->impl.table_exists(tableName, con.get());
             }
-            
-            template<class T, class ...Args>
+
+            template<class T, class... Args>
             prepared_statement_t<select_t<T, Args...>> prepare(select_t<T, Args...> sel) {
                 sel.highest_level = true;
                 auto con = this->get_connection();
                 sqlite3_stmt *stmt;
                 auto db = con.get();
                 auto query = this->string_from_expression(sel, false);
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     return {std::move(sel), stmt, con};
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
-            template<class T, class ...Args>
+
+            template<class T, class... Args>
             prepared_statement_t<get_all_t<T, Args...>> prepare(get_all_t<T, Args...> get) {
                 auto con = this->get_connection();
                 sqlite3_stmt *stmt;
                 auto db = con.get();
                 auto query = this->string_from_expression(get, false);
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     return {std::move(get), stmt, con};
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
 
-            template<class T, class ...Args>
+            template<class T, class... Args>
             prepared_statement_t<get_all_pointer_t<T, Args...>> prepare(get_all_pointer_t<T, Args...> get) {
                 auto con = this->get_connection();
                 sqlite3_stmt *stmt;
                 auto db = con.get();
                 auto query = this->string_from_expression(get, false);
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     return {std::move(get), stmt, con};
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
-            template<class ...Args, class ...Wargs>
-            prepared_statement_t<update_all_t<set_t<Args...>, Wargs...>> prepare(update_all_t<set_t<Args...>, Wargs...> upd) {
+
+            template<class... Args, class... Wargs>
+            prepared_statement_t<update_all_t<set_t<Args...>, Wargs...>>
+            prepare(update_all_t<set_t<Args...>, Wargs...> upd) {
                 auto con = this->get_connection();
                 sqlite3_stmt *stmt;
                 auto db = con.get();
                 auto query = this->string_from_expression(upd, false);
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     return {std::move(upd), stmt, con};
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
-            template<class T, class ...Args>
+
+            template<class T, class... Args>
             prepared_statement_t<remove_all_t<T, Args...>> prepare(remove_all_t<T, Args...> rem) {
                 auto con = this->get_connection();
                 sqlite3_stmt *stmt;
                 auto db = con.get();
                 auto query = this->string_from_expression(rem, false);
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     return {std::move(rem), stmt, std::move(con)};
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
-            template<class T, class ...Ids>
+
+            template<class T, class... Ids>
             prepared_statement_t<get_t<T, Ids...>> prepare(get_t<T, Ids...> g) {
                 auto con = this->get_connection();
                 sqlite3_stmt *stmt;
                 auto db = con.get();
                 auto query = this->string_from_expression(g, false);
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     return {std::move(g), stmt, con};
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
-            template<class T, class ...Ids>
+
+            template<class T, class... Ids>
             prepared_statement_t<get_pointer_t<T, Ids...>> prepare(get_pointer_t<T, Ids...> g) {
                 auto con = this->get_connection();
                 sqlite3_stmt *stmt;
                 auto db = con.get();
                 auto query = this->string_from_expression(g, false);
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     return {std::move(g), stmt, con};
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             template<class T, bool by_ref>
             prepared_statement_t<update_t<T, by_ref>> prepare(update_t<T, by_ref> upd) {
                 auto con = this->get_connection();
                 sqlite3_stmt *stmt;
                 auto db = con.get();
                 auto query = this->string_from_expression(upd, false);
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     return {std::move(upd), stmt, con};
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
-            template<class T, class ...Ids>
+
+            template<class T, class... Ids>
             prepared_statement_t<remove_t<T, Ids...>> prepare(remove_t<T, Ids...> rem) {
                 auto con = this->get_connection();
                 sqlite3_stmt *stmt;
                 auto db = con.get();
                 auto query = this->string_from_expression(rem, false);
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     return {std::move(rem), stmt, con};
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             template<class T, bool by_ref>
             prepared_statement_t<insert_t<T, by_ref>> prepare(insert_t<T, by_ref> ins) {
                 auto con = this->get_connection();
                 sqlite3_stmt *stmt;
                 auto db = con.get();
                 auto query = this->string_from_expression(ins, false);
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     return {std::move(ins), stmt, con};
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             template<class T, bool by_ref>
             prepared_statement_t<replace_t<T, by_ref>> prepare(replace_t<T, by_ref> rep) {
                 auto con = this->get_connection();
                 sqlite3_stmt *stmt;
                 auto db = con.get();
                 auto query = this->string_from_expression(rep, false);
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     return {std::move(rep), stmt, con};
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             template<class It>
             prepared_statement_t<insert_range_t<It>> prepare(insert_range_t<It> ins) {
                 auto con = this->get_connection();
                 sqlite3_stmt *stmt;
                 auto db = con.get();
                 auto query = this->string_from_expression(ins, false);
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     return {std::move(ins), stmt, con};
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             template<class It>
             prepared_statement_t<replace_range_t<It>> prepare(replace_range_t<It> rep) {
                 auto con = this->get_connection();
                 sqlite3_stmt *stmt;
                 auto db = con.get();
                 auto query = this->string_from_expression(rep, false);
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     return {std::move(rep), stmt, con};
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
-            template<class T, bool by_ref, class ...Cols>
+
+            template<class T, bool by_ref, class... Cols>
             prepared_statement_t<insert_explicit<T, by_ref, Cols...>> prepare(insert_explicit<T, by_ref, Cols...> ins) {
                 auto con = this->get_connection();
                 sqlite3_stmt *stmt;
                 auto db = con.get();
                 auto query = this->string_from_expression(ins, false);
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     return {std::move(ins), stmt, con};
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
-            template<class T, bool by_ref, class ...Cols>
+
+            template<class T, bool by_ref, class... Cols>
             int64 execute(const prepared_statement_t<insert_explicit<T, by_ref, Cols...>> &statement) {
                 auto index = 1;
                 auto con = this->get_connection();
@@ -2239,21 +2292,23 @@ namespace sqlite_orm {
                 auto &impl = this->get_impl<T>();
                 auto &o = statement.t.obj;
                 sqlite3_reset(stmt);
-                iterate_tuple(statement.t.columns.columns, [&o, &index, &stmt, &impl, db] (auto &m) {
+                iterate_tuple(statement.t.columns.columns, [&o, &index, &stmt, &impl, db](auto &m) {
                     using column_type = typename std::decay<decltype(m)>::type;
                     using field_type = typename column_result_t<self, column_type>::type;
                     const field_type *value = impl.table.template get_object_field_pointer<field_type>(o, m);
-                    if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, *value)){
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, *value)) {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
                 });
-                if (sqlite3_step(stmt) == SQLITE_DONE) {
+                if(sqlite3_step(stmt) == SQLITE_DONE) {
                     return sqlite3_last_insert_rowid(db);
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             template<class It>
             void execute(const prepared_statement_t<replace_range_t<It>> &statement) {
                 using statement_type = typename std::decay<decltype(statement)>::type;
@@ -2267,29 +2322,34 @@ namespace sqlite_orm {
                 sqlite3_reset(stmt);
                 for(auto it = statement.t.from; it != statement.t.to; ++it) {
                     auto &o = *it;
-                    impl.table.for_each_column([&o, &index, &stmt, db] (auto &c) {
+                    impl.table.for_each_column([&o, &index, &stmt, db](auto &c) {
                         using column_type = typename std::decay<decltype(c)>::type;
                         using field_type = typename column_type::field_type;
-                        if(c.member_pointer){
-                            if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, o.*c.member_pointer)){
-                                throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                        if(c.member_pointer) {
+                            if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, o.*c.member_pointer)) {
+                                throw std::system_error(
+                                    std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                    sqlite3_errmsg(db));
                             }
-                        }else{
+                        } else {
                             using getter_type = typename column_type::getter_type;
                             field_value_holder<getter_type> valueHolder{((o).*(c.getter))()};
-                            if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, valueHolder.value)){
-                                throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                            if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, valueHolder.value)) {
+                                throw std::system_error(
+                                    std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                    sqlite3_errmsg(db));
                             }
                         }
                     });
                 }
-                if (sqlite3_step(stmt) == SQLITE_DONE) {
+                if(sqlite3_step(stmt) == SQLITE_DONE) {
                     //..
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             template<class It>
             void execute(const prepared_statement_t<insert_range_t<It>> &statement) {
                 using statement_type = typename std::decay<decltype(statement)>::type;
@@ -2303,31 +2363,37 @@ namespace sqlite_orm {
                 sqlite3_reset(stmt);
                 for(auto it = statement.t.from; it != statement.t.to; ++it) {
                     auto &o = *it;
-                    impl.table.for_each_column([&o, &index, &stmt, db] (auto &c) {
-                        if(!c.template has<constraints::primary_key_t<>>()){
+                    impl.table.for_each_column([&o, &index, &stmt, db](auto &c) {
+                        if(!c.template has<constraints::primary_key_t<>>()) {
                             using column_type = typename std::decay<decltype(c)>::type;
                             using field_type = typename column_type::field_type;
-                            if(c.member_pointer){
-                                if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, o.*c.member_pointer)){
-                                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                            if(c.member_pointer) {
+                                if(SQLITE_OK !=
+                                   statement_binder<field_type>().bind(stmt, index++, o.*c.member_pointer)) {
+                                    throw std::system_error(
+                                        std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                        sqlite3_errmsg(db));
                                 }
-                            }else{
+                            } else {
                                 using getter_type = typename column_type::getter_type;
                                 field_value_holder<getter_type> valueHolder{((o).*(c.getter))()};
-                                if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, valueHolder.value)){
-                                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                                if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, valueHolder.value)) {
+                                    throw std::system_error(
+                                        std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                        sqlite3_errmsg(db));
                                 }
                             }
                         }
                     });
                 }
-                if (sqlite3_step(stmt) == SQLITE_DONE) {
+                if(sqlite3_step(stmt) == SQLITE_DONE) {
                     //..
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             template<class T, bool by_ref>
             void execute(const prepared_statement_t<replace_t<T, by_ref>> &statement) {
                 auto con = this->get_connection();
@@ -2337,28 +2403,31 @@ namespace sqlite_orm {
                 auto &o = statement.t.obj;
                 auto &impl = this->get_impl<T>();
                 sqlite3_reset(stmt);
-                impl.table.for_each_column([&o, &index, &stmt, db] (auto &c) {
+                impl.table.for_each_column([&o, &index, &stmt, db](auto &c) {
                     using column_type = typename std::decay<decltype(c)>::type;
                     using field_type = typename column_type::field_type;
-                    if(c.member_pointer){
-                        if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, o.*c.member_pointer)){
-                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    if(c.member_pointer) {
+                        if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, o.*c.member_pointer)) {
+                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                    sqlite3_errmsg(db));
                         }
-                    }else{
+                    } else {
                         using getter_type = typename column_type::getter_type;
                         field_value_holder<getter_type> valueHolder{((o).*(c.getter))()};
-                        if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, valueHolder.value)){
-                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                        if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, valueHolder.value)) {
+                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                    sqlite3_errmsg(db));
                         }
                     }
                 });
-                if (sqlite3_step(stmt) == SQLITE_DONE) {
+                if(sqlite3_step(stmt) == SQLITE_DONE) {
                     //..
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             template<class T, bool by_ref>
             int64 execute(const prepared_statement_t<insert_t<T, by_ref>> &statement) {
                 int64 res = 0;
@@ -2370,56 +2439,62 @@ namespace sqlite_orm {
                 auto &o = statement.t.obj;
                 auto compositeKeyColumnNames = impl.table.composite_key_columns_names();
                 sqlite3_reset(stmt);
-                impl.table.for_each_column([&o, &index, &stmt, &impl, &compositeKeyColumnNames, db] (auto &c) {
-                    if(impl.table._without_rowid || !c.template has<constraints::primary_key_t<>>()){
-                        auto it = std::find(compositeKeyColumnNames.begin(),
-                                            compositeKeyColumnNames.end(),
-                                            c.name);
-                        if(it == compositeKeyColumnNames.end()){
+                impl.table.for_each_column([&o, &index, &stmt, &impl, &compositeKeyColumnNames, db](auto &c) {
+                    if(impl.table._without_rowid || !c.template has<constraints::primary_key_t<>>()) {
+                        auto it = std::find(compositeKeyColumnNames.begin(), compositeKeyColumnNames.end(), c.name);
+                        if(it == compositeKeyColumnNames.end()) {
                             using column_type = typename std::decay<decltype(c)>::type;
                             using field_type = typename column_type::field_type;
-                            if(c.member_pointer){
-                                if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, o.*c.member_pointer)){
-                                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                            if(c.member_pointer) {
+                                if(SQLITE_OK !=
+                                   statement_binder<field_type>().bind(stmt, index++, o.*c.member_pointer)) {
+                                    throw std::system_error(
+                                        std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                        sqlite3_errmsg(db));
                                 }
-                            }else{
+                            } else {
                                 using getter_type = typename column_type::getter_type;
                                 field_value_holder<getter_type> valueHolder{((o).*(c.getter))()};
-                                if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, valueHolder.value)){
-                                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                                if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, valueHolder.value)) {
+                                    throw std::system_error(
+                                        std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                        sqlite3_errmsg(db));
                                 }
                             }
                         }
                     }
                 });
-                if (sqlite3_step(stmt) == SQLITE_DONE) {
+                if(sqlite3_step(stmt) == SQLITE_DONE) {
                     res = sqlite3_last_insert_rowid(db);
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
                 return res;
             }
-            
-            template<class T, class ...Ids>
+
+            template<class T, class... Ids>
             void execute(const prepared_statement_t<remove_t<T, Ids...>> &statement) {
                 auto con = this->get_connection();
                 auto db = con.get();
                 auto stmt = statement.stmt;
                 auto index = 1;
                 sqlite3_reset(stmt);
-                iterate_tuple(statement.t.ids, [stmt, &index, db](auto &v){
+                iterate_tuple(statement.t.ids, [stmt, &index, db](auto &v) {
                     using field_type = typename std::decay<decltype(v)>::type;
-                    if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, v)){
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, v)) {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
                 });
-                if (sqlite3_step(stmt) == SQLITE_DONE) {
+                if(sqlite3_step(stmt) == SQLITE_DONE) {
                     //  done..
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             template<class T, bool by_ref>
             void execute(const prepared_statement_t<update_t<T, by_ref>> &statement) {
                 auto con = this->get_connection();
@@ -2429,49 +2504,58 @@ namespace sqlite_orm {
                 auto index = 1;
                 auto &o = statement.t.obj;
                 sqlite3_reset(stmt);
-                impl.table.for_each_column([&o, stmt, &index, db] (auto &c) {
+                impl.table.for_each_column([&o, stmt, &index, db](auto &c) {
                     if(!c.template has<constraints::primary_key_t<>>()) {
                         using column_type = typename std::decay<decltype(c)>::type;
                         using field_type = typename column_type::field_type;
-                        if(c.member_pointer){
+                        if(c.member_pointer) {
                             auto bind_res = statement_binder<field_type>().bind(stmt, index++, o.*c.member_pointer);
-                            if(SQLITE_OK != bind_res){
-                                throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                            if(SQLITE_OK != bind_res) {
+                                throw std::system_error(
+                                    std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                    sqlite3_errmsg(db));
                             }
-                        }else{
+                        } else {
                             using getter_type = typename column_type::getter_type;
                             field_value_holder<getter_type> valueHolder{((o).*(c.getter))()};
-                            if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, valueHolder.value)){
-                                throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                            if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, valueHolder.value)) {
+                                throw std::system_error(
+                                    std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                    sqlite3_errmsg(db));
                             }
                         }
                     }
                 });
-                impl.table.for_each_column([&o, stmt, &index, db] (auto &c) {
+                impl.table.for_each_column([&o, stmt, &index, db](auto &c) {
                     if(c.template has<constraints::primary_key_t<>>()) {
                         using column_type = typename std::decay<decltype(c)>::type;
                         using field_type = typename column_type::field_type;
-                        if(c.member_pointer){
-                            if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, o.*c.member_pointer)){
-                                throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                        if(c.member_pointer) {
+                            if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, o.*c.member_pointer)) {
+                                throw std::system_error(
+                                    std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                    sqlite3_errmsg(db));
                             }
-                        }else{
+                        } else {
                             using getter_type = typename column_type::getter_type;
                             field_value_holder<getter_type> valueHolder{((o).*(c.getter))()};
-                            if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, valueHolder.value)){
-                                throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                            if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, valueHolder.value)) {
+                                throw std::system_error(
+                                    std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                    sqlite3_errmsg(db));
                             }
                         }
                     }
                 });
-                if (sqlite3_step(stmt) == SQLITE_DONE) {
+                if(sqlite3_step(stmt) == SQLITE_DONE) {
                     //  done..
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
-            template<class T, class ...Ids>
+
+            template<class T, class... Ids>
             std::unique_ptr<T> execute(const prepared_statement_t<get_pointer_t<T, Ids...>> &statement) {
                 auto &impl = this->get_impl<T>();
                 auto con = this->get_connection();
@@ -2479,38 +2563,40 @@ namespace sqlite_orm {
                 auto stmt = statement.stmt;
                 auto index = 1;
                 sqlite3_reset(stmt);
-                iterate_tuple(statement.t.ids, [stmt, &index, db](auto &v){
+                iterate_tuple(statement.t.ids, [stmt, &index, db](auto &v) {
                     using field_type = typename std::decay<decltype(v)>::type;
-                    if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, v)){
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, v)) {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
                 });
                 auto stepRes = sqlite3_step(stmt);
-                switch(stepRes){
-                    case SQLITE_ROW:{
+                switch(stepRes) {
+                    case SQLITE_ROW: {
                         auto res = std::make_unique<T>();
                         index = 0;
-                        impl.table.for_each_column([&index, &res, stmt] (auto c) {
+                        impl.table.for_each_column([&index, &res, stmt](auto c) {
                             using field_type = typename decltype(c)::field_type;
                             auto value = row_extractor<field_type>().extract(stmt, index++);
-                            if(c.member_pointer){
+                            if(c.member_pointer) {
                                 (*res).*c.member_pointer = std::move(value);
-                            }else{
+                            } else {
                                 ((*res).*(c.setter))(std::move(value));
                             }
                         });
                         return res;
-                    }break;
-                    case SQLITE_DONE:{
+                    } break;
+                    case SQLITE_DONE: {
                         return {};
-                    }break;
-                    default:{
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    } break;
+                    default: {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
                 }
             }
-            
-            template<class T, class ...Ids>
+
+            template<class T, class... Ids>
             T execute(const prepared_statement_t<get_t<T, Ids...>> &statement) {
                 auto &impl = this->get_impl<T>();
                 auto con = this->get_connection();
@@ -2518,121 +2604,131 @@ namespace sqlite_orm {
                 auto stmt = statement.stmt;
                 auto index = 1;
                 sqlite3_reset(stmt);
-                iterate_tuple(statement.t.ids, [stmt, &index, db](auto &v){
+                iterate_tuple(statement.t.ids, [stmt, &index, db](auto &v) {
                     using field_type = typename std::decay<decltype(v)>::type;
-                    if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, v)){
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, v)) {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
                 });
                 auto stepRes = sqlite3_step(stmt);
-                switch(stepRes){
-                    case SQLITE_ROW:{
+                switch(stepRes) {
+                    case SQLITE_ROW: {
                         T res;
                         index = 0;
-                        impl.table.for_each_column([&index, &res, stmt] (auto &c) {
+                        impl.table.for_each_column([&index, &res, stmt](auto &c) {
                             using column_type = typename std::decay<decltype(c)>::type;
                             using field_type = typename column_type::field_type;
                             auto value = row_extractor<field_type>().extract(stmt, index++);
-                            if(c.member_pointer){
+                            if(c.member_pointer) {
                                 res.*c.member_pointer = std::move(value);
-                            }else{
+                            } else {
                                 ((res).*(c.setter))(std::move(value));
                             }
                         });
                         return res;
-                    }break;
-                    case SQLITE_DONE:{
+                    } break;
+                    case SQLITE_DONE: {
                         throw std::system_error(std::make_error_code(sqlite_orm::orm_error_code::not_found));
-                    }break;
-                    default:{
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    } break;
+                    default: {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
                 }
             }
-            
-            template<class T, class ...Args>
+
+            template<class T, class... Args>
             void execute(const prepared_statement_t<remove_all_t<T, Args...>> &statement) {
                 auto con = this->get_connection();
                 auto db = con.get();
                 auto stmt = statement.stmt;
                 auto index = 1;
                 sqlite3_reset(stmt);
-                iterate_ast(statement.t.conditions, [stmt, &index, db](auto &node){
+                iterate_ast(statement.t.conditions, [stmt, &index, db](auto &node) {
                     using node_type = typename std::decay<decltype(node)>::type;
                     conditional_binder<node_type, is_bindable<node_type>> binder{stmt, index};
-                    if(SQLITE_OK != binder(node)){
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    if(SQLITE_OK != binder(node)) {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
                 });
-                if (sqlite3_step(stmt) == SQLITE_DONE) {
+                if(sqlite3_step(stmt) == SQLITE_DONE) {
                     //  done..
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
-            template<class ...Args, class ...Wargs>
+
+            template<class... Args, class... Wargs>
             void execute(const prepared_statement_t<update_all_t<set_t<Args...>, Wargs...>> &statement) {
                 auto con = this->get_connection();
                 auto db = con.get();
                 auto stmt = statement.stmt;
                 auto index = 1;
                 sqlite3_reset(stmt);
-                statement.t.set.for_each([&index, stmt, db](auto &setArg){
-                    iterate_ast(setArg, [&index, stmt, db](auto &node){
+                statement.t.set.for_each([&index, stmt, db](auto &setArg) {
+                    iterate_ast(setArg, [&index, stmt, db](auto &node) {
                         using node_type = typename std::decay<decltype(node)>::type;
                         conditional_binder<node_type, is_bindable<node_type>> binder{stmt, index};
-                        if(SQLITE_OK != binder(node)){
-                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                        if(SQLITE_OK != binder(node)) {
+                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                    sqlite3_errmsg(db));
                         }
                     });
                 });
-                iterate_ast(statement.t.conditions, [stmt, &index, db](auto &node){
+                iterate_ast(statement.t.conditions, [stmt, &index, db](auto &node) {
                     using node_type = typename std::decay<decltype(node)>::type;
                     conditional_binder<node_type, is_bindable<node_type>> binder{stmt, index};
-                    if(SQLITE_OK != binder(node)){
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    if(SQLITE_OK != binder(node)) {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
                 });
-                if (sqlite3_step(stmt) == SQLITE_DONE) {
+                if(sqlite3_step(stmt) == SQLITE_DONE) {
                     //  done..
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
-            template<class T, class ...Args, class R = typename column_result_t<self, T>::type>
+
+            template<class T, class... Args, class R = typename column_result_t<self, T>::type>
             std::vector<R> execute(const prepared_statement_t<select_t<T, Args...>> &statement) {
                 auto con = this->get_connection();
                 auto db = con.get();
                 auto stmt = statement.stmt;
                 auto index = 1;
                 sqlite3_reset(stmt);
-                iterate_ast(statement.t, [stmt, &index, db](auto &node){
+                iterate_ast(statement.t, [stmt, &index, db](auto &node) {
                     using node_type = typename std::decay<decltype(node)>::type;
                     conditional_binder<node_type, is_bindable<node_type>> binder{stmt, index};
-                    if(SQLITE_OK != binder(node)){
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    if(SQLITE_OK != binder(node)) {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
                 });
                 std::vector<R> res;
                 int stepRes;
-                do{
+                do {
                     stepRes = sqlite3_step(stmt);
-                    switch(stepRes){
-                        case SQLITE_ROW:{
+                    switch(stepRes) {
+                        case SQLITE_ROW: {
                             res.push_back(row_extractor<R>().extract(stmt, 0));
-                        }break;
-                        case SQLITE_DONE: break;
-                        default:{
-                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                        } break;
+                        case SQLITE_DONE:
+                            break;
+                        default: {
+                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                    sqlite3_errmsg(db));
                         }
                     }
-                }while(stepRes != SQLITE_DONE);
+                } while(stepRes != SQLITE_DONE);
                 return res;
             }
-            
-            template<class T, class ...Args>
+
+            template<class T, class... Args>
             std::vector<T> execute(const prepared_statement_t<get_all_t<T, Args...>> &statement) {
                 auto &impl = this->get_impl<T>();
                 auto con = this->get_connection();
@@ -2640,96 +2736,103 @@ namespace sqlite_orm {
                 auto stmt = statement.stmt;
                 auto index = 1;
                 sqlite3_reset(stmt);
-                iterate_ast(statement.t, [stmt, &index, db](auto &node){
+                iterate_ast(statement.t, [stmt, &index, db](auto &node) {
                     using node_type = typename std::decay<decltype(node)>::type;
                     conditional_binder<node_type, is_bindable<node_type>> binder{stmt, index};
-                    if(SQLITE_OK != binder(node)){
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    if(SQLITE_OK != binder(node)) {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
                 });
                 std::vector<T> res;
                 int stepRes;
-                do{
+                do {
                     stepRes = sqlite3_step(stmt);
-                    switch(stepRes){
-                        case SQLITE_ROW:{
+                    switch(stepRes) {
+                        case SQLITE_ROW: {
                             T obj;
                             auto index = 0;
-                            impl.table.for_each_column([&index, &obj, stmt] (auto &c) {
+                            impl.table.for_each_column([&index, &obj, stmt](auto &c) {
                                 using field_type = typename std::decay<decltype(c)>::type::field_type;
                                 auto value = row_extractor<field_type>().extract(stmt, index++);
-                                if(c.member_pointer){
+                                if(c.member_pointer) {
                                     obj.*c.member_pointer = std::move(value);
-                                }else{
+                                } else {
                                     ((obj).*(c.setter))(std::move(value));
                                 }
                             });
                             res.push_back(std::move(obj));
-                        }break;
-                        case SQLITE_DONE: break;
-                        default:{
-                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                        } break;
+                        case SQLITE_DONE:
+                            break;
+                        default: {
+                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                    sqlite3_errmsg(db));
                         }
                     }
-                }while(stepRes != SQLITE_DONE);
+                } while(stepRes != SQLITE_DONE);
                 return res;
             }
-            template<class T, class ...Args>
-            std::vector<std::unique_ptr<T>> execute(const prepared_statement_t<get_all_pointer_t<T, Args...>> &statement) {
+            template<class T, class... Args>
+            std::vector<std::unique_ptr<T>>
+            execute(const prepared_statement_t<get_all_pointer_t<T, Args...>> &statement) {
                 auto &impl = this->get_impl<T>();
                 auto con = this->get_connection();
                 auto db = con.get();
                 auto stmt = statement.stmt;
                 auto index = 1;
                 sqlite3_reset(stmt);
-                iterate_ast(statement.t, [stmt, &index, db](auto &node){
+                iterate_ast(statement.t, [stmt, &index, db](auto &node) {
                     using node_type = typename std::decay<decltype(node)>::type;
                     conditional_binder<node_type, is_bindable<node_type>> binder{stmt, index};
-                    if(SQLITE_OK != binder(node)){
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    if(SQLITE_OK != binder(node)) {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
                 });
                 std::vector<std::unique_ptr<T>> res;
                 int stepRes;
-                do{
+                do {
                     stepRes = sqlite3_step(stmt);
-                    switch(stepRes){
-                        case SQLITE_ROW:{
+                    switch(stepRes) {
+                        case SQLITE_ROW: {
                             auto obj = std::make_unique<T>();
                             auto index = 0;
-                            impl.table.for_each_column([&index, &obj, stmt] (auto &c) {
+                            impl.table.for_each_column([&index, &obj, stmt](auto &c) {
                                 using field_type = typename std::decay<decltype(c)>::type::field_type;
                                 auto value = row_extractor<field_type>().extract(stmt, index++);
-                                if(c.member_pointer){
+                                if(c.member_pointer) {
                                     (*obj).*c.member_pointer = std::move(value);
-                                }else{
+                                } else {
                                     ((*obj).*(c.setter))(std::move(value));
                                 }
                             });
                             res.push_back(std::move(obj));
-                        }break;
-                        case SQLITE_DONE: break;
-                        default:{
-                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                        } break;
+                        case SQLITE_DONE:
+                            break;
+                        default: {
+                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                    sqlite3_errmsg(db));
                         }
                     }
-                }while(stepRes != SQLITE_DONE);
+                } while(stepRes != SQLITE_DONE);
                 return res;
             }
         };
-        
+
         template<class T>
         struct is_storage : std::false_type {};
-        
-        template<class ...Ts>
+
+        template<class... Ts>
         struct is_storage<storage_t<Ts...>> : std::true_type {};
     }
-    
-    template<class ...Ts>
-    internal::storage_t<Ts...> make_storage(const std::string &filename, Ts ...tables) {
+
+    template<class... Ts>
+    internal::storage_t<Ts...> make_storage(const std::string &filename, Ts... tables) {
         return {filename, internal::storage_impl<Ts...>(tables...)};
     }
-    
+
     /**
      *  sqlite3_threadsafe() interface.
      */

--- a/dev/storage_base.h
+++ b/dev/storage_base.h
@@ -1,16 +1,16 @@
 #pragma once
 
-#include <functional>   //  std::function, std::bind
+#include <functional>  //  std::function, std::bind
 #include <sqlite3.h>
-#include <string>   //  std::string
+#include <string>  //  std::string
 #include <sstream>  //  std::stringstream
 #include <utility>  //  std::move
-#include <system_error> //  std::system_error, std::error_code, std::make_error_code
-#include <vector>   //  std::vector
-#include <memory>   //  std::make_shared, std::shared_ptr
+#include <system_error>  //  std::system_error, std::error_code, std::make_error_code
+#include <vector>  //  std::vector
+#include <memory>  //  std::make_shared, std::shared_ptr
 #include <map>  //  std::map
 #include <type_traits>  //  std::decay, std::is_same
-#include <algorithm>    //  std::iter_swap
+#include <algorithm>  //  std::iter_swap
 
 #include "pragma.h"
 #include "limit_accesor.h"
@@ -23,23 +23,23 @@
 #include "backup.h"
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         struct storage_base {
-            using collating_function = std::function<int(int, const void*, int, const void*)>;
-            
-            std::function<void(sqlite3*)> on_open;
+            using collating_function = std::function<int(int, const void *, int, const void *)>;
+
+            std::function<void(sqlite3 *)> on_open;
             pragma_t pragma;
             limit_accesor limit;
-            
+
             transaction_guard_t transaction_guard() {
                 this->begin_transaction();
-                auto commitFunc = std::bind(static_cast<void(storage_base::*)()>(&storage_base::commit), this);
-                auto rollbackFunc = std::bind(static_cast<void(storage_base::*)()>(&storage_base::rollback), this);
+                auto commitFunc = std::bind(static_cast<void (storage_base::*)()>(&storage_base::commit), this);
+                auto rollbackFunc = std::bind(static_cast<void (storage_base::*)()>(&storage_base::rollback), this);
                 return {this->get_connection(), move(commitFunc), move(rollbackFunc)};
             }
-            
+
             void drop_index(const std::string &indexName) {
                 auto con = this->get_connection();
                 auto db = con.get();
@@ -47,35 +47,39 @@ namespace sqlite_orm {
                 ss << "DROP INDEX '" << indexName + "'";
                 auto query = ss.str();
                 sqlite3_stmt *stmt;
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if (sqlite3_step(stmt) == SQLITE_DONE) {
+                    if(sqlite3_step(stmt) == SQLITE_DONE) {
                         //  done..
-                    }else{
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    } else {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
-                }else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             void vacuum() {
                 auto con = this->get_connection();
                 auto db = con.get();
                 std::string query = "VACUUM";
                 sqlite3_stmt *stmt;
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if (sqlite3_step(stmt) == SQLITE_DONE) {
+                    if(sqlite3_step(stmt) == SQLITE_DONE) {
                         //  done..
-                    }else{
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    } else {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
-                }else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             /**
              *  Drops table with given name.
              */
@@ -83,7 +87,7 @@ namespace sqlite_orm {
                 auto con = this->get_connection();
                 this->drop_table_internal(tableName, con.get());
             }
-            
+
             /**
              *  sqlite3_changes function.
              */
@@ -91,7 +95,7 @@ namespace sqlite_orm {
                 auto con = this->get_connection();
                 return sqlite3_changes(con.get());
             }
-            
+
             /**
              *  sqlite3_total_changes function.
              */
@@ -99,57 +103,58 @@ namespace sqlite_orm {
                 auto con = this->get_connection();
                 return sqlite3_total_changes(con.get());
             }
-            
+
             int64 last_insert_rowid() {
                 auto con = this->get_connection();
                 return sqlite3_last_insert_rowid(con.get());
             }
-            
+
             int busy_timeout(int ms) {
                 auto con = this->get_connection();
                 return sqlite3_busy_timeout(con.get(), ms);
             }
-            
+
             /**
              *  Returns libsqltie3 lib version, not sqlite_orm
              */
             std::string libversion() {
                 return sqlite3_libversion();
             }
-            
+
             bool transaction(std::function<bool()> f) {
                 this->begin_transaction();
                 auto con = this->get_connection();
                 auto db = con.get();
                 auto shouldCommit = f();
-                if(shouldCommit){
+                if(shouldCommit) {
                     this->commit(db);
-                }else{
+                } else {
                     this->rollback(db);
                 }
                 return shouldCommit;
             }
-            
+
             std::string current_timestamp() {
                 auto con = this->get_connection();
                 return this->current_timestamp(con.get());
             }
-            
+
 #if SQLITE_VERSION_NUMBER >= 3007010
             /**
              * \fn db_release_memory
-             * \brief Releases freeable memory of database. It is function can/should be called periodically by application,
-             * if application has less memory usage constraint.
-             * \note sqlite3_db_release_memory added in 3.7.10 https://sqlite.org/changes.html
+             * \brief Releases freeable memory of database. It is function can/should be called periodically by
+             * application, if application has less memory usage constraint. \note sqlite3_db_release_memory added
+             * in 3.7.10 https://sqlite.org/changes.html
              */
             int db_release_memory() {
                 auto con = this->get_connection();
                 return sqlite3_db_release_memory(con.get());
             }
 #endif
-            
+
             /**
-             *  Returns existing permanent table names in database. Doesn't check storage itself - works only with actual database.
+             *  Returns existing permanent table names in database. Doesn't check storage itself - works only with
+             * actual database.
              *  @return Returns list of tables in database.
              */
             std::vector<std::string> table_names() {
@@ -158,201 +163,205 @@ namespace sqlite_orm {
                 std::string sql = "SELECT name FROM sqlite_master WHERE type='table'";
                 using data_t = std::vector<std::string>;
                 auto db = con.get();
-                int res = sqlite3_exec(db, sql.c_str(),
-                                       [] (void *data, int argc, char **argv, char ** /*columnName*/) -> int {
-                                           auto& tableNames = *(data_t*)data;
-                                           for(int i = 0; i < argc; i++) {
-                                               if(argv[i]){
-                                                   tableNames.push_back(argv[i]);
-                                               }
-                                           }
-                                           return 0;
-                                       }, &tableNames,nullptr);
-                
+                int res = sqlite3_exec(
+                    db,
+                    sql.c_str(),
+                    [](void *data, int argc, char **argv, char * * /*columnName*/) -> int {
+                        auto &tableNames = *(data_t *)data;
+                        for(int i = 0; i < argc; i++) {
+                            if(argv[i]) {
+                                tableNames.push_back(argv[i]);
+                            }
+                        }
+                        return 0;
+                    },
+                    &tableNames,
+                    nullptr);
+
                 if(res != SQLITE_OK) {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
                 return tableNames;
             }
-            
+
             void open_forever() {
                 this->isOpenedForever = true;
                 this->connection->retain();
-                if(1 == this->connection->retain_count()){
+                if(1 == this->connection->retain_count()) {
                     this->on_open_internal(this->connection->get());
                 }
             }
-            
+
             void create_collation(const std::string &name, collating_function f) {
                 collating_function *functionPointer = nullptr;
-                if(f){
+                if(f) {
                     functionPointer = &(collatingFunctions[name] = std::move(f));
-                }else{
+                } else {
                     collatingFunctions.erase(name);
                 }
-                
+
                 //  create collations if db is open
-                if(this->connection->retain_count() > 0){
+                if(this->connection->retain_count() > 0) {
                     auto db = this->connection->get();
                     if(sqlite3_create_collation(db,
                                                 name.c_str(),
                                                 SQLITE_UTF8,
                                                 functionPointer,
-                                                f ? collate_callback : nullptr) != SQLITE_OK)
-                    {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                                                f ? collate_callback : nullptr) != SQLITE_OK) {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
                 }
             }
-            
+
             void begin_transaction() {
                 this->connection->retain();
-                if(1 == this->connection->retain_count()){
+                if(1 == this->connection->retain_count()) {
                     this->on_open_internal(this->connection->get());
                 }
                 auto db = this->connection->get();
                 this->begin_transaction(db);
             }
-            
+
             void commit() {
                 auto db = this->connection->get();
                 this->commit(db);
                 this->connection->release();
-                if(this->connection->retain_count() < 0){
+                if(this->connection->retain_count() < 0) {
                     throw std::system_error(std::make_error_code(orm_error_code::no_active_transaction));
                 }
             }
-            
+
             void rollback() {
                 auto db = this->connection->get();
                 this->rollback(db);
                 this->connection->release();
-                if(this->connection->retain_count() < 0){
+                if(this->connection->retain_count() < 0) {
                     throw std::system_error(std::make_error_code(orm_error_code::no_active_transaction));
                 }
             }
-            
+
             void backup_to(const std::string &filename) {
                 auto backup = this->make_backup_to(filename);
                 backup.step(-1);
             }
-            
+
             void backup_to(storage_base &other) {
                 auto backup = this->make_backup_to(other);
                 backup.step(-1);
             }
-            
+
             void backup_from(const std::string &filename) {
                 auto backup = this->make_backup_from(filename);
                 backup.step(-1);
             }
-            
+
             void backup_from(storage_base &other) {
                 auto backup = this->make_backup_from(other);
                 backup.step(-1);
             }
-            
+
             backup_t make_backup_to(const std::string &filename) {
                 auto holder = std::make_unique<connection_holder>(filename);
                 return {connection_ref{*holder}, "main", this->get_connection(), "main", move(holder)};
             }
-            
+
             backup_t make_backup_to(storage_base &other) {
                 return {other.get_connection(), "main", this->get_connection(), "main", {}};
             }
-            
+
             backup_t make_backup_from(const std::string &filename) {
                 auto holder = std::make_unique<connection_holder>(filename);
                 return {this->get_connection(), "main", connection_ref{*holder}, "main", move(holder)};
             }
-            
+
             backup_t make_backup_from(storage_base &other) {
                 return {this->get_connection(), "main", other.get_connection(), "main", {}};
             }
-            
+
             const std::string &filename() const {
                 return this->connection->filename;
             }
-            
-        protected:
-            
-            storage_base(const std::string &filename_, int foreignKeysCount):
-            pragma(std::bind(&storage_base::get_connection, this)),
-            limit(std::bind(&storage_base::get_connection, this)),
-            inMemory(filename_.empty() || filename_ == ":memory:"),
-            connection(std::make_unique<connection_holder>(filename_)),
-            cachedForeignKeysCount(foreignKeysCount)
-            {
-                if(this->inMemory){
+
+          protected:
+            storage_base(const std::string &filename_, int foreignKeysCount) :
+                pragma(std::bind(&storage_base::get_connection, this)),
+                limit(std::bind(&storage_base::get_connection, this)),
+                inMemory(filename_.empty() || filename_ == ":memory:"),
+                connection(std::make_unique<connection_holder>(filename_)), cachedForeignKeysCount(foreignKeysCount) {
+                if(this->inMemory) {
                     this->connection->retain();
                     this->on_open_internal(this->connection->get());
                 }
             }
-            
-            storage_base(const storage_base &other):
-            on_open(other.on_open),
-            pragma(std::bind(&storage_base::get_connection, this)),
-            limit(std::bind(&storage_base::get_connection, this)),
-            inMemory(other.inMemory),
-            connection(std::make_unique<connection_holder>(other.connection->filename)),
-            cachedForeignKeysCount(other.cachedForeignKeysCount)
-            {}
-            
+
+            storage_base(const storage_base &other) :
+                on_open(other.on_open), pragma(std::bind(&storage_base::get_connection, this)),
+                limit(std::bind(&storage_base::get_connection, this)), inMemory(other.inMemory),
+                connection(std::make_unique<connection_holder>(other.connection->filename)),
+                cachedForeignKeysCount(other.cachedForeignKeysCount) {}
+
             ~storage_base() {
                 if(this->isOpenedForever) {
                     this->connection->release();
                 }
-                if(this->inMemory){
+                if(this->inMemory) {
                     this->connection->release();
                 }
             }
-            
+
             const bool inMemory;
             bool isOpenedForever = false;
             std::unique_ptr<connection_holder> connection;
             std::map<std::string, collating_function> collatingFunctions;
             const int cachedForeignKeysCount;
-            
+
             connection_ref get_connection() {
                 connection_ref res{*this->connection};
-                if(1 == this->connection->retain_count()){
+                if(1 == this->connection->retain_count()) {
                     this->on_open_internal(this->connection->get());
                 }
                 return res;
             }
-            
+
 #if SQLITE_VERSION_NUMBER >= 3006019
-            
+
             void foreign_keys(sqlite3 *db, bool value) {
                 std::stringstream ss;
                 ss << "PRAGMA foreign_keys = " << value;
                 auto query = ss.str();
                 auto rc = sqlite3_exec(db, query.c_str(), nullptr, nullptr, nullptr);
                 if(rc != SQLITE_OK) {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             bool foreign_keys(sqlite3 *db) {
                 std::string query = "PRAGMA foreign_keys";
                 auto res = false;
-                auto rc = sqlite3_exec(db,
-                                       query.c_str(),
-                                       [](void *data, int argc, char **argv,char **) -> int {
-                                           auto &res = *(bool*)data;
-                                           if(argc){
-                                               res = row_extractor<bool>().extract(argv[0]);
-                                           }
-                                           return 0;
-                                       }, &res, nullptr);
+                auto rc = sqlite3_exec(
+                    db,
+                    query.c_str(),
+                    [](void *data, int argc, char **argv, char **) -> int {
+                        auto &res = *(bool *)data;
+                        if(argc) {
+                            res = row_extractor<bool>().extract(argv[0]);
+                        }
+                        return 0;
+                    },
+                    &res,
+                    nullptr);
                 if(rc != SQLITE_OK) {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
                 return res;
             }
-            
-#endif            
-            template<class O, class T, class G, class S, class ...Op>
+
+#endif
+            template<class O, class T, class G, class S, class... Op>
             std::string serialize_column_schema(const internal::column_t<O, T, G, S, Op...> &c) {
                 std::stringstream ss;
                 ss << "'" << c.name << "' ";
@@ -367,166 +376,177 @@ namespace sqlite_orm {
                     int primaryKeyIndex = -1;
                     int autoincrementIndex = -1;
                     int tupleIndex = 0;
-                    iterate_tuple(c.constraints, [&constraintsStrings, &primaryKeyIndex, &autoincrementIndex, &tupleIndex](auto &v){
-                        using constraint_type = typename std::decay<decltype(v)>::type;
-                        constraintsStrings.push_back(static_cast<std::string>(v));
-                        if(is_primary_key<constraint_type>::value) {
-                            primaryKeyIndex = tupleIndex;
-                        }else if(std::is_same<constraints::autoincrement_t, constraint_type>::value){
-                            autoincrementIndex = tupleIndex;
-                        }
-                        ++tupleIndex;
-                    });
-                    if(primaryKeyIndex != -1 && autoincrementIndex != -1 && autoincrementIndex < primaryKeyIndex){
-                        iter_swap(constraintsStrings.begin() + primaryKeyIndex, constraintsStrings.begin() + autoincrementIndex);
+                    iterate_tuple(c.constraints,
+                                  [&constraintsStrings, &primaryKeyIndex, &autoincrementIndex, &tupleIndex](auto &v) {
+                                      using constraint_type = typename std::decay<decltype(v)>::type;
+                                      constraintsStrings.push_back(static_cast<std::string>(v));
+                                      if(is_primary_key<constraint_type>::value) {
+                                          primaryKeyIndex = tupleIndex;
+                                      } else if(std::is_same<constraints::autoincrement_t, constraint_type>::value) {
+                                          autoincrementIndex = tupleIndex;
+                                      }
+                                      ++tupleIndex;
+                                  });
+                    if(primaryKeyIndex != -1 && autoincrementIndex != -1 && autoincrementIndex < primaryKeyIndex) {
+                        iter_swap(constraintsStrings.begin() + primaryKeyIndex,
+                                  constraintsStrings.begin() + autoincrementIndex);
                     }
-                    for(auto &str : constraintsStrings) {
+                    for(auto &str: constraintsStrings) {
                         ss << str << ' ';
                     }
                 }
-                if(c.not_null()){
+                if(c.not_null()) {
                     ss << "NOT NULL ";
                 }
                 return ss.str();
             }
-            
+
             void on_open_internal(sqlite3 *db) {
-                
+
 #if SQLITE_VERSION_NUMBER >= 3006019
-                if(this->cachedForeignKeysCount){
+                if(this->cachedForeignKeysCount) {
                     this->foreign_keys(db, true);
                 }
 #endif
                 if(this->pragma._synchronous != -1) {
                     this->pragma.synchronous(this->pragma._synchronous);
                 }
-                
+
                 if(this->pragma._journal_mode != -1) {
                     this->pragma.set_pragma("journal_mode", static_cast<journal_mode>(this->pragma._journal_mode), db);
                 }
-                
-                for(auto &p : this->collatingFunctions){
-                    if(sqlite3_create_collation(db,
-                                                p.first.c_str(),
-                                                SQLITE_UTF8,
-                                                &p.second,
-                                                collate_callback) != SQLITE_OK)
-                    {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+
+                for(auto &p: this->collatingFunctions) {
+                    if(sqlite3_create_collation(db, p.first.c_str(), SQLITE_UTF8, &p.second, collate_callback) !=
+                       SQLITE_OK) {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
                 }
-                
-                for(auto &p : this->limit.limits) {
+
+                for(auto &p: this->limit.limits) {
                     sqlite3_limit(db, p.first, p.second);
                 }
-                
-                if(this->on_open){
+
+                if(this->on_open) {
                     this->on_open(db);
                 }
             }
-            
+
             void begin_transaction(sqlite3 *db) {
                 std::stringstream ss;
                 ss << "BEGIN TRANSACTION";
                 auto query = ss.str();
                 sqlite3_stmt *stmt;
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if (sqlite3_step(stmt) == SQLITE_DONE) {
+                    if(sqlite3_step(stmt) == SQLITE_DONE) {
                         //  done..
-                    }else{
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    } else {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
-                }else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             void commit(sqlite3 *db) {
                 std::stringstream ss;
                 ss << "COMMIT";
                 auto query = ss.str();
                 sqlite3_stmt *stmt;
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if (sqlite3_step(stmt) == SQLITE_DONE) {
+                    if(sqlite3_step(stmt) == SQLITE_DONE) {
                         //  done..
-                    }else{
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    } else {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
-                }else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             void rollback(sqlite3 *db) {
                 std::stringstream ss;
                 ss << "ROLLBACK";
                 auto query = ss.str();
                 sqlite3_stmt *stmt;
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if (sqlite3_step(stmt) == SQLITE_DONE) {
+                    if(sqlite3_step(stmt) == SQLITE_DONE) {
                         //  done..
-                    }else{
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    } else {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
-                }else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             std::string current_timestamp(sqlite3 *db) {
                 std::string res;
                 std::stringstream ss;
                 ss << "SELECT CURRENT_TIMESTAMP";
                 auto query = ss.str();
-                auto rc = sqlite3_exec(db,
-                                       query.c_str(),
-                                       [](void *data, int argc, char **argv, char **) -> int {
-                                           auto &res = *(std::string*)data;
-                                           if(argc){
-                                               if(argv[0]){
-                                                   res = row_extractor<std::string>().extract(argv[0]);
-                                               }
-                                           }
-                                           return 0;
-                                       }, &res, nullptr);
+                auto rc = sqlite3_exec(
+                    db,
+                    query.c_str(),
+                    [](void *data, int argc, char **argv, char **) -> int {
+                        auto &res = *(std::string *)data;
+                        if(argc) {
+                            if(argv[0]) {
+                                res = row_extractor<std::string>().extract(argv[0]);
+                            }
+                        }
+                        return 0;
+                    },
+                    &res,
+                    nullptr);
                 if(rc != SQLITE_OK) {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
                 return res;
             }
-            
+
             void drop_table_internal(const std::string &tableName, sqlite3 *db) {
                 std::stringstream ss;
                 ss << "DROP TABLE '" << tableName + "'";
                 auto query = ss.str();
                 sqlite3_stmt *stmt;
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if (sqlite3_step(stmt) == SQLITE_DONE) {
+                    if(sqlite3_step(stmt) == SQLITE_DONE) {
                         //  done..
-                    }else{
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    } else {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
-                }else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             template<class S>
             std::string process_order_by(const conditions::dynamic_order_by_t<S> &orderBy) const {
                 std::vector<std::string> expressions;
-                for(auto &entry : orderBy){
+                for(auto &entry: orderBy) {
                     std::string entryString;
                     {
                         std::stringstream ss;
                         ss << entry.name << " ";
-                        if(!entry._collate_argument.empty()){
+                        if(!entry._collate_argument.empty()) {
                             ss << "COLLATE " << entry._collate_argument << " ";
                         }
-                        switch(entry.asc_desc){
+                        switch(entry.asc_desc) {
                             case 1:
                                 ss << "ASC";
                                 break;
@@ -549,17 +569,17 @@ namespace sqlite_orm {
                 ss << " ";
                 return ss.str();
             }
-            
+
             static int collate_callback(void *arg, int leftLen, const void *lhs, int rightLen, const void *rhs) {
-                auto &f = *(collating_function*)arg;
+                auto &f = *(collating_function *)arg;
                 return f(leftLen, lhs, rightLen, rhs);
             }
-            
+
             //  returns foreign keys count in storage definition
             template<class T>
             static int foreign_keys_count(T &storageImpl) {
                 auto res = 0;
-                storageImpl.for_each([&res](auto impl){
+                storageImpl.for_each([&res](auto impl) {
                     res += impl->foreign_keys_count();
                 });
                 return res;

--- a/dev/storage_traits.h
+++ b/dev/storage_traits.h
@@ -1,79 +1,92 @@
 #include <type_traits>  //  std::is_same, std::enable_if, std::true_type, std::false_type, std::integral_constant
-#include <tuple>    //  std::tuple
+#include <tuple>  //  std::tuple
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
-        template<class ...Ts>
+
+        template<class... Ts>
         struct storage_impl;
-        
+
         template<class T, class... Args>
         struct table_t;
-        
+
         namespace storage_traits {
-            
+
             /**
              *  S - storage_impl type
              *  T - mapped or not mapped data type
              */
             template<class S, class T, class SFINAE = void>
             struct type_is_mapped_impl;
-            
+
             /**
              *  S - storage
              *  T - mapped or not mapped data type
              */
             template<class S, class T>
             struct type_is_mapped : type_is_mapped_impl<typename S::impl_type, T> {};
-            
+
             /**
              *  Final specialisation
              */
             template<class T>
             struct type_is_mapped_impl<storage_impl<>, T, void> : std::false_type {};
-            
+
             template<class S, class T>
-            struct type_is_mapped_impl<S, T, typename std::enable_if<std::is_same<T, typename S::table_type::object_type>::value>::type> : std::true_type {};
-            
+            struct type_is_mapped_impl<
+                S,
+                T,
+                typename std::enable_if<std::is_same<T, typename S::table_type::object_type>::value>::type>
+                : std::true_type {};
+
             template<class S, class T>
-            struct type_is_mapped_impl<S, T, typename std::enable_if<!std::is_same<T, typename S::table_type::object_type>::value>::type>
-            : type_is_mapped_impl<typename S::super, T> {};
-            
-            
+            struct type_is_mapped_impl<
+                S,
+                T,
+                typename std::enable_if<!std::is_same<T, typename S::table_type::object_type>::value>::type>
+                : type_is_mapped_impl<typename S::super, T> {};
+
             /**
              *  S - storage_impl type
              *  T - mapped or not mapped data type
              */
             template<class S, class T, class SFINAE = void>
             struct storage_columns_count_impl;
-            
+
             /**
              *  S - storage
              *  T - mapped or not mapped data type
              */
             template<class S, class T>
             struct storage_columns_count : storage_columns_count_impl<typename S::impl_type, T> {};
-            
+
             /**
              *  Final specialisation
              */
             template<class T>
             struct storage_columns_count_impl<storage_impl<>, T, void> : std::integral_constant<int, 0> {};
-            
+
             template<class S, class T>
-            struct storage_columns_count_impl<S, T,  typename std::enable_if<std::is_same<T, typename S::table_type::object_type>::value>::type> : std::integral_constant<int, S::table_type::columns_count> {};
-            
+            struct storage_columns_count_impl<
+                S,
+                T,
+                typename std::enable_if<std::is_same<T, typename S::table_type::object_type>::value>::type>
+                : std::integral_constant<int, S::table_type::columns_count> {};
+
             template<class S, class T>
-            struct storage_columns_count_impl<S, T,  typename std::enable_if<!std::is_same<T, typename S::table_type::object_type>::value>::type> : storage_columns_count_impl<typename S::super, T> {};
-            
-            
+            struct storage_columns_count_impl<
+                S,
+                T,
+                typename std::enable_if<!std::is_same<T, typename S::table_type::object_type>::value>::type>
+                : storage_columns_count_impl<typename S::super, T> {};
+
             /**
              *  T - table type.
              */
             template<class T>
             struct table_types;
-            
+
             /**
              *  type is std::tuple of field types of mapped colums.
              */
@@ -81,22 +94,21 @@ namespace sqlite_orm {
             struct table_types<table_t<T, Args...>> {
                 using type = std::tuple<typename Args::field_type...>;
             };
-            
-            
+
             /**
              *  S - storage_impl type
              *  T - mapped or not mapped data type
              */
             template<class S, class T, class SFINAE = void>
             struct storage_mapped_columns_impl;
-            
+
             /**
              *  S - storage
              *  T - mapped or not mapped data type
              */
             template<class S, class T>
             struct storage_mapped_columns : storage_mapped_columns_impl<typename S::impl_type, T> {};
-            
+
             /**
              *  Final specialisation
              */
@@ -104,16 +116,23 @@ namespace sqlite_orm {
             struct storage_mapped_columns_impl<storage_impl<>, T, void> {
                 using type = std::tuple<>;
             };
-            
+
             template<class S, class T>
-            struct storage_mapped_columns_impl<S, T, typename std::enable_if<std::is_same<T, typename S::table_type::object_type>::value>::type> {
+            struct storage_mapped_columns_impl<
+                S,
+                T,
+                typename std::enable_if<std::is_same<T, typename S::table_type::object_type>::value>::type> {
                 using table_type = typename S::table_type;
                 using type = typename table_types<table_type>::type;
             };
-            
+
             template<class S, class T>
-            struct storage_mapped_columns_impl<S, T, typename std::enable_if<!std::is_same<T, typename S::table_type::object_type>::value>::type> : storage_mapped_columns_impl<typename S::super, T> {};
-            
+            struct storage_mapped_columns_impl<
+                S,
+                T,
+                typename std::enable_if<!std::is_same<T, typename S::table_type::object_type>::value>::type>
+                : storage_mapped_columns_impl<typename S::super, T> {};
+
         }
     }
 }

--- a/dev/sync_schema_result.h
+++ b/dev/sync_schema_result.h
@@ -3,34 +3,34 @@
 #include <ostream>
 
 namespace sqlite_orm {
-    
+
     enum class sync_schema_result {
-        
+
         /**
          *  created new table, table with the same tablename did not exist
          */
         new_table_created,
-        
+
         /**
          *  table schema is the same as storage, nothing to be done
          */
         already_in_sync,
-        
+
         /**
          *  removed excess columns in table (than storage) without dropping a table
          */
         old_columns_removed,
-        
+
         /**
          *  lacking columns in table (than storage) added without dropping a table
          */
         new_columns_added,
-        
+
         /**
          *  both old_columns_removed and new_columns_added
          */
         new_columns_added_and_old_columns_removed,
-        
+
         /**
          *  old table is dropped and new is recreated. Reasons :
          *      1. delete excess columns in the table than storage if preseve = false
@@ -40,16 +40,21 @@ namespace sqlite_orm {
          */
         dropped_and_recreated,
     };
-    
-    
-    inline std::ostream& operator<<(std::ostream &os, sync_schema_result value) {
-        switch(value){
-            case sync_schema_result::new_table_created: return os << "new table created";
-            case sync_schema_result::already_in_sync: return os << "table and storage is already in sync.";
-            case sync_schema_result::old_columns_removed: return os << "old excess columns removed";
-            case sync_schema_result::new_columns_added: return os << "new columns added";
-            case sync_schema_result::new_columns_added_and_old_columns_removed: return os << "old excess columns removed and new columns added";
-            case sync_schema_result::dropped_and_recreated: return os << "old table dropped and recreated";
+
+    inline std::ostream &operator<<(std::ostream &os, sync_schema_result value) {
+        switch(value) {
+            case sync_schema_result::new_table_created:
+                return os << "new table created";
+            case sync_schema_result::already_in_sync:
+                return os << "table and storage is already in sync.";
+            case sync_schema_result::old_columns_removed:
+                return os << "old excess columns removed";
+            case sync_schema_result::new_columns_added:
+                return os << "new columns added";
+            case sync_schema_result::new_columns_added_and_old_columns_removed:
+                return os << "old excess columns removed and new columns added";
+            case sync_schema_result::dropped_and_recreated:
+                return os << "old table dropped and recreated";
         }
         return os;
     }

--- a/dev/table.h
+++ b/dev/table.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <string>   //  std::string
+#include <string>  //  std::string
 #include <type_traits>  //  std::remove_reference, std::is_same, std::is_base_of
-#include <vector>   //  std::vector
-#include <tuple>    //  std::tuple_size, std::tuple_element
-#include <algorithm>    //  std::reverse, std::find_if
+#include <vector>  //  std::vector
+#include <tuple>  //  std::tuple_size, std::tuple_element
+#include <algorithm>  //  std::reverse, std::find_if
 
 #include "column_result.h"
 #include "static_magic.h"
@@ -16,69 +16,70 @@
 #include "column.h"
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         struct table_base {
-            
+
             /**
              *  Table name.
              */
             const std::string name;
-            
+
             bool _without_rowid = false;
         };
-        
+
         /**
          *  Table interface class. Implementation is hidden in `table_impl` class.
          */
-        template<class T, class ...Cs>
+        template<class T, class... Cs>
         struct table_t : table_base {
             using object_type = T;
             using columns_type = std::tuple<Cs...>;
-            
+
             static constexpr const int columns_count = static_cast<int>(std::tuple_size<columns_type>::value);
-            
+
             columns_type columns;
-            
-            table_t(decltype(name) name_, columns_type columns_): table_base{std::move(name_)}, columns(std::move(columns_)) {}
-            
+
+            table_t(decltype(name) name_, columns_type columns_) :
+                table_base{std::move(name_)}, columns(std::move(columns_)) {}
+
             table_t<T, Cs...> without_rowid() const {
                 auto res = *this;
                 res._without_rowid = true;
                 return res;
             }
-            
+
             /**
              *  Function used to get field value from object by mapped member pointer/setter/getter
              */
             template<class F, class C>
-            const F* get_object_field_pointer(const object_type &obj, C c) const {
+            const F *get_object_field_pointer(const object_type &obj, C c) const {
                 const F *res = nullptr;
-                this->for_each_column_with_field_type<F>([&res, &c, &obj](auto &col){
+                this->for_each_column_with_field_type<F>([&res, &c, &obj](auto &col) {
                     using column_type = typename std::remove_reference<decltype(col)>::type;
                     using member_pointer_t = typename column_type::member_pointer_t;
                     using getter_type = typename column_type::getter_type;
                     using setter_type = typename column_type::setter_type;
                     // Make static_if have at least one input as a workaround for GCC bug:
                     // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64095
-                    if(!res){
-                        static_if<std::is_same<C, member_pointer_t>{}>([&res, &obj, &col](const C &c){
-                            if(compare_any(col.member_pointer, c)){
+                    if(!res) {
+                        static_if<std::is_same<C, member_pointer_t>{}>([&res, &obj, &col](const C &c) {
+                            if(compare_any(col.member_pointer, c)) {
                                 res = &(obj.*col.member_pointer);
                             }
                         })(c);
                     }
-                    if(!res){
-                        static_if<std::is_same<C, getter_type>{}>([&res, &obj, &col](const C &c){
-                            if(compare_any(col.getter, c)){
+                    if(!res) {
+                        static_if<std::is_same<C, getter_type>{}>([&res, &obj, &col](const C &c) {
+                            if(compare_any(col.getter, c)) {
                                 res = &((obj).*(col.getter))();
                             }
                         })(c);
                     }
-                    if(!res){
-                        static_if<std::is_same<C, setter_type>{}>([&res, &obj, &col](const C &c){
-                            if(compare_any(col.setter, c)){
+                    if(!res) {
+                        static_if<std::is_same<C, setter_type>{}>([&res, &obj, &col](const C &c) {
+                            if(compare_any(col.setter, c)) {
                                 res = &((obj).*(col.getter))();
                             }
                         })(c);
@@ -86,67 +87,67 @@ namespace sqlite_orm {
                 });
                 return res;
             }
-            
+
             /**
              *  @return vector of column names of table.
              */
             std::vector<std::string> column_names() const {
                 std::vector<std::string> res;
-                this->for_each_column([&res](auto &c){
+                this->for_each_column([&res](auto &c) {
                     res.push_back(c.name);
                 });
                 return res;
             }
-            
+
             /**
              *  Calls **l** with every primary key dedicated constraint
              */
             template<class L>
             void for_each_primary_key(const L &l) const {
-                iterate_tuple(this->columns, [&l](auto &column){
+                iterate_tuple(this->columns, [&l](auto &column) {
                     using column_type = typename std::decay<decltype(column)>::type;
                     static_if<internal::is_primary_key<column_type>{}>(l)(column);
                 });
             }
-            
+
             std::vector<std::string> composite_key_columns_names() const {
                 std::vector<std::string> res;
-                this->for_each_primary_key([this, &res](auto &c){
+                this->for_each_primary_key([this, &res](auto &c) {
                     res = this->composite_key_columns_names(c);
                 });
                 return res;
             }
-            
+
             std::vector<std::string> primary_key_column_names() const {
                 std::vector<std::string> res;
-                this->for_each_column_with<constraints::primary_key_t<>>([&res](auto &c){
+                this->for_each_column_with<constraints::primary_key_t<>>([&res](auto &c) {
                     res.push_back(c.name);
                 });
-                if(!res.size()){
+                if(!res.size()) {
                     res = this->composite_key_columns_names();
                 }
                 return res;
             }
-            
-            template<class ...Args>
+
+            template<class... Args>
             std::vector<std::string> composite_key_columns_names(const constraints::primary_key_t<Args...> &pk) const {
                 std::vector<std::string> res;
                 using pk_columns_tuple = decltype(pk.columns);
                 res.reserve(std::tuple_size<pk_columns_tuple>::value);
-                iterate_tuple(pk.columns, [this, &res](auto &v){
+                iterate_tuple(pk.columns, [this, &res](auto &v) {
                     res.push_back(this->find_column_name(v));
                 });
                 return res;
             }
-            
+
             /**
              *  Searches column name by class member pointer passed as first argument.
              *  @return column name or empty string if nothing found.
              */
-            template<
-            class F,
-            class O,
-            typename = typename std::enable_if<std::is_member_pointer<F O::*>::value && !std::is_member_function_pointer<F O::*>::value>::type>
+            template<class F,
+                     class O,
+                     typename = typename std::enable_if<std::is_member_pointer<F O::*>::value &&
+                                                        !std::is_member_function_pointer<F O::*>::value>::type>
             std::string find_column_name(F O::*m) const {
                 std::string res;
                 this->template for_each_column_with_field_type<F>([&res, m](auto c) {
@@ -156,13 +157,14 @@ namespace sqlite_orm {
                 });
                 return res;
             }
-            
+
             /**
              *  Searches column name by class getter function member pointer passed as first argument.
              *  @return column name or empty string if nothing found.
              */
             template<class G>
-            std::string find_column_name(G getter, typename std::enable_if<is_getter<G>::value>::type * = nullptr) const {
+            std::string find_column_name(G getter,
+                                         typename std::enable_if<is_getter<G>::value>::type * = nullptr) const {
                 std::string res;
                 using field_type = typename getter_traits<G>::field_type;
                 this->template for_each_column_with_field_type<field_type>([&res, getter](auto c) {
@@ -172,13 +174,14 @@ namespace sqlite_orm {
                 });
                 return res;
             }
-            
+
             /**
              *  Searches column name by class setter function member pointer passed as first argument.
              *  @return column name or empty string if nothing found.
              */
             template<class S>
-            std::string find_column_name(S setter, typename std::enable_if<is_setter<S>::value>::type * = nullptr) const {
+            std::string find_column_name(S setter,
+                                         typename std::enable_if<is_setter<S>::value>::type * = nullptr) const {
                 std::string res;
                 using field_type = typename setter_traits<S>::field_type;
                 this->template for_each_column_with_field_type<field_type>([&res, setter](auto c) {
@@ -188,49 +191,50 @@ namespace sqlite_orm {
                 });
                 return res;
             }
-            
+
             /**
-             *  @return vector of column names that have constraints provided as template arguments (not_null, autoincrement).
+             *  @return vector of column names that have constraints provided as template arguments (not_null,
+             * autoincrement).
              */
-            template<class ...Op>
+            template<class... Op>
             std::vector<std::string> column_names_with() {
                 std::vector<std::string> res;
-                iterate_tuple(this->columns, [&res](auto &column){
+                iterate_tuple(this->columns, [&res](auto &column) {
                     if(column.template has_every<Op...>()) {
                         res.emplace_back(column.name);
                     }
                 });
                 return res;
             }
-            
+
             /**
-             *  Iterates all columns and fires passed lambda. Lambda must have one and only templated argument Otherwise code will
-             *  not compile. Excludes table constraints (e.g. foreign_key_t) at the end of the columns list. To iterate columns with
-             *  table constraints use for_each_column_with_constraints instead.
-             *  L is lambda type. Do not specify it explicitly.
+             *  Iterates all columns and fires passed lambda. Lambda must have one and only templated argument Otherwise
+             * code will not compile. Excludes table constraints (e.g. foreign_key_t) at the end of the columns list. To
+             * iterate columns with table constraints use for_each_column_with_constraints instead. L is lambda type. Do
+             * not specify it explicitly.
              *  @param l Lambda to be called per column itself. Must have signature like this [] (auto col) -> void {}
              */
             template<class L>
             void for_each_column(const L &l) const {
-                iterate_tuple(this->columns, [&l](auto &column){
+                iterate_tuple(this->columns, [&l](auto &column) {
                     using column_type = typename std::decay<decltype(column)>::type;
                     static_if<internal::is_column<column_type>{}>(l)(column);
                 });
             }
-            
+
             template<class L>
             void for_each_column_with_constraints(const L &l) const {
                 iterate_tuple(this->columns, l);
             }
-            
+
             template<class F, class L>
             void for_each_column_with_field_type(const L &l) const {
-                iterate_tuple(this->columns, [&l](auto &column){
+                iterate_tuple(this->columns, [&l](auto &column) {
                     using column_type = typename std::decay<decltype(column)>::type;
                     static_if<std::is_same<F, typename column_type::field_type>{}>(l)(column);
                 });
             }
-            
+
             /**
              *  Iterates all columns that have specified constraints and fires passed lambda.
              *  Lambda must have one and only templated argument Otherwise code will not compile.
@@ -240,23 +244,23 @@ namespace sqlite_orm {
             template<class Op, class L>
             void for_each_column_with(const L &l) const {
                 using tuple_helper::tuple_contains_type;
-                iterate_tuple(this->columns, [&l](auto &column){
+                iterate_tuple(this->columns, [&l](auto &column) {
                     using column_type = typename std::decay<decltype(column)>::type;
                     static_if<tuple_contains_type<Op, typename column_type::constraints_type>{}>(l)(column);
                 });
             }
-            
+
             std::vector<table_info> get_table_info() {
                 std::vector<table_info> res;
                 res.reserve(size_t(this->columns_count));
-                this->for_each_column([&res](auto &col){
+                this->for_each_column([&res](auto &col) {
                     std::string dft;
                     using field_type = typename std::decay<decltype(col)>::type::field_type;
                     if(auto d = col.default_value()) {
                         auto needQuotes = std::is_base_of<text_printer, type_printer<field_type>>::value;
-                        if(needQuotes){
+                        if(needQuotes) {
                             dft = "'" + *d + "'";
-                        }else{
+                        } else {
                             dft = *d;
                         }
                     }
@@ -273,32 +277,29 @@ namespace sqlite_orm {
                 auto compositeKeyColumnNames = this->composite_key_columns_names();
                 for(size_t i = 0; i < compositeKeyColumnNames.size(); ++i) {
                     auto &columnName = compositeKeyColumnNames[i];
-                    auto it = std::find_if(res.begin(),
-                                           res.end(),
-                                           [&columnName](const table_info &ti) {
-                                               return ti.name == columnName;
-                                           });
-                    if(it != res.end()){
+                    auto it = std::find_if(res.begin(), res.end(), [&columnName](const table_info &ti) {
+                        return ti.name == columnName;
+                    });
+                    if(it != res.end()) {
                         it->pk = static_cast<int>(i + 1);
                     }
                 }
                 return res;
             }
-            
         };
     }
-    
+
     /**
      *  Function used for table creation. Do not use table constructor - use this function
      *  cause table class is templated and its constructing too (just like std::make_unique or std::make_pair).
      */
-    template<class ...Cs, class T = typename std::tuple_element<0, std::tuple<Cs...>>::type::object_type>
-    internal::table_t<T, Cs...> make_table(const std::string &name, Cs ...args) {
+    template<class... Cs, class T = typename std::tuple_element<0, std::tuple<Cs...>>::type::object_type>
+    internal::table_t<T, Cs...> make_table(const std::string &name, Cs... args) {
         return {name, std::make_tuple<Cs...>(std::forward<Cs>(args)...)};
     }
-    
-    template<class T, class ...Cs>
-    internal::table_t<T, Cs...> make_table(const std::string &name, Cs ...args) {
+
+    template<class T, class... Cs>
+    internal::table_t<T, Cs...> make_table(const std::string &name, Cs... args) {
         return {name, std::make_tuple<Cs...>(std::forward<Cs>(args)...)};
     }
 }

--- a/dev/table_info.h
+++ b/dev/table_info.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <string>   //  std::string
+#include <string>  //  std::string
 
 namespace sqlite_orm {
-    
+
     struct table_info {
         int cid;
         std::string name;
@@ -12,5 +12,5 @@ namespace sqlite_orm {
         std::string dflt_value;
         int pk;
     };
-    
+
 }

--- a/dev/table_type.h
+++ b/dev/table_type.h
@@ -6,31 +6,33 @@
 #include "column.h"
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         /**
          *  Trait class used to define table mapped type by setter/getter/member
          *  T - member pointer
          */
         template<class T, class SFINAE = void>
         struct table_type;
-        
+
         template<class O, class F>
-        struct table_type<F O::*, typename std::enable_if<std::is_member_pointer<F O::*>::value && !std::is_member_function_pointer<F O::*>::value>::type> {
+        struct table_type<F O::*,
+                          typename std::enable_if<std::is_member_pointer<F O::*>::value &&
+                                                  !std::is_member_function_pointer<F O::*>::value>::type> {
             using type = O;
         };
-        
+
         template<class T>
         struct table_type<T, typename std::enable_if<is_getter<T>::value>::type> {
             using type = typename getter_traits<T>::object_type;
         };
-        
+
         template<class T>
         struct table_type<T, typename std::enable_if<is_setter<T>::value>::type> {
             using type = typename setter_traits<T>::object_type;
         };
-        
+
         template<class T, class F>
         struct table_type<column_pointer<T, F>, void> {
             using type = T;

--- a/dev/transaction_guard.h
+++ b/dev/transaction_guard.h
@@ -1,13 +1,13 @@
 #pragma once
 
-#include <functional>   //  std::function
+#include <functional>  //  std::function
 
 #include "connection_holder.h"
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         /**
          *  Class used as a guard for a transaction. Calls `ROLLBACK` in destructor.
          *  Has explicit `commit()` and `rollback()` functions. After explicit function is fired
@@ -20,23 +20,23 @@ namespace sqlite_orm {
              *  if `gotta_fire` is true
              */
             bool commit_on_destroy = false;
-            
-            transaction_guard_t(connection_ref connection_, std::function<void()> commit_func_, std::function<void()> rollback_func_):
-            connection(std::move(connection_)),
-            commit_func(std::move(commit_func_)),
-            rollback_func(std::move(rollback_func_))
-            {}
-            
+
+            transaction_guard_t(connection_ref connection_,
+                                std::function<void()> commit_func_,
+                                std::function<void()> rollback_func_) :
+                connection(std::move(connection_)),
+                commit_func(std::move(commit_func_)), rollback_func(std::move(rollback_func_)) {}
+
             ~transaction_guard_t() {
-                if(this->gotta_fire){
-                    if(!this->commit_on_destroy){
+                if(this->gotta_fire) {
+                    if(!this->commit_on_destroy) {
                         this->rollback_func();
-                    }else{
+                    } else {
                         this->commit_func();
                     }
                 }
             }
-            
+
             /**
              *  Call `COMMIT` explicitly. After this call
              *  guard will not call `COMMIT` or `ROLLBACK`
@@ -46,7 +46,7 @@ namespace sqlite_orm {
                 this->commit_func();
                 this->gotta_fire = false;
             }
-            
+
             /**
              *  Call `ROLLBACK` explicitly. After this call
              *  guard will not call `COMMIT` or `ROLLBACK`
@@ -56,8 +56,8 @@ namespace sqlite_orm {
                 this->rollback_func();
                 this->gotta_fire = false;
             }
-            
-        protected:
+
+          protected:
             connection_ref connection;
             std::function<void()> commit_func;
             std::function<void()> rollback_func;

--- a/dev/tuple_helper.h
+++ b/dev/tuple_helper.h
@@ -1,83 +1,83 @@
 #pragma once
 
-#include <tuple>    //  std::tuple, std::get
+#include <tuple>  //  std::tuple, std::get
 #include <type_traits>  //  std::false_type, std::true_type
 
 #include "static_magic.h"
 
 namespace sqlite_orm {
-    
+
     //  got from here http://stackoverflow.com/questions/25958259/how-do-i-find-out-if-a-tuple-contains-a-type
     namespace tuple_helper {
-        
-        template <typename T, typename Tuple>
+
+        template<typename T, typename Tuple>
         struct has_type;
-        
-        template <typename T>
+
+        template<typename T>
         struct has_type<T, std::tuple<>> : std::false_type {};
-        
-        template <typename T, typename U, typename... Ts>
+
+        template<typename T, typename U, typename... Ts>
         struct has_type<T, std::tuple<U, Ts...>> : has_type<T, std::tuple<Ts...>> {};
-        
-        template <typename T, typename... Ts>
+
+        template<typename T, typename... Ts>
         struct has_type<T, std::tuple<T, Ts...>> : std::true_type {};
-        
-        template <typename T, typename Tuple>
+
+        template<typename T, typename Tuple>
         using tuple_contains_type = typename has_type<T, Tuple>::type;
-        
-        template<size_t N, class ...Args>
+
+        template<size_t N, class... Args>
         struct iterator {
-            
+
             template<class L>
             void operator()(const std::tuple<Args...> &t, const L &l, bool reverse = true) {
-                if(reverse){
+                if(reverse) {
                     l(std::get<N>(t));
                     iterator<N - 1, Args...>()(t, l, reverse);
-                }else{
+                } else {
                     iterator<N - 1, Args...>()(t, l, reverse);
                     l(std::get<N>(t));
                 }
             }
         };
-        
-        template<class ...Args>
-        struct iterator<0, Args...>{
-            
+
+        template<class... Args>
+        struct iterator<0, Args...> {
+
             template<class L>
             void operator()(const std::tuple<Args...> &t, const L &l, bool /*reverse*/ = true) {
                 l(std::get<0>(t));
             }
         };
-        
+
         template<size_t N>
         struct iterator<N> {
-            
+
             template<class L>
             void operator()(const std::tuple<> &, const L &, bool /*reverse*/ = true) {
                 //..
             }
         };
-        
+
         template<size_t N, size_t I, class L, class R>
         void move_tuple_impl(L &lhs, R &rhs) {
             std::get<I>(lhs) = std::move(std::get<I>(rhs));
-            internal::static_if<std::integral_constant<bool, N != I + 1>{}>([](auto &lhs, auto &rhs){
+            internal::static_if<std::integral_constant<bool, N != I + 1>{}>([](auto &lhs, auto &rhs) {
                 move_tuple_impl<N, I + 1>(lhs, rhs);
             })(lhs, rhs);
         }
     }
-    
+
     namespace internal {
-        
+
         template<size_t N, class L, class R>
         void move_tuple(L &lhs, R &rhs) {
             using bool_type = std::integral_constant<bool, N != 0>;
-            static_if<bool_type{}>([](auto &lhs, auto &rhs){
+            static_if<bool_type{}>([](auto &lhs, auto &rhs) {
                 tuple_helper::move_tuple_impl<N, 0>(lhs, rhs);
             })(lhs, rhs);
         }
-        
-        template<class L, class ...Args>
+
+        template<class L, class... Args>
         void iterate_tuple(const std::tuple<Args...> &t, const L &l) {
             using tuple_type = std::tuple<Args...>;
             tuple_helper::iterator<std::tuple_size<tuple_type>::value - 1, Args...>()(t, l, false);

--- a/dev/type_is_nullable.h
+++ b/dev/type_is_nullable.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include <type_traits>  //  std::false_type, std::true_type
-#include <memory>   //  std::shared_ptr, std::unique_ptr
+#include <memory>  //  std::shared_ptr, std::unique_ptr
 
 namespace sqlite_orm {
-    
+
     /**
      *  This is class that tells `sqlite_orm` that type is nullable. Nullable types
      *  are mapped to sqlite database as `NULL` and not-nullable are mapped as `NOT NULL`.
@@ -18,7 +18,7 @@ namespace sqlite_orm {
             return true;
         }
     };
-    
+
     /**
      *  This is a specialization for std::shared_ptr. std::shared_ptr is nullable in sqlite_orm.
      */
@@ -28,7 +28,7 @@ namespace sqlite_orm {
             return static_cast<bool>(t);
         }
     };
-    
+
     /**
      *  This is a specialization for std::unique_ptr. std::unique_ptr is nullable too.
      */
@@ -38,5 +38,5 @@ namespace sqlite_orm {
             return static_cast<bool>(t);
         }
     };
-    
+
 }

--- a/dev/type_printer.h
+++ b/dev/type_printer.h
@@ -1,103 +1,103 @@
 #pragma once
 
-#include <string>   //  std::string
-#include <memory>   //  std::shared_ptr, std::unique_ptr
-#include <vector>   //  std::vector
+#include <string>  //  std::string
+#include <memory>  //  std::shared_ptr, std::unique_ptr
+#include <vector>  //  std::vector
 
 namespace sqlite_orm {
-    
+
     /**
      *  This class accepts c++ type and transfers it to sqlite name (int -> INTEGER, std::string -> TEXT)
      */
     template<class T>
     struct type_printer;
-    
+
     struct integer_printer {
-        inline const std::string& print() {
+        inline const std::string &print() {
             static const std::string res = "INTEGER";
             return res;
         }
     };
-    
+
     struct text_printer {
-        inline const std::string& print() {
+        inline const std::string &print() {
             static const std::string res = "TEXT";
             return res;
         }
     };
-    
+
     struct real_printer {
-        inline const std::string& print() {
+        inline const std::string &print() {
             static const std::string res = "REAL";
             return res;
         }
     };
-    
+
     struct blob_printer {
-        inline const std::string& print() {
+        inline const std::string &print() {
             static const std::string res = "BLOB";
             return res;
         }
     };
-    
-    //Note unsigned/signed char and simple char used for storing integer values, not char values.
+
+    // Note unsigned/signed char and simple char used for storing integer values, not char values.
     template<>
     struct type_printer<unsigned char> : public integer_printer {};
-    
+
     template<>
     struct type_printer<signed char> : public integer_printer {};
-    
+
     template<>
     struct type_printer<char> : public integer_printer {};
-    
+
     template<>
     struct type_printer<unsigned short int> : public integer_printer {};
-    
+
     template<>
     struct type_printer<short> : public integer_printer {};
-    
+
     template<>
     struct type_printer<unsigned int> : public integer_printer {};
-    
+
     template<>
     struct type_printer<int> : public integer_printer {};
-    
+
     template<>
     struct type_printer<unsigned long> : public integer_printer {};
-    
+
     template<>
     struct type_printer<long> : public integer_printer {};
-    
+
     template<>
     struct type_printer<unsigned long long> : public integer_printer {};
-    
+
     template<>
     struct type_printer<long long> : public integer_printer {};
-    
+
     template<>
     struct type_printer<bool> : public integer_printer {};
-    
+
     template<>
     struct type_printer<std::string> : public text_printer {};
-    
+
     template<>
     struct type_printer<std::wstring> : public text_printer {};
-    
+
     template<>
-    struct type_printer<const char*> : public text_printer {};
-    
+    struct type_printer<const char *> : public text_printer {};
+
     template<>
     struct type_printer<float> : public real_printer {};
-    
+
     template<>
     struct type_printer<double> : public real_printer {};
-    
+
     template<class T>
     struct type_printer<std::shared_ptr<T>> : public type_printer<T> {};
-    
+
     template<class T>
     struct type_printer<std::unique_ptr<T>> : public type_printer<T> {};
-    
+
     template<>
     struct type_printer<std::vector<char>> : public blob_printer {};
 }

--- a/dev/typed_comparator.h
+++ b/dev/typed_comparator.h
@@ -1,9 +1,9 @@
 #pragma once
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         /**
          *  Cute class used to compare setters/getters and member pointers with each other.
          */
@@ -13,14 +13,14 @@ namespace sqlite_orm {
                 return false;
             }
         };
-        
+
         template<class O>
         struct typed_comparator<O, O> {
             bool operator()(const O &lhs, const O &rhs) const {
                 return lhs == rhs;
             }
         };
-        
+
         template<class L, class R>
         bool compare_any(const L &lhs, const R &rhs) {
             return typed_comparator<L, R>()(lhs, rhs);

--- a/dev/view.h
+++ b/dev/view.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <memory>   //  std::shared_ptr
-#include <string>   //  std::string
+#include <memory>  //  std::shared_ptr
+#include <string>  //  std::string
 #include <utility>  //  std::forward, std::move
 #include <sqlite3.h>
-#include <system_error> //  std::system_error
-#include <tuple>    //  std::tuple, std::make_tuple
+#include <system_error>  //  std::system_error
+#include <tuple>  //  std::tuple, std::make_tuple
 
 #include "row_extractor.h"
 #include "statement_finalizer.h"
@@ -16,53 +16,53 @@
 #include "connection_holder.h"
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
-        template<class T, class S, class ...Args>
+
+        template<class T, class S, class... Args>
         struct view_t {
             using mapped_type = T;
             using storage_type = S;
             using self = view_t<T, S, Args...>;
-            
+
             storage_type &storage;
             connection_ref connection;
             get_all_t<T, Args...> args;
-            
-            view_t(storage_type &stor, decltype(connection) conn, Args&& ...args_):
-            storage(stor),
-            connection(std::move(conn)),
-            args{std::make_tuple(std::forward<Args>(args_)...)}{}
-            
+
+            view_t(storage_type &stor, decltype(connection) conn, Args &&... args_) :
+                storage(stor), connection(std::move(conn)), args{std::make_tuple(std::forward<Args>(args_)...)} {}
+
             size_t size() {
                 return this->storage.template count<T>();
             }
-            
+
             bool empty() {
                 return !this->size();
             }
-            
+
             iterator_t<self> end() {
                 return {nullptr, *this};
             }
-            
+
             iterator_t<self> begin() {
                 sqlite3_stmt *stmt = nullptr;
                 auto db = this->connection.get();
                 auto query = this->storage.string_from_expression(this->args, false);
                 auto ret = sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr);
-                if(ret == SQLITE_OK){
+                if(ret == SQLITE_OK) {
                     auto index = 1;
-                    iterate_ast(this->args.conditions, [&index, stmt, db](auto &node){
+                    iterate_ast(this->args.conditions, [&index, stmt, db](auto &node) {
                         using node_type = typename std::decay<decltype(node)>::type;
                         conditional_binder<node_type, is_bindable<node_type>> binder{stmt, index};
-                        if(SQLITE_OK != binder(node)){
-                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                        if(SQLITE_OK != binder(node)) {
+                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                    sqlite3_errmsg(db));
                         }
                     });
                     return {stmt, *this};
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
         };

--- a/examples/blob.cpp
+++ b/examples/blob.cpp
@@ -11,7 +11,7 @@ using std::endl;
 struct User {
     int id;
     std::string name;
-    std::vector<char> hash; //  binary format
+    std::vector<char> hash;  //  binary format
 };
 
 int main(int, char **) {
@@ -27,7 +27,7 @@ int main(int, char **) {
     User alex{
         0,
         "Alex",
-        { 0x10, 0x20, 0x30, 0x40 },
+        {0x10, 0x20, 0x30, 0x40},
     };
     alex.id = storage.insert(alex);
 

--- a/examples/case.cpp
+++ b/examples/case.cpp
@@ -16,7 +16,7 @@ int main() {
         std::string email;
         float marks = 0;
     };
-    
+
     auto storage = make_storage({},
                                 make_table("STUDENT",
                                            make_column("ID", &Student::id, primary_key()),
@@ -24,23 +24,23 @@ int main() {
                                            make_column("EMAIL", &Student::email),
                                            make_column("MARKS", &Student::marks)));
     storage.sync_schema();
-    
-    storage.transaction([&storage]{
+
+    storage.transaction([&storage] {
         storage.replace(Student{1, "Shweta", "shweta@gmail.com", 80});
         storage.replace(Student{2, "Yamini", "rani@gmail.com", 60});
         storage.replace(Student{3, "Sonal", "sonal@gmail.com", 50});
         storage.replace(Student{4, "Jagruti", "jagu@gmail.com", 30});
         return true;
     });
-    
+
     //  list all students
-    for(auto &student : storage.iterate<Student>()) {
+    for(auto &student: storage.iterate<Student>()) {
         cout << storage.dump(student) << endl;
     }
     cout << endl;
-    
-    {   // without alias
-        
+
+    {  // without alias
+
         //  SELECT ID, NAME, MARKS,
         //      CASE
         //      WHEN MARKS >=80 THEN 'A+'
@@ -54,26 +54,27 @@ int main() {
                                            &Student::name,
                                            &Student::marks,
                                            case_<std::string>()
-                                           .when(greater_or_equal(&Student::marks, 80), then("A+"))
-                                           .when(greater_or_equal(&Student::marks, 70), then("A"))
-                                           .when(greater_or_equal(&Student::marks, 60), then("B"))
-                                           .when(greater_or_equal(&Student::marks, 50), then("C"))
-                                           .else_("Sorry!! Failed")
-                                           .end()));
-        for(auto &row : rows) {
-            cout << std::get<0>(row) << ' ' << std::get<1>(row) << ' ' << std::get<2>(row) << ' ' << std::get<3>(row) << endl;
+                                               .when(greater_or_equal(&Student::marks, 80), then("A+"))
+                                               .when(greater_or_equal(&Student::marks, 70), then("A"))
+                                               .when(greater_or_equal(&Student::marks, 60), then("B"))
+                                               .when(greater_or_equal(&Student::marks, 50), then("C"))
+                                               .else_("Sorry!! Failed")
+                                               .end()));
+        for(auto &row: rows) {
+            cout << std::get<0>(row) << ' ' << std::get<1>(row) << ' ' << std::get<2>(row) << ' ' << std::get<3>(row)
+                 << endl;
         }
         cout << endl;
     }
-    {   // with alias
-        
+    {  // with alias
+
         struct GradeAlias : alias_tag {
             static const std::string &get() {
                 static const std::string res = "Grade";
                 return res;
             }
         };
-        
+
         //  SELECT ID, NAME, MARKS,
         //      CASE
         //      WHEN MARKS >=80 THEN 'A+'
@@ -87,17 +88,18 @@ int main() {
                                            &Student::name,
                                            &Student::marks,
                                            as<GradeAlias>(case_<std::string>()
-                                                           .when(greater_or_equal(&Student::marks, 80), then("A+"))
-                                                           .when(greater_or_equal(&Student::marks, 70), then("A"))
-                                                           .when(greater_or_equal(&Student::marks, 60), then("B"))
-                                                           .when(greater_or_equal(&Student::marks, 50), then("C"))
-                                                           .else_("Sorry!! Failed")
-                                                           .end())));
-        for(auto &row : rows) {
-            cout << std::get<0>(row) << ' ' << std::get<1>(row) << ' ' << std::get<2>(row) << ' ' << std::get<3>(row) << endl;
+                                                              .when(greater_or_equal(&Student::marks, 80), then("A+"))
+                                                              .when(greater_or_equal(&Student::marks, 70), then("A"))
+                                                              .when(greater_or_equal(&Student::marks, 60), then("B"))
+                                                              .when(greater_or_equal(&Student::marks, 50), then("C"))
+                                                              .else_("Sorry!! Failed")
+                                                              .end())));
+        for(auto &row: rows) {
+            cout << std::get<0>(row) << ' ' << std::get<1>(row) << ' ' << std::get<2>(row) << ' ' << std::get<3>(row)
+                 << endl;
         }
         cout << endl;
     }
-    
+
     return 0;
 }

--- a/examples/collate.cpp
+++ b/examples/collate.cpp
@@ -19,24 +19,23 @@ struct Foo {
     int baz;
 };
 
-int main(int, char**) {
+int main(int, char **) {
 
     using namespace sqlite_orm;
-    auto storage = make_storage("collate.sqlite",
-                                make_table("users",
-                                           make_column("id", &User::id, primary_key()),
-                                           make_column("name", &User::name),
-                                           make_column("created_at", &User::createdAt)),
-                                make_table("foo",
-                                           make_column("text", &Foo::text, collate_nocase()),
-                                           make_column("baz", &Foo::baz)));
+    auto storage = make_storage(
+        "collate.sqlite",
+        make_table("users",
+                   make_column("id", &User::id, primary_key()),
+                   make_column("name", &User::name),
+                   make_column("created_at", &User::createdAt)),
+        make_table("foo", make_column("text", &Foo::text, collate_nocase()), make_column("baz", &Foo::baz)));
     storage.sync_schema();
     storage.remove_all<User>();
     storage.remove_all<Foo>();
 
-    storage.insert(User{ 0, "Lil Kim", time(nullptr) });
-    storage.insert(User{ 0, "lil kim", time(nullptr) });
-    storage.insert(User{ 0, "Nicki Minaj", time(nullptr) });
+    storage.insert(User{0, "Lil Kim", time(nullptr)});
+    storage.insert(User{0, "lil kim", time(nullptr)});
+    storage.insert(User{0, "Nicki Minaj", time(nullptr)});
 
     //  SELECT COUNT(*) FROM users WHERE name = 'lil kim'
     auto preciseLilKimsCount = storage.count<User>(where(is_equal(&User::name, "lil kim")));
@@ -49,8 +48,8 @@ int main(int, char**) {
     //  SELECT COUNT(*) FROM users
     cout << "total users count = " << storage.count<User>() << endl;
 
-    storage.insert(Foo{ "Touch", 10 });
-    storage.insert(Foo{ "touch", 20 });
+    storage.insert(Foo{"Touch", 10});
+    storage.insert(Foo{"touch", 20});
 
     cout << "foo count = " << storage.count<Foo>(where(c(&Foo::text) == "touch")) << endl;
 

--- a/examples/composite_key.cpp
+++ b/examples/composite_key.cpp
@@ -27,20 +27,21 @@ struct UserVisit {
 
 int main() {
     using namespace sqlite_orm;
-    
-    auto storage = make_storage({},
-                                make_table("users",
-                                           make_column("id", &User::id),
-                                           make_column("first_name", &User::firstName),
-                                           make_column("last_name", &User::lastName),
-                                           primary_key(&User::id, &User::firstName)),
-                                make_table("visits",
-                                           make_column("user_id", &UserVisit::userId),
-                                           make_column("user_first_name", &UserVisit::userFirstName),
-                                           make_column("time", &UserVisit::time),
-                                           foreign_key(&UserVisit::userId, &UserVisit::userFirstName).references(&User::id, &User::firstName)));
+
+    auto storage = make_storage(
+        {},
+        make_table("users",
+                   make_column("id", &User::id),
+                   make_column("first_name", &User::firstName),
+                   make_column("last_name", &User::lastName),
+                   primary_key(&User::id, &User::firstName)),
+        make_table("visits",
+                   make_column("user_id", &UserVisit::userId),
+                   make_column("user_first_name", &UserVisit::userFirstName),
+                   make_column("time", &UserVisit::time),
+                   foreign_key(&UserVisit::userId, &UserVisit::userFirstName).references(&User::id, &User::firstName)));
     storage.sync_schema();
-    
+
     storage.replace(User{
         1,
         "Bebe",
@@ -49,13 +50,13 @@ int main() {
     auto bebeRexha = storage.get<User>(1, "Bebe");
     cout << "bebeRexha = " << storage.dump(bebeRexha) << endl;
     auto bebeRexhaMaybe = storage.get_pointer<User>(1, "Bebe");
-    try{
+    try {
         //  2 and 'Drake' values will be ignored cause they are primary keys
-        storage.insert(User{ 2, "Drake", "Singer" });
-    }catch(const std::system_error& e){
+        storage.insert(User{2, "Drake", "Singer"});
+    } catch(const std::system_error &e) {
         cout << "exception = " << e.what() << endl;
     }
-    storage.replace(User{ 2, "The Weeknd", "Singer" });
+    storage.replace(User{2, "The Weeknd", "Singer"});
     auto weeknd = storage.get<User>(2, "The Weeknd");
     cout << "weeknd = " << storage.dump(weeknd) << endl;
     return 0;

--- a/examples/core_functions.cpp
+++ b/examples/core_functions.cpp
@@ -15,212 +15,221 @@ struct MarvelHero {
 
 int main(int, char **argv) {
     cout << "path = " << argv[0] << endl;
-    
+
     using namespace sqlite_orm;
     auto storage = make_storage("core_functions.sqlite",
                                 make_table("marvel",
-                                           make_column("id",&MarvelHero::id, primary_key()),
+                                           make_column("id", &MarvelHero::id, primary_key()),
                                            make_column("name", &MarvelHero::name),
                                            make_column("abilities", &MarvelHero::abilities),
                                            make_column("points", &MarvelHero::points)));
     storage.sync_schema();
-    
+
     storage.remove_all<MarvelHero>();
-    
+
     //  insert values..
-    storage.insert(MarvelHero{ -1, "Tony Stark", "Iron man, playboy, billionaire, philanthropist", 5 });
-    storage.insert(MarvelHero{ -1, "Thor", "Storm god", -10 });
-    storage.insert(MarvelHero{ -1, "Vision", "Min Stone", 4 });
-    storage.insert(MarvelHero{ -1, "Captain America", "Vibranium shield", -3 });
-    storage.insert(MarvelHero{ -1, "Hulk", "Strength", -15 });
-    storage.insert(MarvelHero{ -1, "Star Lord", "Humor", 19 });
-    storage.insert(MarvelHero{ -1, "Peter Parker", "Spiderman", 16 });
-    storage.insert(MarvelHero{ -1, "Clint Barton", "Hawkeye", -11 });
-    storage.insert(MarvelHero{ -1, "Natasha Romanoff", "Black widow", 8 });
-    storage.insert(MarvelHero{ -1, "Groot", "I am Groot!", 2 });
-    
+    storage.insert(MarvelHero{-1, "Tony Stark", "Iron man, playboy, billionaire, philanthropist", 5});
+    storage.insert(MarvelHero{-1, "Thor", "Storm god", -10});
+    storage.insert(MarvelHero{-1, "Vision", "Min Stone", 4});
+    storage.insert(MarvelHero{-1, "Captain America", "Vibranium shield", -3});
+    storage.insert(MarvelHero{-1, "Hulk", "Strength", -15});
+    storage.insert(MarvelHero{-1, "Star Lord", "Humor", 19});
+    storage.insert(MarvelHero{-1, "Peter Parker", "Spiderman", 16});
+    storage.insert(MarvelHero{-1, "Clint Barton", "Hawkeye", -11});
+    storage.insert(MarvelHero{-1, "Natasha Romanoff", "Black widow", 8});
+    storage.insert(MarvelHero{-1, "Groot", "I am Groot!", 2});
+
     //  SELECT LENGTH(name) FROM marvel
-    auto nameLengths = storage.select(length(&MarvelHero::name));   //  nameLengths is std::vector<int>
+    auto nameLengths = storage.select(length(&MarvelHero::name));  //  nameLengths is std::vector<int>
     cout << "nameLengths.size = " << nameLengths.size() << endl;
-    for(auto &len : nameLengths) {
+    for(auto &len: nameLengths) {
         cout << len << " ";
     }
     cout << endl;
-    
+
     //  SELECT name, LENGTH(name) FROM marvel
-    auto namesWithLengths = storage.select(columns(&MarvelHero::name, length(&MarvelHero::name)));  //  namesWithLengths is std::vector<std::tuple<std::string, int>>
+    auto namesWithLengths = storage.select(
+        columns(&MarvelHero::name,
+                length(&MarvelHero::name)));  //  namesWithLengths is std::vector<std::tuple<std::string, int>>
     cout << "namesWithLengths.size = " << namesWithLengths.size() << endl;
-    for(auto &row : namesWithLengths) {
+    for(auto &row: namesWithLengths) {
         cout << "LENGTH(" << std::get<0>(row) << ") = " << std::get<1>(row) << endl;
     }
-    
+
     //  SELECT name FROM marvel WHERE LENGTH(name) > 5
-    auto namesWithLengthGreaterThan5 = storage.select(&MarvelHero::name, where(length(&MarvelHero::name) > 5));    //  std::vector<std::string>
+    auto namesWithLengthGreaterThan5 =
+        storage.select(&MarvelHero::name, where(length(&MarvelHero::name) > 5));  //  std::vector<std::string>
     cout << "namesWithLengthGreaterThan5.size = " << namesWithLengthGreaterThan5.size() << endl;
-    for(auto &name : namesWithLengthGreaterThan5) {
+    for(auto &name: namesWithLengthGreaterThan5) {
         cout << "name = " << name << endl;
     }
-    
+
     //  SELECT LENGTH('ototo')
     auto custom = storage.select(length("ototo"));
     cout << "custom = " << custom.front() << endl;
-    
+
     //  SELECT LENGTH(1990), LENGTH(CURRENT_TIMESTAMP)
     auto customTwo = storage.select(columns(length(1990), length(storage.current_timestamp())));
     cout << "customTwo = {" << std::get<0>(customTwo.front()) << ", " << std::get<1>(customTwo.front()) << "}" << endl;
-    
+
     //  SELECT ABS(points) FROM marvel
     auto absPoints = storage.select(abs(&MarvelHero::points));  //  std::vector<std::unique_ptr<int>>
     cout << "absPoints: ";
-    for(auto &value : absPoints) {
+    for(auto &value: absPoints) {
         if(value) {
             cout << *value;
-        }else{
+        } else {
             cout << "null";
         }
         cout << " ";
     }
     cout << endl;
-    
+
     //  SELECT name FROM marvel WHERE ABS(points) < 5
     auto namesByAbs = storage.select(&MarvelHero::name, where(abs(&MarvelHero::points) < 5));
     cout << "namesByAbs.size = " << namesByAbs.size() << endl;
-    for(auto &name : namesByAbs) {
+    for(auto &name: namesByAbs) {
         cout << name << endl;
     }
     cout << endl;
-    
+
     //  SELECT length(abs(points)) FROM marvel
     auto twoFunctions = storage.select(length(abs(&MarvelHero::points)));
     cout << "twoFunctions.size = " << twoFunctions.size() << endl;
     cout << endl;
-    
+
     //  SELECT LOWER(name) FROM marvel
     auto lowerNames = storage.select(lower(&MarvelHero::name));
     cout << "lowerNames.size = " << lowerNames.size() << endl;
-    for(auto &name : lowerNames) {
+    for(auto &name: lowerNames) {
         cout << name << endl;
     }
     cout << endl;
-    
+
     //  SELECT UPPER(abilities) FROM marvel
     auto upperAbilities = storage.select(upper(&MarvelHero::abilities));
     cout << "upperAbilities.size = " << upperAbilities.size() << endl;
-    for(auto &abilities : upperAbilities) {
+    for(auto &abilities: upperAbilities) {
         cout << abilities << endl;
     }
     cout << endl;
-    
-    storage.transaction([&]{
+
+    storage.transaction([&] {
         storage.remove_all<MarvelHero>();
-        
+
         //  SELECT changes()
         auto rowsRemoved = storage.select(changes()).front();
         cout << "rowsRemoved = " << rowsRemoved << endl;
         assert(rowsRemoved == storage.changes());
         return false;
     });
-    
+
 #if SQLITE_VERSION_NUMBER >= 3007016
-    
+
     //  SELECT CHAR(67,72,65,82)
-    auto charString = storage.select(char_(67,72,65,82)).front();
+    auto charString = storage.select(char_(67, 72, 65, 82)).front();
     cout << "SELECT CHAR(67,72,65,82) = *" << charString << "*" << endl;
-    
+
     //  SELECT LOWER(name) || '@marvel.com' FROM marvel
     auto emails = storage.select(lower(&MarvelHero::name) || c("@marvel.com"));
     cout << "emails.size = " << emails.size() << endl;
-    for(auto &email : emails) {
+    for(auto &email: emails) {
         cout << email << endl;
     }
     cout << endl;
-    
+
 #endif
-    
+
     //  TRIM examples are taken from here https://www.techonthenet.com/sqlite/functions/trim.php
-    
+
     //  SELECT TRIM('   TechOnTheNet.com   ')
-    cout << "trim '   TechOnTheNet.com   ' = '" << storage.select(trim("   TechOnTheNet.com   ")).front() << "'" << endl;
-    
+    cout << "trim '   TechOnTheNet.com   ' = '" << storage.select(trim("   TechOnTheNet.com   ")).front() << "'"
+         << endl;
+
     //  SELECT TRIM('000123000', '0')
     cout << "TRIM('000123000', '0') = " << storage.select(trim("000123000", "0")).front() << endl;
-    
+
     //  SELECT TRIM('zTOTNxyxzyyy', 'xyz')
     cout << "SELECT TRIM('zTOTNxyxzyyy', 'xyz') = " << storage.select(trim("zTOTNxyxzyyy", "xyz")).front() << endl;
-    
+
     //  SELECT TRIM('42totn6372', '0123456789')
     cout << "TRIM('42totn6372', '0123456789') = " << storage.select(trim("42totn6372", "0123456789")).front() << endl;
-    
+
     //  SELECT RANDOM()
     for(auto i = 0; i < 10; ++i) {
         cout << "RANDOM() = " << storage.select(sqlite_orm::random()).front() << endl;
     }
-    
+
     //  SELECT * FROM marvel ORDER BY RANDOM()
-    for(auto &hero : storage.iterate<MarvelHero>(order_by(sqlite_orm::random()))) {
+    for(auto &hero: storage.iterate<MarvelHero>(order_by(sqlite_orm::random()))) {
         cout << "hero = " << storage.dump(hero) << endl;
     }
-    
+
     //  https://www.techonthenet.com/sqlite/functions/ltrim.php
-    
+
     //  SELECT ltrim('   TechOnTheNet.com');
     cout << "ltrim('   TechOnTheNet.com') = *" << storage.select(ltrim("   TechOnTheNet.com")).front() << "*" << endl;
-    
+
     //  SELECT ltrim('   TechOnTheNet.com   ');
-    cout << "ltrim('   TechOnTheNet.com   ') = *" << storage.select(ltrim("   TechOnTheNet.com   ")).front() << "*" << endl;
-    
+    cout << "ltrim('   TechOnTheNet.com   ') = *" << storage.select(ltrim("   TechOnTheNet.com   ")).front() << "*"
+         << endl;
+
     //  SELECT ltrim('   TechOnTheNet.com    is great!');
-    cout << "ltrim('   TechOnTheNet.com    is great!') = *" << storage.select(ltrim("   TechOnTheNet.com    is great!")).front() << "*" << endl;
-    
+    cout << "ltrim('   TechOnTheNet.com    is great!') = *"
+         << storage.select(ltrim("   TechOnTheNet.com    is great!")).front() << "*" << endl;
+
     //  SELECT ltrim('000123', '0');
     cout << "ltrim('000123', '0') = " << storage.select(ltrim("000123", "0")).front() << endl;
-    
+
     //  SELECT ltrim('123123totn', '123');
     cout << "ltrim('123123totn', '123') = " << storage.select(ltrim("123123totn", "123")).front() << endl;
-    
+
     //  SELECT ltrim('123123totn123', '123');
     cout << "ltrim('123123totn123', '123') = " << storage.select(ltrim("123123totn123", "123")).front() << endl;
-    
+
     //  SELECT ltrim('xyxzyyyTOTN', 'xyz');
     cout << "ltrim('xyxzyyyTOTN', 'xyz') = " << storage.select(ltrim("xyxzyyyTOTN", "xyz")).front() << endl;
-    
+
     //  SELECT ltrim('6372totn', '0123456789');
     cout << "ltrim('6372totn', '0123456789') = " << storage.select(ltrim("6372totn", "0123456789")).front() << endl;
-    
+
     //  https://www.techonthenet.com/sqlite/functions/rtrim.php
-    
+
     //  SELECT rtrim('TechOnTheNet.com   ');
     cout << "rtrim('TechOnTheNet.com   ') = *" << storage.select(rtrim("TechOnTheNet.com   ")).front() << "*" << endl;
-    
+
     //  SELECT rtrim('   TechOnTheNet.com   ');
-    cout << "rtrim('   TechOnTheNet.com   ') = *" << storage.select(rtrim("   TechOnTheNet.com   ")).front() << "*" << endl;
-    
+    cout << "rtrim('   TechOnTheNet.com   ') = *" << storage.select(rtrim("   TechOnTheNet.com   ")).front() << "*"
+         << endl;
+
     //  SELECT rtrim('TechOnTheNet.com    is great!   ');
-    cout << "rtrim('TechOnTheNet.com    is great!   ') = *" << storage.select(rtrim("TechOnTheNet.com    is great!   ")).front() << "*" << endl;
-    
+    cout << "rtrim('TechOnTheNet.com    is great!   ') = *"
+         << storage.select(rtrim("TechOnTheNet.com    is great!   ")).front() << "*" << endl;
+
     //  SELECT rtrim('123000', '0');
     cout << "rtrim('123000', '0') = *" << storage.select(rtrim("123000", "0")).front() << "*" << endl;
-    
+
     //  SELECT rtrim('totn123123', '123');
     cout << "rtrim('totn123123', '123') = *" << storage.select(rtrim("totn123123", "123")).front() << "*" << endl;
-    
+
     //  SELECT rtrim('123totn123123', '123');
     cout << "rtrim('123totn123123', '123') = *" << storage.select(rtrim("123totn123123", "123")).front() << "*" << endl;
-    
+
     //  SELECT rtrim('TOTNxyxzyyy', 'xyz');
     cout << "rtrim('TOTNxyxzyyy', 'xyz') = *" << storage.select(rtrim("TOTNxyxzyyy", "xyz")).front() << "*" << endl;
-    
+
     //  SELECT rtrim('totn6372', '0123456789');
-    cout << "rtrim('totn6372', '0123456789') = *" << storage.select(rtrim("totn6372", "0123456789")).front() << "*" << endl;
-    
+    cout << "rtrim('totn6372', '0123456789') = *" << storage.select(rtrim("totn6372", "0123456789")).front() << "*"
+         << endl;
+
     //  SELECT coalesce(10,20);
     cout << "coalesce(10,20) = " << storage.select(coalesce<int>(10, 20)).front() << endl;
-    
+
     //  SELECT substr('SQLite substr', 8);
     cout << "substr('SQLite substr', 8) = " << storage.select(substr("SQLite substr", 8)).front() << endl;
-    
+
     //  SELECT substr('SQLite substr', 1, 6);
     cout << "substr('SQLite substr', 1, 6) = " << storage.select(substr("SQLite substr", 1, 6)).front() << endl;
-    
+
     return 0;
 }

--- a/examples/cross_join.cpp
+++ b/examples/cross_join.cpp
@@ -10,11 +10,11 @@ using std::cout;
 using std::endl;
 
 namespace DataModel {
-    
+
     struct Rank {
         std::string rank;
     };
-    
+
     struct Suit {
         std::string suit;
     };
@@ -24,26 +24,24 @@ static auto initStorage(const std::string &path) {
     using namespace DataModel;
     using namespace sqlite_orm;
     return make_storage(path,
-                        make_table("ranks",
-                                   make_column("rank", &Rank::rank)),
-                        make_table("suits",
-                                   make_column("suit", &Suit::suit)));
+                        make_table("ranks", make_column("rank", &Rank::rank)),
+                        make_table("suits", make_column("suit", &Suit::suit)));
 }
 
 int main(int, char **) {
     using namespace DataModel;
-    
+
     using Storage = decltype(initStorage(""));
-    
+
     Storage storage = initStorage("cross_join.sqlite");
-    
+
     //  sync schema in case db/tables do not exist
     storage.sync_schema();
-    
+
     //  remove old data if something left from after the last time
     storage.remove_all<Rank>();
     storage.remove_all<Suit>();
-    
+
     storage.insert(Rank{"2"});
     storage.insert(Rank{"3"});
     storage.insert(Rank{"4"});
@@ -57,14 +55,14 @@ int main(int, char **) {
     storage.insert(Rank{"Q"});
     storage.insert(Rank{"K"});
     storage.insert(Rank{"A"});
-    
+
     storage.insert(Suit{"Clubs"});
     storage.insert(Suit{"Diamonds"});
     storage.insert(Suit{"Hearts"});
     storage.insert(Suit{"Spades"});
-    
+
     using namespace sqlite_orm;
-    
+
     /**
      *  When you pass columns(...) with members sqlite_orm gathers all types and creates
      *  a std::set with respective table names. Once you passed `cross_join<T>` as an argument
@@ -76,13 +74,13 @@ int main(int, char **) {
     //  ORDER BY suit;
     auto cards = storage.select(columns(&Rank::rank, &Suit::suit),
                                 cross_join<Suit>(),
-                                order_by(&Suit::suit)); //  cards is vector<tuple<string, string>>
-    
+                                order_by(&Suit::suit));  //  cards is vector<tuple<string, string>>
+
     cout << "cards count = " << cards.size() << endl;
-    for(auto card : cards) {
+    for(auto card: cards) {
         cout << std::get<0>(card) << '\t' << std::get<1>(card) << endl;
     }
     cout << endl;
-    
+
     return 0;
 }

--- a/examples/custom_aliases.cpp
+++ b/examples/custom_aliases.cpp
@@ -41,9 +41,9 @@ struct CompanyNameAlias : alias_tag {
     }
 };
 
-int main(int, char** argv) {
+int main(int, char **argv) {
     cout << argv[0] << endl;
-    
+
     auto storage = make_storage("custom_aliases.sqlite",
                                 make_table("COMPANY",
                                            make_column("ID", &Employee::id, primary_key()),
@@ -58,16 +58,16 @@ int main(int, char** argv) {
     storage.sync_schema();
     storage.remove_all<Department>();
     storage.remove_all<Employee>();
-    
+
     //  insert initial values
-    storage.replace(Employee{ 1, "Paul", 32, "California", 20000.0 });
-    storage.replace(Employee{ 2, "Allen", 25, "Texas", 15000.0 });
-    storage.replace(Employee{ 3, "Teddy", 23, "Norway", 20000.0 });
-    storage.replace(Employee{ 4, "Mark", 25, "Rich-Mond", 65000.0 });
-    storage.replace(Employee{ 5, "David", 27, "Texas", 85000.0 });
-    storage.replace(Employee{ 6, "Kim", 22, "South-Hall", 45000.0 });
-    storage.replace(Employee{ 7, "James", 24, "Houston", 10000.0 });
-    
+    storage.replace(Employee{1, "Paul", 32, "California", 20000.0});
+    storage.replace(Employee{2, "Allen", 25, "Texas", 15000.0});
+    storage.replace(Employee{3, "Teddy", 23, "Norway", 20000.0});
+    storage.replace(Employee{4, "Mark", 25, "Rich-Mond", 65000.0});
+    storage.replace(Employee{5, "David", 27, "Texas", 85000.0});
+    storage.replace(Employee{6, "Kim", 22, "South-Hall", 45000.0});
+    storage.replace(Employee{7, "James", 24, "Houston", 10000.0});
+
     storage.replace(Department{1, "IT Billing", 1});
     storage.replace(Department{2, "Engineering", 2});
     storage.replace(Department{3, "Finance", 7});
@@ -75,32 +75,34 @@ int main(int, char** argv) {
     storage.replace(Department{5, "Finance", 4});
     storage.replace(Department{6, "Engineering", 5});
     storage.replace(Department{7, "Finance", 6});
-    
+
     //  SELECT COMPANY.ID, COMPANY.NAME, COMPANY.AGE, DEPARTMENT.DEPT
     //  FROM COMPANY, DEPARTMENT
     //  WHERE COMPANY.ID = DEPARTMENT.EMP_ID;
     auto simpleRows = storage.select(columns(&Employee::id, &Employee::name, &Employee::age, &Department::dept),
                                      where(is_equal(&Employee::id, &Department::empId)));
     assert(simpleRows.size() == 7);
-    
+
     cout << "ID" << '\t' << "NAME" << '\t' << "AGE" << '\t' << "DEPT" << endl;
     cout << "----------" << '\t' << "----------" << '\t' << "----------" << '\t' << "----------" << endl;
-    for(auto &row : simpleRows) {
-        cout << std::get<0>(row) << '\t' << std::get<1>(row) << '\t' << std::get<2>(row) << '\t' << std::get<3>(row) << endl;
+    for(auto &row: simpleRows) {
+        cout << std::get<0>(row) << '\t' << std::get<1>(row) << '\t' << std::get<2>(row) << '\t' << std::get<3>(row)
+             << endl;
     }
-    
+
     //  SELECT C.ID, C.NAME, C.AGE, D.DEPT
     //  FROM COMPANY AS C, DEPARTMENT AS D
     //  WHERE  C.ID = D.EMP_ID;
     using als_c = alias_c<Employee>;
     using als_d = alias_d<Department>;
-    auto rowsWithTableAliases = storage.select(columns(alias_column<als_c>(&Employee::id),
-                                                       alias_column<als_c>(&Employee::name),
-                                                       alias_column<als_c>(&Employee::age),
-                                                       alias_column<als_d>(&Department::dept)),
-                                               where(is_equal(alias_column<als_c>(&Employee::id), alias_column<als_d>(&Department::empId))));
+    auto rowsWithTableAliases =
+        storage.select(columns(alias_column<als_c>(&Employee::id),
+                               alias_column<als_c>(&Employee::name),
+                               alias_column<als_c>(&Employee::age),
+                               alias_column<als_d>(&Department::dept)),
+                       where(is_equal(alias_column<als_c>(&Employee::id), alias_column<als_d>(&Department::empId))));
     assert(rowsWithTableAliases == simpleRows);
-    
+
     //  SELECT COMPANY.ID as COMPANY_ID, COMPANY.NAME AS COMPANY_NAME, COMPANY.AGE, DEPARTMENT.DEPT
     //  FROM COMPANY, DEPARTMENT
     //  WHERE COMPANY_ID = DEPARTMENT.EMP_ID;
@@ -110,16 +112,17 @@ int main(int, char** argv) {
                                                         &Department::dept),
                                                 where(is_equal(get<EmployeeIdAlias>(), &Department::empId)));
     assert(rowsWithColumnAliases == rowsWithTableAliases);
-    
+
     //  SELECT C.ID AS COMPANY_ID, C.NAME AS COMPANY_NAME, C.AGE, D.DEPT
     //  FROM COMPANY AS C, DEPARTMENT AS D
     //  WHERE  C.ID = D.EMP_ID;
-    auto rowsWithBothTableAndColumnAliases = storage.select(columns(as<EmployeeIdAlias>(alias_column<als_c>(&Employee::id)),
-                                                                    as<CompanyNameAlias>(alias_column<als_c>(&Employee::name)),
-                                                                    alias_column<als_c>(&Employee::age),
-                                                                    alias_column<als_d>(&Department::dept)),
-                                                            where(is_equal(alias_column<als_c>(&Employee::id), alias_column<als_d>(&Department::empId))));
+    auto rowsWithBothTableAndColumnAliases =
+        storage.select(columns(as<EmployeeIdAlias>(alias_column<als_c>(&Employee::id)),
+                               as<CompanyNameAlias>(alias_column<als_c>(&Employee::name)),
+                               alias_column<als_c>(&Employee::age),
+                               alias_column<als_d>(&Department::dept)),
+                       where(is_equal(alias_column<als_c>(&Employee::id), alias_column<als_d>(&Department::empId))));
     assert(rowsWithBothTableAndColumnAliases == rowsWithBothTableAndColumnAliases);
-    
+
     return 0;
 }

--- a/examples/date_time.cpp
+++ b/examples/date_time.cpp
@@ -14,29 +14,28 @@ struct DatetimeText {
 
 int main() {
     using namespace sqlite_orm;
-    
-    auto storage = make_storage("",
-                                make_table("datetime_text",
-                                           make_column("d1", &DatetimeText::d1),
-                                           make_column("d2", &DatetimeText::d2)));
+
+    auto storage = make_storage(
+        "",
+        make_table("datetime_text", make_column("d1", &DatetimeText::d1), make_column("d2", &DatetimeText::d2)));
     storage.sync_schema();
-    
+
     //  SELECT date('now');
     auto now = storage.select(date("now")).front();
     cout << "date('now') = " << now << endl;
-    
+
     //  SELECT date('now','start of month','+1 month','-1 day')
     auto nowWithOffset = storage.select(date("now", "start of month", "+1 month", "-1 day")).front();
     cout << "SELECT date('now','start of month','+1 month','-1 day') = " << nowWithOffset << endl;
-    
+
     //  SELECT DATETIME('now')
     auto nowTime = storage.select(datetime("now")).front();
     cout << "DATETIME('now') = " << nowTime << endl;
-    
+
     //  SELECT DATETIME('now','localtime')
     auto localTime = storage.select(datetime("now", "localtime")).front();
     cout << "DATETIME('now','localtime') = " << localTime << endl;
-    
+
     //  INSERT INTO datetime_text (d1, d2)
     //  VALUES
     //  (
@@ -48,31 +47,30 @@ int main() {
         storage.select(datetime("now", "localtime")).front(),
     };
     storage.insert(datetimeText);
-    
+
     cout << "SELECT * FROM datetime_text = " << storage.dump(storage.get_all<DatetimeText>().front()) << endl;
-    
+
     auto nowWithOffset2 = storage.select(date("now", "+2 day")).front();
     cout << "SELECT date('now','+2 day') = " << nowWithOffset2 << endl;
-    
+
     //  SELECT julianday('now')
     auto juliandayNow = storage.select(julianday("now")).front();
     cout << "SELECT julianday('now') = " << juliandayNow << endl;
-    
+
     //  SELECT julianday('1776-07-04')
     auto oldJulianday = storage.select(julianday("1776-07-04")).front();
     cout << "SELECT julianday('1776-07-04') = " << oldJulianday << endl;
-    
+
     //  SELECT julianday('now') + julianday('1776-07-04')
     auto julianSum = storage.select(julianday("now") + julianday("1776-07-04")).front();
     cout << "SELECT julianday('now') + julianday('1776-07-04') = " << julianSum << endl;
-    
+
     //  SELECT julianday('now') - julianday('1776-07-04')
     auto julianDiff = storage.select(julianday("now") - julianday("1776-07-04")).front();
     cout << "SELECT julianday('now') - julianday('1776-07-04') = " << julianDiff << endl;
-    
+
     //  SELECT (julianday('now') - 2440587.5)*86400.0;
     auto julianConverted = storage.select((julianday("now") - 2440587.5) * 86400.0);
-    
-    
+
     return 0;
 }

--- a/examples/distinct.cpp
+++ b/examples/distinct.cpp
@@ -29,15 +29,15 @@ auto initStorage(const std::string &path) {
 using Storage = decltype(initStorage(""));
 
 int main(int, char **) {
-    
+
     Storage storage = initStorage("distinct.sqlite");
-    
+
     //  sync schema in case this is a very first launch
     storage.sync_schema();
-    
+
     //  remove all employees if it is not the very first launch
     storage.remove_all<Employee>();
-    
+
     //  now let's insert start values to wirk with. We'll make it within a transaction
     //  for better perfomance
     storage.begin_transaction();
@@ -112,31 +112,31 @@ int main(int, char **) {
         5000.0,
     });
     storage.commit();
-    
+
     //  SELECT 'NAME' FROM 'COMPANY'
     auto pureNames = storage.select(&Employee::name);
     cout << "NAME" << endl;
     cout << "----------" << endl;
-    for(auto &name : pureNames) {
+    for(auto &name: pureNames) {
         cout << name << endl;
     }
     cout << endl;
-    
+
     using namespace sqlite_orm;
     //  SELECT DISTINCT 'NAME' FROM 'COMPANY'
     auto distinctNames = storage.select(distinct(&Employee::name));
     cout << "NAME" << endl;
     cout << "----------" << endl;
-    for(auto &name : distinctNames) {
+    for(auto &name: distinctNames) {
         cout << name << endl;
     }
     cout << endl;
-    
+
     //  SELECT DISTINCT 'ADDRESS', 'NAME' FROM 'COMPANY'
     auto severalColumns = storage.select(distinct(columns(&Employee::address, &Employee::name)));
     cout << "ADDRESS" << '\t' << "NAME" << endl;
     cout << "----------" << endl;
-    for(auto &t : severalColumns) {
+    for(auto &t: severalColumns) {
         cout << std::get<0>(t) << '\t' << std::get<1>(t) << endl;
     }
     return 0;

--- a/examples/enum_binding.cpp
+++ b/examples/enum_binding.cpp
@@ -28,9 +28,11 @@ struct SuperHero {
 
 //  also we need transform functions to make string from enum..
 std::string GenderToString(Gender gender) {
-    switch(gender){
-        case Gender::Female:return "female";
-        case Gender::Male:return "male";
+    switch(gender) {
+        case Gender::Female:
+            return "female";
+        case Gender::Male:
+            return "male";
     }
     throw std::domain_error("Invalid Gender enum");
 }
@@ -47,7 +49,7 @@ std::string GenderToString(Gender gender) {
 std::unique_ptr<Gender> GenderFromString(const std::string &s) {
     if(s == "female") {
         return std::make_unique<Gender>(Gender::Female);
-    }else if(s == "male") {
+    } else if(s == "male") {
         return std::make_unique<Gender>(Gender::Male);
     }
     return nullptr;
@@ -101,27 +103,27 @@ namespace sqlite_orm {
     /**
      *  This is a reverse operation: here we have to specify a way to transform string received from
      *  database to our Gender object. Here we call `GenderFromString` and throw `std::runtime_error` if it returns
-     *  nullptr. Every `row_extractor` specialization must have `extract(const char*)` and `extract(sqlite3_stmt *stmt, int columnIndex)`
-     *  functions which return a mapped type value.
+     *  nullptr. Every `row_extractor` specialization must have `extract(const char*)` and `extract(sqlite3_stmt *stmt,
+     * int columnIndex)` functions which return a mapped type value.
      */
     template<>
     struct row_extractor<Gender> {
         Gender extract(const char *row_value) {
-            if(auto gender = GenderFromString(row_value)){
+            if(auto gender = GenderFromString(row_value)) {
                 return *gender;
-            }else{
+            } else {
                 throw std::runtime_error("incorrect gender string (" + std::string(row_value) + ")");
             }
         }
 
         Gender extract(sqlite3_stmt *stmt, int columnIndex) {
             auto str = sqlite3_column_text(stmt, columnIndex);
-            return this->extract((const char*)str);
+            return this->extract((const char *)str);
         }
     };
 }
 
-int main(int/* argc*/, char **/*argv*/) {
+int main(int /* argc*/, char ** /*argv*/) {
     using namespace sqlite_orm;
     auto storage = make_storage("",
                                 make_table("superheros",
@@ -132,7 +134,7 @@ int main(int/* argc*/, char **/*argv*/) {
     storage.remove_all<SuperHero>();
 
     //  insert Batman (male)
-    storage.insert(SuperHero{ -1, "Batman", Gender::Male });
+    storage.insert(SuperHero{-1, "Batman", Gender::Male});
 
     //  get Batman by name
     auto batman = storage.get_all<SuperHero>(where(c(&SuperHero::name) == "Batman")).front();
@@ -141,25 +143,25 @@ int main(int/* argc*/, char **/*argv*/) {
     cout << "batman = " << storage.dump(batman) << endl;
 
     //  insert Wonder woman
-    storage.insert(SuperHero{ -1, "Wonder woman", Gender::Female });
+    storage.insert(SuperHero{-1, "Wonder woman", Gender::Female});
 
     //  get all superheros
     auto allSuperHeros = storage.get_all<SuperHero>();
 
     //  print all superheros
     cout << "allSuperHeros = " << allSuperHeros.size() << endl;
-    for(auto &superHero : allSuperHeros) {
+    for(auto &superHero: allSuperHeros) {
         cout << storage.dump(superHero) << endl;
     }
 
     //  insert a second male (Superman)
-    storage.insert(SuperHero{ -1, "Superman", Gender::Male});
+    storage.insert(SuperHero{-1, "Superman", Gender::Male});
 
     //  get all male superheros (2 expected)
     auto males = storage.get_all<SuperHero>(where(c(&SuperHero::gender) == Gender::Male));
     cout << "males = " << males.size() << endl;
     assert(males.size() == 2);
-    for(auto &superHero : males) {
+    for(auto &superHero: males) {
         cout << storage.dump(superHero) << endl;
     }
 
@@ -167,7 +169,7 @@ int main(int/* argc*/, char **/*argv*/) {
     auto females = storage.get_all<SuperHero>(where(c(&SuperHero::gender) == Gender::Female));
     assert(females.size() == 1);
     cout << "females = " << females.size() << endl;
-    for(auto &superHero : females) {
+    for(auto &superHero: females) {
         cout << storage.dump(superHero) << endl;
     }
 

--- a/examples/except_intersection.cpp
+++ b/examples/except_intersection.cpp
@@ -23,7 +23,7 @@ struct EmpMaster {
 
 int main() {
     using namespace sqlite_orm;
-    
+
     auto storage = make_storage("",
                                 make_table("dept_master",
                                            make_column("dept_id", &DeptMaster::deptId, autoincrement(), primary_key()),
@@ -61,10 +61,9 @@ int main() {
         //  EXCEPT
         //  SELECT dept_id
         //  FROM emp_master
-        auto rows = storage.select(except(select(&DeptMaster::deptId),
-                                          select(&EmpMaster::deptId)));
+        auto rows = storage.select(except(select(&DeptMaster::deptId), select(&EmpMaster::deptId)));
         cout << "rows count = " << rows.size() << endl;
-        for(auto id : rows) {
+        for(auto id: rows) {
             cout << id << endl;
         }
     }
@@ -74,13 +73,12 @@ int main() {
         //  INTERSECT
         //  SELECT dept_id
         //  FROM emp_master
-        auto rows = storage.select(intersect(select(&DeptMaster::deptId),
-                                             select(&EmpMaster::deptId)));
+        auto rows = storage.select(intersect(select(&DeptMaster::deptId), select(&EmpMaster::deptId)));
         cout << "rows count = " << rows.size() << endl;
-        for(auto id : rows) {
+        for(auto id: rows) {
             cout << id << endl;
         }
     }
-    
+
     return 0;
 }

--- a/examples/exists.cpp
+++ b/examples/exists.cpp
@@ -43,7 +43,7 @@ struct Order {
 
 int main(int, char **) {
     using namespace sqlite_orm;
-    
+
     auto storage = make_storage("exists.sqlite",
                                 make_table("customer",
                                            make_column("CUST_CODE", &Customer::code, primary_key()),
@@ -76,7 +76,7 @@ int main(int, char **) {
     storage.remove_all<Order>();
     storage.remove_all<Agent>();
     storage.remove_all<Customer>();
-    
+
     storage.replace(Agent{"A007", "Ramasundar", "Bangalore", 0.15, "077-25814763", ""});
     storage.replace(Agent{"A003", "Alex", "London", 0.13, "075-12458969", ""});
     storage.replace(Agent{"A008", "Alford", "New York", 0.12, "044-25874365", ""});
@@ -89,33 +89,288 @@ int main(int, char **) {
     storage.replace(Agent{"A006", "McDen", "London", 0.15, "078-22255588", ""});
     storage.replace(Agent{"A004", "Ivan", "Torento", 0.15, "008-22544166", ""});
     storage.replace(Agent{"A009", "Benjamin", "Hampshair", 0.11, "008-22536178", ""});
-    
-    storage.replace(Customer{"C00013", "Holmes", "London", "London", "UK", 2, 6000.00, 5000.00, 7000.00, 4000.00, "BBBBBBB", "A003"});
-    storage.replace(Customer{"C00001", "Micheal", "New York", "New York", "USA", 2, 3000.00, 5000.00, 2000.00, 6000.00, "CCCCCCC", "A008"});
-    storage.replace(Customer{"C00020", "Albert", "New York", "New York", "USA", 3, 5000.00, 7000.00, 6000.00, 6000.00, "BBBBSBB", "A008"});
-    storage.replace(Customer{"C00025", "Ravindran", "Bangalore", "Bangalore", "India", 2, 5000.00, 7000.00, 4000.00, 8000.00, "AVAVAVA", "A011"});
-    storage.replace(Customer{"C00024", "Cook", "London", "London", "UK", 2, 4000.00, 9000.00, 7000.00, 6000.00, "FSDDSDF", "A006"});
-    storage.replace(Customer{"C00015", "Stuart", "London", "London", "UK", 1, 6000.00, 8000.00, 3000.00, 11000.00, "GFSGERS", "A003"});
-    storage.replace(Customer{"C00002", "Bolt", "New York", "New York", "USA", 3, 5000.00, 7000.00, 9000.00, 3000.00, "DDNRDRH", "A008"});
-    storage.replace(Customer{"C00018", "Fleming", "Brisban", "Brisban", "Australia", 2, 7000.00, 7000.00, 9000.00, 5000.00, "NHBGVFC", "A005"});
-    storage.replace(Customer{"C00021", "Jacks", "Brisban", "Brisban", "Australia", 1, 7000.00, 7000.00, 7000.00, 7000.00, "WERTGDF", "A005"});
-    storage.replace(Customer{"C00019", "Yearannaidu", "Chennai", "Chennai", "India", 1, 8000.00, 7000.00, 7000.00, 8000.00, "ZZZZBFV", "A010"});
-    storage.replace(Customer{"C00005", "Sasikant", "Mumbai", "Mumbai", "India", 1, 7000.00, 11000.00, 7000.00, 11000.00, "147-25896312", "A002"});
-    storage.replace(Customer{"C00007", "Ramanathan", "Chennai", "Chennai", "India", 1, 7000.00, 11000.00, 9000.00, 9000.00, "GHRDWSD", "A010"});
-    storage.replace(Customer{"C00022", "Avinash", "Mumbai", "Mumbai", "India", 2, 7000.00, 11000.00, 9000.00, 9000.00, "113-12345678", "A002"});
-    storage.replace(Customer{"C00004", "Winston", "Brisban", "Brisban", "Australia", 1, 5000.00, 8000.00, 7000.00, 6000.00, "AAAAAAA", "A005"});
-    storage.replace(Customer{"C00023", "Karl", "London", "London", "UK", 0, 4000.00, 6000.00, 7000.00, 3000.00, "AAAABAA", "A006"});
-    storage.replace(Customer{"C00006", "Shilton", "Torento", "Torento", "Canada", 1, 10000.00, 7000.00, 6000.00, 11000.00, "DDDDDDD", "A004"});
-    storage.replace(Customer{"C00010", "Charles", "Hampshair", "Hampshair", "UK", 3, 6000.00, 4000.00, 5000.00, 5000.00, "MMMMMMM", "A009"});
-    storage.replace(Customer{"C00017", "Srinivas", "Bangalore", "Bangalore", "India", 2, 8000.00, 4000.00, 3000.00, 9000.00, "AAAAAAB", "A007"});
-    storage.replace(Customer{"C00012", "Steven", "San Jose", "San Jose", "USA", 1, 5000.00, 7000.00, 9000.00, 3000.00, "KRFYGJK", "A012"});
-    storage.replace(Customer{"C00008", "Karolina", "Torento", "Torento", "Canada", 1, 7000.00, 7000.00, 9000.00, 5000.00, "HJKORED", "A004"});
-    storage.replace(Customer{"C00003", "Martin", "Torento", "Torento", "Canada", 2, 8000.00, 7000.00, 7000.00, 8000.00, "MJYURFD", "A004"});
-    storage.replace(Customer{"C00009", "Ramesh", "Mumbai", "Mumbai", "India", 3, 8000.00, 7000.00, 3000.00, 12000.00, "Phone No", "A002"});
-    storage.replace(Customer{"C00014", "Rangarappa", "Bangalore", "Bangalore", "India", 2, 8000.00, 11000.00, 7000.00, 12000.00, "AAAATGF", "A001"});
-    storage.replace(Customer{"C00016", "Venkatpati", "Bangalore", "Bangalore", "India", 2, 8000.00, 11000.00, 7000.00, 12000.00, "JRTVFDD", "A007"});
-    storage.replace(Customer{"C00011", "Sundariya", "Chennai", "Chennai", "India", 3, 7000.00, 11000.00, 7000.00, 11000.00, "PPHGRTS", "A010"});
-    
+
+    storage.replace(Customer{"C00013",
+                             "Holmes",
+                             "London",
+                             "London",
+                             "UK",
+                             2,
+                             6000.00,
+                             5000.00,
+                             7000.00,
+                             4000.00,
+                             "BBBBBBB",
+                             "A003"});
+    storage.replace(Customer{"C00001",
+                             "Micheal",
+                             "New York",
+                             "New York",
+                             "USA",
+                             2,
+                             3000.00,
+                             5000.00,
+                             2000.00,
+                             6000.00,
+                             "CCCCCCC",
+                             "A008"});
+    storage.replace(Customer{"C00020",
+                             "Albert",
+                             "New York",
+                             "New York",
+                             "USA",
+                             3,
+                             5000.00,
+                             7000.00,
+                             6000.00,
+                             6000.00,
+                             "BBBBSBB",
+                             "A008"});
+    storage.replace(Customer{"C00025",
+                             "Ravindran",
+                             "Bangalore",
+                             "Bangalore",
+                             "India",
+                             2,
+                             5000.00,
+                             7000.00,
+                             4000.00,
+                             8000.00,
+                             "AVAVAVA",
+                             "A011"});
+    storage.replace(
+        Customer{"C00024", "Cook", "London", "London", "UK", 2, 4000.00, 9000.00, 7000.00, 6000.00, "FSDDSDF", "A006"});
+    storage.replace(Customer{"C00015",
+                             "Stuart",
+                             "London",
+                             "London",
+                             "UK",
+                             1,
+                             6000.00,
+                             8000.00,
+                             3000.00,
+                             11000.00,
+                             "GFSGERS",
+                             "A003"});
+    storage.replace(Customer{"C00002",
+                             "Bolt",
+                             "New York",
+                             "New York",
+                             "USA",
+                             3,
+                             5000.00,
+                             7000.00,
+                             9000.00,
+                             3000.00,
+                             "DDNRDRH",
+                             "A008"});
+    storage.replace(Customer{"C00018",
+                             "Fleming",
+                             "Brisban",
+                             "Brisban",
+                             "Australia",
+                             2,
+                             7000.00,
+                             7000.00,
+                             9000.00,
+                             5000.00,
+                             "NHBGVFC",
+                             "A005"});
+    storage.replace(Customer{"C00021",
+                             "Jacks",
+                             "Brisban",
+                             "Brisban",
+                             "Australia",
+                             1,
+                             7000.00,
+                             7000.00,
+                             7000.00,
+                             7000.00,
+                             "WERTGDF",
+                             "A005"});
+    storage.replace(Customer{"C00019",
+                             "Yearannaidu",
+                             "Chennai",
+                             "Chennai",
+                             "India",
+                             1,
+                             8000.00,
+                             7000.00,
+                             7000.00,
+                             8000.00,
+                             "ZZZZBFV",
+                             "A010"});
+    storage.replace(Customer{"C00005",
+                             "Sasikant",
+                             "Mumbai",
+                             "Mumbai",
+                             "India",
+                             1,
+                             7000.00,
+                             11000.00,
+                             7000.00,
+                             11000.00,
+                             "147-25896312",
+                             "A002"});
+    storage.replace(Customer{"C00007",
+                             "Ramanathan",
+                             "Chennai",
+                             "Chennai",
+                             "India",
+                             1,
+                             7000.00,
+                             11000.00,
+                             9000.00,
+                             9000.00,
+                             "GHRDWSD",
+                             "A010"});
+    storage.replace(Customer{"C00022",
+                             "Avinash",
+                             "Mumbai",
+                             "Mumbai",
+                             "India",
+                             2,
+                             7000.00,
+                             11000.00,
+                             9000.00,
+                             9000.00,
+                             "113-12345678",
+                             "A002"});
+    storage.replace(Customer{"C00004",
+                             "Winston",
+                             "Brisban",
+                             "Brisban",
+                             "Australia",
+                             1,
+                             5000.00,
+                             8000.00,
+                             7000.00,
+                             6000.00,
+                             "AAAAAAA",
+                             "A005"});
+    storage.replace(
+        Customer{"C00023", "Karl", "London", "London", "UK", 0, 4000.00, 6000.00, 7000.00, 3000.00, "AAAABAA", "A006"});
+    storage.replace(Customer{"C00006",
+                             "Shilton",
+                             "Torento",
+                             "Torento",
+                             "Canada",
+                             1,
+                             10000.00,
+                             7000.00,
+                             6000.00,
+                             11000.00,
+                             "DDDDDDD",
+                             "A004"});
+    storage.replace(Customer{"C00010",
+                             "Charles",
+                             "Hampshair",
+                             "Hampshair",
+                             "UK",
+                             3,
+                             6000.00,
+                             4000.00,
+                             5000.00,
+                             5000.00,
+                             "MMMMMMM",
+                             "A009"});
+    storage.replace(Customer{"C00017",
+                             "Srinivas",
+                             "Bangalore",
+                             "Bangalore",
+                             "India",
+                             2,
+                             8000.00,
+                             4000.00,
+                             3000.00,
+                             9000.00,
+                             "AAAAAAB",
+                             "A007"});
+    storage.replace(Customer{"C00012",
+                             "Steven",
+                             "San Jose",
+                             "San Jose",
+                             "USA",
+                             1,
+                             5000.00,
+                             7000.00,
+                             9000.00,
+                             3000.00,
+                             "KRFYGJK",
+                             "A012"});
+    storage.replace(Customer{"C00008",
+                             "Karolina",
+                             "Torento",
+                             "Torento",
+                             "Canada",
+                             1,
+                             7000.00,
+                             7000.00,
+                             9000.00,
+                             5000.00,
+                             "HJKORED",
+                             "A004"});
+    storage.replace(Customer{"C00003",
+                             "Martin",
+                             "Torento",
+                             "Torento",
+                             "Canada",
+                             2,
+                             8000.00,
+                             7000.00,
+                             7000.00,
+                             8000.00,
+                             "MJYURFD",
+                             "A004"});
+    storage.replace(Customer{"C00009",
+                             "Ramesh",
+                             "Mumbai",
+                             "Mumbai",
+                             "India",
+                             3,
+                             8000.00,
+                             7000.00,
+                             3000.00,
+                             12000.00,
+                             "Phone No",
+                             "A002"});
+    storage.replace(Customer{"C00014",
+                             "Rangarappa",
+                             "Bangalore",
+                             "Bangalore",
+                             "India",
+                             2,
+                             8000.00,
+                             11000.00,
+                             7000.00,
+                             12000.00,
+                             "AAAATGF",
+                             "A001"});
+    storage.replace(Customer{"C00016",
+                             "Venkatpati",
+                             "Bangalore",
+                             "Bangalore",
+                             "India",
+                             2,
+                             8000.00,
+                             11000.00,
+                             7000.00,
+                             12000.00,
+                             "JRTVFDD",
+                             "A007"});
+    storage.replace(Customer{"C00011",
+                             "Sundariya",
+                             "Chennai",
+                             "Chennai",
+                             "India",
+                             3,
+                             7000.00,
+                             11000.00,
+                             7000.00,
+                             11000.00,
+                             "PPHGRTS",
+                             "A010"});
+
     storage.replace(Order{"200114", 3500, 2000, "15-AUG-08", "C00002", "A008"});
     storage.replace(Order{"200122", 2500, 400, "16-SEP-08", "C00003", "A004"});
     storage.replace(Order{"200118", 500, 100, "20-JUL-08", "C00023", "A006"});
@@ -150,7 +405,7 @@ int main(int, char **) {
     storage.replace(Order{"200112", 2000, 400, "30-MAY-08", "C00016", "A007"});
     storage.replace(Order{"200113", 4000, 600, "10-JUN-08", "C00022", "A002"});
     storage.replace(Order{"200102", 2000, 300, "25-MAY-08", "C00012", "A012"});
-    
+
     {
         //  SELECT agent_code,agent_name,working_area,commission
         //  FROM agents
@@ -161,12 +416,14 @@ int main(int, char **) {
         //  ORDER BY commission;
         auto rows = storage.select(columns(&Agent::code, &Agent::name, &Agent::workingArea, &Agent::comission),
                                    where(exists(select(asterisk<Customer>(),
-                                                       where(is_equal(&Customer::grade, 3) and is_equal(&Agent::code, &Customer::agentCode))))),
+                                                       where(is_equal(&Customer::grade, 3) and
+                                                             is_equal(&Agent::code, &Customer::agentCode))))),
                                    order_by(&Agent::comission));
         cout << "AGENT_CODE  AGENT_NAME                                WORKING_AREA  COMMISSION" << endl;
         cout << "----------  ----------------------------------------  ------------  ----------" << endl;
-        for(auto &row : rows) {
-            cout << std::get<0>(row) << '\t' <<  std::get<1>(row) << '\t' << std::get<2>(row) << '\t' << std::get<3>(row) << endl;
+        for(auto &row: rows) {
+            cout << std::get<0>(row) << '\t' << std::get<1>(row) << '\t' << std::get<2>(row) << '\t' << std::get<3>(row)
+                 << endl;
         }
     }
     {
@@ -178,16 +435,17 @@ int main(int, char **) {
         //      WHERE grade=2
         //      GROUP BY grade
         //      HAVING COUNT(*)>2);
-        auto rows = storage.select(columns(&Customer::code, &Customer::name, &Customer::city, &Customer::grade),
-                                   where(is_equal(&Customer::grade, 2)
-                                         and exists(select(count<Customer>(),
-                                                           where(is_equal(&Customer::grade, 2)),
-                                                           group_by(&Customer::grade),
-                                                           having(greater_than(count(), 2))))));
+        auto rows =
+            storage.select(columns(&Customer::code, &Customer::name, &Customer::city, &Customer::grade),
+                           where(is_equal(&Customer::grade, 2) and exists(select(count<Customer>(),
+                                                                                 where(is_equal(&Customer::grade, 2)),
+                                                                                 group_by(&Customer::grade),
+                                                                                 having(greater_than(count(), 2))))));
         cout << "CUST_CODE   CUST_NAME   CUST_CITY                            GRADE" << endl;
         cout << "----------  ----------  -----------------------------------  ----------" << endl;
-        for(auto &row : rows) {
-            cout << std::get<0>(row) << '\t' <<  std::get<1>(row) << '\t' << std::get<2>(row) << '\t' << std::get<3>(row) << endl;
+        for(auto &row: rows) {
+            cout << std::get<0>(row) << '\t' << std::get<1>(row) << '\t' << std::get<2>(row) << '\t' << std::get<3>(row)
+                 << endl;
         }
     }
     {
@@ -197,12 +455,13 @@ int main(int, char **) {
         //      (SELECT agent_code
         //      FROM customer
         //      WHERE payment_amt=1400);
-        auto rows = storage.select(columns(&Order::agentCode, &Order::num, &Order::amount, &Order::custCode),
-                                   where(not exists(select(&Customer::agentCode,
-                                                           where(is_equal(&Customer::paymentAmt, 1400))))));
+        auto rows = storage.select(
+            columns(&Order::agentCode, &Order::num, &Order::amount, &Order::custCode),
+            where(not exists(select(&Customer::agentCode, where(is_equal(&Customer::paymentAmt, 1400))))));
         cout << "AGENT_CODE  ORD_NUM     ORD_AMOUNT  CUST_CODE" << endl;
-        for(auto &row : rows) {
-            cout << std::get<0>(row) << '\t' <<  std::get<1>(row) << '\t' << std::get<2>(row) << '\t' << std::get<3>(row) << endl;
+        for(auto &row: rows) {
+            cout << std::get<0>(row) << '\t' << std::get<1>(row) << '\t' << std::get<2>(row) << '\t' << std::get<3>(row)
+                 << endl;
         }
     }
     return 0;

--- a/examples/foreign_key.cpp
+++ b/examples/foreign_key.cpp
@@ -20,14 +20,14 @@ struct Artist {
 struct Track {
     int trackId;
     std::string trackName;
-    std::unique_ptr<int> trackArtist;    //  must map to &Artist::artistId
+    std::unique_ptr<int> trackArtist;  //  must map to &Artist::artistId
 };
 
 int main(int, char **argv) {
     cout << "path = " << argv[0] << endl;
-    
+
     using namespace sqlite_orm;
-    {   //  simple case with foreign key to a single column without actions
+    {  //  simple case with foreign key to a single column without actions
         auto storage = make_storage("foreign_key.sqlite",
                                     make_table("artist",
                                                make_column("artistid", &Artist::artistId, primary_key()),
@@ -38,108 +38,109 @@ int main(int, char **argv) {
                                                make_column("trackartist", &Track::trackArtist),
                                                foreign_key(&Track::trackArtist).references(&Artist::artistId)));
         auto syncSchemaRes = storage.sync_schema();
-        for(auto &p : syncSchemaRes) {
+        for(auto &p: syncSchemaRes) {
             cout << p.first << " " << p.second << endl;
         }
-        
+
         storage.remove_all<Track>();
         storage.remove_all<Artist>();
-        
-        storage.replace(Artist{ 1, "Dean Martin" });
-        storage.replace(Artist{ 2, "Frank Sinatra" });
-        
-        storage.replace(Track{ 11, "That's Amore", std::make_unique<int>(1) });
-        storage.replace(Track{ 12, "Christmas Blues", std::make_unique<int>(1) });
-        storage.replace(Track{ 13, "My Way", std::make_unique<int>(2) });
-        
-        try{
+
+        storage.replace(Artist{1, "Dean Martin"});
+        storage.replace(Artist{2, "Frank Sinatra"});
+
+        storage.replace(Track{11, "That's Amore", std::make_unique<int>(1)});
+        storage.replace(Track{12, "Christmas Blues", std::make_unique<int>(1)});
+        storage.replace(Track{13, "My Way", std::make_unique<int>(2)});
+
+        try {
             //  This fails because value inserted into the trackartist column (3)
             //  does not correspond to row in the artist table.
-            storage.replace(Track{ 14, "Mr. Bojangles", std::make_unique<int>(3) });
+            storage.replace(Track{14, "Mr. Bojangles", std::make_unique<int>(3)});
             assert(0);
-        }catch(const std::system_error& e) {
+        } catch(const std::system_error &e) {
             cout << e.what() << endl;
         }
-        
+
         //  This succeeds because a NULL is inserted into trackartist. A
         //  corresponding row in the artist table is not required in this case.
-        storage.replace(Track{ 14, "Mr. Bojangles", nullptr });
-        
+        storage.replace(Track{14, "Mr. Bojangles", nullptr});
+
         //  Trying to modify the trackartist field of the record after it has
         //  been inserted does not work either, since the new value of trackartist (3)
         //  still does not correspond to any row in the artist table.
-        try{
-            storage.update_all(set(assign(&Track::trackArtist, 3)), where(is_equal(&Track::trackName, "Mr. Bojangles")));
+        try {
+            storage.update_all(set(assign(&Track::trackArtist, 3)),
+                               where(is_equal(&Track::trackName, "Mr. Bojangles")));
             assert(0);
-        }catch(const std::system_error& e) {
+        } catch(const std::system_error &e) {
             cout << e.what() << endl;
         }
-        
+
         //  Insert the required row into the artist table. It is then possible to
         //  update the inserted row to set trackartist to 3 (since a corresponding
         //  row in the artist table now exists).
-        storage.replace(Artist{ 3, "Sammy Davis Jr." });
+        storage.replace(Artist{3, "Sammy Davis Jr."});
         storage.update_all(set(assign(&Track::trackArtist, 3)), where(is_equal(&Track::trackName, "Mr. Bojangles")));
-        
+
         //  Now that "Sammy Davis Jr." (artistid = 3) has been added to the database,
         //  it is possible to INSERT new tracks using this artist without violating
         //  the foreign key constraint:
-        storage.replace(Track{ 15, "Boogie Woogie", std::make_unique<int>(3) });
-        
-        try{
+        storage.replace(Track{15, "Boogie Woogie", std::make_unique<int>(3)});
+
+        try {
             //  Attempting to delete the artist record for "Frank Sinatra" fails, since
             //  the track table contains a row that refer to it.
             storage.remove_all<Artist>(where(is_equal(&Artist::artistName, "Frank Sinatra")));
             assert(0);
-        }catch(const std::system_error& e) {
+        } catch(const std::system_error &e) {
             cout << e.what() << endl;
         }
-        
+
         //  Delete all the records from the track table that refer to the artist
         //  "Frank Sinatra". Only then is it possible to delete the artist.
         storage.remove_all<Track>(where(is_equal(&Track::trackName, "My Way")));
         storage.remove_all<Artist>(where(is_equal(&Artist::artistName, "Frank Sinatra")));
-        
-        try{
+
+        try {
             //  Try to update the artistid of a row in the artist table while there
             //  exists records in the track table that refer to it.
             storage.update_all(set(assign(&Artist::artistId, 4)), where(is_equal(&Artist::artistName, "Dean Martin")));
             assert(0);
-        }catch(const std::system_error& e) {
+        } catch(const std::system_error &e) {
             cout << e.what() << endl;
         }
-        
+
         //  Once all the records that refer to a row in the artist table have
         //  been deleted, it is possible to modify the artistid of the row.
         storage.remove_all<Track>(where(in(&Track::trackName, {"That's Amore", "Christmas Blues"})));
-        storage.update_all(set(c(&Artist::artistId) = 4),
-                           where(c(&Artist::artistName) == "Dean Martin"));
+        storage.update_all(set(c(&Artist::artistId) = 4), where(c(&Artist::artistName) == "Dean Martin"));
     }
-    {   //  case with ON UPDATE CASCADE
-        auto storage = make_storage("foreign_key2.sqlite",
-                                    make_table("artist",
-                                               make_column("artistid", &Artist::artistId, primary_key()),
-                                               make_column("artistname", &Artist::artistName)),
-                                    make_table("track",
-                                               make_column("trackid", &Track::trackId, primary_key()),
-                                               make_column("trackname", &Track::trackName),
-                                               make_column("trackartist", &Track::trackArtist),
-                                               foreign_key(&Track::trackArtist).references(&Artist::artistId).on_update.cascade()));
+    {  //  case with ON UPDATE CASCADE
+        auto storage = make_storage(
+            "foreign_key2.sqlite",
+            make_table("artist",
+                       make_column("artistid", &Artist::artistId, primary_key()),
+                       make_column("artistname", &Artist::artistName)),
+            make_table("track",
+                       make_column("trackid", &Track::trackId, primary_key()),
+                       make_column("trackname", &Track::trackName),
+                       make_column("trackartist", &Track::trackArtist),
+                       foreign_key(&Track::trackArtist).references(&Artist::artistId).on_update.cascade()));
         auto syncSchemaRes = storage.sync_schema();
-        for(auto &p : syncSchemaRes) {
+        for(auto &p: syncSchemaRes) {
             cout << p.first << " " << p.second << endl;
         }
-        
+
         storage.remove_all<Track>();
         storage.remove_all<Artist>();
-        
-        storage.replace(Artist{ 1, "Dean Martin" });
-        storage.replace(Artist{ 2, "Frank Sinatra" });
-        
-        storage.replace(Track{ 11, "That's Amore", std::make_unique<int>(1) });
-        storage.replace(Track{ 12, "Christmas Blues", std::make_unique<int>(1) });
-        storage.replace(Track{ 13, "My Way", std::make_unique<int>(2) });
-        
+
+        storage.replace(Artist{1, "Dean Martin"});
+        storage.replace(Artist{2, "Frank Sinatra"});
+
+        storage.replace(Track{11, "That's Amore", std::make_unique<int>(1)});
+        storage.replace(Track{12, "Christmas Blues", std::make_unique<int>(1)});
+        storage.replace(Track{13, "My Way", std::make_unique<int>(2)});
+
         //  Update the artistid column of the artist record for "Dean Martin".
         //  Normally, this would raise a constraint, as it would orphan the two
         //  dependent records in the track table. However, the ON UPDATE CASCADE clause
@@ -147,60 +148,60 @@ int main(int, char **argv) {
         //  to the child table, preventing the foreign key constraint violation.
         //  UPDATE artist SET artistid = 100 WHERE artistname = 'Dean Martin';
         storage.update_all(set(c(&Artist::artistId) = 100), where(c(&Artist::artistName) == "Dean Martin"));
-        
+
         cout << "artists:" << endl;
-        for(auto &artist : storage.iterate<Artist>()){
+        for(auto &artist: storage.iterate<Artist>()) {
             cout << artist.artistId << '\t' << artist.artistName << endl;
         }
         cout << endl;
-        
+
         cout << "tracks:" << endl;
-        for(auto &track : storage.iterate<Track>()){
+        for(auto &track: storage.iterate<Track>()) {
             cout << track.trackId << '\t' << track.trackName << '\t';
-            if(track.trackArtist){
+            if(track.trackArtist) {
                 cout << *track.trackArtist;
-            }else{
+            } else {
                 cout << "null";
             }
             cout << endl;
         }
         cout << endl;
-        
     }
-    {   //  case with ON DELETE SET DEFAULT
-        auto storage = make_storage("foreign_key3.sqlite",
-                                    make_table("artist",
-                                               make_column("artistid", &Artist::artistId, primary_key()),
-                                               make_column("artistname", &Artist::artistName)),
-                                    make_table("track",
-                                               make_column("trackid", &Track::trackId, primary_key()),
-                                               make_column("trackname", &Track::trackName),
-                                               make_column("trackartist", &Track::trackArtist, default_value(0)),
-                                               foreign_key(&Track::trackArtist).references(&Artist::artistId).on_delete.set_default()));
+    {  //  case with ON DELETE SET DEFAULT
+        auto storage = make_storage(
+            "foreign_key3.sqlite",
+            make_table("artist",
+                       make_column("artistid", &Artist::artistId, primary_key()),
+                       make_column("artistname", &Artist::artistName)),
+            make_table("track",
+                       make_column("trackid", &Track::trackId, primary_key()),
+                       make_column("trackname", &Track::trackName),
+                       make_column("trackartist", &Track::trackArtist, default_value(0)),
+                       foreign_key(&Track::trackArtist).references(&Artist::artistId).on_delete.set_default()));
         auto syncSchemaRes = storage.sync_schema();
-        for(auto &p : syncSchemaRes) {
+        for(auto &p: syncSchemaRes) {
             cout << p.first << " " << p.second << endl;
         }
-        
+
         storage.remove_all<Track>();
         storage.remove_all<Artist>();
-        
-        storage.replace(Artist{ 3, "Sammy Davis Jr." });
-        
-        storage.replace(Track{ 14, "Mr. Bojangles", std::make_unique<int>(3) });
-        
+
+        storage.replace(Artist{3, "Sammy Davis Jr."});
+
+        storage.replace(Track{14, "Mr. Bojangles", std::make_unique<int>(3)});
+
         //  Deleting the row from the parent table causes the child key
         //  value of the dependent row to be set to integer value 0. However, this
         //  value does not correspond to any row in the parent table. Therefore
         //  the foreign key constraint is violated and an is exception thrown.
         //  DELETE FROM artist WHERE artistname = 'Sammy Davis Jr.';
-        try{
+        try {
             storage.remove_all<Artist>(where(c(&Artist::artistName) == "Sammy Davis Jr."));
             assert(0);
-        }catch(const std::system_error& e) {
+        } catch(const std::system_error &e) {
             cout << e.what() << endl;
         }
-        
+
         //  This time, the value 0 does correspond to a parent table row. And
         //  so the DELETE statement does not violate the foreign key constraint
         //  and no exception is thrown.
@@ -208,25 +209,25 @@ int main(int, char **argv) {
         //  DELETE FROM artist WHERE artistname = 'Sammy Davis Jr.'
         storage.replace(Artist{0, "Unknown Artist"});
         storage.remove_all<Artist>(where(c(&Artist::artistName) == "Sammy Davis Jr."));
-        
+
         cout << "artists:" << endl;
-        for(auto &artist : storage.iterate<Artist>()){
+        for(auto &artist: storage.iterate<Artist>()) {
             cout << artist.artistId << '\t' << artist.artistName << endl;
         }
         cout << endl;
-        
+
         cout << "tracks:" << endl;
-        for(auto &track : storage.iterate<Track>()){
+        for(auto &track: storage.iterate<Track>()) {
             cout << track.trackId << '\t' << track.trackName << '\t';
-            if(track.trackArtist){
+            if(track.trackArtist) {
                 cout << *track.trackArtist;
-            }else{
+            } else {
                 cout << "null";
             }
             cout << endl;
         }
         cout << endl;
     }
-    
+
     return 0;
 }

--- a/examples/group_by.cpp
+++ b/examples/group_by.cpp
@@ -19,7 +19,7 @@ struct Employee {
 
 int main(int, char **) {
     using namespace sqlite_orm;
-    
+
     auto storage = make_storage("group_by.sqlite",
                                 make_table("COMPANY",
                                            make_column("ID", &Employee::id, primary_key()),
@@ -29,52 +29,53 @@ int main(int, char **) {
                                            make_column("SALARY", &Employee::salary)));
     storage.sync_schema();
     storage.remove_all<Employee>();
-    
-    storage.insert(Employee{ -1, "Paul", 32, "California", 20000.0});
-    storage.insert(Employee{ -1, "Allen", 25, "Texas", 15000.0});
-    storage.insert(Employee{ -1, "Teddy", 23, "Norway", 20000.0});
-    storage.insert(Employee{ -1, "Mark", 25, "Rich-Mond", 65000.0});
-    storage.insert(Employee{ -1, "David", 27, "Texas", 85000.0});
-    storage.insert(Employee{ -1, "Kim", 22, "South-Hall", 45000.0});
-    storage.insert(Employee{ -1, "James", 24, "Houston", 10000.0});
-    
+
+    storage.insert(Employee{-1, "Paul", 32, "California", 20000.0});
+    storage.insert(Employee{-1, "Allen", 25, "Texas", 15000.0});
+    storage.insert(Employee{-1, "Teddy", 23, "Norway", 20000.0});
+    storage.insert(Employee{-1, "Mark", 25, "Rich-Mond", 65000.0});
+    storage.insert(Employee{-1, "David", 27, "Texas", 85000.0});
+    storage.insert(Employee{-1, "Kim", 22, "South-Hall", 45000.0});
+    storage.insert(Employee{-1, "James", 24, "Houston", 10000.0});
+
     //  If you want to know the total amount of salary on each customer, then GROUP BY query would be as follows:
     //  SELECT NAME, SUM(SALARY)
     //  FROM COMPANY
     //  GROUP BY NAME;
-    auto salaryName = storage.select(columns(&Employee::name, sum(&Employee::salary)),
-                                     group_by(&Employee::name));
-    for(auto &t : salaryName) {
+    auto salaryName = storage.select(columns(&Employee::name, sum(&Employee::salary)), group_by(&Employee::name));
+    for(auto &t: salaryName) {
         cout << std::get<0>(t) << '\t' << *std::get<1>(t) << endl;
     }
-    
+
     //  Now, let us create three more records in COMPANY table using the following INSERT statements:
-    
-    storage.insert(Employee{ -1, "Paul", 24, "Houston", 20000.00});
-    storage.insert(Employee{ -1, "James", 44, "Norway", 5000.00});
-    storage.insert(Employee{ -1, "James", 24, "Texas", 5000.00});
-    
+
+    storage.insert(Employee{-1, "Paul", 24, "Houston", 20000.00});
+    storage.insert(Employee{-1, "James", 44, "Norway", 5000.00});
+    storage.insert(Employee{-1, "James", 24, "Texas", 5000.00});
+
     cout << endl << "Now, our table has the following records with duplicate names:" << endl << endl;
-    
-    for(auto &employee : storage.iterate<Employee>()) {
+
+    for(auto &employee: storage.iterate<Employee>()) {
         cout << storage.dump(employee) << endl;
     }
-    
-    cout << endl << "Again, let us use the same statement to group-by all the records using NAME column as follows:" << endl << endl;
+
+    cout << endl
+         << "Again, let us use the same statement to group-by all the records using NAME column as follows:" << endl
+         << endl;
     salaryName = storage.select(columns(&Employee::name, sum(&Employee::salary)),
                                 group_by(&Employee::name),
                                 order_by(&Employee::name));
-    for(auto &t : salaryName) {
+    for(auto &t: salaryName) {
         cout << std::get<0>(t) << '\t' << *std::get<1>(t) << endl;
     }
-    
+
     cout << endl << "Let us use ORDER BY clause along with GROUP BY clause as follows:" << endl << endl;
     salaryName = storage.select(columns(&Employee::name, sum(&Employee::salary)),
                                 group_by(&Employee::name),
                                 order_by(&Employee::name).desc());
-    for(auto &t : salaryName) {
+    for(auto &t: salaryName) {
         cout << std::get<0>(t) << '\t' << *std::get<1>(t) << endl;
     }
-    
+
     return 0;
 }

--- a/examples/having.cpp
+++ b/examples/having.cpp
@@ -18,9 +18,9 @@ struct Employee {
 };
 
 int main() {
-    
+
     using namespace sqlite_orm;
-    
+
     auto storage = make_storage("having.sqlite",
                                 make_table("COMPANY",
                                            make_column("ID", &Employee::id, primary_key()),
@@ -30,26 +30,26 @@ int main() {
                                            make_column("SALARY", &Employee::salary)));
     storage.sync_schema();
     storage.remove_all<Employee>();
-    
-    storage.replace(Employee{ 1, "Paul", 32, "California", 20000.0 });
-    storage.replace(Employee{ 2, "Allen", 25, "Texas", 15000.0 });
-    storage.replace(Employee{ 3, "Teddy", 23, "Norway", 20000.0 });
-    storage.replace(Employee{ 4, "Mark", 25, "Rich-Mond", 65000.0 });
-    storage.replace(Employee{ 5, "David", 27, "Texas", 85000.0 });
-    storage.replace(Employee{ 6, "Kim", 22, "South-Hall", 45000.0 });
-    storage.replace(Employee{ 7, "James", 24, "Houston", 10000.0 });
-    storage.replace(Employee{ 8, "Paul", 24, "Houston", 20000.0 });
-    storage.replace(Employee{ 9, "James", 44, "Norway", 5000.0 });
-    storage.replace(Employee{ 10, "James", 45, "Texas", 5000.0 });
-    
+
+    storage.replace(Employee{1, "Paul", 32, "California", 20000.0});
+    storage.replace(Employee{2, "Allen", 25, "Texas", 15000.0});
+    storage.replace(Employee{3, "Teddy", 23, "Norway", 20000.0});
+    storage.replace(Employee{4, "Mark", 25, "Rich-Mond", 65000.0});
+    storage.replace(Employee{5, "David", 27, "Texas", 85000.0});
+    storage.replace(Employee{6, "Kim", 22, "South-Hall", 45000.0});
+    storage.replace(Employee{7, "James", 24, "Houston", 10000.0});
+    storage.replace(Employee{8, "Paul", 24, "Houston", 20000.0});
+    storage.replace(Employee{9, "James", 44, "Norway", 5000.0});
+    storage.replace(Employee{10, "James", 45, "Texas", 5000.0});
+
     {
         //  SELECT *
         //  FROM COMPANY
         //  GROUP BY name
         //  HAVING count(name) < 2;
-        auto rows = storage.get_all<Employee>(group_by(&Employee::name),
-                                              having(lesser_than(count(&Employee::name), 2)));
-        for(auto &employee : rows) {
+        auto rows =
+            storage.get_all<Employee>(group_by(&Employee::name), having(lesser_than(count(&Employee::name), 2)));
+        for(auto &employee: rows) {
             cout << storage.dump(employee) << endl;
         }
         cout << endl;
@@ -59,13 +59,13 @@ int main() {
         //  FROM COMPANY
         //  GROUP BY name
         //  HAVING count(name) > 2;
-        auto rows = storage.get_all<Employee>(group_by(&Employee::name),
-                                              having(greater_than(count(&Employee::name), 2)));
-        for(auto &employee : rows) {
+        auto rows =
+            storage.get_all<Employee>(group_by(&Employee::name), having(greater_than(count(&Employee::name), 2)));
+        for(auto &employee: rows) {
             cout << storage.dump(employee) << endl;
         }
         cout << endl;
     }
-    
+
     return 0;
 }

--- a/examples/in_memory.cpp
+++ b/examples/in_memory.cpp
@@ -16,32 +16,32 @@ struct RapArtist {
 };
 
 int main(int, char **) {
-    
+
     auto storage = make_storage(":memory:",
                                 make_table("rap_artists",
                                            make_column("id", &RapArtist::id, primary_key()),
                                            make_column("name", &RapArtist::name)));
     cout << "in memory db opened" << endl;
     storage.sync_schema();
-    
+
     assert(!storage.count<RapArtist>());
-    
-    storage.insert(RapArtist{ -1, "The Weeknd" });
-    
-    storage.transaction([&]{
-        storage.insert(RapArtist{ -1, "Drake" });
+
+    storage.insert(RapArtist{-1, "The Weeknd"});
+
+    storage.transaction([&] {
+        storage.insert(RapArtist{-1, "Drake"});
         return true;
     });
-    
+
     cout << "rap artists count = " << storage.count<RapArtist>() << endl;
-    
+
     //  transaction also work in memory..
-    storage.transaction([&]{
-        storage.insert(RapArtist{ -1, "Kanye West" });
+    storage.transaction([&] {
+        storage.insert(RapArtist{-1, "Kanye West"});
         return false;
     });
-    
+
     cout << "rap artists count = " << storage.count<RapArtist>() << " (no Kanye)" << endl;
-    
+
     return 0;
 }

--- a/examples/index.cpp
+++ b/examples/index.cpp
@@ -26,22 +26,22 @@ auto storage = make_storage("index.sqlite",
                                        make_column("email", &Contract::email)));
 
 int main(int, char **) {
-    
+
     storage.sync_schema();
     storage.remove_all<Contract>();
-    
+
     storage.insert(Contract{
         "John",
         "Doe",
         "john.doe@sqlitetutorial.net",
     });
-    try{
+    try {
         storage.insert(Contract{
             "Johny",
             "Doe",
             "john.doe@sqlitetutorial.net",
         });
-    }catch(const std::system_error& e){
+    } catch(const std::system_error &e) {
         cout << e.what() << endl;
     }
     std::vector<Contract> moreContracts = {
@@ -56,13 +56,12 @@ int main(int, char **) {
             "lisa.smith@sqlitetutorial.net",
         },
     };
-    storage.insert_range(moreContracts.begin(),
-                         moreContracts.end());
-    
+    storage.insert_range(moreContracts.begin(), moreContracts.end());
+
     auto lisas = storage.get_all<Contract>(where(c(&Contract::email) == "lisa.smith@sqlitetutorial.net"));
-    
+
     storage.drop_index("idx_contacts_name");
     storage.drop_index("idx_contacts_email");
-    
+
     return 0;
 }

--- a/examples/insert.cpp
+++ b/examples/insert.cpp
@@ -25,7 +25,7 @@ struct DetailedEmployee : public Employee {
 
 int main(int, char **) {
     using namespace sqlite_orm;
-    
+
     auto storage = make_storage("insert.sqlite",
                                 make_table("COMPANY",
                                            make_column("ID", &Employee::id, primary_key()),
@@ -35,18 +35,18 @@ int main(int, char **) {
                                            make_column("SALARY", &Employee::salary)));
     storage.sync_schema();
     storage.remove_all<Employee>();
-    
-    Employee paul {
+
+    Employee paul{
         -1,
         "Paul",
         32,
         "California",
         20000.00,
     };
-    
+
     //  insert returns inserted id
     paul.id = storage.insert(paul);
-    
+
     storage.insert(Employee{
         -1,
         "Allen",
@@ -54,16 +54,16 @@ int main(int, char **) {
         "Texas",
         15000.00,
     });
-    
+
     DetailedEmployee teddy;
     teddy.name = "Teddy";
     teddy.age = 23;
     teddy.address = "Norway";
     teddy.salary = 20000.00;
-    
+
     //  to insert subclass object as a superclass you have to specify type explicitly
     teddy.id = storage.insert<Employee>(teddy);
-    
+
     std::vector<Employee> otherEmployees;
     otherEmployees.push_back(Employee{
         -1,
@@ -89,13 +89,13 @@ int main(int, char **) {
     //  transaction is optional. It is used here to optimize sqlite usage - every insert opens
     //  and closes database. So triple insert will open and close the db three times.
     //  Transaction openes and closes the db only once.
-    storage.transaction([&]{
-        for(auto &employee : otherEmployees) {
+    storage.transaction([&] {
+        for(auto &employee: otherEmployees) {
             storage.insert(employee);
         }
-        return true;    //  commit
+        return true;  //  commit
     });
-    
+
     Employee james{
         -1,
         "James",
@@ -104,11 +104,11 @@ int main(int, char **) {
         10000.00,
     };
     james.id = storage.insert(james);
-    
+
     cout << "---------------------" << endl;
-    for(auto &employee : storage.iterate<Employee>()){
+    for(auto &employee: storage.iterate<Employee>()) {
         cout << storage.dump(employee) << endl;
     }
-    
+
     return 0;
 }

--- a/examples/iteration.cpp
+++ b/examples/iteration.cpp
@@ -20,51 +20,49 @@ int main(int, char **) {
                                            make_column("name", &MarvelHero::name),
                                            make_column("abilities", &MarvelHero::abilities)));
     storage.sync_schema();
-    
+
     storage.remove_all<MarvelHero>();
-    
+
     //  insert values..
-    storage.insert(MarvelHero{ -1, "Tony Stark", "Iron man, playboy, billionaire, philanthropist" });
-    storage.insert(MarvelHero{ -1, "Thor", "Storm god" });
-    storage.insert(MarvelHero{ -1, "Vision", "Min Stone" });
-    storage.insert(MarvelHero{ -1, "Captain America", "Vibranium shield" });
-    storage.insert(MarvelHero{ -1, "Hulk", "Strength" });
-    storage.insert(MarvelHero{ -1, "Star Lord", "Humor" });
-    storage.insert(MarvelHero{ -1, "Peter Parker", "Spiderman" });
-    storage.insert(MarvelHero{ -1, "Clint Barton", "Hawkeye" });
-    storage.insert(MarvelHero{ -1, "Natasha Romanoff", "Black widow" });
-    storage.insert(MarvelHero{ -1, "Groot", "I am Groot!" });
-    
+    storage.insert(MarvelHero{-1, "Tony Stark", "Iron man, playboy, billionaire, philanthropist"});
+    storage.insert(MarvelHero{-1, "Thor", "Storm god"});
+    storage.insert(MarvelHero{-1, "Vision", "Min Stone"});
+    storage.insert(MarvelHero{-1, "Captain America", "Vibranium shield"});
+    storage.insert(MarvelHero{-1, "Hulk", "Strength"});
+    storage.insert(MarvelHero{-1, "Star Lord", "Humor"});
+    storage.insert(MarvelHero{-1, "Peter Parker", "Spiderman"});
+    storage.insert(MarvelHero{-1, "Clint Barton", "Hawkeye"});
+    storage.insert(MarvelHero{-1, "Natasha Romanoff", "Black widow"});
+    storage.insert(MarvelHero{-1, "Groot", "I am Groot!"});
+
     cout << "Heros count = " << storage.count<MarvelHero>() << endl;
-    
+
     //  iterate through heros - iteration takes less memory than `get_all` because
     //  iteration fetches row by row once it is needed. If you break at any iteration
     //  statement will be cleared without fetching remaining rows.
-    for(auto &hero : storage.iterate<MarvelHero>()) {
+    for(auto &hero: storage.iterate<MarvelHero>()) {
         cout << "hero = " << storage.dump(hero) << endl;
     }
-    
+
     cout << "====" << endl;
-    
+
     //  one can iterate with custom WHERE conditions..
-    for(auto &hero : storage.iterate<MarvelHero>(where(c(&MarvelHero::name) == "Thor"))) {
+    for(auto &hero: storage.iterate<MarvelHero>(where(c(&MarvelHero::name) == "Thor"))) {
         cout << "hero = " << storage.dump(hero) << endl;
     }
-    
+
     cout << "Heros with LENGTH(name) < 6 :" << endl;
-    for(auto &hero : storage.iterate<MarvelHero>(where(length(&MarvelHero::name) < 6))) {
+    for(auto &hero: storage.iterate<MarvelHero>(where(length(&MarvelHero::name) < 6))) {
         cout << "hero = " << storage.dump(hero) << endl;
     }
-    
+
     std::vector<MarvelHero> heroesByAlgorithm;
     heroesByAlgorithm.reserve(static_cast<size_t>(storage.count<MarvelHero>()));
     {
         auto view = storage.iterate<MarvelHero>();
-        std::copy(view.begin(),
-                  view.end(),
-                  std::back_inserter(heroesByAlgorithm));
+        std::copy(view.begin(), view.end(), std::back_inserter(heroesByAlgorithm));
     }
     cout << "heroesByAlgorithm.size = " << heroesByAlgorithm.size() << endl;
-    
+
     return 0;
 }

--- a/examples/key_value.cpp
+++ b/examples/key_value.cpp
@@ -2,22 +2,23 @@
 /******
  This is an implementation of key-value storage just like
  NSUserDefaults on iOS or SharedPreferences on Android.
- Here is the deal: we need to have `setValueForKey` and `getValueByKey` interface. All data must ba saved in sqlite 
+ Here is the deal: we need to have `setValueForKey` and `getValueByKey` interface. All data must ba saved in sqlite
  database.
- To perform this we create schema with table `key_value` and two columns: key:string and value:string. 
- Key column has PRIMARY KEY constraint cause keys must be unique. `setValue` function takes two string arguments: key and value. It creates a KeyValue
- object (KeyValue is a class mapped to the storage) with arguments and calls REPLACE. REPLACE (shorter version of INSERT OR REPLACE)
- removes row with a given primary key if it exists and inserts a given value in the table.
- After this there is a row in the `key_value` table with key and value passed into `setValue` function.
- `getValue` performs `get_pointer` by id and returns its value or returns empty string if nothing obtained from db.
+ To perform this we create schema with table `key_value` and two columns: key:string and value:string.
+ Key column has PRIMARY KEY constraint cause keys must be unique. `setValue` function takes two string arguments: key
+ and value. It creates a KeyValue object (KeyValue is a class mapped to the storage) with arguments and calls REPLACE.
+ REPLACE (shorter version of INSERT OR REPLACE) removes row with a given primary key if it exists and inserts a given
+ value in the table. After this there is a row in the `key_value` table with key and value passed into `setValue`
+ function. `getValue` performs `get_pointer` by id and returns its value or returns empty string if nothing obtained
+ from db.
  ******/
 
 #include <sqlite_orm/sqlite_orm.h>
 
 #include <iostream>
 
-using std::cout;
 using std::cerr;
+using std::cout;
 using std::endl;
 
 /**
@@ -28,7 +29,7 @@ struct KeyValue {
     std::string value;
 };
 
-auto& getStorage() {
+auto &getStorage() {
     using namespace sqlite_orm;
     static auto storage = make_storage("key_value_example.sqlite",
                                        make_table("key_value",
@@ -45,9 +46,9 @@ void setValue(const std::string &key, const std::string &value) {
 
 std::string getValue(const std::string &key) {
     using namespace sqlite_orm;
-    if(auto kv = getStorage().get_pointer<KeyValue>(key)){
+    if(auto kv = getStorage().get_pointer<KeyValue>(key)) {
         return kv->value;
-    }else{
+    } else {
         return {};
     }
 }
@@ -57,30 +58,30 @@ int storedKeysCount() {
 }
 
 int main(int, char **argv) {
-    
-    cout << argv[0] << endl;    //  to know executable path in case if you need to access sqlite directly from sqlite client
-    
-    getStorage().sync_schema(); //  to create table if it doesn't exist
-    
+
+    cout << argv[0]
+         << endl;  //  to know executable path in case if you need to access sqlite directly from sqlite client
+
+    getStorage().sync_schema();  //  to create table if it doesn't exist
+
     struct {
         std::string userId = "userId";
         std::string userName = "userName";
         std::string userGender = "userGender";  //  this key will be missing
-    } keys; //  to keep keys in one place
-    
+    } keys;  //  to keep keys in one place
+
     setValue(keys.userId, "6");
     setValue(keys.userName, "Peter");
-    
+
     auto userId = getValue(keys.userId);
     cout << "userId = " << userId << endl;  //  userId = 6
-    
+
     auto userName = getValue(keys.userName);
     cout << "userName = " << userName << endl;  //  userName = Peter
-    
+
     auto userGender = getValue(keys.userGender);
     cout << "userGender = " << userGender << endl;  //  userGender =
-    
+
     auto kvsCount = storedKeysCount();
     cout << "kvsCount = " << kvsCount << endl;  //  kvsCount = 2
-    
 }

--- a/examples/left_and_inner_join.cpp
+++ b/examples/left_and_inner_join.cpp
@@ -1,7 +1,7 @@
 /**
  *  Example is imlemented from here http://www.sqlitetutorial.net/sqlite-left-join/
- *  In this example you got to download db file 'chinook.db' first from here http://www.sqlitetutorial.net/sqlite-sample-database/
- *  an place the file near executable.
+ *  In this example you got to download db file 'chinook.db' first from here
+ * http://www.sqlitetutorial.net/sqlite-sample-database/ an place the file near executable.
  */
 
 #include <sqlite_orm/sqlite_orm.h>
@@ -35,7 +35,7 @@ struct Track {
     double unitPrice;
 };
 
-inline auto initStorage(const std::string &path){
+inline auto initStorage(const std::string &path) {
     using namespace sqlite_orm;
     return make_storage(path,
                         make_table("artists",
@@ -58,11 +58,11 @@ inline auto initStorage(const std::string &path){
 }
 
 int main(int, char **) {
-    
+
     auto storage = initStorage("chinook.db");
 
     using namespace sqlite_orm;
-    
+
     //  SELECT
     //      artists.ArtistId,
     //      albumId
@@ -75,26 +75,25 @@ int main(int, char **) {
                                left_join<Album>(on(c(&Album::artistId) == &Artist::artistId)),
                                order_by(&Album::albumId));
     cout << "rows count = " << rows.size() << endl;
-    for(auto &row : rows) {
+    for(auto &row: rows) {
         auto &artistId = std::get<0>(row);
-        if(artistId){
+        if(artistId) {
             cout << *artistId;
-        }else{
+        } else {
             cout << "null";
         }
         cout << '\t';
         auto &albumId = std::get<1>(row);
-        if(albumId){
+        if(albumId) {
             cout << *albumId;
-        }else{
+        } else {
             cout << "null";
         }
         cout << endl;
     }
-    
+
     cout << endl;
-    
-    
+
     //  SELECT
     //      artists.ArtistId,
     //      albumId
@@ -107,25 +106,25 @@ int main(int, char **) {
                           left_join<Album>(on(c(&Album::artistId) == &Artist::artistId)),
                           where(is_null(&Album::albumId)));
     cout << "rows count = " << rows.size() << endl;
-    for(auto &row : rows) {
+    for(auto &row: rows) {
         auto &artistId = std::get<0>(row);
-        if(artistId){
+        if(artistId) {
             cout << *artistId;
-        }else{
+        } else {
             cout << "null";
         }
         cout << '\t';
         auto &albumId = std::get<1>(row);
-        if(albumId){
+        if(albumId) {
             cout << *albumId;
-        }else{
+        } else {
             cout << "null";
         }
         cout << endl;
     }
-    
+
     cout << endl;
-    
+
     //  SELECT
     //      trackid,
     //      name,
@@ -136,17 +135,17 @@ int main(int, char **) {
     auto innerJoinRows0 = storage.select(columns(&Track::trackId, &Track::name, &Album::title),
                                          inner_join<Album>(on(c(&Track::albumId) == &Album::albumId)));
     cout << "innerJoinRows0 count = " << innerJoinRows0.size() << endl;
-    for(auto &row : innerJoinRows0) {
+    for(auto &row: innerJoinRows0) {
         cout << std::get<0>(row) << '\t' << std::get<1>(row) << '\t';
-        if(std::get<2>(row)){
+        if(std::get<2>(row)) {
             cout << *std::get<2>(row);
-        }else{
+        } else {
             cout << "null";
         }
         cout << endl;
     }
     cout << endl;
-    
+
     //  SELECT
     //      trackid,
     //      name,
@@ -156,33 +155,34 @@ int main(int, char **) {
     //  FROM
     //      tracks
     //  INNER JOIN albums ON albums.albumid = tracks.albumid;
-    auto innerJoinRows1 = storage.select(columns(&Track::trackId, &Track::name, &Track::albumId, &Album::albumId, &Album::title),
-                                         inner_join<Album>(on(c(&Album::albumId) == &Track::trackId)));
+    auto innerJoinRows1 =
+        storage.select(columns(&Track::trackId, &Track::name, &Track::albumId, &Album::albumId, &Album::title),
+                       inner_join<Album>(on(c(&Album::albumId) == &Track::trackId)));
     cout << "innerJoinRows1 count = " << innerJoinRows1.size() << endl;
-    for(auto &row : innerJoinRows1) {
+    for(auto &row: innerJoinRows1) {
         cout << std::get<0>(row) << '\t' << std::get<1>(row) << '\t';
-        if(std::get<2>(row)){
+        if(std::get<2>(row)) {
             cout << *std::get<2>(row);
-        }else{
+        } else {
             cout << "null";
         }
         cout << '\t';
-        if(std::get<3>(row)){
+        if(std::get<3>(row)) {
             cout << *std::get<3>(row);
-        }else{
+        } else {
             cout << "null";
         }
         cout << '\t';
-        if(std::get<4>(row)){
+        if(std::get<4>(row)) {
             cout << *std::get<4>(row);
-        }else{
+        } else {
             cout << "null";
         }
         cout << '\t';
         cout << endl;
     }
     cout << endl;
-    
+
     //  SELECT
     //      trackid,
     //      tracks.name AS Track,
@@ -196,53 +196,54 @@ int main(int, char **) {
                                          inner_join<Album>(on(c(&Album::albumId) == &Track::albumId)),
                                          inner_join<Artist>(on(c(&Artist::artistId) == &Album::artistId)));
     cout << "innerJoinRows2 count = " << innerJoinRows2.size() << endl;
-    for(auto &row : innerJoinRows2) {
+    for(auto &row: innerJoinRows2) {
         cout << std::get<0>(row) << '\t' << std::get<1>(row) << '\t';
-        if(std::get<2>(row)){
+        if(std::get<2>(row)) {
             cout << *std::get<2>(row);
-        }else{
+        } else {
             cout << "null";
         }
         cout << '\t';
-        if(std::get<3>(row)){
+        if(std::get<3>(row)) {
             cout << *std::get<3>(row);
-        }else{
+        } else {
             cout << "null";
         }
         cout << '\t';
     }
     cout << endl;
-    
+
     {
         /**
-         *  JOIN has many usages so this is another example from here http://www.w3resource.com/sqlite/sqlite-left-join.php
-         *  and here http://www.w3resource.com/sqlite/sqlite-natural-join.php
+         *  JOIN has many usages so this is another example from here
+         * http://www.w3resource.com/sqlite/sqlite-left-join.php and here
+         * http://www.w3resource.com/sqlite/sqlite-natural-join.php
          */
-        
+
         struct Doctor {
             int id;
             std::string name;
             std::string degree;
         };
-        
+
         struct Visit {
             int doctorId;
             std::string patientName;
             std::string vdate;
         };
-        
+
         struct A {
             int id;
             std::string des1;
             std::string des2;
         };
-        
+
         struct B {
             int id;
             std::string des3;
             std::string des4;
         };
-        
+
         auto storage2 = make_storage("doctors.sqlite",
                                      make_table("doctors",
                                                 make_column("doctor_id", &Doctor::id, primary_key()),
@@ -261,27 +262,30 @@ int main(int, char **) {
                                                 make_column("des3", &B::des3),
                                                 make_column("des4", &B::des4)));
         storage2.sync_schema();
-        
-        storage2.replace(Doctor{ 210, "Dr. John Linga", "MD", });
-        storage2.replace(Doctor{ 211, "Dr. Peter Hall", "MBBS" });
-        storage2.replace(Doctor{ 212, "Dr. Ke Gee", "MD" });
-        storage2.replace(Doctor{ 213, "Dr. Pat Fay", "MD" });
-        
-        storage2.replace(Visit{ 210, "Julia Nayer", "2013-10-15" });
-        storage2.replace(Visit{ 214, "TJ Olson", "2013-10-14" });
-        storage2.replace(Visit{ 215, "John Seo", "2013-10-15" });
-        storage2.replace(Visit{ 212, "James Marlow", "2013-10-16" });
-        storage2.replace(Visit{ 212, "Jason Mallin", "2013-10-12" });
-        
-        storage2.replace(A{ 100, "desc11", "desc12" });
-        storage2.replace(A{ 101, "desc21", "desc22" });
-        storage2.replace(A{ 102, "desc31", "desc32" });
-        
-        storage2.replace(B{ 101, "desc41", "desc42" });
-        storage2.replace(B{ 103, "desc51", "desc52" });
-        storage2.replace(B{ 105, "desc61", "desc62" });
-        
-        
+
+        storage2.replace(Doctor{
+            210,
+            "Dr. John Linga",
+            "MD",
+        });
+        storage2.replace(Doctor{211, "Dr. Peter Hall", "MBBS"});
+        storage2.replace(Doctor{212, "Dr. Ke Gee", "MD"});
+        storage2.replace(Doctor{213, "Dr. Pat Fay", "MD"});
+
+        storage2.replace(Visit{210, "Julia Nayer", "2013-10-15"});
+        storage2.replace(Visit{214, "TJ Olson", "2013-10-14"});
+        storage2.replace(Visit{215, "John Seo", "2013-10-15"});
+        storage2.replace(Visit{212, "James Marlow", "2013-10-16"});
+        storage2.replace(Visit{212, "Jason Mallin", "2013-10-12"});
+
+        storage2.replace(A{100, "desc11", "desc12"});
+        storage2.replace(A{101, "desc21", "desc22"});
+        storage2.replace(A{102, "desc31", "desc32"});
+
+        storage2.replace(B{101, "desc41", "desc42"});
+        storage2.replace(B{103, "desc51", "desc52"});
+        storage2.replace(B{105, "desc61", "desc62"});
+
         //  SELECT a.doctor_id,a.doctor_name,
         //      c.patient_name,c.vdate
         //  FROM doctors a
@@ -289,11 +293,12 @@ int main(int, char **) {
         //  ON a.doctor_id=c.doctor_id;
         auto rows = storage2.select(columns(&Doctor::id, &Doctor::name, &Visit::patientName, &Visit::vdate),
                                     left_join<Visit>(on(c(&Doctor::id) == &Visit::doctorId)));
-        for(auto &row : rows) {
-            cout << std::get<0>(row) << '\t' << std::get<1>(row) << '\t' << std::get<2>(row) << '\t' << std::get<3>(row) << endl;
+        for(auto &row: rows) {
+            cout << std::get<0>(row) << '\t' << std::get<1>(row) << '\t' << std::get<2>(row) << '\t' << std::get<3>(row)
+                 << endl;
         }
         cout << endl;
-        
+
         //  SELECT a.doctor_id,a.doctor_name,
         //      c.patient_name,c.vdate
         //  FROM doctors a
@@ -301,25 +306,25 @@ int main(int, char **) {
         //  ON a.doctor_id=c.doctor_id;
         rows = storage2.select(columns(&Doctor::id, &Doctor::name, &Visit::patientName, &Visit::vdate),
                                join<Visit>(on(c(&Doctor::id) == &Visit::doctorId)));
-        for(auto &row : rows) {
-            cout << std::get<0>(row) << '\t' << std::get<1>(row) << '\t' << std::get<2>(row) << '\t' << std::get<3>(row) << endl;
+        for(auto &row: rows) {
+            cout << std::get<0>(row) << '\t' << std::get<1>(row) << '\t' << std::get<2>(row) << '\t' << std::get<3>(row)
+                 << endl;
         }
         cout << endl;
-        
+
         //  SELECT doctor_id,doctor_name,
         //      patient_name,vdate
         //  FROM doctors
         //  LEFT JOIN visits
         //  USING(doctor_id);
         rows = storage2.select(columns(&Doctor::id, &Doctor::name, &Visit::patientName, &Visit::vdate),
-                               left_join<Visit>(using_(&Visit::doctorId))); //  or using_(&Doctor::id)
-        for(auto &row : rows) {
-            cout << std::get<0>(row) << '\t' << std::get<1>(row) << '\t' << std::get<2>(row) << '\t' << std::get<3>(row) << endl;
+                               left_join<Visit>(using_(&Visit::doctorId)));  //  or using_(&Doctor::id)
+        for(auto &row: rows) {
+            cout << std::get<0>(row) << '\t' << std::get<1>(row) << '\t' << std::get<2>(row) << '\t' << std::get<3>(row)
+                 << endl;
         }
         cout << endl;
-        
-        
     }
-    
+
     return 0;
 }

--- a/examples/multi_table_select.cpp
+++ b/examples/multi_table_select.cpp
@@ -24,7 +24,7 @@ struct ReqDetail {
 };
 
 int main(int, char **) {
-    
+
     using namespace sqlite_orm;
     auto storage = make_storage("multi_table_select.sqlite",
                                 make_table("ReqEquip",
@@ -37,53 +37,55 @@ int main(int, char **) {
                                            make_column("StockNumber", &ReqDetail::stockNumber),
                                            make_column("Quantity", &ReqDetail::quantity),
                                            make_column("ItemCost", &ReqDetail::itemCost)));
-    
+
     storage.sync_schema();
     storage.remove_all<ReqEquip>();
     storage.remove_all<ReqDetail>();
-    
-    storage.replace(ReqEquip{ 1000, "Carl Jones", "A. Robinson Mgr", "2007/10/30" });
-    storage.replace(ReqEquip{ 1001, "Peter Smith", "A. Robinson Mgr", "2007/11/05" });
-    storage.replace(ReqEquip{ 1002, "Carl Jones", "A. Robinson Mgr", "2007/11/06" });
-    
-    storage.replace(ReqDetail{ 1000, 51013, 2, 7.52 });
-    storage.replace(ReqDetail{ 1000, 51002, 4, .75 });
-    storage.replace(ReqDetail{ 1000, 43512, 4, 1.52 });
-    storage.replace(ReqDetail{ 1001, 23155, 1, 9.82 });
-    storage.replace(ReqDetail{ 1001, 43111, 1, 3.69 });
-    storage.replace(ReqDetail{ 1002, 51001, 1, .75 });
-    storage.replace(ReqDetail{ 1002, 23155, 1, 9.82 });
-    
+
+    storage.replace(ReqEquip{1000, "Carl Jones", "A. Robinson Mgr", "2007/10/30"});
+    storage.replace(ReqEquip{1001, "Peter Smith", "A. Robinson Mgr", "2007/11/05"});
+    storage.replace(ReqEquip{1002, "Carl Jones", "A. Robinson Mgr", "2007/11/06"});
+
+    storage.replace(ReqDetail{1000, 51013, 2, 7.52});
+    storage.replace(ReqDetail{1000, 51002, 4, .75});
+    storage.replace(ReqDetail{1000, 43512, 4, 1.52});
+    storage.replace(ReqDetail{1001, 23155, 1, 9.82});
+    storage.replace(ReqDetail{1001, 43111, 1, 3.69});
+    storage.replace(ReqDetail{1002, 51001, 1, .75});
+    storage.replace(ReqDetail{1002, 23155, 1, 9.82});
+
     cout << endl;
-    
+
     //  SELECT ReqEquip.ReqNumber, ReqEquip.Requestor, ReqDetail.Quantity, ReqDetail.StockNumber
     //  FROM ReqEquip, ReqDetail
     //  WHERE ReqEquip.ReqNumber = ReqDetail.ReqNumber;
-    auto rows = storage.select(columns(&ReqEquip::reqNumber, &ReqEquip::requestor, &ReqDetail::quantity, &ReqDetail::stockNumber),
-                               where(c(&ReqEquip::reqNumber) == &ReqDetail::reqNumber));
-    for(auto &row : rows) {
+    auto rows = storage.select(
+        columns(&ReqEquip::reqNumber, &ReqEquip::requestor, &ReqDetail::quantity, &ReqDetail::stockNumber),
+        where(c(&ReqEquip::reqNumber) == &ReqDetail::reqNumber));
+    for(auto &row: rows) {
         cout << std::get<0>(row) << '\t';
         cout << std::get<1>(row) << '\t';
         cout << std::get<2>(row) << '\t';
         cout << std::get<3>(row) << '\t';
         cout << endl;
     }
-    
+
     cout << endl;
-    
+
     //  SELECT ReqEquip.ReqNumber, ReqEquip.Requestor, ReqDetail.Quantity, ReqDetail.StockNumber
     //  FROM ReqEquip, ReqDetail
     //  WHERE ReqEquip.ReqNumber = ReqDetail.ReqNumber AND ReqEquip.ReqNumber = 1000;
-    
-    rows = storage.select(columns(&ReqEquip::reqNumber, &ReqEquip::requestor, &ReqDetail::quantity, &ReqDetail::stockNumber),
-                          where(c(&ReqEquip::reqNumber) == &ReqDetail::reqNumber and c(&ReqEquip::reqNumber) == 1000));
-    for(auto &row : rows) {
+
+    rows = storage.select(
+        columns(&ReqEquip::reqNumber, &ReqEquip::requestor, &ReqDetail::quantity, &ReqDetail::stockNumber),
+        where(c(&ReqEquip::reqNumber) == &ReqDetail::reqNumber and c(&ReqEquip::reqNumber) == 1000));
+    for(auto &row: rows) {
         cout << std::get<0>(row) << '\t';
         cout << std::get<1>(row) << '\t';
         cout << std::get<2>(row) << '\t';
         cout << std::get<3>(row) << '\t';
         cout << endl;
     }
-    
+
     return 0;
 }

--- a/examples/natural_join.cpp
+++ b/examples/natural_join.cpp
@@ -27,9 +27,9 @@ struct Visit {
     std::string vdate;
 };
 
-int main(){
+int main() {
     using namespace sqlite_orm;
-    
+
     auto storage = make_storage("natural_join.sqlite",
                                 make_table("doctors",
                                            make_column("doctor_id", &Doctor::doctor_id, primary_key()),
@@ -47,42 +47,36 @@ int main(){
     storage.remove_all<Doctor>();
     storage.remove_all<Speciality>();
     storage.remove_all<Visit>();
-    
+
     storage.replace(Doctor{210, "Dr. John Linga", "MD"});
     storage.replace(Doctor{211, "Dr. Peter Hall", "MBBS"});
     storage.replace(Doctor{212, "Dr. Ke Gee", "MD"});
     storage.replace(Doctor{213, "Dr. Pat Fay", "MD"});
-    
+
     storage.replace(Speciality{1, "CARDIO", 211});
     storage.replace(Speciality{2, "NEURO", 213});
     storage.replace(Speciality{3, "ARTHO", 212});
     storage.replace(Speciality{4, "GYNO", 210});
-    
+
     storage.replace(Visit{210, "Julia Nayer", "2013-10-15"});
     storage.replace(Visit{214, "TJ Olson", "2013-10-14"});
     storage.replace(Visit{215, "John Seo", "2013-10-15"});
     storage.replace(Visit{212, "James Marlow", "2013-10-16"});
     storage.replace(Visit{212, "Jason Mallin", "2013-10-12"});
-    
+
     {
         //  SELECT doctor_id,doctor_name,degree,patient_name,vdate
         //  FROM doctors
         //  NATURAL JOIN visits
         //  WHERE doctors.degree="MD";
-        auto rows = storage.select(columns(&Doctor::doctor_id,
-                                           &Doctor::doctor_name,
-                                           &Doctor::degree,
-                                           &Visit::patient_name,
-                                           &Visit::vdate),
-                                   natural_join<Visit>(),
-                                   where(c(&Doctor::degree) == "MD"));
+        auto rows = storage.select(
+            columns(&Doctor::doctor_id, &Doctor::doctor_name, &Doctor::degree, &Visit::patient_name, &Visit::vdate),
+            natural_join<Visit>(),
+            where(c(&Doctor::degree) == "MD"));
         cout << "rows count = " << rows.size() << endl;
-        for(auto &row : rows) {
-            cout << std::get<0>(row) << '\t'
-            << std::get<1>(row) << '\t'
-            << std::get<2>(row) << '\t'
-            << std::get<3>(row) << '\t'
-            << std::get<4>(row) << endl;
+        for(auto &row: rows) {
+            cout << std::get<0>(row) << '\t' << std::get<1>(row) << '\t' << std::get<2>(row) << '\t' << std::get<3>(row)
+                 << '\t' << std::get<4>(row) << endl;
         }
     }
     cout << endl;
@@ -102,15 +96,11 @@ int main(){
                                    natural_join<Visit>(),
                                    where(c(&Doctor::degree) == "MD"));
         cout << "rows count = " << rows.size() << endl;
-        for(auto &row : rows) {
-            cout << std::get<0>(row) << '\t'
-            << std::get<1>(row) << '\t'
-            << std::get<2>(row) << '\t'
-            << std::get<3>(row) << '\t'
-            << std::get<4>(row) << '\t'
-            << std::get<5>(row) << endl;
+        for(auto &row: rows) {
+            cout << std::get<0>(row) << '\t' << std::get<1>(row) << '\t' << std::get<2>(row) << '\t' << std::get<3>(row)
+                 << '\t' << std::get<4>(row) << '\t' << std::get<5>(row) << endl;
         }
     }
-    
+
     return 0;
 }

--- a/examples/nullable_enum_binding.cpp
+++ b/examples/nullable_enum_binding.cpp
@@ -20,10 +20,13 @@ enum class Gender {
 };
 
 std::unique_ptr<std::string> GenderToString(Gender gender) {
-    switch(gender){
-        case Gender::Female:return std::make_unique<std::string>("female");
-        case Gender::Male:return std::make_unique<std::string>("male");
-        case Gender::None:return {};
+    switch(gender) {
+        case Gender::Female:
+            return std::make_unique<std::string>("female");
+        case Gender::Male:
+            return std::make_unique<std::string>("male");
+        case Gender::None:
+            return {};
     }
     throw std::domain_error("Invalid Gender enum");
 }
@@ -31,7 +34,7 @@ std::unique_ptr<std::string> GenderToString(Gender gender) {
 std::unique_ptr<Gender> GenderFromString(const std::string &s) {
     if(s == "female") {
         return std::make_unique<Gender>(Gender::Female);
-    }else if(s == "male") {
+    } else if(s == "male") {
         return std::make_unique<Gender>(Gender::Male);
     }
     return nullptr;
@@ -52,9 +55,9 @@ namespace sqlite_orm {
     struct statement_binder<Gender> {
 
         int bind(sqlite3_stmt *stmt, int index, const Gender &value) {
-            if(auto str = GenderToString(value)){
+            if(auto str = GenderToString(value)) {
                 return statement_binder<std::string>().bind(stmt, index, *str);
-            }else{
+            } else {
                 return statement_binder<std::nullptr_t>().bind(stmt, index, nullptr);
             }
         }
@@ -63,9 +66,9 @@ namespace sqlite_orm {
     template<>
     struct field_printer<Gender> {
         std::string operator()(const Gender &t) const {
-            if(auto res = GenderToString(t)){
+            if(auto res = GenderToString(t)) {
                 return *res;
-            }else{
+            } else {
                 return "None";
             }
         }
@@ -74,20 +77,20 @@ namespace sqlite_orm {
     template<>
     struct row_extractor<Gender> {
         Gender extract(const char *row_value) {
-            if(row_value){
-                if(auto gender = GenderFromString(row_value)){
+            if(row_value) {
+                if(auto gender = GenderFromString(row_value)) {
                     return *gender;
-                }else{
+                } else {
                     throw std::runtime_error("incorrect gender string (" + std::string(row_value) + ")");
                 }
-            }else{
+            } else {
                 return Gender::None;
             }
         }
 
         Gender extract(sqlite3_stmt *stmt, int columnIndex) {
             auto str = sqlite3_column_text(stmt, columnIndex);
-            return this->extract((const char*)str);
+            return this->extract((const char *)str);
         }
     };
 
@@ -132,19 +135,19 @@ int main(int, char **) {
     });
 
     cout << "All users :" << endl;
-    for(auto &user : storage.iterate<User>()) {
+    for(auto &user: storage.iterate<User>()) {
         cout << storage.dump(user) << endl;
     }
 
     auto allWithNoneGender = storage.get_all<User>(where(is_null(&User::gender)));
     cout << "allWithNoneGender = " << allWithNoneGender.size() << endl;
-    for(auto &user : allWithNoneGender) {
+    for(auto &user: allWithNoneGender) {
         cout << storage.dump(user) << endl;
     }
 
     auto allWithGender = storage.get_all<User>(where(is_not_null(&User::gender)));
     cout << "allWithGender = " << allWithGender.size() << endl;
-    for(auto &user : allWithGender) {
+    for(auto &user: allWithGender) {
         cout << storage.dump(user) << endl;
     }
 

--- a/examples/private_class_members.cpp
+++ b/examples/private_class_members.cpp
@@ -18,26 +18,26 @@ using std::endl;
 class Player {
     int id = 0;
     std::string name;
-    
-public:
-    Player(){}
-    
-    Player(std::string name_):name(std::move(name_)){}
-    
-    Player(int id_, std::string name_):id(id_),name(std::move(name_)){}
-    
+
+  public:
+    Player() {}
+
+    Player(std::string name_) : name(std::move(name_)) {}
+
+    Player(int id_, std::string name_) : id(id_), name(std::move(name_)) {}
+
     std::string getName() const {
         return this->name;
     }
-    
+
     void setName(std::string name) {
         this->name = std::move(name);
     }
-    
+
     int getId() const {
         return this->id;
     }
-    
+
     void setId(int id) {
         this->id = id;
     }
@@ -45,41 +45,43 @@ public:
 
 int main(int, char **) {
     using namespace sqlite_orm;
-    auto storage = make_storage("private.sqlite",
-                                make_table("players",
-                                           make_column("id",
-                                                       &Player::setId,  //  setter
-                                                       &Player::getId,  //  getter
-                                                       primary_key()),
-                                           make_column("name",
-                                                       &Player::getName,    //  BTW order doesn't matter: setter can be placed before getter or opposite.
-                                                       &Player::setName)));
+    auto storage = make_storage(
+        "private.sqlite",
+        make_table(
+            "players",
+            make_column("id",
+                        &Player::setId,  //  setter
+                        &Player::getId,  //  getter
+                        primary_key()),
+            make_column("name",
+                        &Player::getName,  //  BTW order doesn't matter: setter can be placed before getter or opposite.
+                        &Player::setName)));
     storage.sync_schema();
     storage.remove_all<Player>();
-    
+
     auto soloId = storage.insert(Player("Solo"));
-    
+
     auto playersCount = storage.count<Player>();
     cout << "players count = " << playersCount << endl;
     assert(playersCount == 1);
-    
+
     cout << "solo = " << storage.dump(storage.get<Player>(soloId)) << endl;
-    
+
     auto deadpoolId = storage.insert(Player("Deadpool"));
-    
+
     cout << "deadpool = " << storage.dump(storage.get<Player>(deadpoolId)) << endl;
-    
+
     playersCount = storage.count<Player>();
     cout << "players count = " << playersCount << endl;
     assert(playersCount == 2);
-    
+
     auto idsOnly = storage.select(&Player::getId);  //  or storage.select(&Player::setId);
     cout << "idsOnly count = " << idsOnly.size() << endl;
-    
+
     auto somePlayers = storage.get_all<Player>(where(lesser_than(length(&Player::getName), 5)));
     cout << "players with length(name) < 5 = " << somePlayers.size() << endl;
     assert(somePlayers.size() == 1);
-    for(auto &player : somePlayers) {
+    for(auto &player: somePlayers) {
         cout << storage.dump(player) << endl;
     }
 }

--- a/examples/select.cpp
+++ b/examples/select.cpp
@@ -10,8 +10,8 @@ struct Employee {
     int id;
     std::string name;
     int age;
-    std::unique_ptr<std::string> address;   //  optional
-    std::unique_ptr<double> salary; //  optional
+    std::unique_ptr<std::string> address;  //  optional
+    std::unique_ptr<double> salary;  //  optional
 };
 
 using namespace sqlite_orm;
@@ -28,17 +28,17 @@ int main(int, char **) {
                                            make_column("ADDRESS", &Employee::address),
                                            make_column("SALARY", &Employee::salary)));
     storage.sync_schema();
-    storage.remove_all<Employee>(); //  remove all old employees in case they exist in db..
-    
+    storage.remove_all<Employee>();  //  remove all old employees in case they exist in db..
+
     //  create employees..
-    Employee paul{-1, "Paul", 32, std::make_unique<std::string>("California"), std::make_unique<double>(20000.0) };
-    Employee allen{-1, "Allen", 25, std::make_unique<std::string>("Texas"), std::make_unique<double>(15000.0) };
-    Employee teddy{-1, "Teddy", 23, std::make_unique<std::string>("Norway"), std::make_unique<double>(20000.0) };
-    Employee mark{-1, "Mark", 25, std::make_unique<std::string>("Rich-Mond"), std::make_unique<double>(65000.0) };
-    Employee david{-1, "David", 27, std::make_unique<std::string>("Texas"), std::make_unique<double>(85000.0) };
-    Employee kim{-1, "Kim", 22, std::make_unique<std::string>("South-Hall"), std::make_unique<double>(45000.0) };
-    Employee james{-1, "James", 24, std::make_unique<std::string>("Houston"), std::make_unique<double>(10000.0) };
-    
+    Employee paul{-1, "Paul", 32, std::make_unique<std::string>("California"), std::make_unique<double>(20000.0)};
+    Employee allen{-1, "Allen", 25, std::make_unique<std::string>("Texas"), std::make_unique<double>(15000.0)};
+    Employee teddy{-1, "Teddy", 23, std::make_unique<std::string>("Norway"), std::make_unique<double>(20000.0)};
+    Employee mark{-1, "Mark", 25, std::make_unique<std::string>("Rich-Mond"), std::make_unique<double>(65000.0)};
+    Employee david{-1, "David", 27, std::make_unique<std::string>("Texas"), std::make_unique<double>(85000.0)};
+    Employee kim{-1, "Kim", 22, std::make_unique<std::string>("South-Hall"), std::make_unique<double>(45000.0)};
+    Employee james{-1, "James", 24, std::make_unique<std::string>("Houston"), std::make_unique<double>(10000.0)};
+
     //  insert employees. `insert` function returns id of inserted object..
     paul.id = storage.insert(paul);
     allen.id = storage.insert(allen);
@@ -47,7 +47,7 @@ int main(int, char **) {
     david.id = storage.insert(david);
     kim.id = storage.insert(kim);
     james.id = storage.insert(james);
-    
+
     //  print users..
     cout << "paul = " << storage.dump(paul) << endl;
     cout << "allen = " << storage.dump(allen) << endl;
@@ -56,43 +56,42 @@ int main(int, char **) {
     cout << "david = " << storage.dump(david) << endl;
     cout << "kim = " << storage.dump(kim) << endl;
     cout << "james = " << storage.dump(james) << endl;
-    
+
     //  select all employees..
     auto allEmployees = storage.get_all<Employee>();
-    
+
     cout << "allEmployees[0] = " << storage.dump(allEmployees[0]) << endl;
     cout << "allEmployees count = " << allEmployees.size() << endl;
-    
+
     //  now let's select id, name and salary..
-    auto idsNamesSalarys = storage.select(columns(&Employee::id,
-                                                  &Employee::name,
-                                                  &Employee::salary));
+    auto idsNamesSalarys = storage.select(columns(&Employee::id, &Employee::name, &Employee::salary));
     //  decltype(idsNamesSalarys) = std::vector<std::tuple<int, std::string, std::unique_ptr<double>>>
-    for(auto &tpl : idsNamesSalarys) {
+    for(auto &tpl: idsNamesSalarys) {
         cout << "id = " << std::get<0>(tpl) << ", name = " << std::get<1>(tpl) << ", salary = ";
-        if(std::get<2>(tpl)){
+        if(std::get<2>(tpl)) {
             cout << *std::get<2>(tpl);
-        }else{
+        } else {
             cout << "null";
         }
         cout << endl;
     }
-    
+
     cout << endl;
-    
+
     auto allEmployeesTuples = storage.select(asterisk<Employee>());
     cout << "allEmployeesTuples count = " << allEmployeesTuples.size() << endl;
-    for(auto &row : allEmployeesTuples) {   //  row is std::tuple<int, std::string, int, std::unique_ptr<std::string>, std::unique_ptr<double>>
+    for(auto &row: allEmployeesTuples) {  //  row is std::tuple<int, std::string, int, std::unique_ptr<std::string>,
+                                          //  std::unique_ptr<double>>
         cout << std::get<0>(row) << '\t' << std::get<1>(row) << '\t' << std::get<2>(row) << '\t';
-        if(auto &value = std::get<3>(row)){
+        if(auto &value = std::get<3>(row)) {
             cout << *value;
-        }else{
+        } else {
             cout << "null";
         }
         cout << '\t';
-        if(auto &value = std::get<4>(row)){
+        if(auto &value = std::get<4>(row)) {
             cout << *value;
-        }else{
+        } else {
             cout << "null";
         }
         cout << '\t' << endl;

--- a/examples/self_join.cpp
+++ b/examples/self_join.cpp
@@ -35,7 +35,7 @@ struct Employee {
 template<class T>
 struct custom_alias : sqlite_orm::alias_tag {
     using type = T;
-    
+
     static const std::string &get() {
         static const std::string res = "emp";
         return res;
@@ -44,70 +44,155 @@ struct custom_alias : sqlite_orm::alias_tag {
 
 int main() {
     using namespace sqlite_orm;
-    auto storage = make_storage("self_join.sqlite",
-                                make_table("employees",
-                                           make_column("EmployeeId", &Employee::employeeId, autoincrement(), primary_key()),
-                                           make_column("LastName", &Employee::lastName),
-                                           make_column("FirstName", &Employee::firstName),
-                                           make_column("Title", &Employee::title),
-                                           make_column("ReportsTo", &Employee::reportsTo),
-                                           make_column("BirthDate", &Employee::birthDate),
-                                           make_column("HireDate", &Employee::hireDate),
-                                           make_column("Address", &Employee::address),
-                                           make_column("City", &Employee::city),
-                                           make_column("State", &Employee::state),
-                                           make_column("Country", &Employee::country),
-                                           make_column("PostalCode", &Employee::postalCode),
-                                           make_column("Phone", &Employee::phone),
-                                           make_column("Fax", &Employee::fax),
-                                           make_column("Email", &Employee::email),
-                                           foreign_key(&Employee::reportsTo).references(&Employee::employeeId)));
+    auto storage =
+        make_storage("self_join.sqlite",
+                     make_table("employees",
+                                make_column("EmployeeId", &Employee::employeeId, autoincrement(), primary_key()),
+                                make_column("LastName", &Employee::lastName),
+                                make_column("FirstName", &Employee::firstName),
+                                make_column("Title", &Employee::title),
+                                make_column("ReportsTo", &Employee::reportsTo),
+                                make_column("BirthDate", &Employee::birthDate),
+                                make_column("HireDate", &Employee::hireDate),
+                                make_column("Address", &Employee::address),
+                                make_column("City", &Employee::city),
+                                make_column("State", &Employee::state),
+                                make_column("Country", &Employee::country),
+                                make_column("PostalCode", &Employee::postalCode),
+                                make_column("Phone", &Employee::phone),
+                                make_column("Fax", &Employee::fax),
+                                make_column("Email", &Employee::email),
+                                foreign_key(&Employee::reportsTo).references(&Employee::employeeId)));
     storage.sync_schema();
     storage.remove_all<Employee>();
-    
+
     storage.begin_transaction();
     storage.replace(Employee{
-        1, "Adams", "Andrew", "General Manager", {}, "1962-02-18 00:00:00", "2002-08-14 00:00:00",
-        "11120 Jasper Ave NW", "Edmonton", "AB", "Canada", "T5K 2N1", "+1 (780) 428-9482",
-        "+1 (780) 428-3457", "andrew@chinookcorp.com",
+        1,
+        "Adams",
+        "Andrew",
+        "General Manager",
+        {},
+        "1962-02-18 00:00:00",
+        "2002-08-14 00:00:00",
+        "11120 Jasper Ave NW",
+        "Edmonton",
+        "AB",
+        "Canada",
+        "T5K 2N1",
+        "+1 (780) 428-9482",
+        "+1 (780) 428-3457",
+        "andrew@chinookcorp.com",
     });
     storage.replace(Employee{
-        2, "Edwards", "Nancy", "Sales Manager", std::make_unique<int>(1), "1958-12-08 00:00:00",
-        "2002-05-01 00:00:00", "825 8 Ave SW", "Calgary", "AB", "Canada", "T2P 2T3",
-        "+1 (403) 262-3443", "+1 (403) 262-3322", "nancy@chinookcorp.com",
+        2,
+        "Edwards",
+        "Nancy",
+        "Sales Manager",
+        std::make_unique<int>(1),
+        "1958-12-08 00:00:00",
+        "2002-05-01 00:00:00",
+        "825 8 Ave SW",
+        "Calgary",
+        "AB",
+        "Canada",
+        "T2P 2T3",
+        "+1 (403) 262-3443",
+        "+1 (403) 262-3322",
+        "nancy@chinookcorp.com",
     });
-    storage.replace(Employee{
-        3, "Peacock", "Jane", "Sales Support Agent", std::make_unique<int>(2), "1973-08-29 00:00:00",
-        "2002-04-01 00:00:00", "1111 6 Ave SW", "Calgary", "AB", "Canada", "T2P 5M5",
-        "+1 (403) 262-3443", "+1 (403) 262-6712", "jane@chinookcorp.com"
-    });
-    storage.replace(Employee{
-        4, "Park", "Margaret", "Sales Support Agent", std::make_unique<int>(2), "1947-09-19 00:00:00",
-        "2003-05-03 00:00:00", "683 10 Street SW", "Calgary", "AB", "Canada", "T2P 5G3",
-        "+1 (403) 263-4423", "+1 (403) 263-4289", "margaret@chinookcorp.com"
-    });
-    storage.replace(Employee{
-        5, "Johnson", "Steve", "Sales Support Agent", std::make_unique<int>(2), "1965-03-03 00:00:00",
-        "2003-10-17 00:00:00", "7727B 41 Ave", "Calgary", "AB", "Canada", "T3B 1Y7",
-        "1 (780) 836-9987", "1 (780) 836-9543", "steve@chinookcorp.com"
-    });
-    storage.replace(Employee{
-        6, "Mitchell", "Michael", "IT Manager", std::make_unique<int>(1), "1973-07-01 00:00:00",
-        "2003-10-17 00:00:00", "5827 Bowness Road NW", "Calgary", "AB", "Canada", "T3B 0C5",
-        "+1 (403) 246-9887", "+1 (403) 246-9899", "michael@chinookcorp.com"
-    });
-    storage.replace(Employee{
-        7, "King", "Robert", "IT Staff", std::make_unique<int>(6), "1970-05-29 00:00:00",
-        "2004-01-02 00:00:00", "590 Columbia Boulevard West", "Lethbridge", "AB", "Canada",
-        "T1K 5N8", "+1 (403) 456-9986", "+1 (403) 456-8485", "robert@chinookcorp.com"
-    });
-    storage.replace(Employee{
-        8, "Callahan", "Laura", "IT Staff", std::make_unique<int>(6), "1968-01-09 00:00:00",
-        "2004-03-04 00:00:00", "923 7 ST NW", "Lethbridge", "AB", "Canada",
-        "T1H 1Y8", "+1 (403) 467-3351", "+1 (403) 467-8772", "laura@chinookcorp.com"
-    });
+    storage.replace(Employee{3,
+                             "Peacock",
+                             "Jane",
+                             "Sales Support Agent",
+                             std::make_unique<int>(2),
+                             "1973-08-29 00:00:00",
+                             "2002-04-01 00:00:00",
+                             "1111 6 Ave SW",
+                             "Calgary",
+                             "AB",
+                             "Canada",
+                             "T2P 5M5",
+                             "+1 (403) 262-3443",
+                             "+1 (403) 262-6712",
+                             "jane@chinookcorp.com"});
+    storage.replace(Employee{4,
+                             "Park",
+                             "Margaret",
+                             "Sales Support Agent",
+                             std::make_unique<int>(2),
+                             "1947-09-19 00:00:00",
+                             "2003-05-03 00:00:00",
+                             "683 10 Street SW",
+                             "Calgary",
+                             "AB",
+                             "Canada",
+                             "T2P 5G3",
+                             "+1 (403) 263-4423",
+                             "+1 (403) 263-4289",
+                             "margaret@chinookcorp.com"});
+    storage.replace(Employee{5,
+                             "Johnson",
+                             "Steve",
+                             "Sales Support Agent",
+                             std::make_unique<int>(2),
+                             "1965-03-03 00:00:00",
+                             "2003-10-17 00:00:00",
+                             "7727B 41 Ave",
+                             "Calgary",
+                             "AB",
+                             "Canada",
+                             "T3B 1Y7",
+                             "1 (780) 836-9987",
+                             "1 (780) 836-9543",
+                             "steve@chinookcorp.com"});
+    storage.replace(Employee{6,
+                             "Mitchell",
+                             "Michael",
+                             "IT Manager",
+                             std::make_unique<int>(1),
+                             "1973-07-01 00:00:00",
+                             "2003-10-17 00:00:00",
+                             "5827 Bowness Road NW",
+                             "Calgary",
+                             "AB",
+                             "Canada",
+                             "T3B 0C5",
+                             "+1 (403) 246-9887",
+                             "+1 (403) 246-9899",
+                             "michael@chinookcorp.com"});
+    storage.replace(Employee{7,
+                             "King",
+                             "Robert",
+                             "IT Staff",
+                             std::make_unique<int>(6),
+                             "1970-05-29 00:00:00",
+                             "2004-01-02 00:00:00",
+                             "590 Columbia Boulevard West",
+                             "Lethbridge",
+                             "AB",
+                             "Canada",
+                             "T1K 5N8",
+                             "+1 (403) 456-9986",
+                             "+1 (403) 456-8485",
+                             "robert@chinookcorp.com"});
+    storage.replace(Employee{8,
+                             "Callahan",
+                             "Laura",
+                             "IT Staff",
+                             std::make_unique<int>(6),
+                             "1968-01-09 00:00:00",
+                             "2004-03-04 00:00:00",
+                             "923 7 ST NW",
+                             "Lethbridge",
+                             "AB",
+                             "Canada",
+                             "T1H 1Y8",
+                             "+1 (403) 467-3351",
+                             "+1 (403) 467-8772",
+                             "laura@chinookcorp.com"});
     storage.commit();
-    
+
     {
         //  SELECT m.FirstName || ' ' || m.LastName,
         //      employees.FirstName || ' ' || employees.LastName
@@ -115,33 +200,35 @@ int main() {
         //  INNER JOIN employees m
         //  ON m.ReportsTo = employees.EmployeeId
         using als = alias_m<Employee>;
-        auto firstNames = storage.select(columns(c(alias_column<als>(&Employee::firstName)) || " " || c(alias_column<als>(&Employee::lastName)),
-                                                 c(&Employee::firstName) || " " || c(&Employee::lastName)),
-                                         inner_join<als>(on(alias_column<als>(&Employee::reportsTo) == c(&Employee::employeeId))));
+        auto firstNames = storage.select(
+            columns(c(alias_column<als>(&Employee::firstName)) || " " || c(alias_column<als>(&Employee::lastName)),
+                    c(&Employee::firstName) || " " || c(&Employee::lastName)),
+            inner_join<als>(on(alias_column<als>(&Employee::reportsTo) == c(&Employee::employeeId))));
         cout << "firstNames count = " << firstNames.size() << endl;
-        for(auto &row : firstNames) {
+        for(auto &row: firstNames) {
             cout << std::get<0>(row) << '\t' << std::get<1>(row) << endl;
         }
-        
+
         assert(storage.count<Employee>() == storage.count<alias_a<Employee>>());
     }
-    {   //  same query with custom alias 'emp'
+    {  //  same query with custom alias 'emp'
         cout << endl;
-        
+
         //  SELECT emp.FirstName || ' ' || emp.LastName,
         //      employees.FirstName || ' ' || employees.LastName
         //  FROM employees
         //  INNER JOIN employees emp
         //  ON emp.ReportsTo = employees.EmployeeId
         using als = custom_alias<Employee>;
-        auto firstNames = storage.select(columns(c(alias_column<als>(&Employee::firstName)) || " " || c(alias_column<als>(&Employee::lastName)),
-                                                 c(&Employee::firstName) || " " || c(&Employee::lastName)),
-                                         inner_join<als>(on(alias_column<als>(&Employee::reportsTo) == c(&Employee::employeeId))));
+        auto firstNames = storage.select(
+            columns(c(alias_column<als>(&Employee::firstName)) || " " || c(alias_column<als>(&Employee::lastName)),
+                    c(&Employee::firstName) || " " || c(&Employee::lastName)),
+            inner_join<als>(on(alias_column<als>(&Employee::reportsTo) == c(&Employee::employeeId))));
         cout << "firstNames count = " << firstNames.size() << endl;
-        for(auto &row : firstNames) {
+        for(auto &row: firstNames) {
             cout << std::get<0>(row) << '\t' << std::get<1>(row) << endl;
         }
     }
-    
+
     return 0;
 }

--- a/examples/subentities.cpp
+++ b/examples/subentities.cpp
@@ -2,15 +2,14 @@
  *  Our goal is to manage a Student class. Student has basic id, name and roll_number and one more thing:
  *  vector of marks. Mark is a subentity with one to many relation. This example shows how to manage this kind of case.
  *  First of all we got to understand how to keep data in the db. We need two tables: `students` and `marks`. Students
- *  table has column equal to all Student class members exept marks. Marks table has two columns: student_id and value itself.
- *  We create two functions here: inserting/updating student (with his/her marks) and getting student (also with his/her marks).
- *  Schema is:
- *  `CREATE TABLE students (id INTEGER NOT NULL PRIMARY KEY, name TEXT NOT NULL, roll_no INTEGER NOT NULL)`
- *  `CREATE TABLE marks (mark INTEGER NOT NULL, student_id INTEGER NOT NULL)`
- *  One of the main ideas of `sqlite_orm` is to give a developer ability to name tables/columns as he/she wants.
- *  Many other ORM libraries manage subentities automatically and it is not correct cause developer must understand
- *  how everything works inside sqlite otherwise his/her app might not work properly. Also developer must know schema in case he or she needs
- *  a strict access with sqlite client.
+ *  table has column equal to all Student class members exept marks. Marks table has two columns: student_id and value
+ * itself. We create two functions here: inserting/updating student (with his/her marks) and getting student (also with
+ * his/her marks). Schema is: `CREATE TABLE students (id INTEGER NOT NULL PRIMARY KEY, name TEXT NOT NULL, roll_no
+ * INTEGER NOT NULL)` `CREATE TABLE marks (mark INTEGER NOT NULL, student_id INTEGER NOT NULL)` One of the main ideas of
+ * `sqlite_orm` is to give a developer ability to name tables/columns as he/she wants. Many other ORM libraries manage
+ * subentities automatically and it is not correct cause developer must understand how everything works inside sqlite
+ * otherwise his/her app might not work properly. Also developer must know schema in case he or she needs a strict
+ * access with sqlite client.
  */
 
 #include <sqlite_orm/sqlite_orm.h>
@@ -20,13 +19,13 @@ using std::cout;
 using std::endl;
 
 class Mark {
-public:
+  public:
     int value;
     int student_id;
 };
 
-class Student{
-public:
+class Student {
+  public:
     int id;
     std::string name;
     int roll_number;
@@ -34,34 +33,27 @@ public:
 };
 
 using namespace sqlite_orm;
-auto storage = make_storage("subentities.sqlite",
-                            make_table("students",
-                                       make_column("id",
-                                                   &Student::id,
-                                                   primary_key()),
-                                       make_column("name",
-                                                   &Student::name),
-                                       make_column("roll_no",
-                                                   &Student::roll_number)),
-                            make_table("marks",
-                                       make_column("mark",
-                                                   &Mark::value),
-                                       make_column("student_id",
-                                                   &Mark::student_id)));
+auto storage =
+    make_storage("subentities.sqlite",
+                 make_table("students",
+                            make_column("id", &Student::id, primary_key()),
+                            make_column("name", &Student::name),
+                            make_column("roll_no", &Student::roll_number)),
+                 make_table("marks", make_column("mark", &Mark::value), make_column("student_id", &Mark::student_id)));
 
 //  inserts or updates student and does the same with marks
 int addStudent(const Student &student) {
     auto studentId = student.id;
-    if(storage.count<Student>(where(c(&Student::id) == student.id))){
+    if(storage.count<Student>(where(c(&Student::id) == student.id))) {
         storage.update(student);
-    }else{
+    } else {
         studentId = storage.insert(student);
     }
     //  insert all marks within a transaction
-    storage.transaction([&]{
+    storage.transaction([&] {
         storage.remove_all<Mark>(where(c(&Mark::student_id) == studentId));
-        for(auto &mark : student.marks) {
-            storage.insert(Mark{ mark, studentId });
+        for(auto &mark: student.marks) {
+            storage.insert(Mark{mark, studentId});
         }
         return true;
     });
@@ -76,23 +68,23 @@ int addStudent(const Student &student) {
 Student getStudent(int studentId) {
     auto res = storage.get<Student>(studentId);
     res.marks = storage.select(&Mark::value, where(c(&Mark::student_id) == studentId));
-    return res; //  must be moved automatically by compiler
+    return res;  //  must be moved automatically by compiler
 }
 
 int main(int, char **) {
     decltype(Student::id) mikeId;
     decltype(Student::id) annaId;
-    
+
     {
-        storage.sync_schema();    // create tables if they don't exist
-        
-        Student mike{ -1, "Mike", 123, {} };    //  create student named `Mike` without marks and without id
-        mike.marks = { 3, 4, 5 };
+        storage.sync_schema();  // create tables if they don't exist
+
+        Student mike{-1, "Mike", 123, {}};  //  create student named `Mike` without marks and without id
+        mike.marks = {3, 4, 5};
         mike.id = addStudent(mike);
         mikeId = mike.id;
-        
+
         //  also let's create another students with marks..
-        Student anna{ -1, "Anna", 555, {} };
+        Student anna{-1, "Anna", 555, {}};
         anna.marks.push_back(6);
         anna.marks.push_back(7);
         anna.id = addStudent(anna);
@@ -100,24 +92,24 @@ int main(int, char **) {
     }
     // now let's assume we forgot about object `mike`, let's try to get him with his marks
     //  assume we know `mikeId` variable only
-    
+
     {
         auto mike = getStudent(mikeId);
         cout << "mike = " << storage.dump(mike) << endl;
         cout << "mike.marks = ";
-        for(auto &m : mike.marks) {
+        for(auto &m: mike.marks) {
             cout << m << " ";
         }
         cout << endl;
-        
+
         auto anna = getStudent(annaId);
         cout << "anna = " << storage.dump(anna) << endl;
         cout << "anna.marks = ";
-        for(auto &m : anna.marks) {
+        for(auto &m: anna.marks) {
             cout << m << " ";
         }
         cout << endl;
     }
-    
+
     return 0;
 }

--- a/examples/subquery.cpp
+++ b/examples/subquery.cpp
@@ -66,115 +66,1176 @@ int main(int, char **) {
                                            make_column("department_id", &JobHistory::departmentId)));
     storage.sync_schema();
     storage.remove_all<Employee>();
-    
-    storage.replace(Employee{100, "Steven", "King", "SKING", "515.123.4567", "17-Jun-87", "AD_PRES", 24000, {}, {}, 90});
-    storage.replace(Employee{101, "Neena", "Kochhar", "NKOCHHAR", "515.123.4568", "21-Sep-89", "AD_VP", 17000, {}, std::make_unique<int>(100), 90});
-    storage.replace(Employee{102, "Lex", "De Haan", "LDEHAAN", "515.123.4569", "13-Jan-93", "AD_VP", 17000, {}, std::make_unique<int>(100), 90});
-    storage.replace(Employee{103, "Alexander", "Hunold", "AHUNOLD", "590.423.4567", "3-Jan-90", "IT_PROG", 9000, {}, std::make_unique<int>(102), 60});
-    storage.replace(Employee{104, "Bruce", "Ernst", "BERNST", "590.423.4568", "21-May-91", "IT_PROG", 6000, {}, std::make_unique<int>(103), 60});
-    storage.replace(Employee{105, "David", "Austin", "DAUSTIN", "590.423.4569", "25-Jun-97", "IT_PROG", 4800, {}, std::make_unique<int>(103), 60});
-    storage.replace(Employee{106, "Valli", "Pataballa", "VPATABAL", "590.423.4560", "5-Feb-98", "IT_PROG", 4800, {}, std::make_unique<int>(103), 60});
-    storage.replace(Employee{107, "Diana", "Lorentz", "DLORENTZ", "590.423.5567", "7-Feb-99", "IT_PROG", 4200, {}, std::make_unique<int>(103), 60});
-    storage.replace(Employee{108, "Nancy", "Greenberg", "NGREENBE", "515.124.4569", "17-Aug-94", "FI_MGR", 12000, {}, std::make_unique<int>(101), 100});
-    storage.replace(Employee{109, "Daniel", "Faviet", "DFAVIET", "515.124.4169", "16-Aug-94", "FI_ACCOUNT", 9000, {}, std::make_unique<int>(108), 100});
-    storage.replace(Employee{110, "John", "Chen", "JCHEN", "515.124.4269", "28-Sep-97", "FI_ACCOUNT", 8200, {}, std::make_unique<int>(108), 100});
-    storage.replace(Employee{111, "Ismael", "Sciarra", "ISCIARRA", "515.124.4369", "30-Sep-97", "FI_ACCOUNT", 7700, {}, std::make_unique<int>(108), 100});
-    storage.replace(Employee{112, "Jose Manuel", "Urman", "JMURMAN", "515.124.4469", "7-Mar-98", "FI_ACCOUNT", 7800, {}, std::make_unique<int>(108), 100});
-    storage.replace(Employee{113, "Luis", "Popp", "LPOPP", "515.124.4567", "7-Dec-99", "FI_ACCOUNT", 6900, {}, std::make_unique<int>(108), 100});
-    storage.replace(Employee{114, "Den", "Raphaely", "DRAPHEAL", "515.127.4561", "7-Dec-94", "PU_MAN", 11000, {}, std::make_unique<int>(100), 30});
-    storage.replace(Employee{115, "Alexander", "Khoo", "AKHOO", "515.127.4562", "18-May-95", "PU_CLERK", 3100, {}, std::make_unique<int>(114), 30});
-    storage.replace(Employee{116, "Shelli", "Baida", "SBAIDA", "515.127.4563", "24-Dec-97", "PU_CLERK", 2900, {}, std::make_unique<int>(114), 30});
-    storage.replace(Employee{117, "Sigal", "Tobias", "STOBIAS", "515.127.4564", "24-Jul-97", "PU_CLERK", 2800, {}, std::make_unique<int>(114), 30});
-    storage.replace(Employee{118, "Guy", "Himuro", "GHIMURO", "515.127.4565", "15-Nov-98", "PU_CLERK", 2600, {}, std::make_unique<int>(114), 30});
-    storage.replace(Employee{119, "Karen", "Colmenares", "KCOLMENA", "515.127.4566", "10-Aug-99", "PU_CLERK", 2500, {}, std::make_unique<int>(114), 30});
-    storage.replace(Employee{120, "Matthew", "Weiss", "MWEISS", "650.123.1234", "18-Jul-96", "ST_MAN", 8000, {}, std::make_unique<int>(100), 50});
-    storage.replace(Employee{121, "Adam", "Fripp", "AFRIPP", "650.123.2234", "10-Apr-97", "ST_MAN", 8200, {}, std::make_unique<int>(100), 50});
-    storage.replace(Employee{122, "Payam", "Kaufling", "PKAUFLIN", "650.123.3234", "1-May-95", "ST_MAN", 7900, {}, std::make_unique<int>(100), 50});
-    storage.replace(Employee{123, "Shanta", "Vollman", "SVOLLMAN", "650.123.4234", "10-Oct-97", "ST_MAN", 6500, {}, std::make_unique<int>(100), 50});
-    storage.replace(Employee{124, "Kevin", "Mourgos", "KMOURGOS", "650.123.5234", "16-Nov-99", "ST_MAN", 5800, {}, std::make_unique<int>(100), 50});
-    storage.replace(Employee{125, "Julia", "Nayer", "JNAYER", "650.124.1214", "16-Jul-97", "ST_CLERK", 3200, {}, std::make_unique<int>(120), 50});
-    storage.replace(Employee{126, "Irene", "Mikkilineni", "IMIKKILI", "650.124.1224", "28-Sep-98", "ST_CLERK", 2700, {}, std::make_unique<int>(120), 50});
-    storage.replace(Employee{127, "James", "Landry", "JLANDRY", "650.124.1334", "14-Jan-99", "ST_CLERK", 2400, {}, std::make_unique<int>(120), 50});
-    storage.replace(Employee{128, "Steven", "Markle", "SMARKLE", "650.124.1434", "8-Mar-00", "ST_CLERK", 2200, {}, std::make_unique<int>(120), 50});
-    storage.replace(Employee{129, "Laura", "Bissot", "LBISSOT", "650.124.5234", "20-Aug-97", "ST_CLERK", 3300, {}, std::make_unique<int>(121), 50});
-    storage.replace(Employee{130, "Mozhe", "Atkinson", "MATKINSO", "650.124.6234", "30-Oct-97", "ST_CLERK", 2800, {}, std::make_unique<int>(121), 50});
-    storage.replace(Employee{131, "James", "Marlow", "JAMRLOW", "650.124.7234", "16-Feb-97", "ST_CLERK", 2500, {}, std::make_unique<int>(121), 50});
-    storage.replace(Employee{132, "TJ", "Olson", "TJOLSON", "650.124.8234", "10-Apr-99", "ST_CLERK", 2100, {}, std::make_unique<int>(121), 50});
-    storage.replace(Employee{133, "Jason", "Mallin", "JMALLIN", "650.127.1934", "14-Jun-96", "ST_CLERK", 3300, {}, std::make_unique<int>(122), 50});
-    storage.replace(Employee{134, "Michael", "Rogers", "MROGERS", "650.127.1834", "26-Aug-98", "ST_CLERK", 2900, {}, std::make_unique<int>(122), 50});
-    storage.replace(Employee{135, "Ki", "Gee", "KGEE", "650.127.1734", "12-Dec-99", "ST_CLERK", 2400, {}, std::make_unique<int>(122), 50});
-    storage.replace(Employee{136, "Hazel", "Philtanker", "HPHILTAN", "650.127.1634", "6-Feb-00", "ST_CLERK", 2200, {}, std::make_unique<int>(122), 50});
-    storage.replace(Employee{137, "Renske", "Ladwig", "RLADWIG", "650.121.1234", "14-Jul-95", "ST_CLERK", 3600, {}, std::make_unique<int>(123), 50});
-    storage.replace(Employee{138, "Stephen", "Stiles", "SSTILES", "650.121.2034", "26-Oct-97", "ST_CLERK", 3200, {}, std::make_unique<int>(123), 50});
-    storage.replace(Employee{139, "John", "Seo", "JSEO", "650.121.2019", "12-Feb-98", "ST_CLERK", 2700, {}, std::make_unique<int>(123), 50});
-    storage.replace(Employee{140, "Joshua", "Patel", "JPATEL", "650.121.1834", "6-Apr-98", "ST_CLERK", 2500, {}, std::make_unique<int>(123), 50});
-    storage.replace(Employee{141, "Trenna", "Rajs", "TRAJS", "650.121.8009", "17-Oct-95", "ST_CLERK", 3500, {}, std::make_unique<int>(124), 50});
-    storage.replace(Employee{142, "Curtis", "Davies", "CDAVIES", "650.121.2994", "29-Jan-97", "ST_CLERK", 3100, {}, std::make_unique<int>(124), 50});
-    storage.replace(Employee{143, "Randall", "Matos", "RMATOS", "650.121.2874", "15-Mar-98", "ST_CLERK", 2600, {}, std::make_unique<int>(124), 50});
-    storage.replace(Employee{144, "Peter", "Vargas", "PVARGAS", "650.121.2004", "9-Jul-98", "ST_CLERK", 2500, {}, std::make_unique<int>(124), 50});
-    storage.replace(Employee{145, "John", "Russell", "JRUSSEL", "011.44.1344.429268", "1-Oct-96", "SA_MAN", 14000, std::make_unique<double>(0.4), std::make_unique<int>(100), 80});
-    storage.replace(Employee{146, "Karen", "Partners", "KPARTNER", "011.44.1344.467268", "5-Jan-97", "SA_MAN", 13500, std::make_unique<double>(0.3), std::make_unique<int>(100), 80});
-    storage.replace(Employee{147, "Alberto", "Errazuriz", "AERRAZUR", "011.44.1344.429278", "10-Mar-97", "SA_MAN", 12000, std::make_unique<double>(0.3), std::make_unique<int>(100), 80});
-    storage.replace(Employee{148, "Gerald", "Cambrault", "GCAMBRAU", "011.44.1344.619268", "15-Oct-99", "SA_MAN", 11000, std::make_unique<double>(0.3), std::make_unique<int>(100), 80});
-    storage.replace(Employee{149, "Eleni", "Zlotkey", "EZLOTKEY", "011.44.1344.429018", "29-Jan-00", "SA_MAN", 10500, std::make_unique<double>(0.2), std::make_unique<int>(100), 80});
-    storage.replace(Employee{150, "Peter", "Tucker", "PTUCKER", "011.44.1344.129268", "30-Jan-97", "SA_REP", 10000, std::make_unique<double>(0.3), std::make_unique<int>(145), 80});
-    storage.replace(Employee{151, "David", "Bernstein", "DBERNSTE", "011.44.1344.345268", "24-Mar-97", "SA_REP", 9500, std::make_unique<double>(0.25), std::make_unique<int>(145), 80});
-    storage.replace(Employee{152, "Peter", "Hall", "PHALL", "011.44.1344.478968", "20-Aug-97", "SA_REP", 9000, std::make_unique<double>(0.25), std::make_unique<int>(145), 80});
-    storage.replace(Employee{153, "Christopher", "Olsen", "COLSEN", "011.44.1344.498718", "30-Mar-98", "SA_REP", 8000, std::make_unique<double>(0.2), std::make_unique<int>(145), 80});
-    storage.replace(Employee{154, "Nanette", "Cambrault", "NCAMBRAU", "011.44.1344.987668", "9-Dec-98", "SA_REP", 7500, std::make_unique<double>(0.2), std::make_unique<int>(145), 80});
-    storage.replace(Employee{155, "Oliver", "Tuvault", "OTUVAULT", "011.44.1344.486508", "23-Nov-99", "SA_REP", 7000, std::make_unique<double>(0.15), std::make_unique<int>(145), 80});
-    storage.replace(Employee{156, "Janette", "King", "JKING", "011.44.1345.429268", "30-Jan-96", "SA_REP", 10000, std::make_unique<double>(0.35), std::make_unique<int>(146), 80});
-    storage.replace(Employee{157, "Patrick", "Sully", "PSULLY", "011.44.1345.929268", "4-Mar-96", "SA_REP", 9500, std::make_unique<double>(0.35), std::make_unique<int>(146), 80});
-    storage.replace(Employee{158, "Allan", "McEwen", "AMCEWEN", "011.44.1345.829268", "1-Aug-96", "SA_REP", 9000, std::make_unique<double>(0.35), std::make_unique<int>(146), 80});
-    storage.replace(Employee{159, "Lindsey", "Smith", "LSMITH", "011.44.1345.729268", "10-Mar-97", "SA_REP", 8000, std::make_unique<double>(0.3), std::make_unique<int>(146), 80});
-    storage.replace(Employee{160, "Louise", "Doran", "LDORAN", "011.44.1345.629268", "15-Dec-97", "SA_REP", 7500, std::make_unique<double>(0.3), std::make_unique<int>(146), 80});
-    storage.replace(Employee{161, "Sarath", "Sewall", "SSEWALL", "011.44.1345.529268", "3-Nov-98", "SA_REP", 7000, std::make_unique<double>(0.25), std::make_unique<int>(146), 80});
-    storage.replace(Employee{162, "Clara", "Vishney", "CVISHNEY", "011.44.1346.129268", "11-Nov-97", "SA_REP", 10500, std::make_unique<double>(0.25), std::make_unique<int>(147), 80});
-    storage.replace(Employee{163, "Danielle", "Greene", "DGREENE", "011.44.1346.229268", "19-Mar-99", "SA_REP", 9500, std::make_unique<double>(0.15), std::make_unique<int>(147), 80});
-    storage.replace(Employee{164, "Mattea", "Marvins", "MMARVINS", "011.44.1346.329268", "24-Jan-00", "SA_REP", 7200, std::make_unique<double>(0.1), std::make_unique<int>(147), 80});
-    storage.replace(Employee{165, "David", "Lee", "DLEE", "011.44.1346.529268", "23-Feb-00", "SA_REP", 6800, std::make_unique<double>(0.1), std::make_unique<int>(147), 80});
-    storage.replace(Employee{166, "Sundar", "Ande", "SANDE", "011.44.1346.629268", "24-Mar-00", "SA_REP", 6400, std::make_unique<double>(0.1), std::make_unique<int>(147), 80});
-    storage.replace(Employee{167, "Amit", "Banda", "ABANDA", "011.44.1346.729268", "21-Apr-00", "SA_REP", 6200, std::make_unique<double>(0.1), std::make_unique<int>(147), 80});
-    storage.replace(Employee{168, "Lisa", "Ozer", "LOZER", "011.44.1343.929268", "11-Mar-97", "SA_REP", 11500, std::make_unique<double>(0.25), std::make_unique<int>(148), 80});
-    storage.replace(Employee{169, "Harrison", "Bloom", "HBLOOM", "011.44.1343.829268", "23-Mar-98", "SA_REP", 10000, std::make_unique<double>(0.2), std::make_unique<int>(148), 80});
-    storage.replace(Employee{170, "Tayler", "Fox", "TFOX", "011.44.1343.729268", "24-Jan-98", "SA_REP", 9600, std::make_unique<double>(0.2), std::make_unique<int>(148), 80});
-    storage.replace(Employee{171, "William", "Smith", "WSMITH", "011.44.1343.629268", "23-Feb-99", "SA_REP", 7400, std::make_unique<double>(0.15), std::make_unique<int>(148), 80});
-    storage.replace(Employee{172, "Elizabeth", "Bates", "EBATES", "011.44.1343.529268", "24-Mar-99", "SA_REP", 7300, std::make_unique<double>(0.15), std::make_unique<int>(148), 80});
-    storage.replace(Employee{173, "Sundita", "Kumar", "SKUMAR", "011.44.1343.329268", "21-Apr-00", "SA_REP", 6100, std::make_unique<double>(0.1), std::make_unique<int>(148), 80});
-    storage.replace(Employee{174, "Ellen", "Abel", "EABEL", "011.44.1644.429267", "11-May-96", "SA_REP", 11000, std::make_unique<double>(0.3), std::make_unique<int>(149), 80});
-    storage.replace(Employee{175, "Alyssa", "Hutton", "AHUTTON", "011.44.1644.429266", "19-Mar-97", "SA_REP", 8800, std::make_unique<double>(0.25), std::make_unique<int>(149), 80});
-    storage.replace(Employee{176, "Jonathon", "Taylor", "JTAYLOR", "011.44.1644.429265", "24-Mar-98", "SA_REP", 8600, std::make_unique<double>(0.2), std::make_unique<int>(149), 80});
-    storage.replace(Employee{177, "Jack", "Livingston", "JLIVINGS", "011.44.1644.429264", "23-Apr-98", "SA_REP", 8400, std::make_unique<double>(0.2), std::make_unique<int>(149), 80});
-    storage.replace(Employee{178, "Kimberely", "Grant", "KGRANT", "011.44.1644.429263", "24-May-99", "SA_REP", 7000, std::make_unique<double>(0.15), std::make_unique<int>(149), 80});
-    storage.replace(Employee{179, "Charles", "Johnson", "CJOHNSON", "011.44.1644.429262", "4-Jan-00", "SA_REP", 6200, std::make_unique<double>(0.1), std::make_unique<int>(149), 80});
-    storage.replace(Employee{180, "Winston", "Taylor", "WTAYLOR", "650.507.9876", "24-Jan-98", "SH_CLERK", 3200, {}, std::make_unique<int>(120), 50});
-    storage.replace(Employee{181, "Jean", "Fleaur", "JFLEAUR", "650.507.9877", "23-Feb-98", "SH_CLERK", 3100, {}, std::make_unique<int>(120), 50});
-    storage.replace(Employee{182, "Martha", "Sullivan", "MSULLIVA", "650.507.9878", "21-Jun-99", "SH_CLERK", 2500, {}, std::make_unique<int>(120), 50});
-    storage.replace(Employee{183, "Girard", "Geoni", "GGEONI", "650.507.9879", "3-Feb-00", "SH_CLERK", 2800, {}, std::make_unique<int>(120), 50});
-    storage.replace(Employee{184, "Nandita", "Sarchand", "NSARCHAN", "650.509.1876", "27-Jan-96", "SH_CLERK", 4200, {}, std::make_unique<int>(121), 50});
-    storage.replace(Employee{185, "Alexis", "Bull", "ABULL", "650.509.2876", "20-Feb-97", "SH_CLERK", 4100, {}, std::make_unique<int>(121), 50});
-    storage.replace(Employee{186, "Julia", "Dellinger", "JDELLING", "650.509.3876", "24-Jun-98", "SH_CLERK", 3400, {}, std::make_unique<int>(121), 50});
-    storage.replace(Employee{187, "Anthony", "Cabrio", "ACABRIO", "650.509.4876", "7-Feb-99", "SH_CLERK", 3000, {}, std::make_unique<int>(121), 50});
-    storage.replace(Employee{188, "Kelly", "Chung", "KCHUNG", "650.505.1876", "14-Jun-97", "SH_CLERK", 3800, {}, std::make_unique<int>(122), 50});
-    storage.replace(Employee{189, "Jennifer", "Dilly", "JDILLY", "650.505.2876", "13-Aug-97", "SH_CLERK", 3600, {}, std::make_unique<int>(122), 50});
-    storage.replace(Employee{190, "Timothy", "Gates", "TGATES", "650.505.3876", "11-Jul-98", "SH_CLERK", 2900, {}, std::make_unique<int>(122), 50});
-    storage.replace(Employee{191, "Randall", "Perkins", "RPERKINS", "650.505.4876", "19-Dec-99", "SH_CLERK", 2500, {}, std::make_unique<int>(122), 50});
-    storage.replace(Employee{192, "Sarah", "Bell", "SBELL", "650.501.1876", "4-Feb-96", "SH_CLERK", 4000, {}, std::make_unique<int>(123), 50});
-    storage.replace(Employee{193, "Britney", "Everett", "BEVERETT", "650.501.2876", "3-Mar-97", "SH_CLERK", 3900, {}, std::make_unique<int>(123), 50});
-    storage.replace(Employee{194, "Samuel", "McCain", "SMCCAIN", "650.501.3876", "1-Jul-98", "SH_CLERK", 3200, {}, std::make_unique<int>(123), 50});
-    storage.replace(Employee{195, "Vance", "Jones", "VJONES", "650.501.4876", "17-Mar-99", "SH_CLERK", 2800, {}, std::make_unique<int>(123), 50});
-    storage.replace(Employee{196, "Alana", "Walsh", "AWALSH", "650.507.9811", "24-Apr-98", "SH_CLERK", 3100, {}, std::make_unique<int>(124), 50});
-    storage.replace(Employee{197, "Kevin", "Feeney", "KFEENEY", "650.507.9822", "23-May-98", "SH_CLERK", 3000, {}, std::make_unique<int>(124), 50});
-    storage.replace(Employee{198, "Donald", "OConnell", "DOCONNEL", "650.507.9833", "21-Jun-99", "SH_CLERK", 2600, {}, std::make_unique<int>(124), 50});
-    storage.replace(Employee{199, "Douglas", "Grant", "DGRANT", "650.507.9844", "13-Jan-00", "SH_CLERK", 2600, {}, std::make_unique<int>(124), 50});
-    storage.replace(Employee{200, "Jennifer", "Whalen", "JWHALEN", "515.123.4444", "17-Sep-87", "AD_ASST", 4400, {}, std::make_unique<int>(101), 10});
-    storage.replace(Employee{201, "Michael", "Hartstein", "MHARTSTE", "515.123.5555", "17-Feb-96", "MK_MAN", 13000, {}, std::make_unique<int>(100), 20});
-    storage.replace(Employee{202, "Pat", "Fay", "PFAY", "603.123.6666", "17-Aug-97", "MK_REP", 6000, {}, std::make_unique<int>(201), 20});
-    storage.replace(Employee{203, "Susan", "Mavris", "SMAVRIS", "515.123.7777", "7-Jun-94", "HR_REP", 6500, {}, std::make_unique<int>(101), 40});
-    storage.replace(Employee{204, "Hermann", "Baer", "HBAER", "515.123.8888", "7-Jun-94", "PR_REP", 10000, {}, std::make_unique<int>(101), 70});
-    storage.replace(Employee{205, "Shelley", "Higgins", "SHIGGINS", "515.123.8080", "7-Jun-94", "AC_MGR", 12000, {}, std::make_unique<int>(101), 110});
-    storage.replace(Employee{206, "William", "Gietz", "WGIETZ", "515.123.8181", "7-Jun-94", "AC_ACCOUNT", 8300, {}, std::make_unique<int>(205), 110});
-    
+
+    storage.replace(
+        Employee{100, "Steven", "King", "SKING", "515.123.4567", "17-Jun-87", "AD_PRES", 24000, {}, {}, 90});
+    storage.replace(Employee{101,
+                             "Neena",
+                             "Kochhar",
+                             "NKOCHHAR",
+                             "515.123.4568",
+                             "21-Sep-89",
+                             "AD_VP",
+                             17000,
+                             {},
+                             std::make_unique<int>(100),
+                             90});
+    storage.replace(Employee{102,
+                             "Lex",
+                             "De Haan",
+                             "LDEHAAN",
+                             "515.123.4569",
+                             "13-Jan-93",
+                             "AD_VP",
+                             17000,
+                             {},
+                             std::make_unique<int>(100),
+                             90});
+    storage.replace(Employee{103,
+                             "Alexander",
+                             "Hunold",
+                             "AHUNOLD",
+                             "590.423.4567",
+                             "3-Jan-90",
+                             "IT_PROG",
+                             9000,
+                             {},
+                             std::make_unique<int>(102),
+                             60});
+    storage.replace(Employee{104,
+                             "Bruce",
+                             "Ernst",
+                             "BERNST",
+                             "590.423.4568",
+                             "21-May-91",
+                             "IT_PROG",
+                             6000,
+                             {},
+                             std::make_unique<int>(103),
+                             60});
+    storage.replace(Employee{105,
+                             "David",
+                             "Austin",
+                             "DAUSTIN",
+                             "590.423.4569",
+                             "25-Jun-97",
+                             "IT_PROG",
+                             4800,
+                             {},
+                             std::make_unique<int>(103),
+                             60});
+    storage.replace(Employee{106,
+                             "Valli",
+                             "Pataballa",
+                             "VPATABAL",
+                             "590.423.4560",
+                             "5-Feb-98",
+                             "IT_PROG",
+                             4800,
+                             {},
+                             std::make_unique<int>(103),
+                             60});
+    storage.replace(Employee{107,
+                             "Diana",
+                             "Lorentz",
+                             "DLORENTZ",
+                             "590.423.5567",
+                             "7-Feb-99",
+                             "IT_PROG",
+                             4200,
+                             {},
+                             std::make_unique<int>(103),
+                             60});
+    storage.replace(Employee{108,
+                             "Nancy",
+                             "Greenberg",
+                             "NGREENBE",
+                             "515.124.4569",
+                             "17-Aug-94",
+                             "FI_MGR",
+                             12000,
+                             {},
+                             std::make_unique<int>(101),
+                             100});
+    storage.replace(Employee{109,
+                             "Daniel",
+                             "Faviet",
+                             "DFAVIET",
+                             "515.124.4169",
+                             "16-Aug-94",
+                             "FI_ACCOUNT",
+                             9000,
+                             {},
+                             std::make_unique<int>(108),
+                             100});
+    storage.replace(Employee{110,
+                             "John",
+                             "Chen",
+                             "JCHEN",
+                             "515.124.4269",
+                             "28-Sep-97",
+                             "FI_ACCOUNT",
+                             8200,
+                             {},
+                             std::make_unique<int>(108),
+                             100});
+    storage.replace(Employee{111,
+                             "Ismael",
+                             "Sciarra",
+                             "ISCIARRA",
+                             "515.124.4369",
+                             "30-Sep-97",
+                             "FI_ACCOUNT",
+                             7700,
+                             {},
+                             std::make_unique<int>(108),
+                             100});
+    storage.replace(Employee{112,
+                             "Jose Manuel",
+                             "Urman",
+                             "JMURMAN",
+                             "515.124.4469",
+                             "7-Mar-98",
+                             "FI_ACCOUNT",
+                             7800,
+                             {},
+                             std::make_unique<int>(108),
+                             100});
+    storage.replace(Employee{113,
+                             "Luis",
+                             "Popp",
+                             "LPOPP",
+                             "515.124.4567",
+                             "7-Dec-99",
+                             "FI_ACCOUNT",
+                             6900,
+                             {},
+                             std::make_unique<int>(108),
+                             100});
+    storage.replace(Employee{114,
+                             "Den",
+                             "Raphaely",
+                             "DRAPHEAL",
+                             "515.127.4561",
+                             "7-Dec-94",
+                             "PU_MAN",
+                             11000,
+                             {},
+                             std::make_unique<int>(100),
+                             30});
+    storage.replace(Employee{115,
+                             "Alexander",
+                             "Khoo",
+                             "AKHOO",
+                             "515.127.4562",
+                             "18-May-95",
+                             "PU_CLERK",
+                             3100,
+                             {},
+                             std::make_unique<int>(114),
+                             30});
+    storage.replace(Employee{116,
+                             "Shelli",
+                             "Baida",
+                             "SBAIDA",
+                             "515.127.4563",
+                             "24-Dec-97",
+                             "PU_CLERK",
+                             2900,
+                             {},
+                             std::make_unique<int>(114),
+                             30});
+    storage.replace(Employee{117,
+                             "Sigal",
+                             "Tobias",
+                             "STOBIAS",
+                             "515.127.4564",
+                             "24-Jul-97",
+                             "PU_CLERK",
+                             2800,
+                             {},
+                             std::make_unique<int>(114),
+                             30});
+    storage.replace(Employee{118,
+                             "Guy",
+                             "Himuro",
+                             "GHIMURO",
+                             "515.127.4565",
+                             "15-Nov-98",
+                             "PU_CLERK",
+                             2600,
+                             {},
+                             std::make_unique<int>(114),
+                             30});
+    storage.replace(Employee{119,
+                             "Karen",
+                             "Colmenares",
+                             "KCOLMENA",
+                             "515.127.4566",
+                             "10-Aug-99",
+                             "PU_CLERK",
+                             2500,
+                             {},
+                             std::make_unique<int>(114),
+                             30});
+    storage.replace(Employee{120,
+                             "Matthew",
+                             "Weiss",
+                             "MWEISS",
+                             "650.123.1234",
+                             "18-Jul-96",
+                             "ST_MAN",
+                             8000,
+                             {},
+                             std::make_unique<int>(100),
+                             50});
+    storage.replace(Employee{121,
+                             "Adam",
+                             "Fripp",
+                             "AFRIPP",
+                             "650.123.2234",
+                             "10-Apr-97",
+                             "ST_MAN",
+                             8200,
+                             {},
+                             std::make_unique<int>(100),
+                             50});
+    storage.replace(Employee{122,
+                             "Payam",
+                             "Kaufling",
+                             "PKAUFLIN",
+                             "650.123.3234",
+                             "1-May-95",
+                             "ST_MAN",
+                             7900,
+                             {},
+                             std::make_unique<int>(100),
+                             50});
+    storage.replace(Employee{123,
+                             "Shanta",
+                             "Vollman",
+                             "SVOLLMAN",
+                             "650.123.4234",
+                             "10-Oct-97",
+                             "ST_MAN",
+                             6500,
+                             {},
+                             std::make_unique<int>(100),
+                             50});
+    storage.replace(Employee{124,
+                             "Kevin",
+                             "Mourgos",
+                             "KMOURGOS",
+                             "650.123.5234",
+                             "16-Nov-99",
+                             "ST_MAN",
+                             5800,
+                             {},
+                             std::make_unique<int>(100),
+                             50});
+    storage.replace(Employee{125,
+                             "Julia",
+                             "Nayer",
+                             "JNAYER",
+                             "650.124.1214",
+                             "16-Jul-97",
+                             "ST_CLERK",
+                             3200,
+                             {},
+                             std::make_unique<int>(120),
+                             50});
+    storage.replace(Employee{126,
+                             "Irene",
+                             "Mikkilineni",
+                             "IMIKKILI",
+                             "650.124.1224",
+                             "28-Sep-98",
+                             "ST_CLERK",
+                             2700,
+                             {},
+                             std::make_unique<int>(120),
+                             50});
+    storage.replace(Employee{127,
+                             "James",
+                             "Landry",
+                             "JLANDRY",
+                             "650.124.1334",
+                             "14-Jan-99",
+                             "ST_CLERK",
+                             2400,
+                             {},
+                             std::make_unique<int>(120),
+                             50});
+    storage.replace(Employee{128,
+                             "Steven",
+                             "Markle",
+                             "SMARKLE",
+                             "650.124.1434",
+                             "8-Mar-00",
+                             "ST_CLERK",
+                             2200,
+                             {},
+                             std::make_unique<int>(120),
+                             50});
+    storage.replace(Employee{129,
+                             "Laura",
+                             "Bissot",
+                             "LBISSOT",
+                             "650.124.5234",
+                             "20-Aug-97",
+                             "ST_CLERK",
+                             3300,
+                             {},
+                             std::make_unique<int>(121),
+                             50});
+    storage.replace(Employee{130,
+                             "Mozhe",
+                             "Atkinson",
+                             "MATKINSO",
+                             "650.124.6234",
+                             "30-Oct-97",
+                             "ST_CLERK",
+                             2800,
+                             {},
+                             std::make_unique<int>(121),
+                             50});
+    storage.replace(Employee{131,
+                             "James",
+                             "Marlow",
+                             "JAMRLOW",
+                             "650.124.7234",
+                             "16-Feb-97",
+                             "ST_CLERK",
+                             2500,
+                             {},
+                             std::make_unique<int>(121),
+                             50});
+    storage.replace(Employee{132,
+                             "TJ",
+                             "Olson",
+                             "TJOLSON",
+                             "650.124.8234",
+                             "10-Apr-99",
+                             "ST_CLERK",
+                             2100,
+                             {},
+                             std::make_unique<int>(121),
+                             50});
+    storage.replace(Employee{133,
+                             "Jason",
+                             "Mallin",
+                             "JMALLIN",
+                             "650.127.1934",
+                             "14-Jun-96",
+                             "ST_CLERK",
+                             3300,
+                             {},
+                             std::make_unique<int>(122),
+                             50});
+    storage.replace(Employee{134,
+                             "Michael",
+                             "Rogers",
+                             "MROGERS",
+                             "650.127.1834",
+                             "26-Aug-98",
+                             "ST_CLERK",
+                             2900,
+                             {},
+                             std::make_unique<int>(122),
+                             50});
+    storage.replace(Employee{135,
+                             "Ki",
+                             "Gee",
+                             "KGEE",
+                             "650.127.1734",
+                             "12-Dec-99",
+                             "ST_CLERK",
+                             2400,
+                             {},
+                             std::make_unique<int>(122),
+                             50});
+    storage.replace(Employee{136,
+                             "Hazel",
+                             "Philtanker",
+                             "HPHILTAN",
+                             "650.127.1634",
+                             "6-Feb-00",
+                             "ST_CLERK",
+                             2200,
+                             {},
+                             std::make_unique<int>(122),
+                             50});
+    storage.replace(Employee{137,
+                             "Renske",
+                             "Ladwig",
+                             "RLADWIG",
+                             "650.121.1234",
+                             "14-Jul-95",
+                             "ST_CLERK",
+                             3600,
+                             {},
+                             std::make_unique<int>(123),
+                             50});
+    storage.replace(Employee{138,
+                             "Stephen",
+                             "Stiles",
+                             "SSTILES",
+                             "650.121.2034",
+                             "26-Oct-97",
+                             "ST_CLERK",
+                             3200,
+                             {},
+                             std::make_unique<int>(123),
+                             50});
+    storage.replace(Employee{139,
+                             "John",
+                             "Seo",
+                             "JSEO",
+                             "650.121.2019",
+                             "12-Feb-98",
+                             "ST_CLERK",
+                             2700,
+                             {},
+                             std::make_unique<int>(123),
+                             50});
+    storage.replace(Employee{140,
+                             "Joshua",
+                             "Patel",
+                             "JPATEL",
+                             "650.121.1834",
+                             "6-Apr-98",
+                             "ST_CLERK",
+                             2500,
+                             {},
+                             std::make_unique<int>(123),
+                             50});
+    storage.replace(Employee{141,
+                             "Trenna",
+                             "Rajs",
+                             "TRAJS",
+                             "650.121.8009",
+                             "17-Oct-95",
+                             "ST_CLERK",
+                             3500,
+                             {},
+                             std::make_unique<int>(124),
+                             50});
+    storage.replace(Employee{142,
+                             "Curtis",
+                             "Davies",
+                             "CDAVIES",
+                             "650.121.2994",
+                             "29-Jan-97",
+                             "ST_CLERK",
+                             3100,
+                             {},
+                             std::make_unique<int>(124),
+                             50});
+    storage.replace(Employee{143,
+                             "Randall",
+                             "Matos",
+                             "RMATOS",
+                             "650.121.2874",
+                             "15-Mar-98",
+                             "ST_CLERK",
+                             2600,
+                             {},
+                             std::make_unique<int>(124),
+                             50});
+    storage.replace(Employee{144,
+                             "Peter",
+                             "Vargas",
+                             "PVARGAS",
+                             "650.121.2004",
+                             "9-Jul-98",
+                             "ST_CLERK",
+                             2500,
+                             {},
+                             std::make_unique<int>(124),
+                             50});
+    storage.replace(Employee{145,
+                             "John",
+                             "Russell",
+                             "JRUSSEL",
+                             "011.44.1344.429268",
+                             "1-Oct-96",
+                             "SA_MAN",
+                             14000,
+                             std::make_unique<double>(0.4),
+                             std::make_unique<int>(100),
+                             80});
+    storage.replace(Employee{146,
+                             "Karen",
+                             "Partners",
+                             "KPARTNER",
+                             "011.44.1344.467268",
+                             "5-Jan-97",
+                             "SA_MAN",
+                             13500,
+                             std::make_unique<double>(0.3),
+                             std::make_unique<int>(100),
+                             80});
+    storage.replace(Employee{147,
+                             "Alberto",
+                             "Errazuriz",
+                             "AERRAZUR",
+                             "011.44.1344.429278",
+                             "10-Mar-97",
+                             "SA_MAN",
+                             12000,
+                             std::make_unique<double>(0.3),
+                             std::make_unique<int>(100),
+                             80});
+    storage.replace(Employee{148,
+                             "Gerald",
+                             "Cambrault",
+                             "GCAMBRAU",
+                             "011.44.1344.619268",
+                             "15-Oct-99",
+                             "SA_MAN",
+                             11000,
+                             std::make_unique<double>(0.3),
+                             std::make_unique<int>(100),
+                             80});
+    storage.replace(Employee{149,
+                             "Eleni",
+                             "Zlotkey",
+                             "EZLOTKEY",
+                             "011.44.1344.429018",
+                             "29-Jan-00",
+                             "SA_MAN",
+                             10500,
+                             std::make_unique<double>(0.2),
+                             std::make_unique<int>(100),
+                             80});
+    storage.replace(Employee{150,
+                             "Peter",
+                             "Tucker",
+                             "PTUCKER",
+                             "011.44.1344.129268",
+                             "30-Jan-97",
+                             "SA_REP",
+                             10000,
+                             std::make_unique<double>(0.3),
+                             std::make_unique<int>(145),
+                             80});
+    storage.replace(Employee{151,
+                             "David",
+                             "Bernstein",
+                             "DBERNSTE",
+                             "011.44.1344.345268",
+                             "24-Mar-97",
+                             "SA_REP",
+                             9500,
+                             std::make_unique<double>(0.25),
+                             std::make_unique<int>(145),
+                             80});
+    storage.replace(Employee{152,
+                             "Peter",
+                             "Hall",
+                             "PHALL",
+                             "011.44.1344.478968",
+                             "20-Aug-97",
+                             "SA_REP",
+                             9000,
+                             std::make_unique<double>(0.25),
+                             std::make_unique<int>(145),
+                             80});
+    storage.replace(Employee{153,
+                             "Christopher",
+                             "Olsen",
+                             "COLSEN",
+                             "011.44.1344.498718",
+                             "30-Mar-98",
+                             "SA_REP",
+                             8000,
+                             std::make_unique<double>(0.2),
+                             std::make_unique<int>(145),
+                             80});
+    storage.replace(Employee{154,
+                             "Nanette",
+                             "Cambrault",
+                             "NCAMBRAU",
+                             "011.44.1344.987668",
+                             "9-Dec-98",
+                             "SA_REP",
+                             7500,
+                             std::make_unique<double>(0.2),
+                             std::make_unique<int>(145),
+                             80});
+    storage.replace(Employee{155,
+                             "Oliver",
+                             "Tuvault",
+                             "OTUVAULT",
+                             "011.44.1344.486508",
+                             "23-Nov-99",
+                             "SA_REP",
+                             7000,
+                             std::make_unique<double>(0.15),
+                             std::make_unique<int>(145),
+                             80});
+    storage.replace(Employee{156,
+                             "Janette",
+                             "King",
+                             "JKING",
+                             "011.44.1345.429268",
+                             "30-Jan-96",
+                             "SA_REP",
+                             10000,
+                             std::make_unique<double>(0.35),
+                             std::make_unique<int>(146),
+                             80});
+    storage.replace(Employee{157,
+                             "Patrick",
+                             "Sully",
+                             "PSULLY",
+                             "011.44.1345.929268",
+                             "4-Mar-96",
+                             "SA_REP",
+                             9500,
+                             std::make_unique<double>(0.35),
+                             std::make_unique<int>(146),
+                             80});
+    storage.replace(Employee{158,
+                             "Allan",
+                             "McEwen",
+                             "AMCEWEN",
+                             "011.44.1345.829268",
+                             "1-Aug-96",
+                             "SA_REP",
+                             9000,
+                             std::make_unique<double>(0.35),
+                             std::make_unique<int>(146),
+                             80});
+    storage.replace(Employee{159,
+                             "Lindsey",
+                             "Smith",
+                             "LSMITH",
+                             "011.44.1345.729268",
+                             "10-Mar-97",
+                             "SA_REP",
+                             8000,
+                             std::make_unique<double>(0.3),
+                             std::make_unique<int>(146),
+                             80});
+    storage.replace(Employee{160,
+                             "Louise",
+                             "Doran",
+                             "LDORAN",
+                             "011.44.1345.629268",
+                             "15-Dec-97",
+                             "SA_REP",
+                             7500,
+                             std::make_unique<double>(0.3),
+                             std::make_unique<int>(146),
+                             80});
+    storage.replace(Employee{161,
+                             "Sarath",
+                             "Sewall",
+                             "SSEWALL",
+                             "011.44.1345.529268",
+                             "3-Nov-98",
+                             "SA_REP",
+                             7000,
+                             std::make_unique<double>(0.25),
+                             std::make_unique<int>(146),
+                             80});
+    storage.replace(Employee{162,
+                             "Clara",
+                             "Vishney",
+                             "CVISHNEY",
+                             "011.44.1346.129268",
+                             "11-Nov-97",
+                             "SA_REP",
+                             10500,
+                             std::make_unique<double>(0.25),
+                             std::make_unique<int>(147),
+                             80});
+    storage.replace(Employee{163,
+                             "Danielle",
+                             "Greene",
+                             "DGREENE",
+                             "011.44.1346.229268",
+                             "19-Mar-99",
+                             "SA_REP",
+                             9500,
+                             std::make_unique<double>(0.15),
+                             std::make_unique<int>(147),
+                             80});
+    storage.replace(Employee{164,
+                             "Mattea",
+                             "Marvins",
+                             "MMARVINS",
+                             "011.44.1346.329268",
+                             "24-Jan-00",
+                             "SA_REP",
+                             7200,
+                             std::make_unique<double>(0.1),
+                             std::make_unique<int>(147),
+                             80});
+    storage.replace(Employee{165,
+                             "David",
+                             "Lee",
+                             "DLEE",
+                             "011.44.1346.529268",
+                             "23-Feb-00",
+                             "SA_REP",
+                             6800,
+                             std::make_unique<double>(0.1),
+                             std::make_unique<int>(147),
+                             80});
+    storage.replace(Employee{166,
+                             "Sundar",
+                             "Ande",
+                             "SANDE",
+                             "011.44.1346.629268",
+                             "24-Mar-00",
+                             "SA_REP",
+                             6400,
+                             std::make_unique<double>(0.1),
+                             std::make_unique<int>(147),
+                             80});
+    storage.replace(Employee{167,
+                             "Amit",
+                             "Banda",
+                             "ABANDA",
+                             "011.44.1346.729268",
+                             "21-Apr-00",
+                             "SA_REP",
+                             6200,
+                             std::make_unique<double>(0.1),
+                             std::make_unique<int>(147),
+                             80});
+    storage.replace(Employee{168,
+                             "Lisa",
+                             "Ozer",
+                             "LOZER",
+                             "011.44.1343.929268",
+                             "11-Mar-97",
+                             "SA_REP",
+                             11500,
+                             std::make_unique<double>(0.25),
+                             std::make_unique<int>(148),
+                             80});
+    storage.replace(Employee{169,
+                             "Harrison",
+                             "Bloom",
+                             "HBLOOM",
+                             "011.44.1343.829268",
+                             "23-Mar-98",
+                             "SA_REP",
+                             10000,
+                             std::make_unique<double>(0.2),
+                             std::make_unique<int>(148),
+                             80});
+    storage.replace(Employee{170,
+                             "Tayler",
+                             "Fox",
+                             "TFOX",
+                             "011.44.1343.729268",
+                             "24-Jan-98",
+                             "SA_REP",
+                             9600,
+                             std::make_unique<double>(0.2),
+                             std::make_unique<int>(148),
+                             80});
+    storage.replace(Employee{171,
+                             "William",
+                             "Smith",
+                             "WSMITH",
+                             "011.44.1343.629268",
+                             "23-Feb-99",
+                             "SA_REP",
+                             7400,
+                             std::make_unique<double>(0.15),
+                             std::make_unique<int>(148),
+                             80});
+    storage.replace(Employee{172,
+                             "Elizabeth",
+                             "Bates",
+                             "EBATES",
+                             "011.44.1343.529268",
+                             "24-Mar-99",
+                             "SA_REP",
+                             7300,
+                             std::make_unique<double>(0.15),
+                             std::make_unique<int>(148),
+                             80});
+    storage.replace(Employee{173,
+                             "Sundita",
+                             "Kumar",
+                             "SKUMAR",
+                             "011.44.1343.329268",
+                             "21-Apr-00",
+                             "SA_REP",
+                             6100,
+                             std::make_unique<double>(0.1),
+                             std::make_unique<int>(148),
+                             80});
+    storage.replace(Employee{174,
+                             "Ellen",
+                             "Abel",
+                             "EABEL",
+                             "011.44.1644.429267",
+                             "11-May-96",
+                             "SA_REP",
+                             11000,
+                             std::make_unique<double>(0.3),
+                             std::make_unique<int>(149),
+                             80});
+    storage.replace(Employee{175,
+                             "Alyssa",
+                             "Hutton",
+                             "AHUTTON",
+                             "011.44.1644.429266",
+                             "19-Mar-97",
+                             "SA_REP",
+                             8800,
+                             std::make_unique<double>(0.25),
+                             std::make_unique<int>(149),
+                             80});
+    storage.replace(Employee{176,
+                             "Jonathon",
+                             "Taylor",
+                             "JTAYLOR",
+                             "011.44.1644.429265",
+                             "24-Mar-98",
+                             "SA_REP",
+                             8600,
+                             std::make_unique<double>(0.2),
+                             std::make_unique<int>(149),
+                             80});
+    storage.replace(Employee{177,
+                             "Jack",
+                             "Livingston",
+                             "JLIVINGS",
+                             "011.44.1644.429264",
+                             "23-Apr-98",
+                             "SA_REP",
+                             8400,
+                             std::make_unique<double>(0.2),
+                             std::make_unique<int>(149),
+                             80});
+    storage.replace(Employee{178,
+                             "Kimberely",
+                             "Grant",
+                             "KGRANT",
+                             "011.44.1644.429263",
+                             "24-May-99",
+                             "SA_REP",
+                             7000,
+                             std::make_unique<double>(0.15),
+                             std::make_unique<int>(149),
+                             80});
+    storage.replace(Employee{179,
+                             "Charles",
+                             "Johnson",
+                             "CJOHNSON",
+                             "011.44.1644.429262",
+                             "4-Jan-00",
+                             "SA_REP",
+                             6200,
+                             std::make_unique<double>(0.1),
+                             std::make_unique<int>(149),
+                             80});
+    storage.replace(Employee{180,
+                             "Winston",
+                             "Taylor",
+                             "WTAYLOR",
+                             "650.507.9876",
+                             "24-Jan-98",
+                             "SH_CLERK",
+                             3200,
+                             {},
+                             std::make_unique<int>(120),
+                             50});
+    storage.replace(Employee{181,
+                             "Jean",
+                             "Fleaur",
+                             "JFLEAUR",
+                             "650.507.9877",
+                             "23-Feb-98",
+                             "SH_CLERK",
+                             3100,
+                             {},
+                             std::make_unique<int>(120),
+                             50});
+    storage.replace(Employee{182,
+                             "Martha",
+                             "Sullivan",
+                             "MSULLIVA",
+                             "650.507.9878",
+                             "21-Jun-99",
+                             "SH_CLERK",
+                             2500,
+                             {},
+                             std::make_unique<int>(120),
+                             50});
+    storage.replace(Employee{183,
+                             "Girard",
+                             "Geoni",
+                             "GGEONI",
+                             "650.507.9879",
+                             "3-Feb-00",
+                             "SH_CLERK",
+                             2800,
+                             {},
+                             std::make_unique<int>(120),
+                             50});
+    storage.replace(Employee{184,
+                             "Nandita",
+                             "Sarchand",
+                             "NSARCHAN",
+                             "650.509.1876",
+                             "27-Jan-96",
+                             "SH_CLERK",
+                             4200,
+                             {},
+                             std::make_unique<int>(121),
+                             50});
+    storage.replace(Employee{185,
+                             "Alexis",
+                             "Bull",
+                             "ABULL",
+                             "650.509.2876",
+                             "20-Feb-97",
+                             "SH_CLERK",
+                             4100,
+                             {},
+                             std::make_unique<int>(121),
+                             50});
+    storage.replace(Employee{186,
+                             "Julia",
+                             "Dellinger",
+                             "JDELLING",
+                             "650.509.3876",
+                             "24-Jun-98",
+                             "SH_CLERK",
+                             3400,
+                             {},
+                             std::make_unique<int>(121),
+                             50});
+    storage.replace(Employee{187,
+                             "Anthony",
+                             "Cabrio",
+                             "ACABRIO",
+                             "650.509.4876",
+                             "7-Feb-99",
+                             "SH_CLERK",
+                             3000,
+                             {},
+                             std::make_unique<int>(121),
+                             50});
+    storage.replace(Employee{188,
+                             "Kelly",
+                             "Chung",
+                             "KCHUNG",
+                             "650.505.1876",
+                             "14-Jun-97",
+                             "SH_CLERK",
+                             3800,
+                             {},
+                             std::make_unique<int>(122),
+                             50});
+    storage.replace(Employee{189,
+                             "Jennifer",
+                             "Dilly",
+                             "JDILLY",
+                             "650.505.2876",
+                             "13-Aug-97",
+                             "SH_CLERK",
+                             3600,
+                             {},
+                             std::make_unique<int>(122),
+                             50});
+    storage.replace(Employee{190,
+                             "Timothy",
+                             "Gates",
+                             "TGATES",
+                             "650.505.3876",
+                             "11-Jul-98",
+                             "SH_CLERK",
+                             2900,
+                             {},
+                             std::make_unique<int>(122),
+                             50});
+    storage.replace(Employee{191,
+                             "Randall",
+                             "Perkins",
+                             "RPERKINS",
+                             "650.505.4876",
+                             "19-Dec-99",
+                             "SH_CLERK",
+                             2500,
+                             {},
+                             std::make_unique<int>(122),
+                             50});
+    storage.replace(Employee{192,
+                             "Sarah",
+                             "Bell",
+                             "SBELL",
+                             "650.501.1876",
+                             "4-Feb-96",
+                             "SH_CLERK",
+                             4000,
+                             {},
+                             std::make_unique<int>(123),
+                             50});
+    storage.replace(Employee{193,
+                             "Britney",
+                             "Everett",
+                             "BEVERETT",
+                             "650.501.2876",
+                             "3-Mar-97",
+                             "SH_CLERK",
+                             3900,
+                             {},
+                             std::make_unique<int>(123),
+                             50});
+    storage.replace(Employee{194,
+                             "Samuel",
+                             "McCain",
+                             "SMCCAIN",
+                             "650.501.3876",
+                             "1-Jul-98",
+                             "SH_CLERK",
+                             3200,
+                             {},
+                             std::make_unique<int>(123),
+                             50});
+    storage.replace(Employee{195,
+                             "Vance",
+                             "Jones",
+                             "VJONES",
+                             "650.501.4876",
+                             "17-Mar-99",
+                             "SH_CLERK",
+                             2800,
+                             {},
+                             std::make_unique<int>(123),
+                             50});
+    storage.replace(Employee{196,
+                             "Alana",
+                             "Walsh",
+                             "AWALSH",
+                             "650.507.9811",
+                             "24-Apr-98",
+                             "SH_CLERK",
+                             3100,
+                             {},
+                             std::make_unique<int>(124),
+                             50});
+    storage.replace(Employee{197,
+                             "Kevin",
+                             "Feeney",
+                             "KFEENEY",
+                             "650.507.9822",
+                             "23-May-98",
+                             "SH_CLERK",
+                             3000,
+                             {},
+                             std::make_unique<int>(124),
+                             50});
+    storage.replace(Employee{198,
+                             "Donald",
+                             "OConnell",
+                             "DOCONNEL",
+                             "650.507.9833",
+                             "21-Jun-99",
+                             "SH_CLERK",
+                             2600,
+                             {},
+                             std::make_unique<int>(124),
+                             50});
+    storage.replace(Employee{199,
+                             "Douglas",
+                             "Grant",
+                             "DGRANT",
+                             "650.507.9844",
+                             "13-Jan-00",
+                             "SH_CLERK",
+                             2600,
+                             {},
+                             std::make_unique<int>(124),
+                             50});
+    storage.replace(Employee{200,
+                             "Jennifer",
+                             "Whalen",
+                             "JWHALEN",
+                             "515.123.4444",
+                             "17-Sep-87",
+                             "AD_ASST",
+                             4400,
+                             {},
+                             std::make_unique<int>(101),
+                             10});
+    storage.replace(Employee{201,
+                             "Michael",
+                             "Hartstein",
+                             "MHARTSTE",
+                             "515.123.5555",
+                             "17-Feb-96",
+                             "MK_MAN",
+                             13000,
+                             {},
+                             std::make_unique<int>(100),
+                             20});
+    storage.replace(Employee{202,
+                             "Pat",
+                             "Fay",
+                             "PFAY",
+                             "603.123.6666",
+                             "17-Aug-97",
+                             "MK_REP",
+                             6000,
+                             {},
+                             std::make_unique<int>(201),
+                             20});
+    storage.replace(Employee{203,
+                             "Susan",
+                             "Mavris",
+                             "SMAVRIS",
+                             "515.123.7777",
+                             "7-Jun-94",
+                             "HR_REP",
+                             6500,
+                             {},
+                             std::make_unique<int>(101),
+                             40});
+    storage.replace(Employee{204,
+                             "Hermann",
+                             "Baer",
+                             "HBAER",
+                             "515.123.8888",
+                             "7-Jun-94",
+                             "PR_REP",
+                             10000,
+                             {},
+                             std::make_unique<int>(101),
+                             70});
+    storage.replace(Employee{205,
+                             "Shelley",
+                             "Higgins",
+                             "SHIGGINS",
+                             "515.123.8080",
+                             "7-Jun-94",
+                             "AC_MGR",
+                             12000,
+                             {},
+                             std::make_unique<int>(101),
+                             110});
+    storage.replace(Employee{206,
+                             "William",
+                             "Gietz",
+                             "WGIETZ",
+                             "515.123.8181",
+                             "7-Jun-94",
+                             "AC_ACCOUNT",
+                             8300,
+                             {},
+                             std::make_unique<int>(205),
+                             110});
+
     storage.replace(Department{10, "Administration", 200, 1700});
     storage.replace(Department{20, "Marketing", 201, 1800});
     storage.replace(Department{30, "Purchasing", 114, 1700});
@@ -202,7 +1263,7 @@ int main(int, char **) {
     storage.replace(Department{250, "Retail Sales", 0, 1700});
     storage.replace(Department{260, "Recruiting", 0, 1700});
     storage.replace(Department{270, "Payroll", 0, 1700});
-    
+
     storage.replace(JobHistory{102, "1993-01-13", "1998-07-24", "IT_PROG", 60});
     storage.replace(JobHistory{101, "1989-09-21", "1993-10-27", "AC_ACCOUNT", 110});
     storage.replace(JobHistory{101, "1993-10-28", "1997-03-15", "AC_MGR", 110});
@@ -213,7 +1274,7 @@ int main(int, char **) {
     storage.replace(JobHistory{176, "1998-03-24", "1998-12-31", "SA_REP", 80});
     storage.replace(JobHistory{176, "1999-01-01", "1999-12-31", "SA_MAN", 80});
     storage.replace(JobHistory{200, "1994-07-01", "1998-12-31", "AC_ACCOUNT", 90});
-    
+
     {
         //  SELECT first_name, last_name, salary
         //  FROM employees
@@ -221,13 +1282,13 @@ int main(int, char **) {
         //          SELECT salary
         //          FROM employees
         //          WHERE first_name='Alexander');
-        auto rows = storage.select(columns(&Employee::firstName, &Employee::lastName, &Employee::salary),
-                                   where(greater_than(&Employee::salary,
-                                                      select(&Employee::salary,
-                                                             where(is_equal(&Employee::firstName, "Alexander"))))));
+        auto rows = storage.select(
+            columns(&Employee::firstName, &Employee::lastName, &Employee::salary),
+            where(greater_than(&Employee::salary,
+                               select(&Employee::salary, where(is_equal(&Employee::firstName, "Alexander"))))));
         cout << "first_name  last_name   salary" << endl;
         cout << "----------  ----------  ----------" << endl;
-        for(auto &row : rows) {
+        for(auto &row: rows) {
             cout << std::get<0>(row) << '\t' << std::get<1>(row) << '\t' << std::get<2>(row) << endl;
         }
     }
@@ -236,12 +1297,12 @@ int main(int, char **) {
         //  FROM employees
         //  WHERE salary > (SELECT AVG(SALARY) FROM employees);
         auto rows = storage.select(columns(&Employee::id, &Employee::firstName, &Employee::lastName, &Employee::salary),
-                                   where(greater_than(&Employee::salary,
-                                                      select(avg(&Employee::salary)))));
+                                   where(greater_than(&Employee::salary, select(avg(&Employee::salary)))));
         cout << "employee_id  first_name  last_name   salary" << endl;
         cout << "-----------  ----------  ----------  ----------" << endl;
-        for(auto &row : rows) {
-            cout << std::get<0>(row) << '\t' << std::get<1>(row) << '\t' << std::get<2>(row) << '\t' << std::get<3>(row) << endl;
+        for(auto &row: rows) {
+            cout << std::get<0>(row) << '\t' << std::get<1>(row) << '\t' << std::get<2>(row) << '\t' << std::get<3>(row)
+                 << endl;
         }
     }
     {
@@ -250,34 +1311,32 @@ int main(int, char **) {
         //  WHERE department_id IN
         //      (SELECT DEPARTMENT_ID FROM departments
         //      WHERE location_id=1700);
-        auto rows = storage.select(columns(&Employee::firstName, &Employee::lastName, &Employee::departmentId),
-                                   where(in(&Employee::departmentId,
-                                            select(&Department::id,
-                                                   where(c(&Department::locationId) == 1700)))));
+        auto rows = storage.select(
+            columns(&Employee::firstName, &Employee::lastName, &Employee::departmentId),
+            where(in(&Employee::departmentId, select(&Department::id, where(c(&Department::locationId) == 1700)))));
         cout << "first_name  last_name   department_id" << endl;
         cout << "----------  ----------  -------------" << endl;
-        for(auto &row : rows) {
+        for(auto &row: rows) {
             cout << std::get<0>(row) << '\t' << std::get<1>(row) << '\t' << std::get<2>(row) << endl;
         }
     }
     {
-        
+
         //  SELECT first_name, last_name, department_id
         //  FROM employees
         //  WHERE department_id NOT IN
         //  (SELECT DEPARTMENT_ID FROM departments
         //      WHERE manager_id
         //      BETWEEN 100 AND 200);
-        auto rows = storage.select(columns(&Employee::firstName, &Employee::lastName, &Employee::departmentId),
-                                   where(not_in(&Employee::departmentId,
-                                                select(&Department::id,
-                                                       where(between(&Department::managerId, 100, 200))))));
+        auto rows =
+            storage.select(columns(&Employee::firstName, &Employee::lastName, &Employee::departmentId),
+                           where(not_in(&Employee::departmentId,
+                                        select(&Department::id, where(between(&Department::managerId, 100, 200))))));
         cout << "first_name  last_name   department_id" << endl;
         cout << "----------  ----------  -------------" << endl;
-        for(auto &row : rows) {
+        for(auto &row: rows) {
             cout << std::get<0>(row) << '\t' << std::get<1>(row) << '\t' << std::get<2>(row) << endl;
         }
-        
     }
     {
         //  SELECT last_name, salary, department_id
@@ -286,13 +1345,17 @@ int main(int, char **) {
         //      FROM employees
         //      WHERE department_id = e.department_id);
         using als = alias_e<Employee>;
-        auto rows = storage.select(columns(alias_column<als>(&Employee::lastName), alias_column<als>(&Employee::salary), alias_column<als>(&Employee::departmentId)),
-                                   where(greater_than(alias_column<als>(&Employee::salary),
-                                                      select(avg(&Employee::salary),
-                                                             where(is_equal(&Employee::departmentId, alias_column<als>(&Employee::departmentId)))))));
+        auto rows = storage.select(
+            columns(alias_column<als>(&Employee::lastName),
+                    alias_column<als>(&Employee::salary),
+                    alias_column<als>(&Employee::departmentId)),
+            where(greater_than(
+                alias_column<als>(&Employee::salary),
+                select(avg(&Employee::salary),
+                       where(is_equal(&Employee::departmentId, alias_column<als>(&Employee::departmentId)))))));
         cout << "last_name   salary      department_id" << endl;
         cout << "----------  ----------  -------------" << endl;
-        for(auto &row : rows) {
+        for(auto &row: rows) {
             cout << std::get<0>(row) << '\t' << std::get<1>(row) << '\t' << std::get<2>(row) << endl;
         }
     }
@@ -302,18 +1365,18 @@ int main(int, char **) {
         //  WHERE 1 <=
         //      (SELECT COUNT(*) FROM Job_history
         //      WHERE employee_id = employees.employee_id);
-        auto rows = storage.select(columns(&Employee::firstName,
-                                           &Employee::lastName,
-                                           &Employee::id,
-                                           &Employee::jobId),
-                                   where(lesser_or_equal(1, select(count<JobHistory>(),
-                                                                   where(is_equal(&Employee::id, &JobHistory::employeeId))))));
+        auto rows =
+            storage.select(columns(&Employee::firstName, &Employee::lastName, &Employee::id, &Employee::jobId),
+                           where(lesser_or_equal(
+                               1,
+                               select(count<JobHistory>(), where(is_equal(&Employee::id, &JobHistory::employeeId))))));
         cout << "first_name  last_name   employee_id  job_id" << endl;
         cout << "----------  ----------  -----------  ----------" << endl;
-        for(auto &row : rows) {
-            cout << std::get<0>(row) << '\t' << std::get<1>(row) << '\t' << std::get<2>(row) << '\t' << std::get<3>(row) << endl;
+        for(auto &row: rows) {
+            cout << std::get<0>(row) << '\t' << std::get<1>(row) << '\t' << std::get<2>(row) << '\t' << std::get<3>(row)
+                 << endl;
         }
     }
-    
+
     return 0;
 }

--- a/examples/synchronous.cpp
+++ b/examples/synchronous.cpp
@@ -2,8 +2,7 @@
 #include <sqlite_orm/sqlite_orm.h>
 #include <string>
 
-struct Query
-{
+struct Query {
     std::string src_ip;
     uint16_t src_port;
     uint16_t txn_id;
@@ -13,7 +12,7 @@ struct Query
     uint16_t type;
 };
 
-int main(int, char**) {
+int main(int, char **) {
 
     using namespace sqlite_orm;
 

--- a/examples/union.cpp
+++ b/examples/union.cpp
@@ -12,7 +12,7 @@ using std::cout;
 using std::endl;
 
 int main() {
-    
+
     struct Employee {
         int id;
         std::string name;
@@ -20,15 +20,15 @@ int main() {
         std::string address;
         double salary;
     };
-    
+
     struct Department {
         int id;
         std::string dept;
         int employeeId;
     };
-    
+
     using namespace sqlite_orm;
-    
+
     auto storage = make_storage("union.sqlite",
                                 make_table("COMPANY",
                                            make_column("ID", &Employee::id, primary_key()),
@@ -42,11 +42,11 @@ int main() {
                                            make_column("EMP_ID", &Department::employeeId),
                                            foreign_key(&Department::employeeId).references(&Employee::id)));
     storage.sync_schema();
-    
+
     //  order matters
     storage.remove_all<Department>();
     storage.remove_all<Employee>();
-    
+
     storage.replace(Employee{1, "Paul", 32, "California", 20000.0});
     storage.replace(Employee{2, "Allen", 25, "Texas", 15000.0});
     storage.replace(Employee{3, "Teddy", 23, "Norway", 20000.0});
@@ -54,7 +54,7 @@ int main() {
     storage.replace(Employee{5, "David", 27, "Texas", 85000.0});
     storage.replace(Employee{6, "Kim", 22, "South-Hall", 45000.0});
     storage.replace(Employee{7, "James", 24, "Houston", 10000.0});
-    
+
     storage.replace(Department{1, "IT Billing", 1});
     storage.replace(Department{2, "Engineering", 2});
     storage.replace(Department{3, "Finance", 7});
@@ -62,7 +62,7 @@ int main() {
     storage.replace(Department{5, "Finance", 4});
     storage.replace(Department{6, "Engineering", 5});
     storage.replace(Department{7, "Finance", 6});
-    
+
     {
         //  SELECT EMP_ID, NAME, DEPT
         //  FROM COMPANY
@@ -73,16 +73,17 @@ int main() {
         //  FROM COMPANY
         //  LEFT OUTER JOIN DEPARTMENT
         //  ON COMPANY.ID = DEPARTMENT.EMP_ID;
-        auto rows = storage.select(union_(select(columns(&Department::employeeId, &Employee::name, &Department::dept),
-                                                 inner_join<Department>(on(is_equal(&Employee::id, &Department::employeeId)))),
-                                          select(columns(&Department::employeeId, &Employee::name, &Department::dept),
-                                                 left_outer_join<Department>(on(is_equal(&Employee::id, &Department::employeeId))))));
-        
+        auto rows = storage.select(
+            union_(select(columns(&Department::employeeId, &Employee::name, &Department::dept),
+                          inner_join<Department>(on(is_equal(&Employee::id, &Department::employeeId)))),
+                   select(columns(&Department::employeeId, &Employee::name, &Department::dept),
+                          left_outer_join<Department>(on(is_equal(&Employee::id, &Department::employeeId))))));
+
         assert(rows.size() == 7);
-        std::sort(rows.begin(), rows.end(), [](auto &lhs, auto &rhs){
+        std::sort(rows.begin(), rows.end(), [](auto &lhs, auto &rhs) {
             return std::get<0>(lhs) < std::get<0>(rhs);
         });
-        for(auto &row : rows) {
+        for(auto &row: rows) {
             cout << std::get<0>(row) << '\t' << std::get<1>(row) << '\t' << std::get<2>(row) << endl;
         }
         cout << endl;
@@ -97,16 +98,16 @@ int main() {
         //  FROM COMPANY
         //  LEFT OUTER JOIN DEPARTMENT
         //  ON COMPANY.ID = DEPARTMENT.EMP_ID;
-        auto rows = storage.select(union_all(select(columns(&Department::employeeId, &Employee::name, &Department::dept),
-                                                    inner_join<Department>(on(is_equal(&Employee::id, &Department::employeeId)))),
-                                             select(columns(&Department::employeeId, &Employee::name, &Department::dept),
-                                                    left_outer_join<Department>(on(is_equal(&Employee::id, &Department::employeeId))))));
-        for(auto &row : rows) {
+        auto rows = storage.select(
+            union_all(select(columns(&Department::employeeId, &Employee::name, &Department::dept),
+                             inner_join<Department>(on(is_equal(&Employee::id, &Department::employeeId)))),
+                      select(columns(&Department::employeeId, &Employee::name, &Department::dept),
+                             left_outer_join<Department>(on(is_equal(&Employee::id, &Department::employeeId))))));
+        for(auto &row: rows) {
             cout << std::get<0>(row) << '\t' << std::get<1>(row) << '\t' << std::get<2>(row) << endl;
         }
         cout << endl;
     }
-    
-    
+
     return 0;
 }

--- a/examples/unique.cpp
+++ b/examples/unique.cpp
@@ -4,9 +4,9 @@
 #include <memory>
 #include <iostream>
 
+using std::cerr;
 using std::cout;
 using std::endl;
-using std::cerr;
 
 struct Entry {
     int id;
@@ -23,21 +23,20 @@ int main(int, char **) {
                                            make_column("nullable_text", &Entry::nullableColumn)));
     storage.sync_schema();
     storage.remove_all<Entry>();
-    
+
     try {
         auto sameString = "Bebe Rexha";
-        
-        auto id1 = storage.insert(Entry{ 0, sameString, std::make_unique<std::string>("The way I are") });
+
+        auto id1 = storage.insert(Entry{0, sameString, std::make_unique<std::string>("The way I are")});
         cout << "inserted " << storage.dump(storage.get<Entry>(id1)) << endl;
-        
+
         //  it's ok but the next line will throw std::system_error
-        
-        auto id2 = storage.insert(Entry{ 0, sameString, std::make_unique<std::string>("I got you") });
+
+        auto id2 = storage.insert(Entry{0, sameString, std::make_unique<std::string>("I got you")});
         cout << "inserted " << storage.dump(storage.get<Entry>(id2)) << endl;
-    } catch (const std::system_error& e) {
+    } catch(const std::system_error &e) {
         cerr << e.what() << endl;
     }
-    
+
     return 0;
 }
-

--- a/examples/update.cpp
+++ b/examples/update.cpp
@@ -38,16 +38,16 @@ int main(int, char **) {
     stor->remove_all<Employee>();
 
     //  insert initial values
-    stor->replace(Employee{ 1, "Paul", 32, "California", 20000.0 });
-    stor->replace(Employee{ 2, "Allen", 25, "Texas", 15000.0 });
-    stor->replace(Employee{ 3, "Teddy", 23, "Norway", 20000.0 });
-    stor->replace(Employee{ 4, "Mark", 25, "Rich-Mond", 65000.0 });
-    stor->replace(Employee{ 5, "David", 27, "Texas", 85000.0 });
-    stor->replace(Employee{ 6, "Kim", 22, "South-Hall", 45000.0 });
-    stor->replace(Employee{ 7, "James", 24, "Houston", 10000.0 });
+    stor->replace(Employee{1, "Paul", 32, "California", 20000.0});
+    stor->replace(Employee{2, "Allen", 25, "Texas", 15000.0});
+    stor->replace(Employee{3, "Teddy", 23, "Norway", 20000.0});
+    stor->replace(Employee{4, "Mark", 25, "Rich-Mond", 65000.0});
+    stor->replace(Employee{5, "David", 27, "Texas", 85000.0});
+    stor->replace(Employee{6, "Kim", 22, "South-Hall", 45000.0});
+    stor->replace(Employee{7, "James", 24, "Houston", 10000.0});
 
     //  show 'COMPANY' table contents
-    for(auto &employee : stor->iterate<Employee>()) {
+    for(auto &employee: stor->iterate<Employee>()) {
         cout << stor->dump(employee) << endl;
     }
     cout << endl;
@@ -56,22 +56,22 @@ int main(int, char **) {
 
     auto employee6 = stor->get<Employee>(6);
     employee6.address = "Texas";
-    stor->update(employee6);    //  actually this call updates all non-primary-key columns' values to passed object's fields
+    stor->update(
+        employee6);  //  actually this call updates all non-primary-key columns' values to passed object's fields
 
     //  show 'COMPANY' table contents again
-    for(auto &employee : stor->iterate<Employee>()) {
+    for(auto &employee: stor->iterate<Employee>()) {
         cout << stor->dump(employee) << endl;
     }
     cout << endl;
 
     //  'UPDATE COMPANY SET ADDRESS = 'Texas', SALARY = 20000.00 WHERE AGE < 30'
     using namespace sqlite_orm;
-    stor->update_all(set(c(&Employee::address) = "Texas",
-                         c(&Employee::salary) = 20000.00),
+    stor->update_all(set(c(&Employee::address) = "Texas", c(&Employee::salary) = 20000.00),
                      where(c(&Employee::age) < 30));
 
     //  show 'COMPANY' table contents one more time
-    for(auto &employee : stor->iterate<Employee>()) {
+    for(auto &employee: stor->iterate<Employee>()) {
         cout << stor->dump(employee) << endl;
     }
     cout << endl;

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -1,29 +1,28 @@
 #pragma once
 
 #if defined(_MSC_VER)
-# if defined(min)
+#if defined(min)
 __pragma(push_macro("min"))
-# undef min
-# define __RESTORE_MIN__
-# endif
-# if defined(max)
-__pragma(push_macro("max"))
-# undef max
-# define __RESTORE_MAX__
-# endif
-#endif // defined(_MSC_VER)
+#undef min
+#define __RESTORE_MIN__
+#endif
+#if defined(max)
+    __pragma(push_macro("max"))
+#undef max
+#define __RESTORE_MAX__
+#endif
+#endif  // defined(_MSC_VER)
 
 #include <ciso646>  //  due to #166
-
 #pragma once
 
 #include <system_error>  // std::error_code, std::system_error
-#include <string>   //  std::string
+#include <string>  //  std::string
 #include <sqlite3.h>
 #include <stdexcept>
 
 namespace sqlite_orm {
-    
+
     enum class orm_error_code {
         not_found = 1,
         type_is_not_mapped_to_storage,
@@ -38,20 +37,19 @@ namespace sqlite_orm {
         invalid_collate_argument_enum,
         failed_to_init_a_backup,
     };
-    
+
 }
 
 namespace sqlite_orm {
-    
+
     class orm_error_category : public std::error_category {
-    public:
-        
+      public:
         const char *name() const noexcept override final {
             return "ORM error";
         }
-        
+
         std::string message(int c) const override final {
-            switch (static_cast<orm_error_code>(c)) {
+            switch(static_cast<orm_error_code>(c)) {
                 case orm_error_code::not_found:
                     return "Not found";
                 case orm_error_code::type_is_not_mapped_to_storage:
@@ -79,35 +77,33 @@ namespace sqlite_orm {
             }
         }
     };
-    
+
     class sqlite_error_category : public std::error_category {
-    public:
-        
+      public:
         const char *name() const noexcept override final {
             return "SQLite error";
         }
-        
+
         std::string message(int c) const override final {
             return sqlite3_errstr(c);
         }
     };
-    
-    inline const orm_error_category& get_orm_error_category() {
+
+    inline const orm_error_category &get_orm_error_category() {
         static orm_error_category res;
         return res;
     }
-    
-    inline const sqlite_error_category& get_sqlite_error_category() {
+
+    inline const sqlite_error_category &get_sqlite_error_category() {
         static sqlite_error_category res;
         return res;
     }
 }
 
-namespace std
-{
-    template <>
-    struct is_error_code_enum<sqlite_orm::orm_error_code> : std::true_type{};
-    
+namespace std {
+    template<>
+    struct is_error_code_enum<sqlite_orm::orm_error_code> : std::true_type {};
+
     inline std::error_code make_error_code(sqlite_orm::orm_error_code errorCode) {
         return std::error_code(static_cast<int>(errorCode), sqlite_orm::get_orm_error_category());
     }
@@ -115,16 +111,16 @@ namespace std
 #pragma once
 
 #include <map>  //  std::map
-#include <string>   //  std::string
-#include <regex>    //  std::regex, std::regex_match
-#include <memory>   //  std::make_unique, std::unique_ptr
-#include <vector>   //  std::vector
-#include <cctype>   //  std::toupper
+#include <string>  //  std::string
+#include <regex>  //  std::regex, std::regex_match
+#include <memory>  //  std::make_unique, std::unique_ptr
+#include <vector>  //  std::vector
+#include <cctype>  //  std::toupper
 
 namespace sqlite_orm {
     using int64 = sqlite_int64;
     using uint64 = sqlite_uint64;
-    
+
     //  numeric and real are the same for c++
     enum class sqlite_type {
         INTEGER,
@@ -132,70 +128,74 @@ namespace sqlite_orm {
         BLOB,
         REAL,
     };
-    
+
     /**
      *  @param str case doesn't matter - it is uppercased before comparing.
      */
     inline std::unique_ptr<sqlite_type> to_sqlite_type(const std::string &str) {
-        auto asciiStringToUpper = [](std::string &s){
-            std::transform(s.begin(),
-                           s.end(),
-                           s.begin(),
-                           [](char c){
-                               return std::toupper(c);
-                           });
+        auto asciiStringToUpper = [](std::string &s) {
+            std::transform(s.begin(), s.end(), s.begin(), [](char c) {
+                return std::toupper(c);
+            });
         };
         auto upperStr = str;
         asciiStringToUpper(upperStr);
-        
+
         static std::map<sqlite_type, std::vector<std::regex>> typeMap = {
-            { sqlite_type::INTEGER, {
-                std::regex("INT"),
-                std::regex("INT.*"),
-                std::regex("TINYINT"),
-                std::regex("SMALLINT"),
-                std::regex("MEDIUMINT"),
-                std::regex("BIGINT"),
-                std::regex("UNSIGNED BIG INT"),
-                std::regex("INT2"),
-                std::regex("INT8"),
-            } }, { sqlite_type::TEXT, {
-                std::regex("CHARACTER\\([[:digit:]]+\\)"),
-                std::regex("VARCHAR\\([[:digit:]]+\\)"),
-                std::regex("VARYING CHARACTER\\([[:digit:]]+\\)"),
-                std::regex("NCHAR\\([[:digit:]]+\\)"),
-                std::regex("NATIVE CHARACTER\\([[:digit:]]+\\)"),
-                std::regex("NVARCHAR\\([[:digit:]]+\\)"),
-                std::regex("CLOB"),
-                std::regex("TEXT"),
-            } }, { sqlite_type::BLOB, {
-                std::regex("BLOB"),
-            } }, { sqlite_type::REAL, {
-                std::regex("REAL"),
-                std::regex("DOUBLE"),
-                std::regex("DOUBLE PRECISION"),
-                std::regex("FLOAT"),
-                std::regex("NUMERIC"),
-                std::regex("DECIMAL\\([[:digit:]]+,[[:digit:]]+\\)"),
-                std::regex("BOOLEAN"),
-                std::regex("DATE"),
-                std::regex("DATETIME"),
-            } },
+            {sqlite_type::INTEGER,
+             {
+                 std::regex("INT"),
+                 std::regex("INT.*"),
+                 std::regex("TINYINT"),
+                 std::regex("SMALLINT"),
+                 std::regex("MEDIUMINT"),
+                 std::regex("BIGINT"),
+                 std::regex("UNSIGNED BIG INT"),
+                 std::regex("INT2"),
+                 std::regex("INT8"),
+             }},
+            {sqlite_type::TEXT,
+             {
+                 std::regex("CHARACTER\\([[:digit:]]+\\)"),
+                 std::regex("VARCHAR\\([[:digit:]]+\\)"),
+                 std::regex("VARYING CHARACTER\\([[:digit:]]+\\)"),
+                 std::regex("NCHAR\\([[:digit:]]+\\)"),
+                 std::regex("NATIVE CHARACTER\\([[:digit:]]+\\)"),
+                 std::regex("NVARCHAR\\([[:digit:]]+\\)"),
+                 std::regex("CLOB"),
+                 std::regex("TEXT"),
+             }},
+            {sqlite_type::BLOB,
+             {
+                 std::regex("BLOB"),
+             }},
+            {sqlite_type::REAL,
+             {
+                 std::regex("REAL"),
+                 std::regex("DOUBLE"),
+                 std::regex("DOUBLE PRECISION"),
+                 std::regex("FLOAT"),
+                 std::regex("NUMERIC"),
+                 std::regex("DECIMAL\\([[:digit:]]+,[[:digit:]]+\\)"),
+                 std::regex("BOOLEAN"),
+                 std::regex("DATE"),
+                 std::regex("DATETIME"),
+             }},
         };
-        for(auto &p : typeMap) {
-            for(auto &r : p.second) {
-                if(std::regex_match(upperStr, r)){
+        for(auto &p: typeMap) {
+            for(auto &r: p.second) {
+                if(std::regex_match(upperStr, r)) {
                     return std::make_unique<sqlite_type>(p.first);
                 }
             }
         }
-        
+
         return {};
     }
 }
 #pragma once
 
-#include <tuple>    //  std::tuple, std::get
+#include <tuple>  //  std::tuple, std::get
 #include <type_traits>  //  std::false_type, std::true_type
 
 // #include "static_magic.h"
@@ -204,99 +204,108 @@ namespace sqlite_orm {
 #include <type_traits>  //  std::false_type, std::true_type, std::integral_constant
 
 namespace sqlite_orm {
-    
-    //  got from here https://stackoverflow.com/questions/37617677/implementing-a-compile-time-static-if-logic-for-different-string-types-in-a-co
+
+    //  got from here
+    //  https://stackoverflow.com/questions/37617677/implementing-a-compile-time-static-if-logic-for-different-string-types-in-a-co
     namespace internal {
-        
-        template <typename T, typename F>
-        auto static_if(std::true_type, T t, F) { return t; }
-        
-        template <typename T, typename F>
-        auto static_if(std::false_type, T, F f) { return f; }
-        
-        template <bool B, typename T, typename F>
-        auto static_if(T t, F f) { return static_if(std::integral_constant<bool, B>{}, t, f); }
-        
-        template <bool B, typename T>
-        auto static_if(T t) { return static_if(std::integral_constant<bool, B>{}, t, [](auto&&...){}); }
+
+        template<typename T, typename F>
+        auto static_if(std::true_type, T t, F) {
+            return t;
+        }
+
+        template<typename T, typename F>
+        auto static_if(std::false_type, T, F f) {
+            return f;
+        }
+
+        template<bool B, typename T, typename F>
+        auto static_if(T t, F f) {
+            return static_if(std::integral_constant<bool, B>{}, t, f);
+        }
+
+        template<bool B, typename T>
+        auto static_if(T t) {
+            return static_if(std::integral_constant<bool, B>{}, t, [](auto &&...) {});
+        }
     }
-    
+
 }
 
 
 namespace sqlite_orm {
-    
+
     //  got from here http://stackoverflow.com/questions/25958259/how-do-i-find-out-if-a-tuple-contains-a-type
     namespace tuple_helper {
-        
-        template <typename T, typename Tuple>
+
+        template<typename T, typename Tuple>
         struct has_type;
-        
-        template <typename T>
+
+        template<typename T>
         struct has_type<T, std::tuple<>> : std::false_type {};
-        
-        template <typename T, typename U, typename... Ts>
+
+        template<typename T, typename U, typename... Ts>
         struct has_type<T, std::tuple<U, Ts...>> : has_type<T, std::tuple<Ts...>> {};
-        
-        template <typename T, typename... Ts>
+
+        template<typename T, typename... Ts>
         struct has_type<T, std::tuple<T, Ts...>> : std::true_type {};
-        
-        template <typename T, typename Tuple>
+
+        template<typename T, typename Tuple>
         using tuple_contains_type = typename has_type<T, Tuple>::type;
-        
-        template<size_t N, class ...Args>
+
+        template<size_t N, class... Args>
         struct iterator {
-            
+
             template<class L>
             void operator()(const std::tuple<Args...> &t, const L &l, bool reverse = true) {
-                if(reverse){
+                if(reverse) {
                     l(std::get<N>(t));
                     iterator<N - 1, Args...>()(t, l, reverse);
-                }else{
+                } else {
                     iterator<N - 1, Args...>()(t, l, reverse);
                     l(std::get<N>(t));
                 }
             }
         };
-        
-        template<class ...Args>
-        struct iterator<0, Args...>{
-            
+
+        template<class... Args>
+        struct iterator<0, Args...> {
+
             template<class L>
             void operator()(const std::tuple<Args...> &t, const L &l, bool /*reverse*/ = true) {
                 l(std::get<0>(t));
             }
         };
-        
+
         template<size_t N>
         struct iterator<N> {
-            
+
             template<class L>
             void operator()(const std::tuple<> &, const L &, bool /*reverse*/ = true) {
                 //..
             }
         };
-        
+
         template<size_t N, size_t I, class L, class R>
         void move_tuple_impl(L &lhs, R &rhs) {
             std::get<I>(lhs) = std::move(std::get<I>(rhs));
-            internal::static_if<std::integral_constant<bool, N != I + 1>{}>([](auto &lhs, auto &rhs){
+            internal::static_if<std::integral_constant<bool, N != I + 1>{}>([](auto &lhs, auto &rhs) {
                 move_tuple_impl<N, I + 1>(lhs, rhs);
             })(lhs, rhs);
         }
     }
-    
+
     namespace internal {
-        
+
         template<size_t N, class L, class R>
         void move_tuple(L &lhs, R &rhs) {
             using bool_type = std::integral_constant<bool, N != 0>;
-            static_if<bool_type{}>([](auto &lhs, auto &rhs){
+            static_if<bool_type{}>([](auto &lhs, auto &rhs) {
                 tuple_helper::move_tuple_impl<N, 0>(lhs, rhs);
             })(lhs, rhs);
         }
-        
-        template<class L, class ...Args>
+
+        template<class L, class... Args>
         void iterate_tuple(const std::tuple<Args...> &t, const L &l) {
             using tuple_type = std::tuple<Args...>;
             tuple_helper::iterator<std::tuple_size<tuple_type>::value - 1, Args...>()(t, l, false);
@@ -305,155 +314,155 @@ namespace sqlite_orm {
 }
 #pragma once
 
-#include <string>   //  std::string
-#include <memory>   //  std::shared_ptr, std::unique_ptr
-#include <vector>   //  std::vector
+#include <string>  //  std::string
+#include <memory>  //  std::shared_ptr, std::unique_ptr
+#include <vector>  //  std::vector
 
 namespace sqlite_orm {
-    
+
     /**
      *  This class accepts c++ type and transfers it to sqlite name (int -> INTEGER, std::string -> TEXT)
      */
     template<class T>
     struct type_printer;
-    
+
     struct integer_printer {
-        inline const std::string& print() {
+        inline const std::string &print() {
             static const std::string res = "INTEGER";
             return res;
         }
     };
-    
+
     struct text_printer {
-        inline const std::string& print() {
+        inline const std::string &print() {
             static const std::string res = "TEXT";
             return res;
         }
     };
-    
+
     struct real_printer {
-        inline const std::string& print() {
+        inline const std::string &print() {
             static const std::string res = "REAL";
             return res;
         }
     };
-    
+
     struct blob_printer {
-        inline const std::string& print() {
+        inline const std::string &print() {
             static const std::string res = "BLOB";
             return res;
         }
     };
-    
-    //Note unsigned/signed char and simple char used for storing integer values, not char values.
+
+    // Note unsigned/signed char and simple char used for storing integer values, not char values.
     template<>
     struct type_printer<unsigned char> : public integer_printer {};
-    
+
     template<>
     struct type_printer<signed char> : public integer_printer {};
-    
+
     template<>
     struct type_printer<char> : public integer_printer {};
-    
+
     template<>
     struct type_printer<unsigned short int> : public integer_printer {};
-    
+
     template<>
     struct type_printer<short> : public integer_printer {};
-    
+
     template<>
     struct type_printer<unsigned int> : public integer_printer {};
-    
+
     template<>
     struct type_printer<int> : public integer_printer {};
-    
+
     template<>
     struct type_printer<unsigned long> : public integer_printer {};
-    
+
     template<>
     struct type_printer<long> : public integer_printer {};
-    
+
     template<>
     struct type_printer<unsigned long long> : public integer_printer {};
-    
+
     template<>
     struct type_printer<long long> : public integer_printer {};
-    
+
     template<>
     struct type_printer<bool> : public integer_printer {};
-    
+
     template<>
     struct type_printer<std::string> : public text_printer {};
-    
+
     template<>
     struct type_printer<std::wstring> : public text_printer {};
-    
+
     template<>
-    struct type_printer<const char*> : public text_printer {};
-    
+    struct type_printer<const char *> : public text_printer {};
+
     template<>
     struct type_printer<float> : public real_printer {};
-    
+
     template<>
     struct type_printer<double> : public real_printer {};
-    
+
     template<class T>
     struct type_printer<std::shared_ptr<T>> : public type_printer<T> {};
-    
+
     template<class T>
     struct type_printer<std::unique_ptr<T>> : public type_printer<T> {};
-    
+
     template<>
     struct type_printer<std::vector<char>> : public blob_printer {};
 }
 #pragma once
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         enum class collate_argument {
             binary,
             nocase,
             rtrim,
         };
     }
-    
+
 }
 #pragma once
 
-#include <string>   //  std::string
-#include <tuple>    //  std::tuple, std::make_tuple
+#include <string>  //  std::string
+#include <tuple>  //  std::tuple, std::make_tuple
 #include <sstream>  //  std::stringstream
 #include <type_traits>  //  std::is_base_of, std::false_type, std::true_type
 #include <ostream>  //  std::ostream
 
 namespace sqlite_orm {
-    
+
     namespace constraints {
-        
+
         /**
          *  AUTOINCREMENT constraint class.
          */
         struct autoincrement_t {
-            
+
             operator std::string() const {
                 return "AUTOINCREMENT";
             }
         };
-        
+
         struct primary_key_base {
             enum class order_by {
                 unspecified,
                 ascending,
                 descending,
             };
-            
+
             order_by asc_option = order_by::unspecified;
-            
+
             operator std::string() const {
                 std::string res = "PRIMARY KEY";
-                switch(this->asc_option){
+                switch(this->asc_option) {
                     case order_by::ascending:
                         res += " ASC";
                         break;
@@ -466,45 +475,46 @@ namespace sqlite_orm {
                 return res;
             }
         };
-        
+
         /**
          *  PRIMARY KEY constraint class.
-         *  Cs is parameter pack which contains columns (member pointers and/or function pointers). Can be empty when used withen `make_column` function.
+         *  Cs is parameter pack which contains columns (member pointers and/or function pointers). Can be empty when
+         * used withen `make_column` function.
          */
-        template<class ...Cs>
+        template<class... Cs>
         struct primary_key_t : primary_key_base {
             using order_by = primary_key_base::order_by;
-            
+
             std::tuple<Cs...> columns;
-            
-            primary_key_t(decltype(columns) c):columns(std::move(c)){}
-            
-            using field_type = void;    //  for column iteration. Better be deleted
+
+            primary_key_t(decltype(columns) c) : columns(std::move(c)) {}
+
+            using field_type = void;  //  for column iteration. Better be deleted
             using constraints_type = std::tuple<>;
-            
+
             primary_key_t<Cs...> asc() const {
                 auto res = *this;
                 res.asc_option = order_by::ascending;
                 return res;
             }
-            
+
             primary_key_t<Cs...> desc() const {
                 auto res = *this;
                 res.asc_option = order_by::descending;
                 return res;
             }
         };
-        
+
         /**
          *  UNIQUE constraint class.
          */
         struct unique_t {
-            
+
             operator std::string() const {
                 return "UNIQUE";
             }
         };
-        
+
         /**
          *  DEFAULT constraint class.
          *  T is a value type.
@@ -512,47 +522,47 @@ namespace sqlite_orm {
         template<class T>
         struct default_t {
             using value_type = T;
-            
+
             value_type value;
-            
+
             operator std::string() const {
                 std::stringstream ss;
                 ss << "DEFAULT ";
                 auto needQuotes = std::is_base_of<text_printer, type_printer<T>>::value;
-                if(needQuotes){
+                if(needQuotes) {
                     ss << "'";
                 }
                 ss << this->value;
-                if(needQuotes){
+                if(needQuotes) {
                     ss << "'";
                 }
                 return ss.str();
             }
         };
-        
+
 #if SQLITE_VERSION_NUMBER >= 3006019
-        
+
         /**
          *  FOREIGN KEY constraint class.
          *  Cs are columns which has foreign key
          *  Rs are column which C references to
          *  Available in SQLite 3.6.19 or higher
          */
-        
+
         template<class A, class B>
         struct foreign_key_t;
-        
+
         enum class foreign_key_action {
-            none,   //  not specified
+            none,  //  not specified
             no_action,
             restrict_,
             set_null,
             set_default,
             cascade,
         };
-        
+
         inline std::ostream &operator<<(std::ostream &os, foreign_key_action action) {
-            switch(action){
+            switch(action) {
                 case decltype(action)::no_action:
                     os << "NO ACTION";
                     break;
@@ -573,119 +583,111 @@ namespace sqlite_orm {
             }
             return os;
         }
-        
+
         struct on_update_delete_base {
             const bool update;  //  true if update and false if delete
-            
+
             operator std::string() const {
-                if(this->update){
+                if(this->update) {
                     return "ON UPDATE";
-                }else{
+                } else {
                     return "ON DELETE";
                 }
             }
         };
-        
+
         /**
          *  F - foreign key class
          */
         template<class F>
         struct on_update_delete_t : on_update_delete_base {
             using foreign_key_type = F;
-            
+
             const foreign_key_type &fk;
-            
+
             on_update_delete_t(decltype(fk) fk_, decltype(update) update, foreign_key_action action_) :
-            on_update_delete_base{update},
-            fk(fk_),
-            _action(action_)
-            {}
-            
+                on_update_delete_base{update}, fk(fk_), _action(action_) {}
+
             foreign_key_action _action = foreign_key_action::none;
-            
+
             foreign_key_type no_action() const {
                 auto res = this->fk;
-                if(update){
+                if(update) {
                     res.on_update._action = foreign_key_action::no_action;
-                }else{
+                } else {
                     res.on_delete._action = foreign_key_action::no_action;
                 }
                 return res;
             }
-            
+
             foreign_key_type restrict_() const {
                 auto res = this->fk;
-                if(update){
+                if(update) {
                     res.on_update._action = foreign_key_action::restrict_;
-                }else{
+                } else {
                     res.on_delete._action = foreign_key_action::restrict_;
                 }
                 return res;
             }
-            
+
             foreign_key_type set_null() const {
                 auto res = this->fk;
-                if(update){
+                if(update) {
                     res.on_update._action = foreign_key_action::set_null;
-                }else{
+                } else {
                     res.on_delete._action = foreign_key_action::set_null;
                 }
                 return res;
             }
-            
+
             foreign_key_type set_default() const {
                 auto res = this->fk;
-                if(update){
+                if(update) {
                     res.on_update._action = foreign_key_action::set_default;
-                }else{
+                } else {
                     res.on_delete._action = foreign_key_action::set_default;
                 }
                 return res;
             }
-            
+
             foreign_key_type cascade() const {
                 auto res = this->fk;
-                if(update){
+                if(update) {
                     res.on_update._action = foreign_key_action::cascade;
-                }else{
+                } else {
                     res.on_delete._action = foreign_key_action::cascade;
                 }
                 return res;
             }
-            
+
             operator bool() const {
                 return this->_action != decltype(this->_action)::none;
             }
         };
-        
-        template<class ...Cs, class ...Rs>
+
+        template<class... Cs, class... Rs>
         struct foreign_key_t<std::tuple<Cs...>, std::tuple<Rs...>> {
             using columns_type = std::tuple<Cs...>;
             using references_type = std::tuple<Rs...>;
             using self = foreign_key_t<columns_type, references_type>;
-            
+
             columns_type columns;
             references_type references;
-            
+
             on_update_delete_t<self> on_update;
             on_update_delete_t<self> on_delete;
-            
-            static_assert(std::tuple_size<columns_type>::value == std::tuple_size<references_type>::value, "Columns size must be equal to references tuple");
-            
-            foreign_key_t(columns_type columns_, references_type references_):
-            columns(std::move(columns_)),
-            references(std::move(references_)),
-            on_update(*this, true, foreign_key_action::none),
-            on_delete(*this, false, foreign_key_action::none)
-            {}
-            
-            foreign_key_t(const self &other):
-            columns(other.columns),
-            references(other.references),
-            on_update(*this, true, other.on_update._action),
-            on_delete(*this, false, other.on_delete._action)
-            {}
-            
+
+            static_assert(std::tuple_size<columns_type>::value == std::tuple_size<references_type>::value,
+                          "Columns size must be equal to references tuple");
+
+            foreign_key_t(columns_type columns_, references_type references_) :
+                columns(std::move(columns_)), references(std::move(references_)),
+                on_update(*this, true, foreign_key_action::none), on_delete(*this, false, foreign_key_action::none) {}
+
+            foreign_key_t(const self &other) :
+                columns(other.columns), references(other.references), on_update(*this, true, other.on_update._action),
+                on_delete(*this, false, other.on_delete._action) {}
+
             self &operator=(const self &other) {
                 this->columns = other.columns;
                 this->references = other.references;
@@ -693,175 +695,178 @@ namespace sqlite_orm {
                 this->on_delete = {*this, false, other.on_delete._action};
                 return *this;
             }
-            
-            using field_type = void;    //  for column iteration. Better be deleted
+
+            using field_type = void;  //  for column iteration. Better be deleted
             using constraints_type = std::tuple<>;
-            
+
             template<class L>
             void for_each_column(const L &) {}
-            
-            template<class ...Opts>
-            constexpr bool has_every() const  {
+
+            template<class... Opts>
+            constexpr bool has_every() const {
                 return false;
             }
         };
-        
+
         /**
          *  Cs can be a class member pointer, a getter function member pointer or setter
          *  func member pointer
          *  Available in SQLite 3.6.19 or higher
          */
-        template<class ...Cs>
+        template<class... Cs>
         struct foreign_key_intermediate_t {
             using tuple_type = std::tuple<Cs...>;
-            
+
             tuple_type columns;
-            
-            foreign_key_intermediate_t(tuple_type columns_): columns(std::move(columns_)) {}
-            
-            template<class ...Rs>
-            foreign_key_t<std::tuple<Cs...>, std::tuple<Rs...>> references(Rs ...references) {
+
+            foreign_key_intermediate_t(tuple_type columns_) : columns(std::move(columns_)) {}
+
+            template<class... Rs>
+            foreign_key_t<std::tuple<Cs...>, std::tuple<Rs...>> references(Rs... references) {
                 return {std::move(this->columns), std::make_tuple(std::forward<Rs>(references)...)};
             }
         };
 #endif
-        
+
         struct collate_t {
             internal::collate_argument argument = internal::collate_argument::binary;
-            
-            collate_t(internal::collate_argument argument_): argument(argument_) {}
-            
+
+            collate_t(internal::collate_argument argument_) : argument(argument_) {}
+
             operator std::string() const {
                 std::string res = "COLLATE " + this->string_from_collate_argument(this->argument);
                 return res;
             }
-            
-            static std::string string_from_collate_argument(internal::collate_argument argument){
-                switch(argument){
-                    case decltype(argument)::binary: return "BINARY";
-                    case decltype(argument)::nocase: return "NOCASE";
-                    case decltype(argument)::rtrim: return "RTRIM";
+
+            static std::string string_from_collate_argument(internal::collate_argument argument) {
+                switch(argument) {
+                    case decltype(argument)::binary:
+                        return "BINARY";
+                    case decltype(argument)::nocase:
+                        return "NOCASE";
+                    case decltype(argument)::rtrim:
+                        return "RTRIM";
                 }
                 throw std::system_error(std::make_error_code(orm_error_code::invalid_collate_argument_enum));
             }
         };
-        
+
         template<class T>
         struct is_constraint : std::false_type {};
-        
+
         template<>
         struct is_constraint<autoincrement_t> : std::true_type {};
-        
-        template<class ...Cs>
+
+        template<class... Cs>
         struct is_constraint<primary_key_t<Cs...>> : std::true_type {};
-        
+
         template<>
         struct is_constraint<unique_t> : std::true_type {};
-        
+
         template<class T>
         struct is_constraint<default_t<T>> : std::true_type {};
-        
+
         template<class C, class R>
         struct is_constraint<foreign_key_t<C, R>> : std::true_type {};
-        
+
         template<>
         struct is_constraint<collate_t> : std::true_type {};
-        
-        template<class ...Args>
+
+        template<class... Args>
         struct constraints_size;
-        
+
         template<>
         struct constraints_size<> {
             static constexpr const int value = 0;
         };
-        
-        template<class H, class ...Args>
+
+        template<class H, class... Args>
         struct constraints_size<H, Args...> {
             static constexpr const int value = is_constraint<H>::value + constraints_size<Args...>::value;
         };
     }
-    
+
 #if SQLITE_VERSION_NUMBER >= 3006019
-    
+
     /**
      *  FOREIGN KEY constraint construction function that takes member pointer as argument
      *  Available in SQLite 3.6.19 or higher
      */
-    template<class ...Cs>
-    constraints::foreign_key_intermediate_t<Cs...> foreign_key(Cs ...columns) {
+    template<class... Cs>
+    constraints::foreign_key_intermediate_t<Cs...> foreign_key(Cs... columns) {
         return {std::make_tuple(std::forward<Cs>(columns)...)};
     }
 #endif
-    
+
     /**
      *  UNIQUE constraint builder function.
      */
     inline constraints::unique_t unique() {
         return {};
     }
-    
+
     inline constraints::autoincrement_t autoincrement() {
         return {};
     }
-    
-    template<class ...Cs>
-    inline constraints::primary_key_t<Cs...> primary_key(Cs ...cs) {
+
+    template<class... Cs>
+    inline constraints::primary_key_t<Cs...> primary_key(Cs... cs) {
         using ret_type = constraints::primary_key_t<Cs...>;
         return ret_type(std::make_tuple(cs...));
     }
-    
+
     template<class T>
     constraints::default_t<T> default_value(T t) {
         return {std::move(t)};
     }
-    
+
     inline constraints::collate_t collate_nocase() {
         return {internal::collate_argument::nocase};
     }
-    
+
     inline constraints::collate_t collate_binary() {
         return {internal::collate_argument::binary};
     }
-    
+
     inline constraints::collate_t collate_rtrim() {
         return {internal::collate_argument::rtrim};
     }
-    
+
     namespace internal {
-        
+
         /**
          *  FOREIGN KEY traits. Common case
          */
         template<class T>
         struct is_foreign_key : std::false_type {};
-        
+
         /**
          *  FOREIGN KEY traits. Specialized case
          */
         template<class C, class R>
         struct is_foreign_key<constraints::foreign_key_t<C, R>> : std::true_type {};
-        
+
         /**
          *  PRIMARY KEY traits. Common case
          */
         template<class T>
         struct is_primary_key : public std::false_type {};
-        
+
         /**
          *  PRIMARY KEY traits. Specialized case
          */
-        template<class ...Cs>
+        template<class... Cs>
         struct is_primary_key<constraints::primary_key_t<Cs...>> : public std::true_type {};
     }
-    
+
 }
 #pragma once
 
 #include <type_traits>  //  std::false_type, std::true_type
-#include <memory>   //  std::shared_ptr, std::unique_ptr
+#include <memory>  //  std::shared_ptr, std::unique_ptr
 
 namespace sqlite_orm {
-    
+
     /**
      *  This is class that tells `sqlite_orm` that type is nullable. Nullable types
      *  are mapped to sqlite database as `NULL` and not-nullable are mapped as `NOT NULL`.
@@ -875,7 +880,7 @@ namespace sqlite_orm {
             return true;
         }
     };
-    
+
     /**
      *  This is a specialization for std::shared_ptr. std::shared_ptr is nullable in sqlite_orm.
      */
@@ -885,7 +890,7 @@ namespace sqlite_orm {
             return static_cast<bool>(t);
         }
     };
-    
+
     /**
      *  This is a specialization for std::unique_ptr. std::unique_ptr is nullable too.
      */
@@ -895,200 +900,202 @@ namespace sqlite_orm {
             return static_cast<bool>(t);
         }
     };
-    
+
 }
 #pragma once
 
-#include <memory>   //  std::unique_ptr
-#include <string>   //  std::string
+#include <memory>  //  std::unique_ptr
+#include <string>  //  std::string
 #include <sstream>  //  std::stringstream
 
 // #include "constraints.h"
 
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         /**
          *  This class is used in tuple interation to know whether tuple constains `default_value_t`
          *  constraint class and what it's value if it is
          */
         struct default_value_extractor {
-            
+
             template<class A>
-            std::unique_ptr<std::string> operator() (const A &) {
+            std::unique_ptr<std::string> operator()(const A &) {
                 return {};
             }
-            
+
             template<class T>
-            std::unique_ptr<std::string> operator() (const constraints::default_t<T> &t) {
+            std::unique_ptr<std::string> operator()(const constraints::default_t<T> &t) {
                 std::stringstream ss;
                 ss << t.value;
                 return std::make_unique<std::string>(ss.str());
             }
         };
-        
+
     }
-    
+
 }
 #pragma once
 
 #include <type_traits>  //  std::false_type, std::true_type
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         /**
          *  Inherit this class to support arithmetic types overloading
          */
         struct arithmetic_t {};
-        
-        template<class L, class R, class ...Ds>
+
+        template<class L, class R, class... Ds>
         struct binary_operator : Ds... {
             using left_type = L;
             using right_type = R;
-            
+
             left_type lhs;
             right_type rhs;
-            
+
             binary_operator(left_type lhs_, right_type rhs_) : lhs(std::move(lhs_)), rhs(std::move(rhs_)) {}
         };
-        
+
         struct conc_string {
-            operator std::string () const {
+            operator std::string() const {
                 return "||";
             }
         };
-        
+
         /**
          *  Result of concatenation || operator
          */
         template<class L, class R>
         using conc_t = binary_operator<L, R, conc_string>;
-        
+
         struct add_string {
-            operator std::string () const {
+            operator std::string() const {
                 return "+";
             }
         };
-        
+
         /**
          *  Result of addition + operator
          */
         template<class L, class R>
         using add_t = binary_operator<L, R, add_string, arithmetic_t>;
-        
+
         struct sub_string {
-            operator std::string () const {
+            operator std::string() const {
                 return "-";
             }
         };
-        
+
         /**
          *  Result of substitute - operator
          */
         template<class L, class R>
         using sub_t = binary_operator<L, R, sub_string, arithmetic_t>;
-        
+
         struct mul_string {
-            operator std::string () const {
+            operator std::string() const {
                 return "*";
             }
         };
-        
+
         /**
          *  Result of multiply * operator
          */
         template<class L, class R>
         using mul_t = binary_operator<L, R, mul_string, arithmetic_t>;
-        
+
         struct div_string {
-            operator std::string () const {
+            operator std::string() const {
                 return "/";
             }
         };
-        
+
         /**
          *  Result of divide / operator
          */
         template<class L, class R>
         using div_t = binary_operator<L, R, div_string, arithmetic_t>;
-        
+
         struct mod_string {
-            operator std::string () const {
+            operator std::string() const {
                 return "%";
             }
         };
-        
+
         /**
          *  Result of mod % operator
          */
         template<class L, class R>
         using mod_t = binary_operator<L, R, mod_string, arithmetic_t>;
-        
+
         struct assign_string {
-            operator std::string () const {
+            operator std::string() const {
                 return "=";
             }
         };
-        
+
         /**
          *  Result of assign = operator
          */
         template<class L, class R>
         using assign_t = binary_operator<L, R, assign_string>;
-        
+
         /**
          *  Assign operator traits. Common case
          */
         template<class T>
         struct is_assign_t : public std::false_type {};
-        
+
         /**
          *  Assign operator traits. Specialized case
          */
         template<class L, class R>
         struct is_assign_t<assign_t<L, R>> : public std::true_type {};
-        
+
         /**
          *  Is not an operator but a result of c(...) function. Has operator= overloaded which returns assign_t
          */
         template<class T>
         struct expression_t {
             T t;
-            
-            expression_t(T t_): t(std::move(t_)) {}
-            
+
+            expression_t(T t_) : t(std::move(t_)) {}
+
             template<class R>
             assign_t<T, R> operator=(R r) const {
                 return {this->t, std::move(r)};
             }
-            
+
             assign_t<T, std::nullptr_t> operator=(std::nullptr_t) const {
                 return {this->t, nullptr};
             }
         };
-        
+
     }
-    
+
     /**
-     *  Public interface for syntax sugar for columns. Example: `where(c(&User::id) == 5)` or `storage.update(set(c(&User::name) = "Dua Lipa"));
+     *  Public interface for syntax sugar for columns. Example: `where(c(&User::id) == 5)` or
+     * `storage.update(set(c(&User::name) = "Dua Lipa"));
      */
     template<class T>
     internal::expression_t<T> c(T t) {
         return {std::move(t)};
     }
-    
+
     /**
-     *  Public interface for || concatenation operator. Example: `select(conc(&User::name, "@gmail.com"));` => SELECT name || '@gmail.com' FROM users
+     *  Public interface for || concatenation operator. Example: `select(conc(&User::name, "@gmail.com"));` => SELECT
+     * name || '@gmail.com' FROM users
      */
     template<class L, class R>
     internal::conc_t<L, R> conc(L l, R r) {
         return {std::move(l), std::move(r)};
     }
-    
+
     /**
      *  Public interface for + operator. Example: `select(add(&User::age, 100));` => SELECT age + 100 FROM users
      */
@@ -1096,7 +1103,7 @@ namespace sqlite_orm {
     internal::add_t<L, R> add(L l, R r) {
         return {std::move(l), std::move(r)};
     }
-    
+
     /**
      *  Public interface for - operator. Example: `select(add(&User::age, 1));` => SELECT age - 1 FROM users
      */
@@ -1104,33 +1111,33 @@ namespace sqlite_orm {
     internal::sub_t<L, R> sub(L l, R r) {
         return {std::move(l), std::move(r)};
     }
-    
+
     template<class L, class R>
     internal::mul_t<L, R> mul(L l, R r) {
         return {std::move(l), std::move(r)};
     }
-    
+
     template<class L, class R>
     internal::div_t<L, R> div(L l, R r) {
         return {std::move(l), std::move(r)};
     }
-    
+
     template<class L, class R>
     internal::mod_t<L, R> mod(L l, R r) {
         return {std::move(l), std::move(r)};
     }
-    
+
     template<class L, class R>
     internal::assign_t<L, R> assign(L l, R r) {
         return {std::move(l), std::move(r)};
     }
-    
+
 }
 #pragma once
 
-#include <tuple>    //  std::tuple
-#include <string>   //  std::string
-#include <memory>   //  std::unique_ptr
+#include <tuple>  //  std::tuple
+#include <string>  //  std::string
+#include <memory>  //  std::unique_ptr
 #include <type_traits>  //  std::true_type, std::false_type, std::is_same, std::enable_if, std::is_member_pointer, std::is_member_function_pointer
 
 // #include "type_is_nullable.h"
@@ -1143,24 +1150,24 @@ namespace sqlite_orm {
 
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         struct column_base {
-            
+
             /**
              *  Column name. Specified during construction in `make_column`.
              */
             const std::string name;
         };
-        
+
         /**
          *  This class stores single column info. column_t is a pair of [column_name:member_pointer] mapped to a storage
          *  O is a mapped class, e.g. User
          *  T is a mapped class'es field type, e.g. &User::name
          *  Op... is a constraints pack, e.g. primary_key_t, autoincrement_t etc
          */
-        template<class O, class T, class G/* = const T& (O::*)() const*/, class S/* = void (O::*)(T)*/, class ...Op>
+        template<class O, class T, class G /* = const T& (O::*)() const*/, class S /* = void (O::*)(T)*/, class... Op>
         struct column_t : column_base {
             using object_type = O;
             using field_type = T;
@@ -1168,295 +1175,309 @@ namespace sqlite_orm {
             using member_pointer_t = field_type object_type::*;
             using getter_type = G;
             using setter_type = S;
-            
+
             /**
              *  Member pointer used to read/write member
              */
-            member_pointer_t member_pointer/* = nullptr*/;
-            
+            member_pointer_t member_pointer /* = nullptr*/;
+
             /**
              *  Getter member function pointer to get a value. If member_pointer is null than
              *  `getter` and `setter` must be not null
              */
-            getter_type getter/* = nullptr*/;
-            
+            getter_type getter /* = nullptr*/;
+
             /**
              *  Setter member function
              */
-            setter_type setter/* = nullptr*/;
-            
+            setter_type setter /* = nullptr*/;
+
             /**
              *  Constraints tuple
              */
             constraints_type constraints;
-            
-            column_t(std::string name, member_pointer_t member_pointer_, getter_type getter_, setter_type setter_, constraints_type constraints_):
-            column_base{std::move(name)}, member_pointer(member_pointer_), getter(getter_), setter(setter_), constraints(std::move(constraints_))
-            {}
-            
+
+            column_t(std::string name,
+                     member_pointer_t member_pointer_,
+                     getter_type getter_,
+                     setter_type setter_,
+                     constraints_type constraints_) :
+                column_base{std::move(name)},
+                member_pointer(member_pointer_), getter(getter_), setter(setter_),
+                constraints(std::move(constraints_)) {}
+
             /**
              *  Simplified interface for `NOT NULL` constraint
              */
             bool not_null() const {
                 return !type_is_nullable<field_type>::value;
             }
-            
+
             template<class Opt>
             constexpr bool has() const {
                 return tuple_helper::tuple_contains_type<Opt, constraints_type>::value;
             }
-            
-            template<class O1, class O2, class ...Opts>
-            constexpr bool has_every() const  {
+
+            template<class O1, class O2, class... Opts>
+            constexpr bool has_every() const {
                 if(has<O1>() && has<O2>()) {
                     return true;
-                }else{
+                } else {
                     return has_every<Opts...>();
                 }
             }
-            
+
             template<class O1>
             constexpr bool has_every() const {
                 return has<O1>();
             }
-            
+
             /**
              *  Simplified interface for `DEFAULT` constraint
              *  @return string representation of default value if it exists otherwise nullptr
              */
             std::unique_ptr<std::string> default_value() const {
                 std::unique_ptr<std::string> res;
-                iterate_tuple(this->constraints, [&res](auto &v){
+                iterate_tuple(this->constraints, [&res](auto &v) {
                     auto dft = internal::default_value_extractor()(v);
-                    if(dft){
+                    if(dft) {
                         res = std::move(dft);
                     }
                 });
                 return res;
             }
         };
-        
+
         /**
          *  Column traits. Common case.
          */
         template<class T>
         struct is_column : public std::false_type {};
-        
+
         /**
          *  Column traits. Specialized case case.
          */
-        template<class O, class T, class ...Op>
+        template<class O, class T, class... Op>
         struct is_column<column_t<O, T, Op...>> : public std::true_type {};
-        
+
         template<class T, class SFINAE = void>
         struct is_field_member_pointer : std::false_type {};
-        
+
         template<class T>
-        struct is_field_member_pointer<T, typename std::enable_if<std::is_member_pointer<T>::value && !std::is_member_function_pointer<T>::value>::type> : std::true_type {};
-        
+        struct is_field_member_pointer<T,
+                                       typename std::enable_if<std::is_member_pointer<T>::value &&
+                                                               !std::is_member_function_pointer<T>::value>::type>
+            : std::true_type {};
+
         /**
          *  Getters aliases
          */
         template<class O, class T>
         using getter_by_value_const = T (O::*)() const;
-        
+
         template<class O, class T>
         using getter_by_value = T (O::*)();
-        
+
         template<class O, class T>
-        using getter_by_ref_const = T& (O::*)() const;
-        
+        using getter_by_ref_const = T &(O::*)() const;
+
         template<class O, class T>
-        using getter_by_ref = T& (O::*)();
-        
+        using getter_by_ref = T &(O::*)();
+
         template<class O, class T>
-        using getter_by_const_ref_const = const T& (O::*)() const;
-        
+        using getter_by_const_ref_const = const T &(O::*)() const;
+
         template<class O, class T>
-        using getter_by_const_ref = const T& (O::*)();
-        
+        using getter_by_const_ref = const T &(O::*)();
+
         /**
          *  Setters aliases
          */
         template<class O, class T>
         using setter_by_value = void (O::*)(T);
-        
+
         template<class O, class T>
-        using setter_by_ref = void (O::*)(T&);
-        
+        using setter_by_ref = void (O::*)(T &);
+
         template<class O, class T>
-        using setter_by_const_ref = void (O::*)(const T&);
-        
+        using setter_by_const_ref = void (O::*)(const T &);
+
         template<class T>
         struct is_getter : std::false_type {};
-        
+
         template<class O, class T>
         struct is_getter<getter_by_value_const<O, T>> : std::true_type {};
-        
+
         template<class O, class T>
         struct is_getter<getter_by_value<O, T>> : std::true_type {};
-        
+
         template<class O, class T>
         struct is_getter<getter_by_ref_const<O, T>> : std::true_type {};
-        
+
         template<class O, class T>
         struct is_getter<getter_by_ref<O, T>> : std::true_type {};
-        
+
         template<class O, class T>
         struct is_getter<getter_by_const_ref_const<O, T>> : std::true_type {};
-        
+
         template<class O, class T>
         struct is_getter<getter_by_const_ref<O, T>> : std::true_type {};
-        
+
         template<class T>
         struct is_setter : std::false_type {};
-        
+
         template<class O, class T>
         struct is_setter<setter_by_value<O, T>> : std::true_type {};
-        
+
         template<class O, class T>
         struct is_setter<setter_by_ref<O, T>> : std::true_type {};
-        
+
         template<class O, class T>
         struct is_setter<setter_by_const_ref<O, T>> : std::true_type {};
-        
+
         template<class T>
         struct getter_traits;
-        
+
         template<class O, class T>
         struct getter_traits<getter_by_value_const<O, T>> {
             using object_type = O;
             using field_type = T;
-            
+
             static constexpr const bool returns_lvalue = false;
         };
-        
+
         template<class O, class T>
         struct getter_traits<getter_by_value<O, T>> {
             using object_type = O;
             using field_type = T;
-            
+
             static constexpr const bool returns_lvalue = false;
         };
-        
+
         template<class O, class T>
         struct getter_traits<getter_by_ref_const<O, T>> {
             using object_type = O;
             using field_type = T;
-            
+
             static constexpr const bool returns_lvalue = true;
         };
-        
+
         template<class O, class T>
         struct getter_traits<getter_by_ref<O, T>> {
             using object_type = O;
             using field_type = T;
-            
+
             static constexpr const bool returns_lvalue = true;
         };
-        
+
         template<class O, class T>
         struct getter_traits<getter_by_const_ref_const<O, T>> {
             using object_type = O;
             using field_type = T;
-            
+
             static constexpr const bool returns_lvalue = true;
         };
-        
+
         template<class O, class T>
         struct getter_traits<getter_by_const_ref<O, T>> {
             using object_type = O;
             using field_type = T;
-            
+
             static constexpr const bool returns_lvalue = true;
         };
-        
+
         template<class T>
         struct setter_traits;
-        
+
         template<class O, class T>
         struct setter_traits<setter_by_value<O, T>> {
             using object_type = O;
             using field_type = T;
         };
-        
+
         template<class O, class T>
         struct setter_traits<setter_by_ref<O, T>> {
             using object_type = O;
             using field_type = T;
         };
-        
+
         template<class O, class T>
         struct setter_traits<setter_by_const_ref<O, T>> {
             using object_type = O;
             using field_type = T;
         };
     }
-    
+
     /**
      *  Column builder function. You should use it to create columns instead of constructor
      */
-    template<class O, class T,
-    typename = typename std::enable_if<!std::is_member_function_pointer<T O::*>::value>::type,
-    class ...Op>
-    internal::column_t<O, T, const T& (O::*)() const, void (O::*)(T), Op...> make_column(const std::string &name, T O::*m, Op ...constraints){
-        static_assert(constraints::constraints_size<Op...>::value == std::tuple_size<std::tuple<Op...>>::value, "Incorrect constraints pack");
+    template<class O,
+             class T,
+             typename = typename std::enable_if<!std::is_member_function_pointer<T O::*>::value>::type,
+             class... Op>
+    internal::column_t<O, T, const T &(O::*)() const, void (O::*)(T), Op...>
+    make_column(const std::string &name, T O::*m, Op... constraints) {
+        static_assert(constraints::constraints_size<Op...>::value == std::tuple_size<std::tuple<Op...>>::value,
+                      "Incorrect constraints pack");
         return {name, m, nullptr, nullptr, std::make_tuple(constraints...)};
     }
-    
+
     /**
      *  Column builder function with setter and getter. You should use it to create columns instead of constructor
      */
-    template<class G, class S,
-    typename = typename std::enable_if<internal::is_getter<G>::value>::type,
-    typename = typename std::enable_if<internal::is_setter<S>::value>::type,
-    class ...Op>
-    internal::column_t<
-    typename internal::setter_traits<S>::object_type,
-    typename internal::setter_traits<S>::field_type,
-    G, S, Op...> make_column(const std::string &name,
-                             S setter,
-                             G getter,
-                             Op ...constraints)
-    {
-        static_assert(std::is_same<typename internal::setter_traits<S>::field_type, typename internal::getter_traits<G>::field_type>::value,
+    template<class G,
+             class S,
+             typename = typename std::enable_if<internal::is_getter<G>::value>::type,
+             typename = typename std::enable_if<internal::is_setter<S>::value>::type,
+             class... Op>
+    internal::column_t<typename internal::setter_traits<S>::object_type,
+                       typename internal::setter_traits<S>::field_type,
+                       G,
+                       S,
+                       Op...>
+    make_column(const std::string &name, S setter, G getter, Op... constraints) {
+        static_assert(std::is_same<typename internal::setter_traits<S>::field_type,
+                                   typename internal::getter_traits<G>::field_type>::value,
                       "Getter and setter must get and set same data type");
-        static_assert(constraints::constraints_size<Op...>::value == std::tuple_size<std::tuple<Op...>>::value, "Incorrect constraints pack");
+        static_assert(constraints::constraints_size<Op...>::value == std::tuple_size<std::tuple<Op...>>::value,
+                      "Incorrect constraints pack");
         return {name, nullptr, getter, setter, std::make_tuple(constraints...)};
     }
-    
+
     /**
-     *  Column builder function with getter and setter (reverse order). You should use it to create columns instead of constructor
+     *  Column builder function with getter and setter (reverse order). You should use it to create columns instead of
+     * constructor
      */
-    template<class G, class S,
-    typename = typename std::enable_if<internal::is_getter<G>::value>::type,
-    typename = typename std::enable_if<internal::is_setter<S>::value>::type,
-    class ...Op>
-    internal::column_t<
-    typename internal::setter_traits<S>::object_type,
-    typename internal::setter_traits<S>::field_type,
-    G, S, Op...> make_column(const std::string &name,
-                             G getter,
-                             S setter,
-                             Op ...constraints)
-    {
-        static_assert(std::is_same<typename internal::setter_traits<S>::field_type, typename internal::getter_traits<G>::field_type>::value,
+    template<class G,
+             class S,
+             typename = typename std::enable_if<internal::is_getter<G>::value>::type,
+             typename = typename std::enable_if<internal::is_setter<S>::value>::type,
+             class... Op>
+    internal::column_t<typename internal::setter_traits<S>::object_type,
+                       typename internal::setter_traits<S>::field_type,
+                       G,
+                       S,
+                       Op...>
+    make_column(const std::string &name, G getter, S setter, Op... constraints) {
+        static_assert(std::is_same<typename internal::setter_traits<S>::field_type,
+                                   typename internal::getter_traits<G>::field_type>::value,
                       "Getter and setter must get and set same data type");
-        static_assert(constraints::constraints_size<Op...>::value == std::tuple_size<std::tuple<Op...>>::value, "Incorrect constraints pack");
+        static_assert(constraints::constraints_size<Op...>::value == std::tuple_size<std::tuple<Op...>>::value,
+                      "Incorrect constraints pack");
         return {name, nullptr, getter, setter, std::make_tuple(constraints...)};
     }
-    
+
 }
 #pragma once
 
-#include <string>   //  std::string
+#include <string>  //  std::string
 #include <sstream>  //  std::stringstream
-#include <vector>   //  std::vector
+#include <vector>  //  std::vector
 #include <cstddef>  //  std::nullptr_t
-#include <memory>   //  std::shared_ptr, std::unique_ptr
+#include <memory>  //  std::shared_ptr, std::unique_ptr
 
 namespace sqlite_orm {
-    
+
     /**
      *  Is used to print members mapped to objects in storage_t::dump member function.
      *  Other developers can create own specialization to map custom types
@@ -1469,7 +1490,7 @@ namespace sqlite_orm {
             return stream.str();
         }
     };
-    
+
     /**
      *  Upgrade to integer is required when using unsigned char(uint8_t)
      */
@@ -1481,7 +1502,7 @@ namespace sqlite_orm {
             return stream.str();
         }
     };
-    
+
     /**
      *  Upgrade to integer is required when using signed char(int8_t)
      */
@@ -1493,7 +1514,7 @@ namespace sqlite_orm {
             return stream.str();
         }
     };
-    
+
     /**
      *  char is neigher signer char nor unsigned char so it has its own specialization
      */
@@ -1505,50 +1526,50 @@ namespace sqlite_orm {
             return stream.str();
         }
     };
-    
+
     template<>
     struct field_printer<std::string> {
         std::string operator()(const std::string &t) const {
             return t;
         }
     };
-    
+
     template<>
     struct field_printer<std::vector<char>> {
         std::string operator()(const std::vector<char> &t) const {
             std::stringstream ss;
             ss << std::hex;
-            for(auto c : t) {
+            for(auto c: t) {
                 ss << c;
             }
             return ss.str();
         }
     };
-    
+
     template<>
     struct field_printer<std::nullptr_t> {
         std::string operator()(const std::nullptr_t &) const {
             return "null";
         }
     };
-    
+
     template<class T>
     struct field_printer<std::shared_ptr<T>> {
         std::string operator()(const std::shared_ptr<T> &t) const {
-            if(t){
+            if(t) {
                 return field_printer<T>()(*t);
-            }else{
+            } else {
                 return field_printer<std::nullptr_t>()(nullptr);
             }
         }
     };
-    
+
     template<class T>
     struct field_printer<std::unique_ptr<T>> {
         std::string operator()(const std::unique_ptr<T> &t) const {
-            if(t){
+            if(t) {
                 return field_printer<T>()(*t);
-            }else{
+            } else {
                 return field_printer<std::nullptr_t>()(nullptr);
             }
         }
@@ -1556,9 +1577,9 @@ namespace sqlite_orm {
 }
 #pragma once
 
-#include <string>   //  std::string
+#include <string>  //  std::string
 #include <type_traits>  //  std::enable_if, std::is_same
-#include <vector>   //  std::vector
+#include <vector>  //  std::vector
 
 // #include "collate_argument.h"
 
@@ -1568,9 +1589,9 @@ namespace sqlite_orm {
 
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         /**
          *  This is a cute class which allows storing something or nothing
          *  depending on template argument. Useful for optional class members
@@ -1578,19 +1599,19 @@ namespace sqlite_orm {
         template<class T>
         struct optional_container {
             using type = T;
-            
+
             type field;
-            
+
             template<class L>
             void apply(const L &l) const {
                 l(this->field);
             }
         };
-        
+
         template<>
-        struct optional_container<void>{
+        struct optional_container<void> {
             using type = void;
-            
+
             template<class L>
             void apply(const L &) const {
                 //..
@@ -1601,9 +1622,9 @@ namespace sqlite_orm {
 
 
 namespace sqlite_orm {
-    
+
     namespace conditions {
-        
+
         /**
          *  Stores LIMIT/OFFSET info
          */
@@ -1612,37 +1633,35 @@ namespace sqlite_orm {
             bool has_offset = false;
             bool offset_is_implicit = false;
             int off = 0;
-            
+
             limit_t() = default;
-            
-            limit_t(decltype(lim) lim_): lim(lim_) {}
-            
+
+            limit_t(decltype(lim) lim_) : lim(lim_) {}
+
             limit_t(decltype(lim) lim_,
                     decltype(has_offset) has_offset_,
                     decltype(offset_is_implicit) offset_is_implicit_,
-                    decltype(off) off_):
-            lim(lim_),
-            has_offset(has_offset_),
-            offset_is_implicit(offset_is_implicit_),
-            off(off_){}
-            
-            operator std::string () const {
+                    decltype(off) off_) :
+                lim(lim_),
+                has_offset(has_offset_), offset_is_implicit(offset_is_implicit_), off(off_) {}
+
+            operator std::string() const {
                 return "LIMIT";
             }
         };
-        
+
         /**
          *  Stores OFFSET only info
          */
         struct offset_t {
             int off;
         };
-        
+
         /**
          *  Inherit from this class if target class can be chained with other conditions with '&&' and '||' operators
          */
         struct condition_t {};
-        
+
         /**
          *  Collated something
          */
@@ -1650,48 +1669,48 @@ namespace sqlite_orm {
         struct collate_t : public condition_t {
             T expr;
             internal::collate_argument argument;
-            
-            collate_t(T expr_, internal::collate_argument argument_): expr(expr_), argument(argument_) {}
-            
-            operator std::string () const {
+
+            collate_t(T expr_, internal::collate_argument argument_) : expr(expr_), argument(argument_) {}
+
+            operator std::string() const {
                 return constraints::collate_t{this->argument};
             }
         };
-        
+
         struct named_collate_base {
             std::string name;
-            
-            operator std::string () const {
+
+            operator std::string() const {
                 return "COLLATE " + this->name;
             }
         };
-        
+
         /**
          *  Collated something with custom collate function
          */
         template<class T>
         struct named_collate : named_collate_base {
             T expr;
-            
-            named_collate(T expr_, std::string name_): named_collate_base{std::move(name_)}, expr(std::move(expr_)) {}
+
+            named_collate(T expr_, std::string name_) : named_collate_base{std::move(name_)}, expr(std::move(expr_)) {}
         };
-        
+
         struct negated_condition_string {
-            operator std::string () const {
+            operator std::string() const {
                 return "NOT";
             }
         };
-        
+
         /**
          *  Result of not operator
          */
         template<class C>
         struct negated_condition_t : condition_t, negated_condition_string {
             C c;
-            
-            negated_condition_t(C c_): c(std::move(c_)) {}
+
+            negated_condition_t(C c_) : c(std::move(c_)) {}
         };
-        
+
         /**
          *  Base class for binary conditions
          */
@@ -1699,320 +1718,319 @@ namespace sqlite_orm {
         struct binary_condition : public condition_t {
             L l;
             R r;
-            
+
             binary_condition() = default;
-            
-            binary_condition(L l_, R r_): l(std::move(l_)), r(std::move(r_)) {}
+
+            binary_condition(L l_, R r_) : l(std::move(l_)), r(std::move(r_)) {}
         };
-        
+
         struct and_condition_string {
-            operator std::string () const {
+            operator std::string() const {
                 return "AND";
             }
         };
-        
+
         /**
          *  Result of and operator
          */
         template<class L, class R>
         struct and_condition_t : binary_condition<L, R>, and_condition_string {
             using super = binary_condition<L, R>;
-            
+
             using super::super;
         };
-        
+
         struct or_condition_string {
-            operator std::string () const {
+            operator std::string() const {
                 return "OR";
             }
         };
-        
+
         /**
          *  Result of or operator
          */
         template<class L, class R>
         struct or_condition_t : binary_condition<L, R>, or_condition_string {
             using super = binary_condition<L, R>;
-            
+
             using super::super;
         };
-        
+
         struct is_equal_string {
-            operator std::string () const {
+            operator std::string() const {
                 return "=";
             }
         };
-        
+
         /**
          *  = and == operators object
          */
         template<class L, class R>
         struct is_equal_t : binary_condition<L, R>, is_equal_string {
             using self = is_equal_t<L, R>;
-            
+
             using binary_condition<L, R>::binary_condition;
-            
+
             negated_condition_t<self> operator!() const {
                 return {*this};
             }
-            
+
             collate_t<self> collate_binary() const {
                 return {*this, internal::collate_argument::binary};
             }
-            
+
             collate_t<self> collate_nocase() const {
                 return {*this, internal::collate_argument::nocase};
             }
-            
+
             collate_t<self> collate_rtrim() const {
                 return {*this, internal::collate_argument::rtrim};
             }
-            
+
             named_collate<self> collate(std::string name) const {
                 return {*this, std::move(name)};
             }
-            
         };
-        
+
         struct is_not_equal_string {
-            operator std::string () const {
+            operator std::string() const {
                 return "!=";
             }
         };
-        
+
         /**
          *  != operator object
          */
         template<class L, class R>
         struct is_not_equal_t : binary_condition<L, R>, is_not_equal_string {
             using self = is_not_equal_t<L, R>;
-            
+
             using binary_condition<L, R>::binary_condition;
-            
+
             negated_condition_t<self> operator!() const {
                 return {*this};
             }
-            
+
             collate_t<self> collate_binary() const {
                 return {*this, internal::collate_argument::binary};
             }
-            
+
             collate_t<self> collate_nocase() const {
                 return {*this, internal::collate_argument::nocase};
             }
-            
+
             collate_t<self> collate_rtrim() const {
                 return {*this, internal::collate_argument::rtrim};
             }
         };
-        
+
         struct greater_than_string {
-            operator std::string () const {
+            operator std::string() const {
                 return ">";
             }
         };
-        
+
         /**
          *  > operator object.
          */
         template<class L, class R>
         struct greater_than_t : binary_condition<L, R>, greater_than_string {
             using self = greater_than_t<L, R>;
-            
+
             using binary_condition<L, R>::binary_condition;
-            
+
             negated_condition_t<self> operator!() const {
                 return {*this};
             }
-            
+
             collate_t<self> collate_binary() const {
                 return {*this, internal::collate_argument::binary};
             }
-            
+
             collate_t<self> collate_nocase() const {
                 return {*this, internal::collate_argument::nocase};
             }
-            
+
             collate_t<self> collate_rtrim() const {
                 return {*this, internal::collate_argument::rtrim};
             }
         };
-        
+
         struct greater_or_equal_string {
-            operator std::string () const {
+            operator std::string() const {
                 return ">=";
             }
         };
-        
+
         /**
          *  >= operator object.
          */
         template<class L, class R>
         struct greater_or_equal_t : binary_condition<L, R>, greater_or_equal_string {
             using self = greater_or_equal_t<L, R>;
-            
+
             using binary_condition<L, R>::binary_condition;
-            
+
             negated_condition_t<self> operator!() const {
                 return {*this};
             }
-            
+
             collate_t<self> collate_binary() const {
                 return {*this, internal::collate_argument::binary};
             }
-            
+
             collate_t<self> collate_nocase() const {
                 return {*this, internal::collate_argument::nocase};
             }
-            
+
             collate_t<self> collate_rtrim() const {
                 return {*this, internal::collate_argument::rtrim};
             }
         };
-        
+
         struct lesser_than_string {
-            operator std::string () const {
+            operator std::string() const {
                 return "<";
             }
         };
-        
+
         /**
          *  < operator object.
          */
         template<class L, class R>
         struct lesser_than_t : binary_condition<L, R>, lesser_than_string {
             using self = lesser_than_t<L, R>;
-            
+
             using binary_condition<L, R>::binary_condition;
-            
+
             negated_condition_t<self> operator!() const {
                 return {*this};
             }
-            
+
             collate_t<self> collate_binary() const {
                 return {*this, internal::collate_argument::binary};
             }
-            
+
             collate_t<self> collate_nocase() const {
                 return {*this, internal::collate_argument::nocase};
             }
-            
+
             collate_t<self> collate_rtrim() const {
                 return {*this, internal::collate_argument::rtrim};
             }
         };
-        
+
         struct lesser_or_equal_string {
-            operator std::string () const {
+            operator std::string() const {
                 return "<=";
             }
         };
-        
+
         /**
          *  <= operator object.
          */
         template<class L, class R>
         struct lesser_or_equal_t : binary_condition<L, R>, lesser_or_equal_string {
             using self = lesser_or_equal_t<L, R>;
-            
+
             using binary_condition<L, R>::binary_condition;
-            
+
             negated_condition_t<lesser_or_equal_t<L, R>> operator!() const {
                 return {*this};
             }
-            
+
             collate_t<self> collate_binary() const {
                 return {*this, internal::collate_argument::binary};
             }
-            
+
             collate_t<self> collate_nocase() const {
                 return {*this, internal::collate_argument::nocase};
             }
-            
+
             collate_t<self> collate_rtrim() const {
                 return {*this, internal::collate_argument::rtrim};
             }
         };
-        
+
         struct in_base {
             bool negative = false;  //  used in not_in
-            
-            operator std::string () const {
-                if(!this->negative){
+
+            operator std::string() const {
+                if(!this->negative) {
                     return "IN";
-                }else{
+                } else {
                     return "NOT IN";
                 }
             }
         };
-        
+
         /**
          *  IN operator object.
          */
         template<class L, class A>
         struct in_t : condition_t, in_base {
             using self = in_t<L, A>;
-            
-            L l;    //  left expression
-            A arg;       //  in arg
-            
-            in_t(L l_, A arg_, bool negative): in_base{negative}, l(l_), arg(std::move(arg_)) {}
-            
+
+            L l;  //  left expression
+            A arg;  //  in arg
+
+            in_t(L l_, A arg_, bool negative) : in_base{negative}, l(l_), arg(std::move(arg_)) {}
+
             negated_condition_t<self> operator!() const {
                 return {*this};
             }
         };
-        
+
         struct is_null_string {
-            operator std::string () const {
+            operator std::string() const {
                 return "IS NULL";
             }
         };
-        
+
         /**
          *  IS NULL operator object.
          */
         template<class T>
         struct is_null_t : is_null_string {
             using self = is_null_t<T>;
-            
+
             T t;
-            
+
             is_null_t(T t_) : t(std::move(t_)) {}
-            
+
             negated_condition_t<self> operator!() const {
                 return {*this};
             }
         };
-        
+
         struct is_not_null_string {
-            operator std::string () const {
+            operator std::string() const {
                 return "IS NOT NULL";
             }
         };
-        
+
         /**
          *  IS NOT NULL operator object.
          */
         template<class T>
         struct is_not_null_t : is_not_null_string {
             using self = is_not_null_t<T>;
-            
+
             T t;
-            
+
             is_not_null_t(T t_) : t(std::move(t_)) {}
-            
+
             negated_condition_t<self> operator!() const {
                 return {*this};
             }
         };
-        
+
         struct where_string {
-            operator std::string () const {
+            operator std::string() const {
                 return "WHERE";
             }
         };
-        
+
         /**
          *  WHERE argument holder.
          *  C is conditions type. Can be any condition like: is_equal_t, is_null_t, exists_t etc
@@ -2020,147 +2038,148 @@ namespace sqlite_orm {
         template<class C>
         struct where_t : where_string {
             C c;
-            
+
             where_t(C c_) : c(std::move(c_)) {}
         };
-        
+
         struct order_by_base {
-            int asc_desc = 0;   //  1: asc, -1: desc
+            int asc_desc = 0;  //  1: asc, -1: desc
             std::string _collate_argument;
         };
-        
+
         struct order_by_string {
             operator std::string() const {
                 return "ORDER BY";
             }
         };
-        
+
         /**
          *  ORDER BY argument holder.
          */
         template<class O>
         struct order_by_t : order_by_base, order_by_string {
             using self = order_by_t<O>;
-            
+
             O o;
-            
-            order_by_t(O o_): o(std::move(o_)) {}
-            
+
+            order_by_t(O o_) : o(std::move(o_)) {}
+
             self asc() {
                 auto res = *this;
                 res.asc_desc = 1;
                 return res;
             }
-            
+
             self desc() {
                 auto res = *this;
                 res.asc_desc = -1;
                 return res;
             }
-            
+
             self collate_binary() const {
                 auto res = *this;
-                res._collate_argument = constraints::collate_t::string_from_collate_argument(internal::collate_argument::binary);
+                res._collate_argument =
+                    constraints::collate_t::string_from_collate_argument(internal::collate_argument::binary);
                 return res;
             }
-            
+
             self collate_nocase() const {
                 auto res = *this;
-                res._collate_argument = constraints::collate_t::string_from_collate_argument(internal::collate_argument::nocase);
+                res._collate_argument =
+                    constraints::collate_t::string_from_collate_argument(internal::collate_argument::nocase);
                 return res;
             }
-            
+
             self collate_rtrim() const {
                 auto res = *this;
-                res._collate_argument = constraints::collate_t::string_from_collate_argument(internal::collate_argument::rtrim);
+                res._collate_argument =
+                    constraints::collate_t::string_from_collate_argument(internal::collate_argument::rtrim);
                 return res;
             }
-            
+
             self collate(std::string name) const {
                 auto res = *this;
                 res._collate_argument = std::move(name);
                 return res;
             }
         };
-        
+
         /**
          *  ORDER BY pack holder.
          */
-        template<class ...Args>
+        template<class... Args>
         struct multi_order_by_t : order_by_string {
             using args_type = std::tuple<Args...>;
-            
+
             args_type args;
-            
+
             multi_order_by_t(args_type &&args_) : args(std::move(args_)) {}
         };
-        
+
         /**
          *  S - storage class
          */
         template<class S>
         struct dynamic_order_by_t : order_by_string {
             using storage_type = S;
-            
+
             struct entry_t : order_by_base {
                 std::string name;
-                
+
                 entry_t(decltype(name) name_, int asc_desc, std::string collate_argument) :
-                order_by_base{asc_desc, move(collate_argument)},
-                name(move(name_))
-                {}
+                    order_by_base{asc_desc, move(collate_argument)}, name(move(name_)) {}
             };
-            
+
             using const_iterator = typename std::vector<entry_t>::const_iterator;
-            
-            dynamic_order_by_t(const storage_type &storage_): storage(storage_) {}
-            
+
+            dynamic_order_by_t(const storage_type &storage_) : storage(storage_) {}
+
             template<class O>
             void push_back(order_by_t<O> order_by) {
                 auto columnName = this->storage.string_from_expression(order_by.o, true);
                 entries.emplace_back(move(columnName), order_by.asc_desc, move(order_by._collate_argument));
             }
-            
+
             const_iterator begin() const {
                 return this->entries.begin();
             }
-            
+
             const_iterator end() const {
                 return this->entries.end();
             }
-            
+
             void clear() {
                 this->entries.clear();
             }
-            
-        protected:
+
+          protected:
             std::vector<entry_t> entries;
             const storage_type &storage;
         };
-        
+
         struct group_by_string {
             operator std::string() const {
                 return "GROUP BY";
             }
         };
-        
+
         /**
          *  GROUP BY pack holder.
          */
-        template<class ...Args>
+        template<class... Args>
         struct group_by_t : group_by_string {
             using args_type = std::tuple<Args...>;
             args_type args;
-            
-            group_by_t(args_type &&args_): args(std::move(args_)) {}
+
+            group_by_t(args_type &&args_) : args(std::move(args_)) {}
         };
-        
+
         struct between_string {
             operator std::string() const {
                 return "BETWEEN";
             }
         };
-        
+
         /**
          *  BETWEEN operator object.
          */
@@ -2169,16 +2188,16 @@ namespace sqlite_orm {
             A expr;
             T b1;
             T b2;
-            
-            between_t(A expr_, T b1_, T b2_): expr(std::move(expr_)), b1(std::move(b1_)), b2(std::move(b2_)) {}
+
+            between_t(A expr_, T b1_, T b2_) : expr(std::move(expr_)), b1(std::move(b1_)), b2(std::move(b2_)) {}
         };
-        
+
         struct like_string {
             operator std::string() const {
                 return "LIKE";
             }
         };
-        
+
         /**
          *  LIKE operator object.
          */
@@ -2188,54 +2207,53 @@ namespace sqlite_orm {
             using arg_t = A;
             using pattern_t = T;
             using escape_t = E;
-            
+
             arg_t arg;
             pattern_t pattern;
             internal::optional_container<escape_t> arg3;  //  not escape cause escape exists as a function here
-            
-            like_t(arg_t arg_, pattern_t pattern_, internal::optional_container<escape_t> escape):
-            arg(std::move(arg_)), pattern(std::move(pattern_)), arg3(std::move(escape)) {}
-            
+
+            like_t(arg_t arg_, pattern_t pattern_, internal::optional_container<escape_t> escape) :
+                arg(std::move(arg_)), pattern(std::move(pattern_)), arg3(std::move(escape)) {}
+
             template<class C>
             like_t<A, T, C> escape(C c) const {
                 internal::optional_container<C> arg3{std::move(c)};
                 return {std::move(this->arg), std::move(this->pattern), std::move(arg3)};
             }
-            
+
             negated_condition_t<self> operator!() const {
                 return {*this};
             }
         };
-        
+
         struct glob_string {
             operator std::string() const {
                 return "GLOB";
             }
         };
-        
+
         template<class A, class T>
         struct glob_t : condition_t, glob_string {
             using self = glob_t<A, T>;
             using arg_t = A;
             using pattern_t = T;
-            
+
             arg_t arg;
             pattern_t pattern;
-            
-            glob_t(arg_t arg_, pattern_t pattern_):
-            arg(std::move(arg_)), pattern(std::move(pattern_)) {}
-            
+
+            glob_t(arg_t arg_, pattern_t pattern_) : arg(std::move(arg_)), pattern(std::move(pattern_)) {}
+
             negated_condition_t<self> operator!() const {
                 return {*this};
             }
         };
-        
+
         struct cross_join_string {
             operator std::string() const {
                 return "CROSS JOIN";
             }
         };
-        
+
         /**
          *  CROSS JOIN holder.
          *  T is joined type which represents any mapped table.
@@ -2244,13 +2262,13 @@ namespace sqlite_orm {
         struct cross_join_t : cross_join_string {
             using type = T;
         };
-        
+
         struct natural_join_string {
             operator std::string() const {
                 return "NATURAL JOIN";
             }
         };
-        
+
         /**
          *  NATURAL JOIN holder.
          *  T is joined type which represents any mapped table.
@@ -2259,13 +2277,13 @@ namespace sqlite_orm {
         struct natural_join_t : natural_join_string {
             using type = T;
         };
-        
+
         struct left_join_string {
             operator std::string() const {
                 return "LEFT JOIN";
             }
         };
-        
+
         /**
          *  LEFT JOIN holder.
          *  T is joined type which represents any mapped table.
@@ -2275,18 +2293,18 @@ namespace sqlite_orm {
         struct left_join_t : left_join_string {
             using type = T;
             using on_type = O;
-            
+
             on_type constraint;
-            
+
             left_join_t(on_type constraint_) : constraint(std::move(constraint_)) {}
         };
-        
+
         struct join_string {
             operator std::string() const {
                 return "JOIN";
             }
         };
-        
+
         /**
          *  Simple JOIN holder.
          *  T is joined type which represents any mapped table.
@@ -2296,18 +2314,18 @@ namespace sqlite_orm {
         struct join_t : join_string {
             using type = T;
             using on_type = O;
-            
+
             on_type constraint;
-            
+
             join_t(on_type constraint_) : constraint(std::move(constraint_)) {}
         };
-        
+
         struct left_outer_join_string {
             operator std::string() const {
                 return "LEFT OUTER JOIN";
             }
         };
-        
+
         /**
          *  LEFT OUTER JOIN holder.
          *  T is joined type which represents any mapped table.
@@ -2317,18 +2335,18 @@ namespace sqlite_orm {
         struct left_outer_join_t : left_outer_join_string {
             using type = T;
             using on_type = O;
-            
+
             on_type constraint;
-            
+
             left_outer_join_t(on_type constraint_) : constraint(std::move(constraint_)) {}
         };
-        
+
         struct on_string {
             operator std::string() const {
                 return "ON";
             }
         };
-        
+
         /**
          *  on(...) argument holder used for JOIN, LEFT JOIN, LEFT OUTER JOIN and INNER JOIN
          *  T is on type argument.
@@ -2336,30 +2354,30 @@ namespace sqlite_orm {
         template<class T>
         struct on_t : on_string {
             using arg_type = T;
-            
+
             arg_type arg;
-            
+
             on_t(arg_type arg_) : arg(std::move(arg_)) {}
         };
-        
+
         /**
          *  USING argument holder.
          */
         template<class F, class O>
         struct using_t {
             F O::*column = nullptr;
-            
+
             operator std::string() const {
                 return "USING";
             }
         };
-        
+
         struct inner_join_string {
             operator std::string() const {
                 return "INNER JOIN";
             }
         };
-        
+
         /**
          *  INNER JOIN holder.
          *  T is joined type which represents any mapped table.
@@ -2369,38 +2387,38 @@ namespace sqlite_orm {
         struct inner_join_t : inner_join_string {
             using type = T;
             using on_type = O;
-            
+
             on_type constraint;
-            
+
             inner_join_t(on_type constraint_) : constraint(std::move(constraint_)) {}
         };
-        
+
         struct exists_string {
             operator std::string() const {
                 return "EXISTS";
             }
         };
-        
+
         template<class T>
         struct exists_t : condition_t, exists_string {
             using type = T;
             using self = exists_t<type>;
-            
+
             type t;
-            
+
             exists_t(T t_) : t(std::move(t_)) {}
-            
+
             negated_condition_t<self> operator!() const {
                 return {*this};
             }
         };
-        
+
         struct having_string {
             operator std::string() const {
                 return "HAVING";
             }
         };
-        
+
         /**
          *  HAVING holder.
          *  T is having argument type.
@@ -2408,30 +2426,30 @@ namespace sqlite_orm {
         template<class T>
         struct having_t : having_string {
             using type = T;
-            
+
             type t;
-            
+
             having_t(type t_) : t(std::move(t_)) {}
         };
-    
+
         struct cast_string {
             operator std::string() const {
                 return "CAST";
             }
         };
-        
+
         template<class T, class E>
         struct cast_t : cast_string {
             using to_type = T;
             using expression_type = E;
-            
+
             expression_type expression;
-            
+
             cast_t(expression_type expression_) : expression(std::move(expression_)) {}
         };
-        
+
     }
-    
+
     /**
      *  Cute operators for columns
      */
@@ -2439,381 +2457,379 @@ namespace sqlite_orm {
     conditions::lesser_than_t<T, R> operator<(internal::expression_t<T> expr, R r) {
         return {expr.t, r};
     }
-    
+
     template<class L, class T>
     conditions::lesser_than_t<L, T> operator<(L l, internal::expression_t<T> expr) {
         return {l, expr.t};
     }
-    
+
     template<class T, class R>
     conditions::lesser_or_equal_t<T, R> operator<=(internal::expression_t<T> expr, R r) {
         return {expr.t, r};
     }
-    
+
     template<class L, class T>
     conditions::lesser_or_equal_t<L, T> operator<=(L l, internal::expression_t<T> expr) {
         return {l, expr.t};
     }
-    
+
     template<class T, class R>
     conditions::greater_than_t<T, R> operator>(internal::expression_t<T> expr, R r) {
         return {expr.t, r};
     }
-    
+
     template<class L, class T>
     conditions::greater_than_t<L, T> operator>(L l, internal::expression_t<T> expr) {
         return {l, expr.t};
     }
-    
+
     template<class T, class R>
     conditions::greater_or_equal_t<T, R> operator>=(internal::expression_t<T> expr, R r) {
         return {expr.t, r};
     }
-    
+
     template<class L, class T>
     conditions::greater_or_equal_t<L, T> operator>=(L l, internal::expression_t<T> expr) {
         return {l, expr.t};
     }
-    
+
     template<class T, class R>
     conditions::is_equal_t<T, R> operator==(internal::expression_t<T> expr, R r) {
         return {expr.t, r};
     }
-    
+
     template<class L, class T>
     conditions::is_equal_t<L, T> operator==(L l, internal::expression_t<T> expr) {
         return {l, expr.t};
     }
-    
+
     template<class T, class R>
     conditions::is_not_equal_t<T, R> operator!=(internal::expression_t<T> expr, R r) {
         return {expr.t, r};
     }
-    
+
     template<class L, class T>
     conditions::is_not_equal_t<L, T> operator!=(L l, internal::expression_t<T> expr) {
         return {l, expr.t};
     }
-    
+
     template<class T, class R>
     internal::conc_t<T, R> operator||(internal::expression_t<T> expr, R r) {
         return {expr.t, r};
     }
-    
+
     template<class L, class T>
     internal::conc_t<L, T> operator||(L l, internal::expression_t<T> expr) {
         return {l, expr.t};
     }
-    
+
     template<class L, class R>
     internal::conc_t<L, R> operator||(internal::expression_t<L> l, internal::expression_t<R> r) {
         return {l.t, r.t};
     }
-    
+
     template<class T, class R>
     internal::add_t<T, R> operator+(internal::expression_t<T> expr, R r) {
         return {expr.t, r};
     }
-    
+
     template<class L, class T>
     internal::add_t<L, T> operator+(L l, internal::expression_t<T> expr) {
         return {l, expr.t};
     }
-    
+
     template<class L, class R>
     internal::add_t<L, R> operator+(internal::expression_t<L> l, internal::expression_t<R> r) {
         return {l.t, r.t};
     }
-    
+
     template<class T, class R>
     internal::sub_t<T, R> operator-(internal::expression_t<T> expr, R r) {
         return {expr.t, r};
     }
-    
+
     template<class L, class T>
     internal::sub_t<L, T> operator-(L l, internal::expression_t<T> expr) {
         return {l, expr.t};
     }
-    
+
     template<class L, class R>
     internal::sub_t<L, R> operator-(internal::expression_t<L> l, internal::expression_t<R> r) {
         return {l.t, r.t};
     }
-    
+
     template<class T, class R>
     internal::mul_t<T, R> operator*(internal::expression_t<T> expr, R r) {
         return {expr.t, r};
     }
-    
+
     template<class L, class T>
     internal::mul_t<L, T> operator*(L l, internal::expression_t<T> expr) {
         return {l, expr.t};
     }
-    
+
     template<class L, class R>
     internal::mul_t<L, R> operator*(internal::expression_t<L> l, internal::expression_t<R> r) {
         return {l.t, r.t};
     }
-    
+
     template<class T, class R>
     internal::div_t<T, R> operator/(internal::expression_t<T> expr, R r) {
         return {expr.t, r};
     }
-    
+
     template<class L, class T>
     internal::div_t<L, T> operator/(L l, internal::expression_t<T> expr) {
         return {l, expr.t};
     }
-    
+
     template<class L, class R>
     internal::div_t<L, R> operator/(internal::expression_t<L> l, internal::expression_t<R> r) {
         return {l.t, r.t};
     }
-    
+
     template<class T, class R>
     internal::mod_t<T, R> operator%(internal::expression_t<T> expr, R r) {
         return {expr.t, r};
     }
-    
+
     template<class L, class T>
     internal::mod_t<L, T> operator%(L l, internal::expression_t<T> expr) {
         return {l, expr.t};
     }
-    
+
     template<class L, class R>
     internal::mod_t<L, R> operator%(internal::expression_t<L> l, internal::expression_t<R> r) {
         return {l.t, r.t};
     }
-    
+
     template<class F, class O>
     conditions::using_t<F, O> using_(F O::*p) {
         return {p};
     }
-    
+
     template<class T>
     conditions::on_t<T> on(T t) {
         return {t};
     }
-    
+
     template<class T>
     conditions::cross_join_t<T> cross_join() {
         return {};
     }
-    
+
     template<class T>
     conditions::natural_join_t<T> natural_join() {
         return {};
     }
-    
+
     template<class T, class O>
     conditions::left_join_t<T, O> left_join(O o) {
         return {o};
     }
-    
+
     template<class T, class O>
     conditions::join_t<T, O> join(O o) {
         return {o};
     }
-    
+
     template<class T, class O>
     conditions::left_outer_join_t<T, O> left_outer_join(O o) {
         return {o};
     }
-    
+
     template<class T, class O>
     conditions::inner_join_t<T, O> inner_join(O o) {
         return {o};
     }
-    
+
     inline conditions::offset_t offset(int off) {
         return {off};
     }
-    
+
     inline conditions::limit_t limit(int lim) {
         return {lim};
     }
-    
+
     inline conditions::limit_t limit(int off, int lim) {
         return {lim, true, true, off};
     }
-    
+
     inline conditions::limit_t limit(int lim, conditions::offset_t offt) {
-        return {lim, true, false, offt.off };
+        return {lim, true, false, offt.off};
     }
-    
-    template<
-    class L,
-    class R,
-    typename = typename std::enable_if<std::is_base_of<conditions::condition_t, L>::value || std::is_base_of<conditions::condition_t, R>::value>::type
-    >
-    conditions::and_condition_t<L, R> operator &&(const L &l, const R &r) {
+
+    template<class L,
+             class R,
+             typename = typename std::enable_if<std::is_base_of<conditions::condition_t, L>::value ||
+                                                std::is_base_of<conditions::condition_t, R>::value>::type>
+    conditions::and_condition_t<L, R> operator&&(const L &l, const R &r) {
         return {l, r};
     }
-    
-    template<
-    class L,
-    class R,
-    typename = typename std::enable_if<std::is_base_of<conditions::condition_t, L>::value || std::is_base_of<conditions::condition_t, R>::value>::type
-    >
-    conditions::or_condition_t<L, R> operator ||(const L &l, const R &r) {
+
+    template<class L,
+             class R,
+             typename = typename std::enable_if<std::is_base_of<conditions::condition_t, L>::value ||
+                                                std::is_base_of<conditions::condition_t, R>::value>::type>
+    conditions::or_condition_t<L, R> operator||(const L &l, const R &r) {
         return {l, r};
     }
-    
+
     template<class T>
     conditions::is_not_null_t<T> is_not_null(T t) {
         return {t};
     }
-    
+
     template<class T>
     conditions::is_null_t<T> is_null(T t) {
         return {t};
     }
-    
+
     template<class L, class E>
     conditions::in_t<L, std::vector<E>> in(L l, std::vector<E> values) {
         return {std::move(l), std::move(values), false};
     }
-    
+
     template<class L, class E>
     conditions::in_t<L, std::vector<E>> in(L l, std::initializer_list<E> values) {
         return {std::move(l), std::move(values), false};
     }
-    
+
     template<class L, class A>
     conditions::in_t<L, A> in(L l, A arg) {
         return {std::move(l), std::move(arg), false};
     }
-    
+
     template<class L, class E>
     conditions::in_t<L, std::vector<E>> not_in(L l, std::vector<E> values) {
         return {std::move(l), std::move(values), true};
     }
-    
+
     template<class L, class E>
     conditions::in_t<L, std::vector<E>> not_in(L l, std::initializer_list<E> values) {
         return {std::move(l), std::move(values), true};
     }
-    
+
     template<class L, class A>
     conditions::in_t<L, A> not_in(L l, A arg) {
         return {std::move(l), std::move(arg), true};
     }
-    
+
     template<class L, class R>
     conditions::is_equal_t<L, R> is_equal(L l, R r) {
         return {l, r};
     }
-    
+
     template<class L, class R>
     conditions::is_equal_t<L, R> eq(L l, R r) {
         return {l, r};
     }
-    
+
     template<class L, class R>
     conditions::is_not_equal_t<L, R> is_not_equal(L l, R r) {
         return {l, r};
     }
-    
+
     template<class L, class R>
     conditions::is_not_equal_t<L, R> ne(L l, R r) {
         return {l, r};
     }
-    
+
     template<class L, class R>
     conditions::greater_than_t<L, R> greater_than(L l, R r) {
         return {l, r};
     }
-    
+
     template<class L, class R>
     conditions::greater_than_t<L, R> gt(L l, R r) {
         return {l, r};
     }
-    
+
     template<class L, class R>
     conditions::greater_or_equal_t<L, R> greater_or_equal(L l, R r) {
         return {l, r};
     }
-    
+
     template<class L, class R>
     conditions::greater_or_equal_t<L, R> ge(L l, R r) {
         return {l, r};
     }
-    
+
     template<class L, class R>
     conditions::lesser_than_t<L, R> lesser_than(L l, R r) {
         return {l, r};
     }
-    
+
     template<class L, class R>
     conditions::lesser_than_t<L, R> lt(L l, R r) {
         return {l, r};
     }
-    
+
     template<class L, class R>
     conditions::lesser_or_equal_t<L, R> lesser_or_equal(L l, R r) {
         return {l, r};
     }
-    
+
     template<class L, class R>
     conditions::lesser_or_equal_t<L, R> le(L l, R r) {
         return {l, r};
     }
-    
+
     template<class C>
     conditions::where_t<C> where(C c) {
         return {c};
     }
-    
+
     template<class O>
     conditions::order_by_t<O> order_by(O o) {
         return {o};
     }
-    
-    template<class ...Args>
-    conditions::multi_order_by_t<Args...> multi_order_by(Args&& ...args) {
+
+    template<class... Args>
+    conditions::multi_order_by_t<Args...> multi_order_by(Args &&... args) {
         return {std::make_tuple(std::forward<Args>(args)...)};
     }
-    
+
     template<class S>
     conditions::dynamic_order_by_t<S> dynamic_order_by(const S &storage) {
         return {storage};
     }
-    
-    template<class ...Args>
-    conditions::group_by_t<Args...> group_by(Args&& ...args) {
+
+    template<class... Args>
+    conditions::group_by_t<Args...> group_by(Args &&... args) {
         return {std::make_tuple(std::forward<Args>(args)...)};
     }
-    
+
     template<class A, class T>
     conditions::between_t<A, T> between(A expr, T b1, T b2) {
         return {expr, b1, b2};
     }
-    
+
     template<class A, class T>
     conditions::like_t<A, T, void> like(A a, T t) {
         return {std::move(a), std::move(t), {}};
     }
-    
+
     template<class A, class T>
     conditions::glob_t<A, T> glob(A a, T t) {
         return {std::move(a), std::move(t)};
     }
-    
+
     template<class A, class T, class E>
     conditions::like_t<A, T, E> like(A a, T t, E e) {
         return {std::move(a), std::move(t), {std::move(e)}};
     }
-    
+
     template<class T>
     conditions::exists_t<T> exists(T t) {
         return {std::move(t)};
     }
-    
+
     template<class T>
     conditions::having_t<T> having(T t) {
         return {t};
     }
-    
+
     template<class T, class E>
     conditions::cast_t<T, E> cast(E e) {
         return {e};
@@ -2823,18 +2839,18 @@ namespace sqlite_orm {
 
 #include <type_traits>  //  std::enable_if, std::is_base_of, std::is_member_pointer
 #include <sstream>  //  std::stringstream
-#include <string>   //  std::string
+#include <string>  //  std::string
 
 namespace sqlite_orm {
-    
+
     /**
      *  This is base class for every class which is used as a custom table alias.
      *  For more information please look through self_join.cpp example
      */
     struct alias_tag {};
-    
+
     namespace internal {
-        
+
         /**
          *  This is a common built-in class used for custom single character table aliases.
          *  Also you can use language aliases `alias_a`, `alias_b` etc. instead
@@ -2842,12 +2858,12 @@ namespace sqlite_orm {
         template<class T, char A>
         struct table_alias : alias_tag {
             using type = T;
-            
+
             static char get() {
                 return A;
             }
         };
-        
+
         /**
          *  Column expression with table alias attached like 'C.ID'. This is not a column alias
          */
@@ -2855,17 +2871,17 @@ namespace sqlite_orm {
         struct alias_column_t {
             using alias_type = T;
             using column_type = C;
-            
+
             column_type column;
-            
-            alias_column_t() {};
-            
-            alias_column_t(column_type column_): column(column_) {}
+
+            alias_column_t(){};
+
+            alias_column_t(column_type column_) : column(column_) {}
         };
-        
+
         template<class T, class SFINAE = void>
         struct alias_extractor;
-        
+
         template<class T>
         struct alias_extractor<T, typename std::enable_if<std::is_base_of<alias_tag, T>::value>::type> {
             static std::string get() {
@@ -2874,74 +2890,101 @@ namespace sqlite_orm {
                 return ss.str();
             }
         };
-        
+
         template<class T>
         struct alias_extractor<T, typename std::enable_if<!std::is_base_of<alias_tag, T>::value>::type> {
             static std::string get() {
                 return {};
             }
         };
-        
+
         template<class T, class E>
         struct as_t {
             using alias_type = T;
             using expression_type = E;
-            
+
             expression_type expression;
         };
-        
+
         template<class T>
         struct alias_holder {
             using type = T;
         };
     }
-    
+
     /**
      *  @return column with table alias attached. Place it instead of a column statement in case you need to specify a
      *  column with table alias prefix like 'a.column'. For more information please look through self_join.cpp example
      */
     template<class T, class C>
     internal::alias_column_t<T, C> alias_column(C c) {
-        static_assert(std::is_member_pointer<C>::value, "alias_column argument must be a member pointer mapped to a storage");
+        static_assert(std::is_member_pointer<C>::value,
+                      "alias_column argument must be a member pointer mapped to a storage");
         return {c};
     }
-    
+
     template<class T, class E>
     internal::as_t<T, E> as(E expression) {
         return {std::move(expression)};
     }
-    
+
     template<class T>
     internal::alias_holder<T> get() {
         return {};
     }
-    
-    template<class T> using alias_a = internal::table_alias<T, 'a'>;
-    template<class T> using alias_b = internal::table_alias<T, 'b'>;
-    template<class T> using alias_c = internal::table_alias<T, 'c'>;
-    template<class T> using alias_d = internal::table_alias<T, 'd'>;
-    template<class T> using alias_e = internal::table_alias<T, 'e'>;
-    template<class T> using alias_f = internal::table_alias<T, 'f'>;
-    template<class T> using alias_g = internal::table_alias<T, 'g'>;
-    template<class T> using alias_h = internal::table_alias<T, 'h'>;
-    template<class T> using alias_i = internal::table_alias<T, 'i'>;
-    template<class T> using alias_j = internal::table_alias<T, 'j'>;
-    template<class T> using alias_k = internal::table_alias<T, 'k'>;
-    template<class T> using alias_l = internal::table_alias<T, 'l'>;
-    template<class T> using alias_m = internal::table_alias<T, 'm'>;
-    template<class T> using alias_n = internal::table_alias<T, 'n'>;
-    template<class T> using alias_o = internal::table_alias<T, 'o'>;
-    template<class T> using alias_p = internal::table_alias<T, 'p'>;
-    template<class T> using alias_q = internal::table_alias<T, 'q'>;
-    template<class T> using alias_r = internal::table_alias<T, 'r'>;
-    template<class T> using alias_s = internal::table_alias<T, 's'>;
-    template<class T> using alias_t = internal::table_alias<T, 't'>;
-    template<class T> using alias_u = internal::table_alias<T, 'u'>;
-    template<class T> using alias_v = internal::table_alias<T, 'v'>;
-    template<class T> using alias_w = internal::table_alias<T, 'w'>;
-    template<class T> using alias_x = internal::table_alias<T, 'x'>;
-    template<class T> using alias_y = internal::table_alias<T, 'y'>;
-    template<class T> using alias_z = internal::table_alias<T, 'z'>;
+
+    template<class T>
+    using alias_a = internal::table_alias<T, 'a'>;
+    template<class T>
+    using alias_b = internal::table_alias<T, 'b'>;
+    template<class T>
+    using alias_c = internal::table_alias<T, 'c'>;
+    template<class T>
+    using alias_d = internal::table_alias<T, 'd'>;
+    template<class T>
+    using alias_e = internal::table_alias<T, 'e'>;
+    template<class T>
+    using alias_f = internal::table_alias<T, 'f'>;
+    template<class T>
+    using alias_g = internal::table_alias<T, 'g'>;
+    template<class T>
+    using alias_h = internal::table_alias<T, 'h'>;
+    template<class T>
+    using alias_i = internal::table_alias<T, 'i'>;
+    template<class T>
+    using alias_j = internal::table_alias<T, 'j'>;
+    template<class T>
+    using alias_k = internal::table_alias<T, 'k'>;
+    template<class T>
+    using alias_l = internal::table_alias<T, 'l'>;
+    template<class T>
+    using alias_m = internal::table_alias<T, 'm'>;
+    template<class T>
+    using alias_n = internal::table_alias<T, 'n'>;
+    template<class T>
+    using alias_o = internal::table_alias<T, 'o'>;
+    template<class T>
+    using alias_p = internal::table_alias<T, 'p'>;
+    template<class T>
+    using alias_q = internal::table_alias<T, 'q'>;
+    template<class T>
+    using alias_r = internal::table_alias<T, 'r'>;
+    template<class T>
+    using alias_s = internal::table_alias<T, 's'>;
+    template<class T>
+    using alias_t = internal::table_alias<T, 't'>;
+    template<class T>
+    using alias_u = internal::table_alias<T, 'u'>;
+    template<class T>
+    using alias_v = internal::table_alias<T, 'v'>;
+    template<class T>
+    using alias_w = internal::table_alias<T, 'w'>;
+    template<class T>
+    using alias_x = internal::table_alias<T, 'x'>;
+    template<class T>
+    using alias_y = internal::table_alias<T, 'y'>;
+    template<class T>
+    using alias_z = internal::table_alias<T, 'z'>;
 }
 #pragma once
 
@@ -2949,103 +2992,102 @@ namespace sqlite_orm {
 
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
-        template<class ...Args>
+
+        template<class... Args>
         struct join_iterator {
-            
+
             template<class L>
             void operator()(const L &) {
                 //..
             }
         };
-        
+
         template<>
         struct join_iterator<> {
-            
+
             template<class L>
             void operator()(const L &) {
                 //..
             }
         };
-        
-        template<class H, class ...Tail>
-        struct join_iterator<H, Tail...> : public join_iterator<Tail...>{
+
+        template<class H, class... Tail>
+        struct join_iterator<H, Tail...> : public join_iterator<Tail...> {
             using super = join_iterator<Tail...>;
-            
+
             template<class L>
             void operator()(const L &l) {
                 this->super::operator()(l);
             }
-            
         };
-        
-        template<class T, class ...Tail>
-        struct join_iterator<conditions::cross_join_t<T>, Tail...> : public join_iterator<Tail...>{
+
+        template<class T, class... Tail>
+        struct join_iterator<conditions::cross_join_t<T>, Tail...> : public join_iterator<Tail...> {
             using super = join_iterator<Tail...>;
             using join_type = conditions::cross_join_t<T>;
-            
+
             template<class L>
             void operator()(const L &l) {
                 l(*this);
                 this->super::operator()(l);
             }
         };
-        
-        template<class T, class ...Tail>
-        struct join_iterator<conditions::natural_join_t<T>, Tail...> : public join_iterator<Tail...>{
+
+        template<class T, class... Tail>
+        struct join_iterator<conditions::natural_join_t<T>, Tail...> : public join_iterator<Tail...> {
             using super = join_iterator<Tail...>;
             using join_type = conditions::natural_join_t<T>;
-            
+
             template<class L>
             void operator()(const L &l) {
                 l(*this);
                 this->super::operator()(l);
             }
         };
-        
-        template<class T, class O, class ...Tail>
+
+        template<class T, class O, class... Tail>
         struct join_iterator<conditions::left_join_t<T, O>, Tail...> : public join_iterator<Tail...> {
             using super = join_iterator<Tail...>;
             using join_type = conditions::left_join_t<T, O>;
-            
+
             template<class L>
             void operator()(const L &l) {
                 l(*this);
                 this->super::operator()(l);
             }
         };
-        
-        template<class T, class O, class ...Tail>
+
+        template<class T, class O, class... Tail>
         struct join_iterator<conditions::join_t<T, O>, Tail...> : public join_iterator<Tail...> {
             using super = join_iterator<Tail...>;
             using join_type = conditions::join_t<T, O>;
-            
+
             template<class L>
             void operator()(const L &l) {
                 l(*this);
                 this->super::operator()(l);
             }
         };
-        
-        template<class T, class O, class ...Tail>
+
+        template<class T, class O, class... Tail>
         struct join_iterator<conditions::left_outer_join_t<T, O>, Tail...> : public join_iterator<Tail...> {
             using super = join_iterator<Tail...>;
             using join_type = conditions::left_outer_join_t<T, O>;
-            
+
             template<class L>
             void operator()(const L &l) {
                 l(*this);
                 this->super::operator()(l);
             }
         };
-        
-        template<class T, class O, class ...Tail>
+
+        template<class T, class O, class... Tail>
         struct join_iterator<conditions::inner_join_t<T, O>, Tail...> : public join_iterator<Tail...> {
             using super = join_iterator<Tail...>;
             using join_type = conditions::inner_join_t<T, O>;
-            
+
             template<class L>
             void operator()(const L &l) {
                 l(*this);
@@ -3056,11 +3098,11 @@ namespace sqlite_orm {
 }
 #pragma once
 
-#include <string>   //  std::string
-#include <tuple>    //  std::make_tuple, std::tuple_size
+#include <string>  //  std::string
+#include <tuple>  //  std::make_tuple, std::tuple_size
 #include <type_traits>  //  std::forward, std::is_base_of, std::enable_if
-#include <memory>   //  std::unique_ptr
-#include <vector>   //  std::vector
+#include <memory>  //  std::unique_ptr
+#include <vector>  //  std::vector
 
 // #include "conditions.h"
 
@@ -3072,218 +3114,218 @@ namespace sqlite_orm {
 #include <type_traits>  //  std::true_type, std::false_type, std::declval
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         /*
          * This is because of bug in MSVC, for more information, please visit
          * https://stackoverflow.com/questions/34672441/stdis-base-of-for-template-classes/34672753#34672753
          */
 #if defined(_MSC_VER)
-        template <template <typename...> class Base, typename Derived>
+        template<template<typename...> class Base, typename Derived>
         struct is_base_of_template_impl {
             template<typename... Ts>
-            static constexpr std::true_type test(const Base<Ts...>*);
-            
+            static constexpr std::true_type test(const Base<Ts...> *);
+
             static constexpr std::false_type test(...);
-            
-            using type = decltype(test(std::declval<Derived*>()));
+
+            using type = decltype(test(std::declval<Derived *>()));
         };
-        
-        template <typename Derived, template <typename...> class Base>
+
+        template<typename Derived, template<typename...> class Base>
         using is_base_of_template = typename is_base_of_template_impl<Base, Derived>::type;
-        
+
 #else
-        template <template <typename...> class C, typename...Ts>
-        std::true_type is_base_of_template_impl(const C<Ts...>*);
-        
-        template <template <typename...> class C>
+        template<template<typename...> class C, typename... Ts>
+        std::true_type is_base_of_template_impl(const C<Ts...> *);
+
+        template<template<typename...> class C>
         std::false_type is_base_of_template_impl(...);
-        
-        template <typename T, template <typename...> class C>
-        using is_base_of_template = decltype(is_base_of_template_impl<C>(std::declval<T*>()));
-        
+
+        template<typename T, template<typename...> class C>
+        using is_base_of_template = decltype(is_base_of_template_impl<C>(std::declval<T *>()));
+
 #endif
     }
 }
 
 
 namespace sqlite_orm {
-    
+
     namespace core_functions {
-        
+
         /**
          *  Base class for operator overloading
          *  R - return type
          *  S - class with operator std::string
          *  Args - function arguments types
          */
-        template<class R, class S, class ...Args>
+        template<class R, class S, class... Args>
         struct core_function_t : S, internal::arithmetic_t {
             using return_type = R;
             using string_type = S;
             using args_type = std::tuple<Args...>;
-            
+
             static constexpr const size_t args_size = std::tuple_size<args_type>::value;
-            
+
             args_type args;
-            
+
             core_function_t(args_type &&args_) : args(std::move(args_)) {}
         };
-        
+
         struct length_string {
             operator std::string() const {
                 return "LENGTH";
             }
         };
-        
+
         struct abs_string {
             operator std::string() const {
                 return "ABS";
             }
         };
-        
+
         struct lower_string {
             operator std::string() const {
                 return "LOWER";
             }
         };
-        
+
         struct upper_string {
             operator std::string() const {
                 return "UPPER";
             }
         };
-        
+
         struct changes_string {
             operator std::string() const {
                 return "CHANGES";
             }
         };
-        
+
         struct trim_string {
             operator std::string() const {
                 return "TRIM";
             }
         };
-        
+
         struct ltrim_string {
             operator std::string() const {
                 return "LTRIM";
             }
         };
-        
+
         struct rtrim_string {
             operator std::string() const {
                 return "RTRIM";
             }
         };
-        
+
 #if SQLITE_VERSION_NUMBER >= 3007016
-        
+
         struct char_string {
             operator std::string() const {
                 return "CHAR";
             }
         };
-        
+
         struct random_string {
             operator std::string() const {
                 return "RANDOM";
             }
         };
-        
+
 #endif
-        
+
         struct coalesce_string {
             operator std::string() const {
                 return "COALESCE";
             }
         };
-        
+
         struct date_string {
             operator std::string() const {
                 return "DATE";
             }
         };
-        
+
         struct datetime_string {
             operator std::string() const {
                 return "DATETIME";
             }
         };
-        
+
         struct julianday_string {
             operator std::string() const {
                 return "JULIANDAY";
             }
         };
-        
+
         struct zeroblob_string {
             operator std::string() const {
                 return "ZEROBLOB";
             }
         };
-        
+
         struct substr_string {
             operator std::string() const {
                 return "SUBSTR";
             }
         };
     }
-    
+
     /**
      *  Cute operators for core functions
      */
-    
-    template<
-    class F,
-    class R,
-    typename = typename std::enable_if<internal::is_base_of_template<F, core_functions::core_function_t>::value>::type>
+
+    template<class F,
+             class R,
+             typename = typename std::enable_if<
+                 internal::is_base_of_template<F, core_functions::core_function_t>::value>::type>
     conditions::lesser_than_t<F, R> operator<(F f, R r) {
         return {std::move(f), std::move(r)};
     }
-    
-    template<
-    class F,
-    class R,
-    typename = typename std::enable_if<internal::is_base_of_template<F, core_functions::core_function_t>::value>::type>
+
+    template<class F,
+             class R,
+             typename = typename std::enable_if<
+                 internal::is_base_of_template<F, core_functions::core_function_t>::value>::type>
     conditions::lesser_or_equal_t<F, R> operator<=(F f, R r) {
         return {std::move(f), std::move(r)};
     }
-    
-    template<
-    class F,
-    class R,
-    typename = typename std::enable_if<internal::is_base_of_template<F, core_functions::core_function_t>::value>::type>
+
+    template<class F,
+             class R,
+             typename = typename std::enable_if<
+                 internal::is_base_of_template<F, core_functions::core_function_t>::value>::type>
     conditions::greater_than_t<F, R> operator>(F f, R r) {
         return {std::move(f), std::move(r)};
     }
-    
-    template<
-    class F,
-    class R,
-    typename = typename std::enable_if<internal::is_base_of_template<F, core_functions::core_function_t>::value>::type>
+
+    template<class F,
+             class R,
+             typename = typename std::enable_if<
+                 internal::is_base_of_template<F, core_functions::core_function_t>::value>::type>
     conditions::greater_or_equal_t<F, R> operator>=(F f, R r) {
         return {std::move(f), std::move(r)};
     }
-    
-    template<
-    class F,
-    class R,
-    typename = typename std::enable_if<internal::is_base_of_template<F, core_functions::core_function_t>::value>::type>
+
+    template<class F,
+             class R,
+             typename = typename std::enable_if<
+                 internal::is_base_of_template<F, core_functions::core_function_t>::value>::type>
     conditions::is_equal_t<F, R> operator==(F f, R r) {
         return {std::move(f), std::move(r)};
     }
-    
-    template<
-    class F,
-    class R,
-    typename = typename std::enable_if<internal::is_base_of_template<F, core_functions::core_function_t>::value>::type>
+
+    template<class F,
+             class R,
+             typename = typename std::enable_if<
+                 internal::is_base_of_template<F, core_functions::core_function_t>::value>::type>
     conditions::is_not_equal_t<F, R> operator!=(F f, R r) {
         return {std::move(f), std::move(r)};
     }
-    
+
     /**
      *  LENGTH(x) function https://sqlite.org/lang_corefunc.html#length
      */
@@ -3292,7 +3334,7 @@ namespace sqlite_orm {
         std::tuple<T> args{std::forward<T>(t)};
         return {std::move(args)};
     }
-    
+
     /**
      *  ABS(x) function https://sqlite.org/lang_corefunc.html#abs
      */
@@ -3301,7 +3343,7 @@ namespace sqlite_orm {
         std::tuple<T> args{std::forward<T>(t)};
         return {std::move(args)};
     }
-    
+
     /**
      *  LOWER(x) function https://sqlite.org/lang_corefunc.html#lower
      */
@@ -3310,7 +3352,7 @@ namespace sqlite_orm {
         std::tuple<T> args{std::forward<T>(t)};
         return {std::move(args)};
     }
-    
+
     /**
      *  UPPER(x) function https://sqlite.org/lang_corefunc.html#upper
      */
@@ -3319,14 +3361,14 @@ namespace sqlite_orm {
         std::tuple<T> args{std::forward<T>(t)};
         return {std::move(args)};
     }
-    
+
     /**
      *  CHANGES() function https://sqlite.org/lang_corefunc.html#changes
      */
     inline core_functions::core_function_t<int, core_functions::changes_string> changes() {
         return {{}};
     }
-    
+
     /**
      *  TRIM(X) function https://sqlite.org/lang_corefunc.html#trim
      */
@@ -3335,7 +3377,7 @@ namespace sqlite_orm {
         std::tuple<T> args{std::forward<T>(t)};
         return {std::move(args)};
     }
-    
+
     /**
      *  TRIM(X,Y) function https://sqlite.org/lang_corefunc.html#trim
      */
@@ -3344,7 +3386,7 @@ namespace sqlite_orm {
         std::tuple<X, Y> args{std::forward<X>(x), std::forward<Y>(y)};
         return {std::move(args)};
     }
-    
+
     /**
      *  LTRIM(X) function https://sqlite.org/lang_corefunc.html#ltrim
      */
@@ -3353,7 +3395,7 @@ namespace sqlite_orm {
         std::tuple<X> args{std::forward<X>(x)};
         return {std::move(args)};
     }
-    
+
     /**
      *  LTRIM(X,Y) function https://sqlite.org/lang_corefunc.html#ltrim
      */
@@ -3362,7 +3404,7 @@ namespace sqlite_orm {
         std::tuple<X, Y> args{std::forward<X>(x), std::forward<Y>(y)};
         return {std::move(args)};
     }
-    
+
     /**
      *  RTRIM(X) function https://sqlite.org/lang_corefunc.html#rtrim
      */
@@ -3371,7 +3413,7 @@ namespace sqlite_orm {
         std::tuple<X> args{std::forward<X>(x)};
         return {std::move(args)};
     }
-    
+
     /**
      *  RTRIM(X,Y) function https://sqlite.org/lang_corefunc.html#rtrim
      */
@@ -3380,61 +3422,61 @@ namespace sqlite_orm {
         std::tuple<X, Y> args{std::forward<X>(x), std::forward<Y>(y)};
         return {std::move(args)};
     }
-    
+
 #if SQLITE_VERSION_NUMBER >= 3007016
-    
+
     /**
      *  CHAR(X1,X2,...,XN) function https://sqlite.org/lang_corefunc.html#char
      */
-    template<class ...Args>
-    core_functions::core_function_t<std::string, core_functions::char_string, Args...> char_(Args&& ...args) {
+    template<class... Args>
+    core_functions::core_function_t<std::string, core_functions::char_string, Args...> char_(Args &&... args) {
         return {std::make_tuple(std::forward<Args>(args)...)};
     }
-    
+
     /**
      *  RANDOM() function https://www.sqlite.org/lang_corefunc.html#random
      */
     inline core_functions::core_function_t<int, core_functions::random_string> random() {
         return {{}};
     }
-    
+
 #endif
-    
+
     /**
      *  COALESCE(X,Y,...) function https://www.sqlite.org/lang_corefunc.html#coalesce
      */
-    template<class R, class ...Args>
-    core_functions::core_function_t<R, core_functions::coalesce_string, Args...> coalesce(Args&& ...args) {
+    template<class R, class... Args>
+    core_functions::core_function_t<R, core_functions::coalesce_string, Args...> coalesce(Args &&... args) {
         return {std::make_tuple(std::forward<Args>(args)...)};
     }
-    
+
     /**
      *  DATE(timestring, modifier, modifier, ...) function https://www.sqlite.org/lang_datefunc.html
      */
-    template<class ...Args>
-    core_functions::core_function_t<std::string, core_functions::date_string, Args...> date(Args &&...args) {
+    template<class... Args>
+    core_functions::core_function_t<std::string, core_functions::date_string, Args...> date(Args &&... args) {
         std::tuple<Args...> t{std::forward<Args>(args)...};
         return {std::move(t)};
     }
-    
+
     /**
      *  DATETIME(timestring, modifier, modifier, ...) function https://www.sqlite.org/lang_datefunc.html
      */
-    template<class ...Args>
-    core_functions::core_function_t<std::string, core_functions::datetime_string, Args...> datetime(Args &&...args) {
+    template<class... Args>
+    core_functions::core_function_t<std::string, core_functions::datetime_string, Args...> datetime(Args &&... args) {
         std::tuple<Args...> t{std::forward<Args>(args)...};
         return {std::move(t)};
     }
-    
+
     /**
      *  JULIANDAY(timestring, modifier, modifier, ...) function https://www.sqlite.org/lang_datefunc.html
      */
-    template<class ...Args>
-    core_functions::core_function_t<double, core_functions::julianday_string, Args...> julianday(Args &&...args) {
+    template<class... Args>
+    core_functions::core_function_t<double, core_functions::julianday_string, Args...> julianday(Args &&... args) {
         std::tuple<Args...> t{std::forward<Args>(args)...};
         return {std::move(t)};
     }
-    
+
     /**
      *  ZEROBLOB(N) function https://www.sqlite.org/lang_corefunc.html#zeroblob
      */
@@ -3443,7 +3485,7 @@ namespace sqlite_orm {
         std::tuple<N> args{std::forward<N>(n)};
         return {std::move(args)};
     }
-    
+
     /**
      *  SUBSTR(X,Y) function https://www.sqlite.org/lang_corefunc.html#substr
      */
@@ -3452,7 +3494,7 @@ namespace sqlite_orm {
         std::tuple<X, Y> args{std::forward<X>(x), std::forward<Y>(y)};
         return {std::move(args)};
     }
-    
+
     /**
      *  SUBSTR(X,Y,Z) function https://www.sqlite.org/lang_corefunc.html#substr
      */
@@ -3461,43 +3503,48 @@ namespace sqlite_orm {
         std::tuple<X, Y, Z> args{std::forward<X>(x), std::forward<Y>(y), std::forward<Z>(z)};
         return {std::move(args)};
     }
-    
-    template<
-    class L,
-    class R,
-    typename = typename std::enable_if<(std::is_base_of<internal::arithmetic_t, L>::value + std::is_base_of<internal::arithmetic_t, R>::value > 0)>::type>
+
+    template<class L,
+             class R,
+             typename = typename std::enable_if<(std::is_base_of<internal::arithmetic_t, L>::value +
+                                                     std::is_base_of<internal::arithmetic_t, R>::value >
+                                                 0)>::type>
     internal::add_t<L, R> operator+(L l, R r) {
         return {std::move(l), std::move(r)};
     }
-    
-    template<
-    class L,
-    class R,
-    typename = typename std::enable_if<(std::is_base_of<internal::arithmetic_t, L>::value + std::is_base_of<internal::arithmetic_t, R>::value > 0)>::type>
+
+    template<class L,
+             class R,
+             typename = typename std::enable_if<(std::is_base_of<internal::arithmetic_t, L>::value +
+                                                     std::is_base_of<internal::arithmetic_t, R>::value >
+                                                 0)>::type>
     internal::sub_t<L, R> operator-(L l, R r) {
         return {std::move(l), std::move(r)};
     }
-    
-    template<
-    class L,
-    class R,
-    typename = typename std::enable_if<(std::is_base_of<internal::arithmetic_t, L>::value + std::is_base_of<internal::arithmetic_t, R>::value > 0)>::type>
+
+    template<class L,
+             class R,
+             typename = typename std::enable_if<(std::is_base_of<internal::arithmetic_t, L>::value +
+                                                     std::is_base_of<internal::arithmetic_t, R>::value >
+                                                 0)>::type>
     internal::mul_t<L, R> operator*(L l, R r) {
         return {std::move(l), std::move(r)};
     }
-    
-    template<
-    class L,
-    class R,
-    typename = typename std::enable_if<(std::is_base_of<internal::arithmetic_t, L>::value + std::is_base_of<internal::arithmetic_t, R>::value > 0)>::type>
+
+    template<class L,
+             class R,
+             typename = typename std::enable_if<(std::is_base_of<internal::arithmetic_t, L>::value +
+                                                     std::is_base_of<internal::arithmetic_t, R>::value >
+                                                 0)>::type>
     internal::div_t<L, R> operator/(L l, R r) {
         return {std::move(l), std::move(r)};
     }
-    
-    template<
-    class L,
-    class R,
-    typename = typename std::enable_if<(std::is_base_of<internal::arithmetic_t, L>::value + std::is_base_of<internal::arithmetic_t, R>::value > 0)>::type>
+
+    template<class L,
+             class R,
+             typename = typename std::enable_if<(std::is_base_of<internal::arithmetic_t, L>::value +
+                                                     std::is_base_of<internal::arithmetic_t, R>::value >
+                                                 0)>::type>
     internal::mod_t<L, R> operator%(L l, R r) {
         return {std::move(l), std::move(r)};
     }
@@ -3505,27 +3552,27 @@ namespace sqlite_orm {
 #pragma once
 
 namespace sqlite_orm {
-    
+
     namespace aggregate_functions {
-        
+
         template<class T>
         struct avg_t {
             T t;
-            
+
             operator std::string() const {
                 return "AVG";
             }
         };
-        
+
         template<class T>
         struct count_t {
             T t;
-            
+
             operator std::string() const {
                 return "COUNT";
             }
         };
-        
+
         /**
          *  T is use to specify type explicitly for queries like
          *  SELECT COUNT(*) FROM table_name;
@@ -3534,119 +3581,119 @@ namespace sqlite_orm {
         template<class T>
         struct count_asterisk_t {
             using type = T;
-            
+
             operator std::string() const {
                 return "COUNT";
             }
         };
-        
+
         struct count_asterisk_without_type {
             operator std::string() const {
                 return "COUNT";
             }
         };
-        
+
         template<class T>
         struct sum_t {
             T t;
-            
+
             operator std::string() const {
                 return "SUM";
             }
         };
-        
+
         template<class T>
         struct total_t {
             T t;
-            
+
             operator std::string() const {
                 return "TOTAL";
             }
         };
-        
+
         template<class T>
         struct max_t {
             T t;
-            
+
             operator std::string() const {
                 return "MAX";
             }
         };
-        
+
         template<class T>
         struct min_t {
             T t;
-            
+
             operator std::string() const {
                 return "MIN";
             }
         };
-        
+
         template<class T>
         struct group_concat_single_t {
             T t;
-            
+
             operator std::string() const {
                 return "GROUP_CONCAT";
             }
         };
-        
+
         template<class T>
         struct group_concat_double_t {
             T t;
             std::string y;
-            
+
             operator std::string() const {
                 return "GROUP_CONCAT";
             }
         };
-        
+
     }
-    
+
     template<class T>
     aggregate_functions::avg_t<T> avg(T t) {
         return {t};
     }
-    
+
     template<class T>
     aggregate_functions::count_t<T> count(T t) {
         return {t};
     }
-    
+
     inline aggregate_functions::count_asterisk_without_type count() {
         return {};
     }
-    
+
     template<class T>
     aggregate_functions::count_asterisk_t<T> count() {
         return {};
     }
-    
+
     template<class T>
     aggregate_functions::sum_t<T> sum(T t) {
         return {t};
     }
-    
+
     template<class T>
     aggregate_functions::max_t<T> max(T t) {
         return {t};
     }
-    
+
     template<class T>
     aggregate_functions::min_t<T> min(T t) {
         return {t};
     }
-    
+
     template<class T>
     aggregate_functions::total_t<T> total(T t) {
         return {t};
     }
-    
+
     template<class T>
     aggregate_functions::group_concat_single_t<T> group_concat(T t) {
         return {t};
     }
-    
+
     template<class T, class Y>
     aggregate_functions::group_concat_double_t<T> group_concat(T t, Y y) {
         return {t, y};
@@ -3655,9 +3702,9 @@ namespace sqlite_orm {
 #pragma once
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         /**
          *  Cute class used to compare setters/getters and member pointers with each other.
          */
@@ -3667,14 +3714,14 @@ namespace sqlite_orm {
                 return false;
             }
         };
-        
+
         template<class O>
         struct typed_comparator<O, O> {
             bool operator()(const O &lhs, const O &rhs) const {
                 return lhs == rhs;
             }
         };
-        
+
         template<class L, class R>
         bool compare_any(const L &lhs, const R &rhs) {
             return typed_comparator<L, R>()(lhs, rhs);
@@ -3683,9 +3730,9 @@ namespace sqlite_orm {
 }
 #pragma once
 
-#include <string>   //  std::string
+#include <string>  //  std::string
 #include <utility>  //  std::declval
-#include <tuple>    //  std::tuple, std::get, std::tuple_size
+#include <tuple>  //  std::tuple, std::get, std::tuple_size
 
 // #include "is_base_of_template.h"
 
@@ -3695,74 +3742,75 @@ namespace sqlite_orm {
 
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         /**
          *  DISCTINCT generic container.
          */
         template<class T>
         struct distinct_t {
             T t;
-            
+
             operator std::string() const {
                 return "DISTINCT";
             }
         };
-        
+
         /**
          *  ALL generic container.
          */
         template<class T>
         struct all_t {
             T t;
-            
+
             operator std::string() const {
                 return "ALL";
             }
         };
-        
-        template<class ...Args>
+
+        template<class... Args>
         struct columns_t {
             using columns_type = std::tuple<Args...>;
-            
+
             columns_type columns;
             bool distinct = false;
-            
+
             static constexpr const int count = std::tuple_size<columns_type>::value;
         };
-        
-        template<class ...Args>
+
+        template<class... Args>
         struct set_t {
-            
+
             operator std::string() const {
                 return "SET";
             }
-            
+
             template<class F>
             void for_each(F) const {
                 //..
             }
         };
-        
-        template<class L, class ...Args>
+
+        template<class L, class... Args>
         struct set_t<L, Args...> : public set_t<Args...> {
-            static_assert(is_assign_t<typename std::remove_reference<L>::type>::value, "set_t argument must be assign_t");
-            
+            static_assert(is_assign_t<typename std::remove_reference<L>::type>::value,
+                          "set_t argument must be assign_t");
+
             L l;
-            
+
             using super = set_t<Args...>;
             using self = set_t<L, Args...>;
-            
-            set_t(L l_, Args&& ...args) : super(std::forward<Args>(args)...), l(std::forward<L>(l_)) {}
-            
+
+            set_t(L l_, Args &&... args) : super(std::forward<Args>(args)...), l(std::forward<L>(l_)) {}
+
             template<class F>
             void for_each(F f) const {
                 f(l);
                 this->super::for_each(f);
             }
         };
-        
+
         /**
          *  This class is used to store explicit mapped type T and its column descriptor (member pointer/getter/setter).
          *  Is useful when mapped type is derived from other type and base class has members mapped to a storage.
@@ -3771,23 +3819,23 @@ namespace sqlite_orm {
         struct column_pointer {
             using type = T;
             using field_type = F;
-            
+
             field_type field;
         };
-        
+
         /**
          *  Subselect object type.
          */
-        template<class T, class ...Args>
+        template<class T, class... Args>
         struct select_t {
             using return_type = T;
             using conditions_type = std::tuple<Args...>;
-            
+
             return_type col;
             conditions_type conditions;
             bool highest_level = false;
         };
-        
+
         /**
          *  Base for UNION, UNION ALL, EXCEPT and INTERSECT
          */
@@ -3795,28 +3843,28 @@ namespace sqlite_orm {
         struct compound_operator {
             using left_type = L;
             using right_type = R;
-            
+
             left_type left;
             right_type right;
-            
-            compound_operator(left_type l, right_type r): left(std::move(l)), right(std::move(r)) {
+
+            compound_operator(left_type l, right_type r) : left(std::move(l)), right(std::move(r)) {
                 this->left.highest_level = true;
                 this->right.highest_level = true;
             }
         };
-        
+
         struct union_base {
             bool all = false;
-            
+
             operator std::string() const {
-                if(!this->all){
+                if(!this->all) {
                     return "UNION";
-                }else{
+                } else {
                     return "UNION ALL";
                 }
             }
         };
-        
+
         /**
          *  UNION object type.
          */
@@ -3824,12 +3872,13 @@ namespace sqlite_orm {
         struct union_t : public compound_operator<L, R>, union_base {
             using left_type = typename compound_operator<L, R>::left_type;
             using right_type = typename compound_operator<L, R>::right_type;
-            
-            union_t(left_type l, right_type r, decltype(all) all): compound_operator<L, R>(std::move(l), std::move(r)), union_base{all} {}
-            
-            union_t(left_type l, right_type r): union_t(std::move(l), std::move(r), false) {}
+
+            union_t(left_type l, right_type r, decltype(all) all) :
+                compound_operator<L, R>(std::move(l), std::move(r)), union_base{all} {}
+
+            union_t(left_type l, right_type r) : union_t(std::move(l), std::move(r), false) {}
         };
-        
+
         /**
          *  EXCEPT object type.
          */
@@ -3838,14 +3887,14 @@ namespace sqlite_orm {
             using super = compound_operator<L, R>;
             using left_type = typename super::left_type;
             using right_type = typename super::right_type;
-            
+
             using super::super;
-            
+
             operator std::string() const {
                 return "EXCEPT";
             }
         };
-        
+
         /**
          *  INTERSECT object type.
          */
@@ -3854,14 +3903,14 @@ namespace sqlite_orm {
             using super = compound_operator<L, R>;
             using left_type = typename super::left_type;
             using right_type = typename super::right_type;
-            
+
             using super::super;
-            
+
             operator std::string() const {
                 return "INTERSECT";
             }
         };
-        
+
         /**
          *  Generic way to get DISTINCT value from any type.
          */
@@ -3869,52 +3918,52 @@ namespace sqlite_orm {
         bool get_distinct(const T &) {
             return false;
         }
-        
-        template<class ...Args>
+
+        template<class... Args>
         bool get_distinct(const columns_t<Args...> &cols) {
             return cols.distinct;
         }
-        
+
         template<class T>
         struct asterisk_t {
             using type = T;
         };
-        
+
         template<class T>
         struct then_t {
             using expression_type = T;
-            
+
             expression_type expression;
         };
-        
-        template<class R, class T, class E, class ...Args>
+
+        template<class R, class T, class E, class... Args>
         struct simple_case_t {
             using return_type = R;
             using case_expression_type = T;
             using args_type = std::tuple<Args...>;
             using else_expression_type = E;
-            
+
             optional_container<case_expression_type> case_expression;
             args_type args;
             optional_container<else_expression_type> else_expression;
         };
-        
+
         /**
          *  T is a case expression type
          *  E is else type (void is ELSE is omitted)
          *  Args... is a pack of WHEN expressions
          */
-        template<class R, class T, class E, class ...Args>
+        template<class R, class T, class E, class... Args>
         struct simple_case_builder {
             using return_type = R;
             using case_expression_type = T;
             using args_type = std::tuple<Args...>;
             using else_expression_type = E;
-            
+
             optional_container<case_expression_type> case_expression;
             args_type args;
             optional_container<else_expression_type> else_expression;
-            
+
             template<class W, class Th>
             simple_case_builder<R, T, E, Args..., std::pair<W, Th>> when(W w, then_t<Th> t) {
                 using result_args_type = std::tuple<Args..., std::pair<W, Th>>;
@@ -3924,63 +3973,63 @@ namespace sqlite_orm {
                 std::get<std::tuple_size<result_args_type>::value - 1>(result_args) = std::move(newPair);
                 return {std::move(this->case_expression), std::move(result_args), std::move(this->else_expression)};
             }
-            
+
             simple_case_t<R, T, E, Args...> end() {
                 return {std::move(this->case_expression), std::move(args), std::move(this->else_expression)};
             }
-            
+
             template<class El>
             simple_case_builder<R, T, El, Args...> else_(El el) {
                 return {{std::move(this->case_expression)}, std::move(args), {std::move(el)}};
             }
         };
     }
-    
+
     template<class T>
     internal::then_t<T> then(T t) {
         return {std::move(t)};
     }
-    
+
     template<class R, class T>
     internal::simple_case_builder<R, T, void> case_(T t) {
         return {{std::move(t)}};
     }
-    
+
     template<class R>
     internal::simple_case_builder<R, void, void> case_() {
         return {};
     }
-    
+
     template<class T>
     internal::distinct_t<T> distinct(T t) {
         return {std::move(t)};
     }
-    
+
     template<class T>
     internal::all_t<T> all(T t) {
         return {std::move(t)};
     }
-    
-    template<class ...Args>
+
+    template<class... Args>
     internal::columns_t<Args...> distinct(internal::columns_t<Args...> cols) {
         cols.distinct = true;
         return cols;
     }
-    
+
     /**
      *  SET keyword used in UPDATE ... SET queries.
      *  Args must have `assign_t` type. E.g. set(assign(&User::id, 5)) or set(c(&User::id) = 5)
      */
-    template<class ...Args>
-    internal::set_t<Args...> set(Args&& ...args) {
+    template<class... Args>
+    internal::set_t<Args...> set(Args &&... args) {
         return {std::forward<Args>(args)...};
     }
-    
-    template<class ...Args>
-    internal::columns_t<Args...> columns(Args&& ...args) {
+
+    template<class... Args>
+    internal::columns_t<Args...> columns(Args &&... args) {
         return {std::make_tuple<Args...>(std::forward<Args>(args)...)};
     }
-    
+
     /**
      *  Use it like this:
      *  struct MyType : BaseType { ... };
@@ -3990,15 +4039,15 @@ namespace sqlite_orm {
     internal::column_pointer<T, F> column(F f) {
         return {f};
     }
-    
+
     /**
      *  Public function for subselect query. Is useful in UNION queries.
      */
-    template<class T, class ...Args>
-    internal::select_t<T, Args...> select(T t, Args ...args) {
+    template<class T, class... Args>
+    internal::select_t<T, Args...> select(T t, Args... args) {
         return {std::move(t), std::make_tuple<Args...>(std::forward<Args>(args)...)};
     }
-    
+
     /**
      *  Public function for UNION operator.
      *  lhs and rhs are subselect objects.
@@ -4008,7 +4057,7 @@ namespace sqlite_orm {
     internal::union_t<L, R> union_(L lhs, R rhs) {
         return {std::move(lhs), std::move(rhs)};
     }
-    
+
     /**
      *  Public function for EXCEPT operator.
      *  lhs and rhs are subselect objects.
@@ -4018,12 +4067,12 @@ namespace sqlite_orm {
     internal::except_t<L, R> except(L lhs, R rhs) {
         return {std::move(lhs), std::move(rhs)};
     }
-    
+
     template<class L, class R>
     internal::intersect_t<L, R> intersect(L lhs, R rhs) {
         return {std::move(lhs), std::move(rhs)};
     }
-    
+
     /**
      *  Public function for UNION ALL operator.
      *  lhs and rhs are subselect objects.
@@ -4033,7 +4082,7 @@ namespace sqlite_orm {
     internal::union_t<L, R> union_all(L lhs, R rhs) {
         return {std::move(lhs), std::move(rhs), true};
     }
-    
+
     template<class T>
     internal::asterisk_t<T> asterisk() {
         return {};
@@ -4041,35 +4090,36 @@ namespace sqlite_orm {
 }
 #pragma once
 
-#include <string>   //  std::string
+#include <string>  //  std::string
 #include <sqlite3.h>
-#include <system_error> //  std::error_code, std::system_error
+#include <system_error>  //  std::error_code, std::system_error
 
 // #include "error_code.h"
 
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         struct database_connection {
-            
+
             database_connection(const std::string &filename) {
                 auto rc = sqlite3_open(filename.c_str(), &this->db);
-                if(rc != SQLITE_OK){
-                    throw std::system_error(std::error_code(sqlite3_errcode(this->db), get_sqlite_error_category()), sqlite3_errmsg(this->db));
+                if(rc != SQLITE_OK) {
+                    throw std::system_error(std::error_code(sqlite3_errcode(this->db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(this->db));
                 }
             }
-            
+
             ~database_connection() {
                 sqlite3_close(this->db);
             }
-            
-            sqlite3* get_db() {
+
+            sqlite3 *get_db() {
                 return this->db;
             }
-            
-        protected:
+
+          protected:
             sqlite3 *db = nullptr;
         };
     }
@@ -4084,31 +4134,33 @@ namespace sqlite_orm {
 
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         /**
          *  Trait class used to define table mapped type by setter/getter/member
          *  T - member pointer
          */
         template<class T, class SFINAE = void>
         struct table_type;
-        
+
         template<class O, class F>
-        struct table_type<F O::*, typename std::enable_if<std::is_member_pointer<F O::*>::value && !std::is_member_function_pointer<F O::*>::value>::type> {
+        struct table_type<F O::*,
+                          typename std::enable_if<std::is_member_pointer<F O::*>::value &&
+                                                  !std::is_member_function_pointer<F O::*>::value>::type> {
             using type = O;
         };
-        
+
         template<class T>
         struct table_type<T, typename std::enable_if<is_getter<T>::value>::type> {
             using type = typename getter_traits<T>::object_type;
         };
-        
+
         template<class T>
         struct table_type<T, typename std::enable_if<is_setter<T>::value>::type> {
             using type = typename setter_traits<T>::object_type;
         };
-        
+
         template<class T, class F>
         struct table_type<column_pointer<T, F>, void> {
             using type = T;
@@ -4117,10 +4169,10 @@ namespace sqlite_orm {
 }
 #pragma once
 
-#include <string>   //  std::string
+#include <string>  //  std::string
 
 namespace sqlite_orm {
-    
+
     struct table_info {
         int cid;
         std::string name;
@@ -4129,22 +4181,22 @@ namespace sqlite_orm {
         std::string dflt_value;
         int pk;
     };
-    
+
 }
 #pragma once
 
 #include <sqlite3.h>
 
 namespace sqlite_orm {
-    
+
     /**
      *  Guard class which finalizes `sqlite3_stmt` in dtor
      */
     struct statement_finalizer {
         sqlite3_stmt *stmt = nullptr;
-        
-        statement_finalizer(decltype(stmt) stmt_): stmt(stmt_) {}
-        
+
+        statement_finalizer(decltype(stmt) stmt_) : stmt(stmt_) {}
+
         inline ~statement_finalizer() {
             sqlite3_finalize(this->stmt);
         }
@@ -4153,53 +4205,46 @@ namespace sqlite_orm {
 #pragma once
 
 namespace sqlite_orm {
-    
+
     /**
      *  Helper classes used by statement_binder and row_extractor.
      */
-    struct int_or_smaller_tag{};
-    struct bigint_tag{};
-    struct real_tag{};
-    
+    struct int_or_smaller_tag {};
+    struct bigint_tag {};
+    struct real_tag {};
+
     template<class V>
-    struct arithmetic_tag
-    {
-        using type = std::conditional_t<
-        std::is_integral<V>::value,
-        // Integer class
-        std::conditional_t<
-        sizeof(V) <= sizeof(int),
-        int_or_smaller_tag,
-        bigint_tag
-        >,
-        // Floating-point class
-        real_tag
-        >;
+    struct arithmetic_tag {
+        using type = std::conditional_t<std::is_integral<V>::value,
+                                        // Integer class
+                                        std::conditional_t<sizeof(V) <= sizeof(int), int_or_smaller_tag, bigint_tag>,
+                                        // Floating-point class
+                                        real_tag>;
     };
-    
+
     template<class V>
     using arithmetic_tag_t = typename arithmetic_tag<V>::type;
 }
 #pragma once
 
 namespace sqlite_orm {
-    
+
     /**
      *  Specialization for optional type (std::shared_ptr / std::unique_ptr).
      */
-    template <typename T>
+    template<typename T>
     struct is_std_ptr : std::false_type {};
-    
-    template <typename T>
+
+    template<typename T>
     struct is_std_ptr<std::shared_ptr<T>> : std::true_type {
-        static std::shared_ptr<T> make(const T& v) {
+        static std::shared_ptr<T> make(const T &v) {
             return std::make_shared<T>(v);
         }
     };
-    
-    template <typename T>
+
+    template<typename T>
     struct is_std_ptr<std::unique_ptr<T>> : std::true_type {
-        static std::unique_ptr<T> make(const T& v) {
+        static std::unique_ptr<T> make(const T &v) {
             return std::make_unique<T>(v);
         }
     };
@@ -4208,11 +4253,11 @@ namespace sqlite_orm {
 
 #include <sqlite3.h>
 #include <type_traits>  //  std::enable_if_t, std::is_arithmetic, std::is_same, std::true_type, std::false_type
-#include <string>   //  std::string, std::wstring
+#include <string>  //  std::string, std::wstring
 #ifndef SQLITE_ORM_OMITS_CODECVT
 #include <codecvt>  //  std::wstring_convert, std::codecvt_utf8_utf16
 #endif  //  SQLITE_ORM_OMITS_CODECVT
-#include <vector>   //  std::vector
+#include <vector>  //  std::vector
 #include <cstddef>  //  std::nullptr_t
 #include <utility>  //  std::declval
 
@@ -4220,13 +4265,13 @@ namespace sqlite_orm {
 
 
 namespace sqlite_orm {
-    
+
     /**
      *  Helper class used for binding fields to sqlite3 statements.
      */
     template<class V, typename Enable = void>
     struct statement_binder : std::false_type {};
-    
+
     /**
      *  Specialization for arithmetic types.
      */
@@ -4235,49 +4280,52 @@ namespace sqlite_orm {
         int bind(sqlite3_stmt *stmt, int index, const V &value) {
             return bind(stmt, index, value, tag());
         }
-        
-    private:
+
+      private:
         using tag = arithmetic_tag_t<V>;
-        
-        int bind(sqlite3_stmt *stmt, int index, const V &value, const int_or_smaller_tag&) {
+
+        int bind(sqlite3_stmt *stmt, int index, const V &value, const int_or_smaller_tag &) {
             return sqlite3_bind_int(stmt, index, static_cast<int>(value));
         }
-        
-        int bind(sqlite3_stmt *stmt, int index, const V &value, const bigint_tag&) {
+
+        int bind(sqlite3_stmt *stmt, int index, const V &value, const bigint_tag &) {
             return sqlite3_bind_int64(stmt, index, static_cast<sqlite3_int64>(value));
         }
-        
-        int bind(sqlite3_stmt *stmt, int index, const V &value, const real_tag&) {
+
+        int bind(sqlite3_stmt *stmt, int index, const V &value, const real_tag &) {
             return sqlite3_bind_double(stmt, index, static_cast<double>(value));
         }
     };
-    
-    
+
     /**
      *  Specialization for std::string and C-string.
      */
     template<class V>
-    struct statement_binder<V, std::enable_if_t<std::is_same<V, std::string>::value || std::is_same<V, const char*>::value>> {
+    struct statement_binder<
+        V,
+        std::enable_if_t<std::is_same<V, std::string>::value || std::is_same<V, const char *>::value>> {
         int bind(sqlite3_stmt *stmt, int index, const V &value) {
             return sqlite3_bind_text(stmt, index, string_data(value), -1, SQLITE_TRANSIENT);
         }
-        
-    private:
-        const char* string_data(const std::string& s) const {
+
+      private:
+        const char *string_data(const std::string &s) const {
             return s.c_str();
         }
-        
-        const char* string_data(const char* s) const{
+
+        const char *string_data(const char *s) const {
             return s;
         }
     };
-    
+
 #ifndef SQLITE_ORM_OMITS_CODECVT
     /**
      *  Specialization for std::wstring and C-wstring.
      */
     template<class V>
-    struct statement_binder<V, std::enable_if_t<std::is_same<V, std::wstring>::value || std::is_same<V, const wchar_t*>::value>> {
+    struct statement_binder<
+        V,
+        std::enable_if_t<std::is_same<V, std::wstring>::value || std::is_same<V, const wchar_t *>::value>> {
         int bind(sqlite3_stmt *stmt, int index, const V &value) {
             std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
             std::string utf8Str = converter.to_bytes(value);
@@ -4285,7 +4333,7 @@ namespace sqlite_orm {
         }
     };
 #endif  //  SQLITE_ORM_OMITS_CODECVT
-    
+
     /**
      *  Specialization for std::nullptr_t.
      */
@@ -4295,66 +4343,67 @@ namespace sqlite_orm {
             return sqlite3_bind_null(stmt, index);
         }
     };
-    
+
     template<class V>
     struct statement_binder<V, std::enable_if_t<is_std_ptr<V>::value>> {
         using value_type = typename V::element_type;
-        
+
         int bind(sqlite3_stmt *stmt, int index, const V &value) {
-            if(value){
+            if(value) {
                 return statement_binder<value_type>().bind(stmt, index, *value);
-            }else{
+            } else {
                 return statement_binder<std::nullptr_t>().bind(stmt, index, nullptr);
             }
         }
     };
-    
+
     /**
      *  Specialization for optional type (std::vector<char>).
      */
     template<>
     struct statement_binder<std::vector<char>, void> {
         int bind(sqlite3_stmt *stmt, int index, const std::vector<char> &value) {
-            if (value.size()) {
-                return sqlite3_bind_blob(stmt, index, (const void *)&value.front(), int(value.size()), SQLITE_TRANSIENT);
-            }else{
+            if(value.size()) {
+                return sqlite3_bind_blob(stmt,
+                                         index,
+                                         (const void *)&value.front(),
+                                         int(value.size()),
+                                         SQLITE_TRANSIENT);
+            } else {
                 return sqlite3_bind_blob(stmt, index, "", 0, SQLITE_TRANSIENT);
             }
         }
     };
-    
+
     namespace internal {
-        
+
         template<class T>
         using is_bindable = std::integral_constant<bool, !std::is_base_of<std::false_type, statement_binder<T>>::value>;
-        
+
         struct conditional_binder_base {
             sqlite3_stmt *stmt = nullptr;
             int &index;
-            
-            conditional_binder_base(decltype(stmt) stmt_, decltype(index) index_):
-            stmt(stmt_),
-            index(index_)
-            {}
+
+            conditional_binder_base(decltype(stmt) stmt_, decltype(index) index_) : stmt(stmt_), index(index_) {}
         };
-        
+
         template<class T, class C>
         struct conditional_binder;
-        
+
         template<class T>
         struct conditional_binder<T, std::true_type> : conditional_binder_base {
-            
+
             using conditional_binder_base::conditional_binder_base;
-            
+
             int operator()(const T &t) const {
                 return statement_binder<T>().bind(this->stmt, this->index++, t);
             }
         };
-        
+
         template<class T>
         struct conditional_binder<T, std::false_type> : conditional_binder_base {
             using conditional_binder_base::conditional_binder_base;
-            
+
             int operator()(const T &) const {
                 return SQLITE_OK;
             }
@@ -4366,35 +4415,35 @@ namespace sqlite_orm {
 #include <sqlite3.h>
 #include <type_traits>  //  std::enable_if_t, std::is_arithmetic, std::is_same, std::enable_if
 #include <cstdlib>  //  atof, atoi, atoll
-#include <string>   //  std::string, std::wstring
+#include <string>  //  std::string, std::wstring
 #ifndef SQLITE_ORM_OMITS_CODECVT
 #include <codecvt>  //  std::wstring_convert, std::codecvt_utf8_utf16
 #endif  //  SQLITE_ORM_OMITS_CODECVT
-#include <vector>   //  std::vector
+#include <vector>  //  std::vector
 #include <cstring>  //  strlen
-#include <algorithm>    //  std::copy
-#include <iterator> //  std::back_inserter
-#include <tuple>    //  std::tuple, std::tuple_size, std::tuple_element
+#include <algorithm>  //  std::copy
+#include <iterator>  //  std::back_inserter
+#include <tuple>  //  std::tuple, std::tuple_size, std::tuple_element
 
 // #include "arithmetic_tag.h"
 
 // #include "journal_mode.h"
 
 
-#include <string>   //  std::string
-#include <memory>   //  std::unique_ptr
-#include <array>    //  std::array
-#include <algorithm>    //  std::transform
-#include <locale>   // std::toupper
+#include <string>  //  std::string
+#include <memory>  //  std::unique_ptr
+#include <array>  //  std::array
+#include <algorithm>  //  std::transform
+#include <locale>  // std::toupper
 
 namespace sqlite_orm {
-    
-    /**
-     *  Caps case cause of 1) delete keyword; 2) https://www.sqlite.org/pragma.html#pragma_journal_mode original spelling
-     */
-    #ifdef DELETE
-        #undef DELETE
-    #endif
+
+/**
+ *  Caps case cause of 1) delete keyword; 2) https://www.sqlite.org/pragma.html#pragma_journal_mode original spelling
+ */
+#ifdef DELETE
+#undef DELETE
+#endif
     enum class journal_mode : signed char {
         DELETE = 0,
         TRUNCATE = 1,
@@ -4402,11 +4451,11 @@ namespace sqlite_orm {
         MEMORY = 3,
         WAL = 4,
         OFF = 5,
-        };
-    
+    };
+
     namespace internal {
-        
-        inline const std::string& to_string(journal_mode j) {
+
+        inline const std::string &to_string(journal_mode j) {
             static std::string res[] = {
                 "DELETE",
                 "TRUNCATE",
@@ -4417,7 +4466,7 @@ namespace sqlite_orm {
             };
             return res[static_cast<int>(j)];
         }
-        
+
         inline std::unique_ptr<journal_mode> journal_mode_from_string(const std::string &str) {
             std::string upper_str;
             std::transform(str.begin(), str.end(), std::back_inserter(upper_str), ::toupper);
@@ -4429,8 +4478,8 @@ namespace sqlite_orm {
                 journal_mode::WAL,
                 journal_mode::OFF,
             };
-            for(auto j : all) {
-                if(to_string(j) == upper_str){
+            for(auto j: all) {
+                if(to_string(j) == upper_str) {
                     return std::make_unique<journal_mode>(j);
                 }
             }
@@ -4443,89 +4492,80 @@ namespace sqlite_orm {
 
 
 namespace sqlite_orm {
-    
+
     /**
      *  Helper class used to cast values from argv to V class
      *  which depends from column type.
      *
      */
     template<class V, typename Enable = void>
-    struct row_extractor
-    {
+    struct row_extractor {
         //  used in sqlite3_exec (select)
         V extract(const char *row_value);
-        
+
         //  used in sqlite_column (iteration, get_all)
         V extract(sqlite3_stmt *stmt, int columnIndex);
     };
-    
+
     /**
      *  Specialization for arithmetic types.
      */
     template<class V>
-    struct row_extractor<
-    V,
-    std::enable_if_t<std::is_arithmetic<V>::value>
-    >
-    {
+    struct row_extractor<V, std::enable_if_t<std::is_arithmetic<V>::value>> {
         V extract(const char *row_value) {
             return extract(row_value, tag());
         }
-        
+
         V extract(sqlite3_stmt *stmt, int columnIndex) {
             return extract(stmt, columnIndex, tag());
         }
-        
-    private:
+
+      private:
         using tag = arithmetic_tag_t<V>;
-        
-        V extract(const char *row_value, const int_or_smaller_tag&) {
+
+        V extract(const char *row_value, const int_or_smaller_tag &) {
             return static_cast<V>(atoi(row_value));
         }
-        
-        V extract(sqlite3_stmt *stmt, int columnIndex, const int_or_smaller_tag&) {
+
+        V extract(sqlite3_stmt *stmt, int columnIndex, const int_or_smaller_tag &) {
             return static_cast<V>(sqlite3_column_int(stmt, columnIndex));
         }
-        
-        V extract(const char *row_value, const bigint_tag&) {
+
+        V extract(const char *row_value, const bigint_tag &) {
             return static_cast<V>(atoll(row_value));
         }
-        
-        V extract(sqlite3_stmt *stmt, int columnIndex, const bigint_tag&) {
+
+        V extract(sqlite3_stmt *stmt, int columnIndex, const bigint_tag &) {
             return static_cast<V>(sqlite3_column_int64(stmt, columnIndex));
         }
-        
-        V extract(const char *row_value, const real_tag&) {
+
+        V extract(const char *row_value, const real_tag &) {
             return static_cast<V>(atof(row_value));
         }
-        
-        V extract(sqlite3_stmt *stmt, int columnIndex, const real_tag&) {
+
+        V extract(sqlite3_stmt *stmt, int columnIndex, const real_tag &) {
             return static_cast<V>(sqlite3_column_double(stmt, columnIndex));
         }
     };
-    
+
     /**
      *  Specialization for std::string.
      */
     template<class V>
-    struct row_extractor<
-    V,
-    std::enable_if_t<std::is_same<V, std::string>::value>
-    >
-    {
+    struct row_extractor<V, std::enable_if_t<std::is_same<V, std::string>::value>> {
         std::string extract(const char *row_value) {
-            if(row_value){
+            if(row_value) {
                 return row_value;
-            }else{
+            } else {
                 return {};
             }
         }
-        
+
         std::string extract(sqlite3_stmt *stmt, int columnIndex) {
-            auto cStr = (const char*)sqlite3_column_text(stmt, columnIndex);
-            if(cStr){
+            auto cStr = (const char *)sqlite3_column_text(stmt, columnIndex);
+            if(cStr) {
                 return cStr;
-            }else{
+            } else {
                 return {};
             }
         }
@@ -4535,26 +4575,22 @@ namespace sqlite_orm {
      *  Specialization for std::wstring.
      */
     template<class V>
-    struct row_extractor<
-    V,
-    std::enable_if_t<std::is_same<V, std::wstring>::value>
-    >
-    {
+    struct row_extractor<V, std::enable_if_t<std::is_same<V, std::wstring>::value>> {
         std::wstring extract(const char *row_value) {
-            if(row_value){
+            if(row_value) {
                 std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
                 return converter.from_bytes(row_value);
-            }else{
+            } else {
                 return {};
             }
         }
-        
+
         std::wstring extract(sqlite3_stmt *stmt, int columnIndex) {
-            auto cStr = (const char*)sqlite3_column_text(stmt, columnIndex);
-            if(cStr){
+            auto cStr = (const char *)sqlite3_column_text(stmt, columnIndex);
+            if(cStr) {
                 std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
                 return converter.from_bytes(cStr);
-            }else{
+            } else {
                 return {};
             }
         }
@@ -4564,169 +4600,150 @@ namespace sqlite_orm {
      *  Specialization for std::vector<char>.
      */
     template<class V>
-    struct row_extractor<
-    V,
-    std::enable_if_t<std::is_same<V, std::vector<char>>::value>
-    >
-    {
+    struct row_extractor<V, std::enable_if_t<std::is_same<V, std::vector<char>>::value>> {
         std::vector<char> extract(const char *row_value) {
-            if(row_value){
+            if(row_value) {
                 auto len = ::strlen(row_value);
                 return this->go(row_value, len);
-            }else{
+            } else {
                 return {};
             }
         }
-        
+
         std::vector<char> extract(sqlite3_stmt *stmt, int columnIndex) {
             auto bytes = static_cast<const char *>(sqlite3_column_blob(stmt, columnIndex));
             auto len = sqlite3_column_bytes(stmt, columnIndex);
             return this->go(bytes, len);
         }
-        
-    protected:
-        
+
+      protected:
         std::vector<char> go(const char *bytes, size_t len) {
-            if(len){
+            if(len) {
                 std::vector<char> res;
                 res.reserve(len);
-                std::copy(bytes,
-                          bytes + len,
-                          std::back_inserter(res));
+                std::copy(bytes, bytes + len, std::back_inserter(res));
                 return res;
-            }else{
+            } else {
                 return {};
             }
         }
     };
-    
+
     template<class V>
-    struct row_extractor<
-    V,
-    std::enable_if_t<is_std_ptr<V>::value>
-    >
-    {
+    struct row_extractor<V, std::enable_if_t<is_std_ptr<V>::value>> {
         using value_type = typename V::element_type;
-        
+
         V extract(const char *row_value) {
-            if(row_value){
+            if(row_value) {
                 return is_std_ptr<V>::make(row_extractor<value_type>().extract(row_value));
-            }else{
+            } else {
                 return {};
             }
         }
-        
+
         V extract(sqlite3_stmt *stmt, int columnIndex) {
             auto type = sqlite3_column_type(stmt, columnIndex);
-            if(type != SQLITE_NULL){
+            if(type != SQLITE_NULL) {
                 return is_std_ptr<V>::make(row_extractor<value_type>().extract(stmt, columnIndex));
-            }else{
+            } else {
                 return {};
             }
         }
     };
-    
+
     /**
      *  Specialization for std::vector<char>.
      */
     template<>
     struct row_extractor<std::vector<char>> {
         std::vector<char> extract(const char *row_value) {
-            if(row_value){
+            if(row_value) {
                 auto len = ::strlen(row_value);
                 return this->go(row_value, len);
-            }else{
+            } else {
                 return {};
             }
         }
-        
+
         std::vector<char> extract(sqlite3_stmt *stmt, int columnIndex) {
             auto bytes = static_cast<const char *>(sqlite3_column_blob(stmt, columnIndex));
             auto len = static_cast<size_t>(sqlite3_column_bytes(stmt, columnIndex));
             return this->go(bytes, len);
         }
-        
-    protected:
-        
+
+      protected:
         std::vector<char> go(const char *bytes, size_t len) {
-            if(len){
+            if(len) {
                 std::vector<char> res;
                 res.reserve(len);
-                std::copy(bytes,
-                          bytes + len,
-                          std::back_inserter(res));
+                std::copy(bytes, bytes + len, std::back_inserter(res));
                 return res;
-            }else{
+            } else {
                 return {};
             }
         }
     };
-    
-    template<class ...Args>
+
+    template<class... Args>
     struct row_extractor<std::tuple<Args...>> {
-        
+
         std::tuple<Args...> extract(char **argv) {
             std::tuple<Args...> res;
             this->extract<std::tuple_size<decltype(res)>::value>(res, argv);
             return res;
         }
-        
+
         std::tuple<Args...> extract(sqlite3_stmt *stmt, int /*columnIndex*/) {
             std::tuple<Args...> res;
             this->extract<std::tuple_size<decltype(res)>::value>(res, stmt);
             return res;
         }
-        
-    protected:
-        
+
+      protected:
         template<size_t I, typename std::enable_if<I != 0>::type * = nullptr>
         void extract(std::tuple<Args...> &t, sqlite3_stmt *stmt) {
             using tuple_type = typename std::tuple_element<I - 1, typename std::tuple<Args...>>::type;
             std::get<I - 1>(t) = row_extractor<tuple_type>().extract(stmt, I - 1);
             this->extract<I - 1>(t, stmt);
         }
-        
+
         template<size_t I, typename std::enable_if<I == 0>::type * = nullptr>
         void extract(std::tuple<Args...> &, sqlite3_stmt *) {
             //..
         }
-        
+
         template<size_t I, typename std::enable_if<I != 0>::type * = nullptr>
         void extract(std::tuple<Args...> &t, char **argv) {
             using tuple_type = typename std::tuple_element<I - 1, typename std::tuple<Args...>>::type;
             std::get<I - 1>(t) = row_extractor<tuple_type>().extract(argv[I - 1]);
             this->extract<I - 1>(t, argv);
         }
-        
+
         template<size_t I, typename std::enable_if<I == 0>::type * = nullptr>
         void extract(std::tuple<Args...> &, char **) {
             //..
         }
     };
-    
+
     /**
      *  Specialization for journal_mode.
      */
     template<class V>
-    struct row_extractor<
-    V,
-    std::enable_if_t<std::is_same<V, journal_mode>::value>
-    >
-    {
+    struct row_extractor<V, std::enable_if_t<std::is_same<V, journal_mode>::value>> {
         journal_mode extract(const char *row_value) {
-            if(row_value){
-                if(auto res = internal::journal_mode_from_string(row_value)){
+            if(row_value) {
+                if(auto res = internal::journal_mode_from_string(row_value)) {
                     return std::move(*res);
-                }else{
+                } else {
                     throw std::system_error(std::make_error_code(orm_error_code::incorrect_journal_mode_string));
                 }
-            }else{
+            } else {
                 throw std::system_error(std::make_error_code(orm_error_code::incorrect_journal_mode_string));
             }
         }
-        
+
         journal_mode extract(sqlite3_stmt *stmt, int columnIndex) {
-            auto cStr = (const char*)sqlite3_column_text(stmt, columnIndex);
+            auto cStr = (const char *)sqlite3_column_text(stmt, columnIndex);
             return this->extract(cStr);
         }
     };
@@ -4736,34 +4753,34 @@ namespace sqlite_orm {
 #include <ostream>
 
 namespace sqlite_orm {
-    
+
     enum class sync_schema_result {
-        
+
         /**
          *  created new table, table with the same tablename did not exist
          */
         new_table_created,
-        
+
         /**
          *  table schema is the same as storage, nothing to be done
          */
         already_in_sync,
-        
+
         /**
          *  removed excess columns in table (than storage) without dropping a table
          */
         old_columns_removed,
-        
+
         /**
          *  lacking columns in table (than storage) added without dropping a table
          */
         new_columns_added,
-        
+
         /**
          *  both old_columns_removed and new_columns_added
          */
         new_columns_added_and_old_columns_removed,
-        
+
         /**
          *  old table is dropped and new is recreated. Reasons :
          *      1. delete excess columns in the table than storage if preseve = false
@@ -4773,51 +4790,56 @@ namespace sqlite_orm {
          */
         dropped_and_recreated,
     };
-    
-    
-    inline std::ostream& operator<<(std::ostream &os, sync_schema_result value) {
-        switch(value){
-            case sync_schema_result::new_table_created: return os << "new table created";
-            case sync_schema_result::already_in_sync: return os << "table and storage is already in sync.";
-            case sync_schema_result::old_columns_removed: return os << "old excess columns removed";
-            case sync_schema_result::new_columns_added: return os << "new columns added";
-            case sync_schema_result::new_columns_added_and_old_columns_removed: return os << "old excess columns removed and new columns added";
-            case sync_schema_result::dropped_and_recreated: return os << "old table dropped and recreated";
+
+    inline std::ostream &operator<<(std::ostream &os, sync_schema_result value) {
+        switch(value) {
+            case sync_schema_result::new_table_created:
+                return os << "new table created";
+            case sync_schema_result::already_in_sync:
+                return os << "table and storage is already in sync.";
+            case sync_schema_result::old_columns_removed:
+                return os << "old excess columns removed";
+            case sync_schema_result::new_columns_added:
+                return os << "new columns added";
+            case sync_schema_result::new_columns_added_and_old_columns_removed:
+                return os << "old excess columns removed and new columns added";
+            case sync_schema_result::dropped_and_recreated:
+                return os << "old table dropped and recreated";
         }
         return os;
     }
 }
 #pragma once
 
-#include <tuple>    //  std::tuple, std::make_tuple
-#include <string>   //  std::string
+#include <tuple>  //  std::tuple, std::make_tuple
+#include <string>  //  std::string
 #include <utility>  //  std::forward
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
-        template<class ...Cols>
+
+        template<class... Cols>
         struct index_t {
             using columns_type = std::tuple<Cols...>;
             using object_type = void;
-            
+
             std::string name;
             bool unique;
             columns_type columns;
-            
+
             template<class L>
             void for_each_column_with_constraints(const L &) {}
         };
     }
-    
-    template<class ...Cols>
-    internal::index_t<Cols...> make_index(const std::string &name, Cols ...cols) {
+
+    template<class... Cols>
+    internal::index_t<Cols...> make_index(const std::string &name, Cols... cols) {
         return {name, false, std::make_tuple(std::forward<Cols>(cols)...)};
     }
-    
-    template<class ...Cols>
-    internal::index_t<Cols...> make_unique_index(const std::string &name, Cols ...cols) {
+
+    template<class... Cols>
+    internal::index_t<Cols...> make_unique_index(const std::string &name, Cols... cols) {
         return {name, true, std::make_tuple(std::forward<Cols>(cols)...)};
     }
 }
@@ -4827,9 +4849,9 @@ namespace sqlite_orm {
 
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         /**
          *  If T is alias than mapped_type_proxy<T>::type is alias::type
          *  otherwise T is T.
@@ -4838,7 +4860,7 @@ namespace sqlite_orm {
         struct mapped_type_proxy {
             using type = T;
         };
-        
+
         template<class T>
         struct mapped_type_proxy<T, typename std::enable_if<std::is_base_of<alias_tag, T>::value>::type> {
             using type = typename T::type;
@@ -4847,35 +4869,35 @@ namespace sqlite_orm {
 }
 #pragma once
 
-#include <string>   //  std::string
+#include <string>  //  std::string
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         struct rowid_t {
             operator std::string() const {
                 return "rowid";
             }
         };
-        
+
         struct oid_t {
             operator std::string() const {
                 return "oid";
             }
         };
-        
+
         struct _rowid_t {
             operator std::string() const {
                 return "_rowid_";
             }
         };
-        
+
         template<class T>
         struct table_rowid_t : public rowid_t {
             using type = T;
         };
-        
+
         template<class T>
         struct table_oid_t : public oid_t {
             using type = T;
@@ -4884,31 +4906,31 @@ namespace sqlite_orm {
         struct table__rowid_t : public _rowid_t {
             using type = T;
         };
-        
+
     }
-    
+
     inline internal::rowid_t rowid() {
         return {};
     }
-    
+
     inline internal::oid_t oid() {
         return {};
     }
-    
+
     inline internal::_rowid_t _rowid_() {
         return {};
     }
-    
+
     template<class T>
     internal::table_rowid_t<T> rowid() {
         return {};
     }
-    
+
     template<class T>
     internal::table_oid_t<T> oid() {
         return {};
     }
-    
+
     template<class T>
     internal::table__rowid_t<T> _rowid_() {
         return {};
@@ -4917,7 +4939,7 @@ namespace sqlite_orm {
 #pragma once
 
 #include <type_traits>  //  std::enable_if, std::is_same, std::decay
-#include <tuple>    //  std::tuple
+#include <tuple>  //  std::tuple
 
 // #include "core_functions.h"
 
@@ -4935,81 +4957,94 @@ namespace sqlite_orm {
 
 // #include "storage_traits.h"
 #include <type_traits>  //  std::is_same, std::enable_if, std::true_type, std::false_type, std::integral_constant
-#include <tuple>    //  std::tuple
+#include <tuple>  //  std::tuple
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
-        template<class ...Ts>
+
+        template<class... Ts>
         struct storage_impl;
-        
+
         template<class T, class... Args>
         struct table_t;
-        
+
         namespace storage_traits {
-            
+
             /**
              *  S - storage_impl type
              *  T - mapped or not mapped data type
              */
             template<class S, class T, class SFINAE = void>
             struct type_is_mapped_impl;
-            
+
             /**
              *  S - storage
              *  T - mapped or not mapped data type
              */
             template<class S, class T>
             struct type_is_mapped : type_is_mapped_impl<typename S::impl_type, T> {};
-            
+
             /**
              *  Final specialisation
              */
             template<class T>
             struct type_is_mapped_impl<storage_impl<>, T, void> : std::false_type {};
-            
+
             template<class S, class T>
-            struct type_is_mapped_impl<S, T, typename std::enable_if<std::is_same<T, typename S::table_type::object_type>::value>::type> : std::true_type {};
-            
+            struct type_is_mapped_impl<
+                S,
+                T,
+                typename std::enable_if<std::is_same<T, typename S::table_type::object_type>::value>::type>
+                : std::true_type {};
+
             template<class S, class T>
-            struct type_is_mapped_impl<S, T, typename std::enable_if<!std::is_same<T, typename S::table_type::object_type>::value>::type>
-            : type_is_mapped_impl<typename S::super, T> {};
-            
-            
+            struct type_is_mapped_impl<
+                S,
+                T,
+                typename std::enable_if<!std::is_same<T, typename S::table_type::object_type>::value>::type>
+                : type_is_mapped_impl<typename S::super, T> {};
+
             /**
              *  S - storage_impl type
              *  T - mapped or not mapped data type
              */
             template<class S, class T, class SFINAE = void>
             struct storage_columns_count_impl;
-            
+
             /**
              *  S - storage
              *  T - mapped or not mapped data type
              */
             template<class S, class T>
             struct storage_columns_count : storage_columns_count_impl<typename S::impl_type, T> {};
-            
+
             /**
              *  Final specialisation
              */
             template<class T>
             struct storage_columns_count_impl<storage_impl<>, T, void> : std::integral_constant<int, 0> {};
-            
+
             template<class S, class T>
-            struct storage_columns_count_impl<S, T,  typename std::enable_if<std::is_same<T, typename S::table_type::object_type>::value>::type> : std::integral_constant<int, S::table_type::columns_count> {};
-            
+            struct storage_columns_count_impl<
+                S,
+                T,
+                typename std::enable_if<std::is_same<T, typename S::table_type::object_type>::value>::type>
+                : std::integral_constant<int, S::table_type::columns_count> {};
+
             template<class S, class T>
-            struct storage_columns_count_impl<S, T,  typename std::enable_if<!std::is_same<T, typename S::table_type::object_type>::value>::type> : storage_columns_count_impl<typename S::super, T> {};
-            
-            
+            struct storage_columns_count_impl<
+                S,
+                T,
+                typename std::enable_if<!std::is_same<T, typename S::table_type::object_type>::value>::type>
+                : storage_columns_count_impl<typename S::super, T> {};
+
             /**
              *  T - table type.
              */
             template<class T>
             struct table_types;
-            
+
             /**
              *  type is std::tuple of field types of mapped colums.
              */
@@ -5017,22 +5052,21 @@ namespace sqlite_orm {
             struct table_types<table_t<T, Args...>> {
                 using type = std::tuple<typename Args::field_type...>;
             };
-            
-            
+
             /**
              *  S - storage_impl type
              *  T - mapped or not mapped data type
              */
             template<class S, class T, class SFINAE = void>
             struct storage_mapped_columns_impl;
-            
+
             /**
              *  S - storage
              *  T - mapped or not mapped data type
              */
             template<class S, class T>
             struct storage_mapped_columns : storage_mapped_columns_impl<typename S::impl_type, T> {};
-            
+
             /**
              *  Final specialisation
              */
@@ -5040,25 +5074,32 @@ namespace sqlite_orm {
             struct storage_mapped_columns_impl<storage_impl<>, T, void> {
                 using type = std::tuple<>;
             };
-            
+
             template<class S, class T>
-            struct storage_mapped_columns_impl<S, T, typename std::enable_if<std::is_same<T, typename S::table_type::object_type>::value>::type> {
+            struct storage_mapped_columns_impl<
+                S,
+                T,
+                typename std::enable_if<std::is_same<T, typename S::table_type::object_type>::value>::type> {
                 using table_type = typename S::table_type;
                 using type = typename table_types<table_type>::type;
             };
-            
+
             template<class S, class T>
-            struct storage_mapped_columns_impl<S, T, typename std::enable_if<!std::is_same<T, typename S::table_type::object_type>::value>::type> : storage_mapped_columns_impl<typename S::super, T> {};
-            
+            struct storage_mapped_columns_impl<
+                S,
+                T,
+                typename std::enable_if<!std::is_same<T, typename S::table_type::object_type>::value>::type>
+                : storage_mapped_columns_impl<typename S::super, T> {};
+
         }
     }
 }
 
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         /**
          *  This is a proxy class used to define what type must have result type depending on select
          *  arguments (member pointer, aggregate functions, etc). Below you can see specializations
@@ -5070,12 +5111,15 @@ namespace sqlite_orm {
          */
         template<class St, class T, class SFINAE = void>
         struct column_result_t;
-        
+
         template<class St, class O, class F>
-        struct column_result_t<St, F O::*, typename std::enable_if<std::is_member_pointer<F O::*>::value && !std::is_member_function_pointer<F O::*>::value>::type> {
+        struct column_result_t<St,
+                               F O::*,
+                               typename std::enable_if<std::is_member_pointer<F O::*>::value &&
+                                                       !std::is_member_function_pointer<F O::*>::value>::type> {
             using type = F;
         };
-        
+
         /**
          *  Common case for all getter types. Getter types are defined in column.h file
          */
@@ -5083,7 +5127,7 @@ namespace sqlite_orm {
         struct column_result_t<St, T, typename std::enable_if<is_getter<T>::value>::type> {
             using type = typename getter_traits<T>::field_type;
         };
-        
+
         /**
          *  Common case for all setter types. Setter types are defined in column.h file
          */
@@ -5091,158 +5135,162 @@ namespace sqlite_orm {
         struct column_result_t<St, T, typename std::enable_if<is_setter<T>::value>::type> {
             using type = typename setter_traits<T>::field_type;
         };
-        
+
         template<class St, class T>
-        struct column_result_t<St, T, typename std::enable_if<is_base_of_template<T, core_functions::core_function_t>::value>::type> {
+        struct column_result_t<
+            St,
+            T,
+            typename std::enable_if<is_base_of_template<T, core_functions::core_function_t>::value>::type> {
             using type = typename T::return_type;
         };
-        
+
         template<class St, class T>
         struct column_result_t<St, aggregate_functions::avg_t<T>, void> {
             using type = double;
         };
-        
+
         template<class St, class T>
         struct column_result_t<St, aggregate_functions::count_t<T>, void> {
             using type = int;
         };
-        
+
         template<class St, class T>
         struct column_result_t<St, aggregate_functions::count_asterisk_t<T>, void> {
             using type = int;
         };
-        
+
         template<class St, class T>
         struct column_result_t<St, aggregate_functions::sum_t<T>, void> {
             using type = std::unique_ptr<double>;
         };
-        
+
         template<class St, class T>
         struct column_result_t<St, aggregate_functions::total_t<T>, void> {
             using type = double;
         };
-        
+
         template<class St, class T>
         struct column_result_t<St, aggregate_functions::group_concat_single_t<T>, void> {
             using type = std::string;
         };
-        
+
         template<class St, class T>
         struct column_result_t<St, aggregate_functions::group_concat_double_t<T>, void> {
             using type = std::string;
         };
-        
+
         template<class St, class T>
         struct column_result_t<St, aggregate_functions::max_t<T>, void> {
             using type = std::unique_ptr<typename column_result_t<St, T>::type>;
         };
-        
+
         template<class St, class T>
         struct column_result_t<St, aggregate_functions::min_t<T>, void> {
             using type = std::unique_ptr<typename column_result_t<St, T>::type>;
         };
-        
+
         template<class St>
         struct column_result_t<St, aggregate_functions::count_asterisk_without_type, void> {
             using type = int;
         };
-        
+
         template<class St, class T>
         struct column_result_t<St, distinct_t<T>, void> {
             using type = typename column_result_t<St, T>::type;
         };
-        
+
         template<class St, class T>
         struct column_result_t<St, all_t<T>, void> {
             using type = typename column_result_t<St, T>::type;
         };
-        
+
         template<class St, class L, class R>
         struct column_result_t<St, conc_t<L, R>, void> {
             using type = std::string;
         };
-        
+
         template<class St, class L, class R>
         struct column_result_t<St, add_t<L, R>, void> {
             using type = double;
         };
-        
+
         template<class St, class L, class R>
         struct column_result_t<St, sub_t<L, R>, void> {
             using type = double;
         };
-        
+
         template<class St, class L, class R>
         struct column_result_t<St, mul_t<L, R>, void> {
             using type = double;
         };
-        
+
         template<class St, class L, class R>
         struct column_result_t<St, internal::div_t<L, R>, void> {
             using type = double;
         };
-        
+
         template<class St, class L, class R>
         struct column_result_t<St, mod_t<L, R>, void> {
             using type = double;
         };
-        
+
         template<class St>
         struct column_result_t<St, rowid_t, void> {
             using type = int64;
         };
-        
+
         template<class St>
         struct column_result_t<St, oid_t, void> {
             using type = int64;
         };
-        
+
         template<class St>
         struct column_result_t<St, _rowid_t, void> {
             using type = int64;
         };
-        
+
         template<class St, class T>
         struct column_result_t<St, table_rowid_t<T>, void> {
             using type = int64;
         };
-        
+
         template<class St, class T>
         struct column_result_t<St, table_oid_t<T>, void> {
             using type = int64;
         };
-        
+
         template<class St, class T>
         struct column_result_t<St, table__rowid_t<T>, void> {
             using type = int64;
         };
-        
+
         template<class St, class T, class C>
         struct column_result_t<St, alias_column_t<T, C>, void> {
             using type = typename column_result_t<St, C>::type;
         };
-        
+
         template<class St, class T, class F>
         struct column_result_t<St, column_pointer<T, F>> : column_result_t<St, F, void> {};
-        
-        template<class St, class ...Args>
+
+        template<class St, class... Args>
         struct column_result_t<St, columns_t<Args...>, void> {
             using type = std::tuple<typename column_result_t<St, typename std::decay<Args>::type>::type...>;
         };
-        
-        template<class St, class T, class ...Args>
+
+        template<class St, class T, class... Args>
         struct column_result_t<St, select_t<T, Args...>> : column_result_t<St, T, void> {};
-        
+
         template<class St, class T>
         struct column_result_t<St, T, typename std::enable_if<is_base_of_template<T, compound_operator>::value>::type> {
             using left_type = typename T::left_type;
             using right_type = typename T::right_type;
             using left_result = typename column_result_t<St, left_type>::type;
             using right_result = typename column_result_t<St, right_type>::type;
-            static_assert(std::is_same<left_result, right_result>::value, "Compound subselect queries must return same types");
+            static_assert(std::is_same<left_result, right_result>::value,
+                          "Compound subselect queries must return same types");
             using type = left_result;
         };
-        
+
         /**
          *  Result for the most simple queries like `SELECT 1`
          */
@@ -5250,43 +5298,43 @@ namespace sqlite_orm {
         struct column_result_t<St, T, typename std::enable_if<std::is_arithmetic<T>::value>::type> {
             using type = T;
         };
-        
+
         /**
          *  Result for the most simple queries like `SELECT 'ototo'`
          */
         template<class St>
-        struct column_result_t<St, const char*, void> {
+        struct column_result_t<St, const char *, void> {
             using type = std::string;
         };
-        
+
         template<class St, class T, class E>
         struct column_result_t<St, as_t<T, E>, void> : column_result_t<St, typename std::decay<E>::type, void> {};
-        
+
         template<class St, class T>
         struct column_result_t<St, asterisk_t<T>, void> {
             using type = typename storage_traits::storage_mapped_columns<St, T>::type;
         };
-        
+
         template<class St, class T, class E>
         struct column_result_t<St, conditions::cast_t<T, E>, void> {
             using type = T;
         };
-        
-        template<class St, class R, class T, class E, class ...Args>
+
+        template<class St, class R, class T, class E, class... Args>
         struct column_result_t<St, simple_case_t<R, T, E, Args...>, void> {
             using type = R;
         };
-        
+
         template<class St, class A, class T, class E>
         struct column_result_t<St, conditions::like_t<A, T, E>, void> {
             using type = bool;
         };
-        
+
         template<class St, class A, class T>
         struct column_result_t<St, conditions::glob_t<A, T>, void> {
             using type = bool;
         };
-        
+
         template<class St, class C>
         struct column_result_t<St, conditions::negated_condition_t<C>, void> {
             using type = bool;
@@ -5295,11 +5343,11 @@ namespace sqlite_orm {
 }
 #pragma once
 
-#include <string>   //  std::string
+#include <string>  //  std::string
 #include <type_traits>  //  std::remove_reference, std::is_same, std::is_base_of
-#include <vector>   //  std::vector
-#include <tuple>    //  std::tuple_size, std::tuple_element
-#include <algorithm>    //  std::reverse, std::find_if
+#include <vector>  //  std::vector
+#include <tuple>  //  std::tuple_size, std::tuple_element
+#include <algorithm>  //  std::reverse, std::find_if
 
 // #include "column_result.h"
 
@@ -5319,69 +5367,70 @@ namespace sqlite_orm {
 
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         struct table_base {
-            
+
             /**
              *  Table name.
              */
             const std::string name;
-            
+
             bool _without_rowid = false;
         };
-        
+
         /**
          *  Table interface class. Implementation is hidden in `table_impl` class.
          */
-        template<class T, class ...Cs>
+        template<class T, class... Cs>
         struct table_t : table_base {
             using object_type = T;
             using columns_type = std::tuple<Cs...>;
-            
+
             static constexpr const int columns_count = static_cast<int>(std::tuple_size<columns_type>::value);
-            
+
             columns_type columns;
-            
-            table_t(decltype(name) name_, columns_type columns_): table_base{std::move(name_)}, columns(std::move(columns_)) {}
-            
+
+            table_t(decltype(name) name_, columns_type columns_) :
+                table_base{std::move(name_)}, columns(std::move(columns_)) {}
+
             table_t<T, Cs...> without_rowid() const {
                 auto res = *this;
                 res._without_rowid = true;
                 return res;
             }
-            
+
             /**
              *  Function used to get field value from object by mapped member pointer/setter/getter
              */
             template<class F, class C>
-            const F* get_object_field_pointer(const object_type &obj, C c) const {
+            const F *get_object_field_pointer(const object_type &obj, C c) const {
                 const F *res = nullptr;
-                this->for_each_column_with_field_type<F>([&res, &c, &obj](auto &col){
+                this->for_each_column_with_field_type<F>([&res, &c, &obj](auto &col) {
                     using column_type = typename std::remove_reference<decltype(col)>::type;
                     using member_pointer_t = typename column_type::member_pointer_t;
                     using getter_type = typename column_type::getter_type;
                     using setter_type = typename column_type::setter_type;
                     // Make static_if have at least one input as a workaround for GCC bug:
                     // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64095
-                    if(!res){
-                        static_if<std::is_same<C, member_pointer_t>{}>([&res, &obj, &col](const C &c){
-                            if(compare_any(col.member_pointer, c)){
+                    if(!res) {
+                        static_if<std::is_same<C, member_pointer_t>{}>([&res, &obj, &col](const C &c) {
+                            if(compare_any(col.member_pointer, c)) {
                                 res = &(obj.*col.member_pointer);
                             }
                         })(c);
                     }
-                    if(!res){
-                        static_if<std::is_same<C, getter_type>{}>([&res, &obj, &col](const C &c){
-                            if(compare_any(col.getter, c)){
+                    if(!res) {
+                        static_if<std::is_same<C, getter_type>{}>([&res, &obj, &col](const C &c) {
+                            if(compare_any(col.getter, c)) {
                                 res = &((obj).*(col.getter))();
                             }
                         })(c);
                     }
-                    if(!res){
-                        static_if<std::is_same<C, setter_type>{}>([&res, &obj, &col](const C &c){
-                            if(compare_any(col.setter, c)){
+                    if(!res) {
+                        static_if<std::is_same<C, setter_type>{}>([&res, &obj, &col](const C &c) {
+                            if(compare_any(col.setter, c)) {
                                 res = &((obj).*(col.getter))();
                             }
                         })(c);
@@ -5389,67 +5438,67 @@ namespace sqlite_orm {
                 });
                 return res;
             }
-            
+
             /**
              *  @return vector of column names of table.
              */
             std::vector<std::string> column_names() const {
                 std::vector<std::string> res;
-                this->for_each_column([&res](auto &c){
+                this->for_each_column([&res](auto &c) {
                     res.push_back(c.name);
                 });
                 return res;
             }
-            
+
             /**
              *  Calls **l** with every primary key dedicated constraint
              */
             template<class L>
             void for_each_primary_key(const L &l) const {
-                iterate_tuple(this->columns, [&l](auto &column){
+                iterate_tuple(this->columns, [&l](auto &column) {
                     using column_type = typename std::decay<decltype(column)>::type;
                     static_if<internal::is_primary_key<column_type>{}>(l)(column);
                 });
             }
-            
+
             std::vector<std::string> composite_key_columns_names() const {
                 std::vector<std::string> res;
-                this->for_each_primary_key([this, &res](auto &c){
+                this->for_each_primary_key([this, &res](auto &c) {
                     res = this->composite_key_columns_names(c);
                 });
                 return res;
             }
-            
+
             std::vector<std::string> primary_key_column_names() const {
                 std::vector<std::string> res;
-                this->for_each_column_with<constraints::primary_key_t<>>([&res](auto &c){
+                this->for_each_column_with<constraints::primary_key_t<>>([&res](auto &c) {
                     res.push_back(c.name);
                 });
-                if(!res.size()){
+                if(!res.size()) {
                     res = this->composite_key_columns_names();
                 }
                 return res;
             }
-            
-            template<class ...Args>
+
+            template<class... Args>
             std::vector<std::string> composite_key_columns_names(const constraints::primary_key_t<Args...> &pk) const {
                 std::vector<std::string> res;
                 using pk_columns_tuple = decltype(pk.columns);
                 res.reserve(std::tuple_size<pk_columns_tuple>::value);
-                iterate_tuple(pk.columns, [this, &res](auto &v){
+                iterate_tuple(pk.columns, [this, &res](auto &v) {
                     res.push_back(this->find_column_name(v));
                 });
                 return res;
             }
-            
+
             /**
              *  Searches column name by class member pointer passed as first argument.
              *  @return column name or empty string if nothing found.
              */
-            template<
-            class F,
-            class O,
-            typename = typename std::enable_if<std::is_member_pointer<F O::*>::value && !std::is_member_function_pointer<F O::*>::value>::type>
+            template<class F,
+                     class O,
+                     typename = typename std::enable_if<std::is_member_pointer<F O::*>::value &&
+                                                        !std::is_member_function_pointer<F O::*>::value>::type>
             std::string find_column_name(F O::*m) const {
                 std::string res;
                 this->template for_each_column_with_field_type<F>([&res, m](auto c) {
@@ -5459,13 +5508,14 @@ namespace sqlite_orm {
                 });
                 return res;
             }
-            
+
             /**
              *  Searches column name by class getter function member pointer passed as first argument.
              *  @return column name or empty string if nothing found.
              */
             template<class G>
-            std::string find_column_name(G getter, typename std::enable_if<is_getter<G>::value>::type * = nullptr) const {
+            std::string find_column_name(G getter,
+                                         typename std::enable_if<is_getter<G>::value>::type * = nullptr) const {
                 std::string res;
                 using field_type = typename getter_traits<G>::field_type;
                 this->template for_each_column_with_field_type<field_type>([&res, getter](auto c) {
@@ -5475,13 +5525,14 @@ namespace sqlite_orm {
                 });
                 return res;
             }
-            
+
             /**
              *  Searches column name by class setter function member pointer passed as first argument.
              *  @return column name or empty string if nothing found.
              */
             template<class S>
-            std::string find_column_name(S setter, typename std::enable_if<is_setter<S>::value>::type * = nullptr) const {
+            std::string find_column_name(S setter,
+                                         typename std::enable_if<is_setter<S>::value>::type * = nullptr) const {
                 std::string res;
                 using field_type = typename setter_traits<S>::field_type;
                 this->template for_each_column_with_field_type<field_type>([&res, setter](auto c) {
@@ -5491,49 +5542,50 @@ namespace sqlite_orm {
                 });
                 return res;
             }
-            
+
             /**
-             *  @return vector of column names that have constraints provided as template arguments (not_null, autoincrement).
+             *  @return vector of column names that have constraints provided as template arguments (not_null,
+             * autoincrement).
              */
-            template<class ...Op>
+            template<class... Op>
             std::vector<std::string> column_names_with() {
                 std::vector<std::string> res;
-                iterate_tuple(this->columns, [&res](auto &column){
+                iterate_tuple(this->columns, [&res](auto &column) {
                     if(column.template has_every<Op...>()) {
                         res.emplace_back(column.name);
                     }
                 });
                 return res;
             }
-            
+
             /**
-             *  Iterates all columns and fires passed lambda. Lambda must have one and only templated argument Otherwise code will
-             *  not compile. Excludes table constraints (e.g. foreign_key_t) at the end of the columns list. To iterate columns with
-             *  table constraints use for_each_column_with_constraints instead.
-             *  L is lambda type. Do not specify it explicitly.
+             *  Iterates all columns and fires passed lambda. Lambda must have one and only templated argument Otherwise
+             * code will not compile. Excludes table constraints (e.g. foreign_key_t) at the end of the columns list. To
+             * iterate columns with table constraints use for_each_column_with_constraints instead. L is lambda type. Do
+             * not specify it explicitly.
              *  @param l Lambda to be called per column itself. Must have signature like this [] (auto col) -> void {}
              */
             template<class L>
             void for_each_column(const L &l) const {
-                iterate_tuple(this->columns, [&l](auto &column){
+                iterate_tuple(this->columns, [&l](auto &column) {
                     using column_type = typename std::decay<decltype(column)>::type;
                     static_if<internal::is_column<column_type>{}>(l)(column);
                 });
             }
-            
+
             template<class L>
             void for_each_column_with_constraints(const L &l) const {
                 iterate_tuple(this->columns, l);
             }
-            
+
             template<class F, class L>
             void for_each_column_with_field_type(const L &l) const {
-                iterate_tuple(this->columns, [&l](auto &column){
+                iterate_tuple(this->columns, [&l](auto &column) {
                     using column_type = typename std::decay<decltype(column)>::type;
                     static_if<std::is_same<F, typename column_type::field_type>{}>(l)(column);
                 });
             }
-            
+
             /**
              *  Iterates all columns that have specified constraints and fires passed lambda.
              *  Lambda must have one and only templated argument Otherwise code will not compile.
@@ -5543,23 +5595,23 @@ namespace sqlite_orm {
             template<class Op, class L>
             void for_each_column_with(const L &l) const {
                 using tuple_helper::tuple_contains_type;
-                iterate_tuple(this->columns, [&l](auto &column){
+                iterate_tuple(this->columns, [&l](auto &column) {
                     using column_type = typename std::decay<decltype(column)>::type;
                     static_if<tuple_contains_type<Op, typename column_type::constraints_type>{}>(l)(column);
                 });
             }
-            
+
             std::vector<table_info> get_table_info() {
                 std::vector<table_info> res;
                 res.reserve(size_t(this->columns_count));
-                this->for_each_column([&res](auto &col){
+                this->for_each_column([&res](auto &col) {
                     std::string dft;
                     using field_type = typename std::decay<decltype(col)>::type::field_type;
                     if(auto d = col.default_value()) {
                         auto needQuotes = std::is_base_of<text_printer, type_printer<field_type>>::value;
-                        if(needQuotes){
+                        if(needQuotes) {
                             dft = "'" + *d + "'";
-                        }else{
+                        } else {
                             dft = *d;
                         }
                     }
@@ -5576,47 +5628,44 @@ namespace sqlite_orm {
                 auto compositeKeyColumnNames = this->composite_key_columns_names();
                 for(size_t i = 0; i < compositeKeyColumnNames.size(); ++i) {
                     auto &columnName = compositeKeyColumnNames[i];
-                    auto it = std::find_if(res.begin(),
-                                           res.end(),
-                                           [&columnName](const table_info &ti) {
-                                               return ti.name == columnName;
-                                           });
-                    if(it != res.end()){
+                    auto it = std::find_if(res.begin(), res.end(), [&columnName](const table_info &ti) {
+                        return ti.name == columnName;
+                    });
+                    if(it != res.end()) {
                         it->pk = static_cast<int>(i + 1);
                     }
                 }
                 return res;
             }
-            
         };
     }
-    
+
     /**
      *  Function used for table creation. Do not use table constructor - use this function
      *  cause table class is templated and its constructing too (just like std::make_unique or std::make_pair).
      */
-    template<class ...Cs, class T = typename std::tuple_element<0, std::tuple<Cs...>>::type::object_type>
-    internal::table_t<T, Cs...> make_table(const std::string &name, Cs ...args) {
+    template<class... Cs, class T = typename std::tuple_element<0, std::tuple<Cs...>>::type::object_type>
+    internal::table_t<T, Cs...> make_table(const std::string &name, Cs... args) {
         return {name, std::make_tuple<Cs...>(std::forward<Cs>(args)...)};
     }
-    
-    template<class T, class ...Cs>
-    internal::table_t<T, Cs...> make_table(const std::string &name, Cs ...args) {
+
+    template<class T, class... Cs>
+    internal::table_t<T, Cs...> make_table(const std::string &name, Cs... args) {
         return {name, std::make_tuple<Cs...>(std::forward<Cs>(args)...)};
     }
 }
 #pragma once
 
-#include <string>   //  std::string
-#include <sqlite3.h>    
+#include <string>  //  std::string
+#include <sqlite3.h>
 #include <cstddef>  //  std::nullptr_t
-#include <system_error> //  std::system_error, std::error_code
+#include <system_error>  //  std::system_error, std::error_code
 #include <sstream>  //  std::stringstream
 #include <cstdlib>  //  std::atoi
 #include <type_traits>  //  std::forward, std::enable_if, std::is_same, std::remove_reference, std::false_type, std::true_type
 #include <utility>  //  std::pair, std::make_pair
-#include <vector>   //  std::vector
-#include <algorithm>    //  std::find_if
+#include <vector>  //  std::vector
+#include <algorithm>  //  std::find_if
 
 // #include "error_code.h"
 
@@ -5646,21 +5695,21 @@ namespace sqlite_orm {
 
 namespace sqlite_orm {
     namespace internal {
-        
+
         template<class T, class SFINAE = void>
         struct field_value_holder;
-        
+
         template<class T>
         struct field_value_holder<T, typename std::enable_if<getter_traits<T>::returns_lvalue>::type> {
             using type = typename getter_traits<T>::field_type;
-            
+
             const type &value;
         };
-        
+
         template<class T>
         struct field_value_holder<T, typename std::enable_if<!getter_traits<T>::returns_lvalue>::type> {
             using type = typename getter_traits<T>::field_type;
-            
+
             type value;
         };
     }
@@ -5668,163 +5717,174 @@ namespace sqlite_orm {
 
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         struct storage_impl_base {
-            
+
             bool table_exists(const std::string &tableName, sqlite3 *db) {
                 auto res = false;
                 std::stringstream ss;
-                ss << "SELECT COUNT(*) FROM sqlite_master WHERE type = '" << "table" << "' AND name = '" << tableName << "'";
+                ss << "SELECT COUNT(*) FROM sqlite_master WHERE type = '"
+                   << "table"
+                   << "' AND name = '" << tableName << "'";
                 auto query = ss.str();
-                auto rc = sqlite3_exec(db,
-                                       query.c_str(),
-                                       [](void *data, int argc, char **argv,char ** /*azColName*/) -> int {
-                                           auto &res = *(bool*)data;
-                                           if(argc){
-                                               res = !!std::atoi(argv[0]);
-                                           }
-                                           return 0;
-                                       }, &res, nullptr);
+                auto rc = sqlite3_exec(
+                    db,
+                    query.c_str(),
+                    [](void *data, int argc, char **argv, char * * /*azColName*/) -> int {
+                        auto &res = *(bool *)data;
+                        if(argc) {
+                            res = !!std::atoi(argv[0]);
+                        }
+                        return 0;
+                    },
+                    &res,
+                    nullptr);
                 if(rc != SQLITE_OK) {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
                 return res;
             }
-            
+
             void rename_table(sqlite3 *db, const std::string &oldName, const std::string &newName) {
                 std::stringstream ss;
                 ss << "ALTER TABLE " << oldName << " RENAME TO " << newName;
                 auto query = ss.str();
                 sqlite3_stmt *stmt;
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if (sqlite3_step(stmt) == SQLITE_DONE) {
+                    if(sqlite3_step(stmt) == SQLITE_DONE) {
                         //  done..
-                    }else{
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    } else {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
-                }else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
-            static bool get_remove_add_columns(std::vector<table_info*>& columnsToAdd,
-                                               std::vector<table_info>& storageTableInfo,
-                                               std::vector<table_info>& dbTableInfo)
-            {
+
+            static bool get_remove_add_columns(std::vector<table_info *> &columnsToAdd,
+                                               std::vector<table_info> &storageTableInfo,
+                                               std::vector<table_info> &dbTableInfo) {
                 bool notEqual = false;
-                
+
                 //  iterate through storage columns
-                for(size_t storageColumnInfoIndex = 0; storageColumnInfoIndex < storageTableInfo.size(); ++storageColumnInfoIndex) {
-                    
+                for(size_t storageColumnInfoIndex = 0; storageColumnInfoIndex < storageTableInfo.size();
+                    ++storageColumnInfoIndex) {
+
                     //  get storage's column info
                     auto &storageColumnInfo = storageTableInfo[storageColumnInfoIndex];
                     auto &columnName = storageColumnInfo.name;
-                    
+
                     //  search for a column in db eith the same name
-                    auto dbColumnInfoIt = std::find_if(dbTableInfo.begin(),
-                                                       dbTableInfo.end(),
-                                                       [&columnName](auto &ti){
-                                                           return ti.name == columnName;
-                                                       });
-                    if(dbColumnInfoIt != dbTableInfo.end()){
+                    auto dbColumnInfoIt = std::find_if(dbTableInfo.begin(), dbTableInfo.end(), [&columnName](auto &ti) {
+                        return ti.name == columnName;
+                    });
+                    if(dbColumnInfoIt != dbTableInfo.end()) {
                         auto &dbColumnInfo = *dbColumnInfoIt;
                         auto dbColumnInfoType = to_sqlite_type(dbColumnInfo.type);
                         auto storageColumnInfoType = to_sqlite_type(storageColumnInfo.type);
                         if(dbColumnInfoType && storageColumnInfoType) {
-                            auto columnsAreEqual = dbColumnInfo.name == storageColumnInfo.name &&
-                            *dbColumnInfoType == *storageColumnInfoType &&
-                            dbColumnInfo.notnull == storageColumnInfo.notnull &&
-                            (dbColumnInfo.dflt_value.length() > 0) == (storageColumnInfo.dflt_value.length() > 0) &&
-                            dbColumnInfo.pk == storageColumnInfo.pk;
-                            if(!columnsAreEqual){
+                            auto columnsAreEqual =
+                                dbColumnInfo.name == storageColumnInfo.name &&
+                                *dbColumnInfoType == *storageColumnInfoType &&
+                                dbColumnInfo.notnull == storageColumnInfo.notnull &&
+                                (dbColumnInfo.dflt_value.length() > 0) == (storageColumnInfo.dflt_value.length() > 0) &&
+                                dbColumnInfo.pk == storageColumnInfo.pk;
+                            if(!columnsAreEqual) {
                                 notEqual = true;
                                 break;
                             }
                             dbTableInfo.erase(dbColumnInfoIt);
-                            storageTableInfo.erase(storageTableInfo.begin() + static_cast<ptrdiff_t>(storageColumnInfoIndex));
+                            storageTableInfo.erase(storageTableInfo.begin() +
+                                                   static_cast<ptrdiff_t>(storageColumnInfoIndex));
                             --storageColumnInfoIndex;
-                        }else{
-                            
+                        } else {
+
                             //  undefined type/types
                             notEqual = true;
                             break;
                         }
-                    }else{
+                    } else {
                         columnsToAdd.push_back(&storageColumnInfo);
                     }
                 }
                 return notEqual;
             }
-            
+
             std::vector<table_info> get_table_info(const std::string &tableName, sqlite3 *db) {
                 std::vector<table_info> res;
                 auto query = "PRAGMA table_info('" + tableName + "')";
-                auto rc = sqlite3_exec(db,
-                                       query.c_str(),
-                                       [](void *data, int argc, char **argv,char **) -> int {
-                                           auto &res = *(std::vector<table_info>*)data;
-                                           if(argc){
-                                               auto index = 0;
-                                               auto cid = std::atoi(argv[index++]);
-                                               std::string name = argv[index++];
-                                               std::string type = argv[index++];
-                                               bool notnull = !!std::atoi(argv[index++]);
-                                               std::string dflt_value = argv[index] ? argv[index] : "";
-                                               index++;
-                                               auto pk = std::atoi(argv[index++]);
-                                               res.push_back(table_info{cid, name, type, notnull, dflt_value, pk});
-                                           }
-                                           return 0;
-                                       }, &res, nullptr);
+                auto rc = sqlite3_exec(
+                    db,
+                    query.c_str(),
+                    [](void *data, int argc, char **argv, char **) -> int {
+                        auto &res = *(std::vector<table_info> *)data;
+                        if(argc) {
+                            auto index = 0;
+                            auto cid = std::atoi(argv[index++]);
+                            std::string name = argv[index++];
+                            std::string type = argv[index++];
+                            bool notnull = !!std::atoi(argv[index++]);
+                            std::string dflt_value = argv[index] ? argv[index] : "";
+                            index++;
+                            auto pk = std::atoi(argv[index++]);
+                            res.push_back(table_info{cid, name, type, notnull, dflt_value, pk});
+                        }
+                        return 0;
+                    },
+                    &res,
+                    nullptr);
                 if(rc != SQLITE_OK) {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
                 return res;
             }
-            
         };
-        
+
         /**
          *  This is a generic implementation. Used as a tail in storage_impl inheritance chain
          */
-        template<class ...Ts>
+        template<class... Ts>
         struct storage_impl;
-        
-        template<class H, class ...Ts>
+
+        template<class H, class... Ts>
         struct storage_impl<H, Ts...> : public storage_impl<Ts...> {
             using table_type = H;
             using super = storage_impl<Ts...>;
-            
-            storage_impl(H h, Ts ...ts) : super(std::forward<Ts>(ts)...), table(std::move(h)) {}
-            
+
+            storage_impl(H h, Ts... ts) : super(std::forward<Ts>(ts)...), table(std::move(h)) {}
+
             table_type table;
-            
+
             template<class L>
             void for_each(const L &l) {
                 this->super::for_each(l);
                 l(this);
             }
-            
+
 #if SQLITE_VERSION_NUMBER >= 3006019
-            
+
             /**
              *  Returns foreign keys count in table definition
              */
             int foreign_keys_count() {
                 auto res = 0;
-                this->table.for_each_column_with_constraints([&res](auto &c){
+                this->table.for_each_column_with_constraints([&res](auto &c) {
                     if(internal::is_foreign_key<typename std::decay<decltype(c)>::type>::value) {
                         ++res;
                     }
                 });
                 return res;
             }
-            
+
 #endif
-            
+
             /**
              *  Is used to get column name by member pointer to a base class.
              *  Main difference between `column_name` and `column_name_simple` is that
@@ -5834,7 +5894,7 @@ namespace sqlite_orm {
             std::string column_name_simple(F O::*m) const {
                 return this->table.find_column_name(m);
             }
-            
+
             /**
              *  Same thing as above for getter.
              */
@@ -5842,7 +5902,7 @@ namespace sqlite_orm {
             std::string column_name_simple(T g) const {
                 return this->table.find_column_name(g);
             }
-            
+
             /**
              *  Same thing as above for setter.
              */
@@ -5850,106 +5910,114 @@ namespace sqlite_orm {
             std::string column_name_simple(T s) const {
                 return this->table.find_column_name(s);
             }
-            
+
             /**
              *  Cute function used to find column name by its type and member pointer. Uses SFINAE to
              *  skip inequal type O.
              */
             template<class O, class F, class HH = typename H::object_type>
-            std::string column_name(F O::*m, typename std::enable_if<std::is_same<O, HH>::value>::type * = nullptr) const {
+            std::string column_name(F O::*m,
+                                    typename std::enable_if<std::is_same<O, HH>::value>::type * = nullptr) const {
                 return this->table.find_column_name(m);
             }
-            
+
             /**
              *  Opposite version of function defined above. Just calls same function in superclass.
              */
             template<class O, class F, class HH = typename H::object_type>
-            std::string column_name(F O::*m, typename std::enable_if<!std::is_same<O, HH>::value>::type * = nullptr) const {
+            std::string column_name(F O::*m,
+                                    typename std::enable_if<!std::is_same<O, HH>::value>::type * = nullptr) const {
                 return this->super::column_name(m);
             }
-            
+
             /**
              *  Cute function used to find column name by its type and getter pointer. Uses SFINAE to
              *  skip inequal type O.
              */
             template<class O, class F, class HH = typename H::object_type>
-            std::string column_name(const F& (O::*g)() const, typename std::enable_if<std::is_same<O, HH>::value>::type * = nullptr) const {
+            std::string column_name(const F &(O::*g)() const,
+                                    typename std::enable_if<std::is_same<O, HH>::value>::type * = nullptr) const {
                 return this->table.find_column_name(g);
             }
-            
+
             /**
              *  Opposite version of function defined above. Just calls same function in superclass.
              */
             template<class O, class F, class HH = typename H::object_type>
-            std::string column_name(const F& (O::*g)() const, typename std::enable_if<!std::is_same<O, HH>::value>::type * = nullptr) const {
+            std::string column_name(const F &(O::*g)() const,
+                                    typename std::enable_if<!std::is_same<O, HH>::value>::type * = nullptr) const {
                 return this->super::column_name(g);
             }
-            
+
             /**
              *  Cute function used to find column name by its type and setter pointer. Uses SFINAE to
              *  skip inequal type O.
              */
             template<class O, class F, class HH = typename H::object_type>
-            std::string column_name(void (O::*s)(F), typename std::enable_if<std::is_same<O, HH>::value>::type * = nullptr) const {
+            std::string column_name(void (O::*s)(F),
+                                    typename std::enable_if<std::is_same<O, HH>::value>::type * = nullptr) const {
                 return this->table.find_column_name(s);
             }
-            
+
             /**
              *  Opposite version of function defined above. Just calls same function in superclass.
              */
             template<class O, class F, class HH = typename H::object_type>
-            std::string column_name(void (O::*s)(F), typename std::enable_if<!std::is_same<O, HH>::value>::type * = nullptr) const {
+            std::string column_name(void (O::*s)(F),
+                                    typename std::enable_if<!std::is_same<O, HH>::value>::type * = nullptr) const {
                 return this->super::column_name(s);
             }
-            
+
             template<class T, class F, class HH = typename H::object_type>
-            std::string column_name(const column_pointer<T, F> &c, typename std::enable_if<std::is_same<T, HH>::value>::type * = nullptr) const {
+            std::string column_name(const column_pointer<T, F> &c,
+                                    typename std::enable_if<std::is_same<T, HH>::value>::type * = nullptr) const {
                 return this->column_name_simple(c.field);
             }
-            
+
             template<class T, class F, class HH = typename H::object_type>
-            std::string column_name(const column_pointer<T, F> &c, typename std::enable_if<!std::is_same<T, HH>::value>::type * = nullptr) const {
+            std::string column_name(const column_pointer<T, F> &c,
+                                    typename std::enable_if<!std::is_same<T, HH>::value>::type * = nullptr) const {
                 return this->super::column_name(c);
             }
-            
+
             template<class O, class HH = typename H::object_type>
-            auto& get_impl(typename std::enable_if<std::is_same<O, HH>::value>::type * = nullptr) const {
+            auto &get_impl(typename std::enable_if<std::is_same<O, HH>::value>::type * = nullptr) const {
                 return *this;
             }
-            
+
             template<class O, class HH = typename H::object_type>
-            auto& get_impl(typename std::enable_if<!std::is_same<O, HH>::value>::type * = nullptr) const {
+            auto &get_impl(typename std::enable_if<!std::is_same<O, HH>::value>::type * = nullptr) const {
                 return this->super::template get_impl<O>();
             }
-            
+
             template<class O, class HH = typename H::object_type>
             std::string find_table_name(typename std::enable_if<std::is_same<O, HH>::value>::type * = nullptr) const {
                 return this->table.name;
             }
-            
+
             template<class O, class HH = typename H::object_type>
             std::string find_table_name(typename std::enable_if<!std::is_same<O, HH>::value>::type * = nullptr) const {
                 return this->super::template find_table_name<O>();
             }
-            
+
             template<class O, class HH = typename H::object_type>
             std::string dump(const O &o, typename std::enable_if<!std::is_same<O, HH>::value>::type * = nullptr) {
                 return this->super::dump(o, nullptr);
             }
-            
+
             template<class O, class HH = typename H::object_type>
             std::string dump(const O &o, typename std::enable_if<std::is_same<O, HH>::value>::type * = nullptr) {
                 std::stringstream ss;
                 ss << "{ ";
                 using pair = std::pair<std::string, std::string>;
                 std::vector<pair> pairs;
-                this->table.for_each_column([&pairs, &o] (auto &c) {
+                this->table.for_each_column([&pairs, &o](auto &c) {
                     using column_type = typename std::decay<decltype(c)>::type;
                     using field_type = typename column_type::field_type;
                     pair p{c.name, ""};
-                    if(c.member_pointer){
+                    if(c.member_pointer) {
                         p.second = field_printer<field_type>()(o.*c.member_pointer);
-                    }else{
+                    } else {
                         using getter_type = typename column_type::getter_type;
                         field_value_holder<getter_type> valueHolder{((o).*(c.getter))()};
                         p.second = field_printer<field_type>()(valueHolder.value);
@@ -5961,21 +6029,21 @@ namespace sqlite_orm {
                     ss << p.first << " : '" << p.second << "'";
                     if(i < pairs.size() - 1) {
                         ss << ", ";
-                    }else{
+                    } else {
                         ss << " }";
                     }
                 }
                 return ss.str();
             }
-            
+
             void add_column(const table_info &ti, sqlite3 *db) {
                 std::stringstream ss;
                 ss << "ALTER TABLE " << this->table.name << " ADD COLUMN " << ti.name << " ";
                 ss << ti.type << " ";
-                if(ti.pk){
+                if(ti.pk) {
                     ss << "PRIMARY KEY ";
                 }
-                if(ti.notnull){
+                if(ti.notnull) {
                     ss << "NOT NULL ";
                 }
                 if(ti.dflt_value.length()) {
@@ -5984,18 +6052,20 @@ namespace sqlite_orm {
                 auto query = ss.str();
                 sqlite3_stmt *stmt;
                 auto prepareResult = sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr);
-                if (prepareResult == SQLITE_OK) {
+                if(prepareResult == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if (sqlite3_step(stmt) == SQLITE_DONE) {
+                    if(sqlite3_step(stmt) == SQLITE_DONE) {
                         //..
-                    }else{
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    } else {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             /**
              *  Copies current table to another table with a given **name**.
              *  Performs CREATE TABLE %name% AS SELECT %this->table.columns_names()% FROM &this->table.name%;
@@ -6003,7 +6073,7 @@ namespace sqlite_orm {
             void copy_table(sqlite3 *db, const std::string &name) {
                 std::stringstream ss;
                 std::vector<std::string> columnNames;
-                this->table.for_each_column([&columnNames] (auto &c) {
+                this->table.for_each_column([&columnNames](auto &c) {
                     columnNames.emplace_back(c.name);
                 });
                 auto columnNamesCount = columnNames.size();
@@ -6027,129 +6097,132 @@ namespace sqlite_orm {
                 ss << "FROM '" << this->table.name << "' ";
                 auto query = ss.str();
                 sqlite3_stmt *stmt;
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if (sqlite3_step(stmt) == SQLITE_DONE) {
+                    if(sqlite3_step(stmt) == SQLITE_DONE) {
                         //..
-                    }else{
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    } else {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             sync_schema_result schema_status(sqlite3 *db, bool preserve) {
-                
+
                 auto res = sync_schema_result::already_in_sync;
-                
+
                 //  first let's see if table with such name exists..
                 auto gottaCreateTable = !this->table_exists(this->table.name, db);
-                if(!gottaCreateTable){
-                    
+                if(!gottaCreateTable) {
+
                     //  get table info provided in `make_table` call..
                     auto storageTableInfo = this->table.get_table_info();
-                    
+
                     //  now get current table info from db using `PRAGMA table_info` query..
                     auto dbTableInfo = this->get_table_info(this->table.name, db);
-                    
+
                     //  this vector will contain pointers to columns that gotta be added..
-                    std::vector<table_info*> columnsToAdd;
-                    
+                    std::vector<table_info *> columnsToAdd;
+
                     if(this->get_remove_add_columns(columnsToAdd, storageTableInfo, dbTableInfo)) {
                         gottaCreateTable = true;
                     }
-                    
-                    if(!gottaCreateTable){  //  if all storage columns are equal to actual db columns but there are excess columns at the db..
-                        if(dbTableInfo.size() > 0){
-                            //extra table columns than storage columns
-                            if(!preserve){
+
+                    if(!gottaCreateTable) {  //  if all storage columns are equal to actual db columns but there are
+                                             //  excess columns at the db..
+                        if(dbTableInfo.size() > 0) {
+                            // extra table columns than storage columns
+                            if(!preserve) {
                                 gottaCreateTable = true;
-                            }else{
+                            } else {
                                 res = decltype(res)::old_columns_removed;
                             }
                         }
                     }
-                    if(gottaCreateTable){
+                    if(gottaCreateTable) {
                         res = decltype(res)::dropped_and_recreated;
-                    }else{
-                        if(columnsToAdd.size()){
-                            //extra storage columns than table columns
-                            for(auto columnPointer : columnsToAdd) {
-                                if(columnPointer->notnull && columnPointer->dflt_value.empty()){
+                    } else {
+                        if(columnsToAdd.size()) {
+                            // extra storage columns than table columns
+                            for(auto columnPointer: columnsToAdd) {
+                                if(columnPointer->notnull && columnPointer->dflt_value.empty()) {
                                     gottaCreateTable = true;
                                     break;
                                 }
                             }
-                            if(!gottaCreateTable){
+                            if(!gottaCreateTable) {
                                 if(res == decltype(res)::old_columns_removed) {
                                     res = decltype(res)::new_columns_added_and_old_columns_removed;
-                                }else{
+                                } else {
                                     res = decltype(res)::new_columns_added;
                                 }
-                            }else{
+                            } else {
                                 res = decltype(res)::dropped_and_recreated;
                             }
-                        }else{
-                            if(res != decltype(res)::old_columns_removed){
+                        } else {
+                            if(res != decltype(res)::old_columns_removed) {
                                 res = decltype(res)::already_in_sync;
                             }
                         }
                     }
-                }else{
+                } else {
                     res = decltype(res)::new_table_created;
                 }
                 return res;
             }
-            
-        private:
+
+          private:
             using self = storage_impl<H, Ts...>;
         };
-        
+
         template<>
         struct storage_impl<> : storage_impl_base {
-            
+
             template<class O>
             std::string find_table_name() const {
                 return {};
             }
-            
+
             template<class L>
             void for_each(const L &) {}
-            
+
             int foreign_keys_count() {
                 return 0;
             }
-            
+
             template<class O>
             std::string dump(const O &, sqlite3 *, std::nullptr_t) {
                 throw std::system_error(std::make_error_code(orm_error_code::type_is_not_mapped_to_storage));
             }
         };
-        
+
         template<class T>
         struct is_storage_impl : std::false_type {};
-        
-        template<class ...Ts>
+
+        template<class... Ts>
         struct is_storage_impl<storage_impl<Ts...>> : std::true_type {};
     }
 }
 #pragma once
 
-#include <memory>   //  std::unique/shared_ptr, std::make_unique/shared
-#include <string>   //  std::string
+#include <memory>  //  std::unique/shared_ptr, std::make_unique/shared
+#include <string>  //  std::string
 #include <sqlite3.h>
 #include <type_traits>  //  std::remove_reference, std::is_base_of, std::decay, std::false_type, std::true_type
 #include <cstddef>  //  std::ptrdiff_t
-#include <iterator> //  std::input_iterator_tag, std::iterator_traits, std::distance
-#include <functional>   //  std::function
+#include <iterator>  //  std::input_iterator_tag, std::iterator_traits, std::distance
+#include <functional>  //  std::function
 #include <sstream>  //  std::stringstream
 #include <map>  //  std::map
-#include <vector>   //  std::vector
-#include <tuple>    //  std::tuple_size, std::tuple, std::make_tuple
+#include <vector>  //  std::vector
+#include <tuple>  //  std::tuple_size, std::tuple, std::make_tuple
 #include <utility>  //  std::forward, std::pair
 #include <set>  //  std::set
-#include <algorithm>    //  std::find
+#include <algorithm>  //  std::find
 
 // #include "alias.h"
 
@@ -6200,12 +6273,12 @@ namespace sqlite_orm {
 // #include "view.h"
 
 
-#include <memory>   //  std::shared_ptr
-#include <string>   //  std::string
+#include <memory>  //  std::shared_ptr
+#include <string>  //  std::string
 #include <utility>  //  std::forward, std::move
 #include <sqlite3.h>
-#include <system_error> //  std::system_error
-#include <tuple>    //  std::tuple, std::make_tuple
+#include <system_error>  //  std::system_error
+#include <tuple>  //  std::tuple, std::make_tuple
 
 // #include "row_extractor.h"
 
@@ -6216,13 +6289,13 @@ namespace sqlite_orm {
 // #include "iterator.h"
 
 
-#include <memory>   //  std::shared_ptr, std::unique_ptr, std::make_shared
+#include <memory>  //  std::shared_ptr, std::unique_ptr, std::make_shared
 #include <sqlite3.h>
 #include <type_traits>  //  std::decay
 #include <utility>  //  std::move
 #include <cstddef>  //  std::ptrdiff_t
-#include <iterator> //  std::input_iterator_tag
-#include <system_error> //  std::system_error
+#include <iterator>  //  std::input_iterator_tag
+#include <system_error>  //  std::system_error
 #include <ios>  //  std::make_error_code
 
 // #include "row_extractor.h"
@@ -6233,16 +6306,15 @@ namespace sqlite_orm {
 
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         template<class V>
         struct iterator_t {
             using view_type = V;
             using value_type = typename view_type::mapped_type;
-            
-        protected:
-            
+
+          protected:
             /**
              *  The double-indirection is so that copies of the iterator
              *  share the same sqlite3_stmt from a sqlite3_prepare_v2()
@@ -6251,105 +6323,107 @@ namespace sqlite_orm {
              */
             std::shared_ptr<sqlite3_stmt *> stmt;
             view_type &view;
-            
+
             /**
              *  shared_ptr is used over unique_ptr here
              *  so that the iterator can be copyable.
              */
             std::shared_ptr<value_type> current;
-            
+
             void extract_value(std::unique_ptr<value_type> &temp) {
                 temp = std::make_unique<value_type>();
                 auto &storage = this->view.storage;
                 auto &impl = storage.template get_impl<value_type>();
                 auto index = 0;
-                impl.table.for_each_column([&index, &temp, this] (auto &c) {
+                impl.table.for_each_column([&index, &temp, this](auto &c) {
                     using field_type = typename std::decay<decltype(c)>::type::field_type;
                     auto value = row_extractor<field_type>().extract(*this->stmt, index++);
-                    if(c.member_pointer){
+                    if(c.member_pointer) {
                         auto member_pointer = c.member_pointer;
                         (*temp).*member_pointer = std::move(value);
-                    }else{
+                    } else {
                         ((*temp).*(c.setter))(std::move(value));
                     }
                 });
             }
-            
-        public:
+
+          public:
             using difference_type = std::ptrdiff_t;
             using pointer = value_type *;
             using reference = value_type &;
             using iterator_category = std::input_iterator_tag;
-            
-            iterator_t(sqlite3_stmt *stmt_, view_type &view_): stmt(std::make_shared<sqlite3_stmt *>(stmt_)), view(view_) {
+
+            iterator_t(sqlite3_stmt *stmt_, view_type &view_) :
+                stmt(std::make_shared<sqlite3_stmt *>(stmt_)), view(view_) {
                 this->operator++();
             }
-            
+
             iterator_t(const iterator_t &) = default;
-            
-            iterator_t(iterator_t&&) = default;
-            
-            iterator_t& operator=(iterator_t &&) = default;
-            
-            iterator_t& operator=(const iterator_t &) = default;
-            
+
+            iterator_t(iterator_t &&) = default;
+
+            iterator_t &operator=(iterator_t &&) = default;
+
+            iterator_t &operator=(const iterator_t &) = default;
+
             ~iterator_t() {
-                if(this->stmt){
+                if(this->stmt) {
                     statement_finalizer f{*this->stmt};
                 }
             }
-            
+
             value_type &operator*() {
                 if(!this->stmt) {
                     throw std::system_error(std::make_error_code(orm_error_code::trying_to_dereference_null_iterator));
                 }
-                if(!this->current){
+                if(!this->current) {
                     std::unique_ptr<value_type> value;
                     this->extract_value(value);
                     this->current = move(value);
                 }
                 return *this->current;
             }
-            
+
             value_type *operator->() {
                 return &(this->operator*());
             }
-            
+
             void operator++() {
-                if(this->stmt && *this->stmt){
+                if(this->stmt && *this->stmt) {
                     auto ret = sqlite3_step(*this->stmt);
-                    switch(ret){
+                    switch(ret) {
                         case SQLITE_ROW:
                             this->current = nullptr;
                             break;
-                        case SQLITE_DONE:{
+                        case SQLITE_DONE: {
                             statement_finalizer f{*this->stmt};
                             *this->stmt = nullptr;
-                        }break;
-                        default:{
+                        } break;
+                        default: {
                             auto db = this->view.connection.get();
-                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                    sqlite3_errmsg(db));
                         }
                     }
                 }
             }
-            
+
             void operator++(int) {
                 this->operator++();
             }
-            
+
             bool operator==(const iterator_t &other) const {
-                if(this->stmt && other.stmt){
+                if(this->stmt && other.stmt) {
                     return *this->stmt == *other.stmt;
-                }else{
-                    if(!this->stmt && !other.stmt){
+                } else {
+                    if(!this->stmt && !other.stmt) {
                         return true;
-                    }else{
+                    } else {
                         return false;
                     }
                 }
             }
-            
+
             bool operator!=(const iterator_t &other) const {
                 return !(*this == other);
             }
@@ -6360,7 +6434,7 @@ namespace sqlite_orm {
 // #include "ast_iterator.h"
 
 
-#include <vector>   //  std::vector
+#include <vector>  //  std::vector
 
 // #include "conditions.h"
 
@@ -6376,93 +6450,87 @@ namespace sqlite_orm {
 
 
 #include <sqlite3.h>
-#include <iterator> //  std::iterator_traits
-#include <string>   //  std::string
+#include <iterator>  //  std::iterator_traits
+#include <string>  //  std::string
 #include <type_traits>  //  std::true_type, std::false_type
 
 // #include "connection_holder.h"
 
 
 #include <sqlite3.h>
-#include <string>   //  std::string
-#include <system_error> //  std::system_error
+#include <string>  //  std::string
+#include <system_error>  //  std::system_error
 
 // #include "error_code.h"
 
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         struct connection_holder {
-            
-            connection_holder(std::string filename_) :
-            filename(move(filename_))
-            {}
-            
+
+            connection_holder(std::string filename_) : filename(move(filename_)) {}
+
             void retain() {
                 ++this->_retain_count;
                 if(1 == this->_retain_count) {
                     auto rc = sqlite3_open(this->filename.c_str(), &this->db);
-                    if(rc != SQLITE_OK){
-                        throw std::system_error(std::error_code(sqlite3_errcode(this->db), get_sqlite_error_category()), sqlite3_errmsg(this->db));
+                    if(rc != SQLITE_OK) {
+                        throw std::system_error(std::error_code(sqlite3_errcode(this->db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(this->db));
                     }
                 }
             }
-            
+
             void release() {
                 --this->_retain_count;
-                if(0 == this->_retain_count){
+                if(0 == this->_retain_count) {
                     auto rc = sqlite3_close(this->db);
-                    if(rc != SQLITE_OK){
-                        throw std::system_error(std::error_code(sqlite3_errcode(this->db), get_sqlite_error_category()), sqlite3_errmsg(this->db));
+                    if(rc != SQLITE_OK) {
+                        throw std::system_error(std::error_code(sqlite3_errcode(this->db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(this->db));
                     }
                 }
             }
-            
+
             sqlite3 *get() const {
                 return this->db;
             }
-            
+
             int retain_count() const {
                 return this->_retain_count;
             }
-            
+
             const std::string filename;
-            
-        protected:
+
+          protected:
             sqlite3 *db = nullptr;
             int _retain_count = 0;
         };
-        
+
         struct connection_ref {
-            connection_ref(connection_holder &holder_) :
-            holder(holder_)
-            {
+            connection_ref(connection_holder &holder_) : holder(holder_) {
                 this->holder.retain();
             }
-            
-            connection_ref(const connection_ref &other) :
-            holder(other.holder)
-            {
+
+            connection_ref(const connection_ref &other) : holder(other.holder) {
                 this->holder.retain();
             }
-            
-            connection_ref(connection_ref &&other) :
-            holder(other.holder)
-            {
+
+            connection_ref(connection_ref &&other) : holder(other.holder) {
                 this->holder.retain();
             }
-            
+
             ~connection_ref() {
                 this->holder.release();
             }
-            
+
             sqlite3 *get() const {
                 return this->holder.get();
             }
-            
-        protected:
+
+          protected:
             connection_holder &holder;
         };
     }
@@ -6472,95 +6540,93 @@ namespace sqlite_orm {
 
 
 namespace sqlite_orm {
-    
+
     template<class T>
     struct by_val {
         using type = T;
-        
+
         type obj;
     };
-    
+
     namespace internal {
-        
+
         template<class T>
         struct is_by_val : std::false_type {};
-        
+
         template<class T>
         struct is_by_val<by_val<T>> : std::true_type {};
-        
+
         struct prepared_statement_base {
             sqlite3_stmt *stmt = nullptr;
             connection_ref con;
-            
+
             ~prepared_statement_base() {
-                if(this->stmt){
+                if(this->stmt) {
                     sqlite3_finalize(this->stmt);
                     this->stmt = nullptr;
                 }
             }
-            
+
             std::string sql() const {
-                if(this->stmt){
-                    if(auto res = sqlite3_sql(this->stmt)){
+                if(this->stmt) {
+                    if(auto res = sqlite3_sql(this->stmt)) {
                         return res;
-                    }else{
+                    } else {
                         return {};
                     }
-                }else{
+                } else {
                     return {};
                 }
             }
-            
+
             std::string expanded_sql() const {
-                if(this->stmt){
-                    if(auto res = sqlite3_expanded_sql(this->stmt)){
+                if(this->stmt) {
+                    if(auto res = sqlite3_expanded_sql(this->stmt)) {
                         std::string result = res;
                         sqlite3_free(res);
                         return result;
-                    }else{
+                    } else {
                         return {};
                     }
-                }else{
+                } else {
                     return {};
                 }
             }
 #if SQLITE_VERSION_NUMBER >= 3027000
             std::string normalized_sql() const {
-                if(this->stmt){
-                    if(auto res = sqlite3_normalized_sql(this->stmt)){
+                if(this->stmt) {
+                    if(auto res = sqlite3_normalized_sql(this->stmt)) {
                         return res;
-                    }else{
+                    } else {
                         return {};
                     }
-                }else{
+                } else {
                     return {};
                 }
             }
 #endif
         };
-        
+
         template<class T>
         struct prepared_statement_t : prepared_statement_base {
             using expression_type = T;
-            
+
             expression_type t;
-            
+
             prepared_statement_t(T t_, sqlite3_stmt *stmt, connection_ref con_) :
-            prepared_statement_base{stmt, std::move(con_)},
-            t(std::move(t_))
-            {}
+                prepared_statement_base{stmt, std::move(con_)}, t(std::move(t_)) {}
         };
-        
-        template<class T, class ...Args>
+
+        template<class T, class... Args>
         struct get_all_t {
             using type = T;
-            
+
             using conditions_type = std::tuple<Args...>;
-            
+
             conditions_type conditions;
         };
 
-        template<class T, class ...Args>
+        template<class T, class... Args>
         struct get_all_pointer_t {
             using type = T;
 
@@ -6568,252 +6634,253 @@ namespace sqlite_orm {
 
             conditions_type conditions;
         };
-        
-        template<class T, class ...Wargs>
+
+        template<class T, class... Wargs>
         struct update_all_t;
-        
-        template<class ...Args, class ...Wargs>
+
+        template<class... Args, class... Wargs>
         struct update_all_t<set_t<Args...>, Wargs...> {
             using set_type = set_t<Args...>;
             using conditions_type = std::tuple<Wargs...>;
-            
+
             set_type set;
             conditions_type conditions;
         };
-        
-        template<class T, class ...Args>
+
+        template<class T, class... Args>
         struct remove_all_t {
             using type = T;
-            
+
             using conditions_type = std::tuple<Args...>;
-            
+
             conditions_type conditions;
         };
-        
-        template<class T, class ...Ids>
+
+        template<class T, class... Ids>
         struct get_t {
             using type = T;
-            
+
             using ids_type = std::tuple<Ids...>;
-            
+
             ids_type ids;
         };
-        
-        template<class T, class ...Ids>
+
+        template<class T, class... Ids>
         struct get_pointer_t {
             using type = T;
-            
+
             using ids_type = std::tuple<Ids...>;
-            
+
             ids_type ids;
         };
-        
+
         template<class T, bool by_ref>
         struct update_t;
-        
+
         template<class T>
-        struct update_t<T, true>{
+        struct update_t<T, true> {
             using type = T;
-            
+
             const type &obj;
-            
+
             update_t(decltype(obj) obj_) : obj(obj_) {}
         };
-        
+
         template<class T>
-        struct update_t<T, false>{
+        struct update_t<T, false> {
             using type = T;
-            
+
             type obj;
         };
-        
-        template<class T, class ...Ids>
+
+        template<class T, class... Ids>
         struct remove_t {
             using type = T;
-            
+
             using ids_type = std::tuple<Ids...>;
-            
+
             ids_type ids;
         };
-        
+
         template<class T, bool by_ref>
         struct insert_t;
-        
+
         template<class T>
         struct insert_t<T, true> {
             using type = T;
-            
+
             const type &obj;
-            
+
             insert_t(decltype(obj) obj_) : obj(obj_) {}
         };
-        
+
         template<class T>
         struct insert_t<T, false> {
             using type = T;
-            
+
             type obj;
         };
-        
-        template<class T, bool by_ref, class ...Cols>
+
+        template<class T, bool by_ref, class... Cols>
         struct insert_explicit;
-        
-        template<class T, class ...Cols>
+
+        template<class T, class... Cols>
         struct insert_explicit<T, true, Cols...> {
             using type = T;
             using columns_type = columns_t<Cols...>;
-            
+
             const type &obj;
             columns_type columns;
-            
+
             insert_explicit(decltype(obj) obj_, decltype(columns) columns_) : obj(obj_), columns(std::move(columns_)) {}
         };
-        
-        template<class T, class ...Cols>
+
+        template<class T, class... Cols>
         struct insert_explicit<T, false, Cols...> {
             using type = T;
             using columns_type = columns_t<Cols...>;
-            
+
             type obj;
             columns_type columns;
-            
+
             insert_explicit(decltype(obj) obj_, decltype(columns) columns_) : obj(obj_), columns(std::move(columns_)) {}
         };
-        
+
         template<class T, bool by_ref>
         struct replace_t;
-        
+
         template<class T>
         struct replace_t<T, true> {
             using type = T;
-            
+
             const type &obj;
-            
+
             replace_t(decltype(obj) obj_) : obj(obj_) {}
         };
-        
+
         template<class T>
         struct replace_t<T, false> {
             using type = T;
-            
+
             type obj;
         };
-        
+
         template<class It>
         struct insert_range_t {
             using iterator_type = It;
             using object_type = typename std::iterator_traits<iterator_type>::value_type;
-            
+
             iterator_type from;
             iterator_type to;
         };
-        
+
         template<class It>
         struct replace_range_t {
             using iterator_type = It;
             using object_type = typename std::iterator_traits<iterator_type>::value_type;
-            
+
             iterator_type from;
             iterator_type to;
         };
     }
-    
+
     template<class It>
     internal::replace_range_t<It> replace_range(It from, It to) {
         return {std::move(from), std::move(to)};
     }
-    
+
     template<class It>
     internal::insert_range_t<It> insert_range(It from, It to) {
         return {std::move(from), std::move(to)};
     }
-    
+
     template<class T>
     internal::replace_t<T, true> replace(const T &obj) {
         static_assert(!internal::is_by_val<T>::value, "by_val is not allowed here");
         return {obj};
     }
-    
+
     template<class B>
     internal::replace_t<typename B::type, false> replace(typename B::type obj) {
         static_assert(internal::is_by_val<B>::value, "by_val expected");
         return {std::move(obj)};
     }
-    
+
     template<class T>
     internal::insert_t<T, true> insert(const T &obj) {
         static_assert(!internal::is_by_val<T>::value, "by_val is not allowed here");
         return {obj};
     }
-    
+
     template<class B>
     internal::insert_t<typename B::type, false> insert(typename B::type obj) {
         static_assert(internal::is_by_val<B>::value, "by_val expected");
         return {std::move(obj)};
     }
-    
-    template<class T, class ...Cols>
+
+    template<class T, class... Cols>
     internal::insert_explicit<T, true, Cols...> insert(const T &obj, internal::columns_t<Cols...> cols) {
         static_assert(!internal::is_by_val<T>::value, "by_val is not allowed here");
         return {obj, std::move(cols)};
     }
-    
-    template<class B, class ...Cols>
-    internal::insert_explicit<typename B::type, false, Cols...> insert(typename B::type obj, internal::columns_t<Cols...> cols) {
+
+    template<class B, class... Cols>
+    internal::insert_explicit<typename B::type, false, Cols...> insert(typename B::type obj,
+                                                                       internal::columns_t<Cols...> cols) {
         static_assert(internal::is_by_val<B>::value, "by_val expected");
         return {std::move(obj), std::move(cols)};
     }
-    
-    template<class T, class ...Ids>
-    internal::remove_t<T, Ids...> remove(Ids ...ids) {
+
+    template<class T, class... Ids>
+    internal::remove_t<T, Ids...> remove(Ids... ids) {
         std::tuple<Ids...> idsTuple{std::forward<Ids>(ids)...};
         return {move(idsTuple)};
     }
-    
+
     template<class T>
     internal::update_t<T, true> update(const T &obj) {
         static_assert(!internal::is_by_val<T>::value, "by_val is not allowed here");
         return {obj};
     }
-    
+
     template<class B>
     internal::update_t<typename B::type, false> update(typename B::type obj) {
         static_assert(internal::is_by_val<B>::value, "by_val expected");
         return {std::move(obj)};
     }
-    
-    template<class T, class ...Ids>
-    internal::get_t<T, Ids...> get(Ids ...ids) {
+
+    template<class T, class... Ids>
+    internal::get_t<T, Ids...> get(Ids... ids) {
         std::tuple<Ids...> idsTuple{std::forward<Ids>(ids)...};
         return {move(idsTuple)};
     }
-    
-    template<class T, class ...Ids>
-    internal::get_pointer_t<T, Ids...> get_pointer(Ids ...ids) {
+
+    template<class T, class... Ids>
+    internal::get_pointer_t<T, Ids...> get_pointer(Ids... ids) {
         std::tuple<Ids...> idsTuple{std::forward<Ids>(ids)...};
         return {move(idsTuple)};
     }
-    
-    template<class T, class ...Args>
-    internal::remove_all_t<T, Args...> remove_all(Args ...args) {
-        std::tuple<Args...> conditions{std::forward<Args>(args)...};
-        return {move(conditions)};
-    }
-    
-    template<class T, class ...Args>
-    internal::get_all_t<T, Args...> get_all(Args ...args) {
+
+    template<class T, class... Args>
+    internal::remove_all_t<T, Args...> remove_all(Args... args) {
         std::tuple<Args...> conditions{std::forward<Args>(args)...};
         return {move(conditions)};
     }
 
-    template<class T, class ...Args>
-    internal::get_all_pointer_t<T, Args...> get_all_pointer(Args ...args) {
+    template<class T, class... Args>
+    internal::get_all_t<T, Args...> get_all(Args... args) {
         std::tuple<Args...> conditions{std::forward<Args>(args)...};
         return {move(conditions)};
     }
-    
-    template<class ...Args, class ...Wargs>
-    internal::update_all_t<internal::set_t<Args...>, Wargs...> update_all(internal::set_t<Args...> set, Wargs ...wh) {
+
+    template<class T, class... Args>
+    internal::get_all_pointer_t<T, Args...> get_all_pointer(Args... args) {
+        std::tuple<Args...> conditions{std::forward<Args>(args)...};
+        return {move(conditions)};
+    }
+
+    template<class... Args, class... Wargs>
+    internal::update_all_t<internal::set_t<Args...>, Wargs...> update_all(internal::set_t<Args...> set, Wargs... wh) {
         std::tuple<Wargs...> conditions{std::forward<Wargs>(wh)...};
         return {std::move(set), move(conditions)};
     }
@@ -6821,9 +6888,9 @@ namespace sqlite_orm {
 
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         /**
          *  ast_iterator accepts an any expression and a callable object
          *  which will be called for any node of provided expression.
@@ -6836,7 +6903,7 @@ namespace sqlite_orm {
         template<class T, class SFINAE = void>
         struct ast_iterator {
             using node_type = T;
-            
+
             /**
              *  L is a callable type. Mostly is templated lambda
              */
@@ -6845,7 +6912,7 @@ namespace sqlite_orm {
                 l(t);
             }
         };
-        
+
         /**
          *  Simplified API
          */
@@ -6854,115 +6921,117 @@ namespace sqlite_orm {
             ast_iterator<T> iterator;
             iterator(t, l);
         }
-        
+
         template<class C>
         struct ast_iterator<conditions::where_t<C>, void> {
             using node_type = conditions::where_t<C>;
-         
+
             template<class L>
             void operator()(const node_type &where, const L &l) const {
                 iterate_ast(where.c, l);
             }
         };
-        
+
         template<class T>
-        struct ast_iterator<T, typename std::enable_if<is_base_of_template<T, conditions::binary_condition>::value>::type> {
+        struct ast_iterator<
+            T,
+            typename std::enable_if<is_base_of_template<T, conditions::binary_condition>::value>::type> {
             using node_type = T;
-            
+
             template<class L>
             void operator()(const node_type &binaryCondition, const L &l) const {
                 iterate_ast(binaryCondition.l, l);
                 iterate_ast(binaryCondition.r, l);
             }
         };
-        
-        template<class L, class R, class ...Ds>
+
+        template<class L, class R, class... Ds>
         struct ast_iterator<binary_operator<L, R, Ds...>, void> {
             using node_type = binary_operator<L, R, Ds...>;
-            
+
             template<class C>
             void operator()(const node_type &binaryOperator, const C &l) const {
                 iterate_ast(binaryOperator.lhs, l);
                 iterate_ast(binaryOperator.rhs, l);
             }
         };
-        
-        template<class ...Args>
+
+        template<class... Args>
         struct ast_iterator<columns_t<Args...>, void> {
             using node_type = columns_t<Args...>;
-            
+
             template<class L>
             void operator()(const node_type &cols, const L &l) const {
                 iterate_ast(cols.columns, l);
             }
         };
-        
+
         template<class L, class A>
         struct ast_iterator<conditions::in_t<L, A>, void> {
             using node_type = conditions::in_t<L, A>;
-            
+
             template<class C>
             void operator()(const node_type &in, const C &l) const {
                 iterate_ast(in.l, l);
                 iterate_ast(in.arg, l);
             }
         };
-        
+
         template<class T>
         struct ast_iterator<std::vector<T>, void> {
             using node_type = std::vector<T>;
-            
+
             template<class L>
             void operator()(const node_type &vec, const L &l) const {
-                for(auto &i : vec) {
+                for(auto &i: vec) {
                     iterate_ast(i, l);
                 }
             }
         };
-        
+
         template<>
         struct ast_iterator<std::vector<char>, void> {
             using node_type = std::vector<char>;
-            
+
             template<class L>
             void operator()(const node_type &vec, const L &l) const {
                 l(vec);
             }
         };
-        
+
         template<class T>
         struct ast_iterator<T, typename std::enable_if<is_base_of_template<T, compound_operator>::value>::type> {
             using node_type = T;
-            
+
             template<class L>
             void operator()(const node_type &c, const L &l) const {
                 iterate_ast(c.left, l);
                 iterate_ast(c.right, l);
             }
         };
-        
-        template<class T, class ...Args>
+
+        template<class T, class... Args>
         struct ast_iterator<select_t<T, Args...>, void> {
             using node_type = select_t<T, Args...>;
-            
+
             template<class L>
             void operator()(const node_type &sel, const L &l) const {
                 iterate_ast(sel.col, l);
                 iterate_ast(sel.conditions, l);
             }
         };
-        
-        template<class T, class ...Args>
+
+        template<class T, class... Args>
         struct ast_iterator<get_all_t<T, Args...>, void> {
             using node_type = get_all_t<T, Args...>;
-            
+
             template<class L>
             void operator()(const node_type &get, const L &l) const {
                 iterate_ast(get.conditions, l);
             }
         };
 
-        template<class T, class ...Args>
+        template<class T, class... Args>
         struct ast_iterator<get_all_pointer_t<T, Args...>, void> {
             using node_type = get_all_pointer_t<T, Args...>;
 
@@ -6972,77 +7041,77 @@ namespace sqlite_orm {
             }
         };
 
-        template<class ...Args>
+        template<class... Args>
         struct ast_iterator<std::tuple<Args...>, void> {
             using node_type = std::tuple<Args...>;
-            
+
             template<class L>
             void operator()(const node_type &tuple, const L &l) const {
-                iterate_tuple(tuple, [&l](auto &v){
+                iterate_tuple(tuple, [&l](auto &v) {
                     iterate_ast(v, l);
                 });
             }
         };
-        
+
         template<class T>
         struct ast_iterator<conditions::having_t<T>, void> {
             using node_type = conditions::having_t<T>;
-            
+
             template<class L>
             void operator()(const node_type &hav, const L &l) const {
                 iterate_ast(hav.t, l);
             }
         };
-        
+
         template<class T, class E>
         struct ast_iterator<conditions::cast_t<T, E>, void> {
             using node_type = conditions::cast_t<T, E>;
-            
+
             template<class L>
             void operator()(const node_type &c, const L &l) const {
                 iterate_ast(c.expression, l);
             }
         };
-        
+
         template<class T>
         struct ast_iterator<conditions::exists_t<T>, void> {
             using node_type = conditions::exists_t<T>;
-            
+
             template<class L>
             void operator()(const node_type &e, const L &l) const {
                 iterate_ast(e.t, l);
             }
         };
-        
+
         template<class A, class T, class E>
         struct ast_iterator<conditions::like_t<A, T, E>, void> {
             using node_type = conditions::like_t<A, T, E>;
-            
+
             template<class L>
             void operator()(const node_type &lk, const L &l) const {
                 iterate_ast(lk.arg, l);
                 iterate_ast(lk.pattern, l);
-                lk.arg3.apply([&l](auto &value){
+                lk.arg3.apply([&l](auto &value) {
                     iterate_ast(value, l);
                 });
             }
         };
-        
+
         template<class A, class T>
         struct ast_iterator<conditions::glob_t<A, T>, void> {
             using node_type = conditions::glob_t<A, T>;
-            
+
             template<class L>
             void operator()(const node_type &lk, const L &l) const {
                 iterate_ast(lk.arg, l);
                 iterate_ast(lk.pattern, l);
             }
         };
-        
+
         template<class A, class T>
         struct ast_iterator<conditions::between_t<A, T>, void> {
             using node_type = conditions::between_t<A, T>;
-            
+
             template<class L>
             void operator()(const node_type &b, const L &l) const {
                 iterate_ast(b.expr, l);
@@ -7050,110 +7119,110 @@ namespace sqlite_orm {
                 iterate_ast(b.b2, l);
             }
         };
-        
+
         template<class T>
         struct ast_iterator<conditions::named_collate<T>, void> {
             using node_type = conditions::named_collate<T>;
-            
+
             template<class L>
             void operator()(const node_type &col, const L &l) const {
                 iterate_ast(col.expr, l);
             }
         };
-        
+
         template<class C>
         struct ast_iterator<conditions::negated_condition_t<C>, void> {
             using node_type = conditions::negated_condition_t<C>;
-            
+
             template<class L>
             void operator()(const node_type &neg, const L &l) const {
                 iterate_ast(neg.c, l);
             }
         };
-        
-        template<class R, class S, class ...Args>
+
+        template<class R, class S, class... Args>
         struct ast_iterator<core_functions::core_function_t<R, S, Args...>, void> {
             using node_type = core_functions::core_function_t<R, S, Args...>;
-            
+
             template<class L>
             void operator()(const node_type &f, const L &l) const {
                 iterate_ast(f.args, l);
             }
         };
-        
+
         template<class T, class O>
         struct ast_iterator<conditions::left_join_t<T, O>, void> {
             using node_type = conditions::left_join_t<T, O>;
-            
+
             template<class L>
             void operator()(const node_type &j, const L &l) const {
                 iterate_ast(j.constraint, l);
             }
         };
-        
+
         template<class T>
         struct ast_iterator<conditions::on_t<T>, void> {
             using node_type = conditions::on_t<T>;
-            
+
             template<class L>
             void operator()(const node_type &o, const L &l) const {
                 iterate_ast(o.arg, l);
             }
         };
-        
+
         template<class T, class O>
         struct ast_iterator<conditions::join_t<T, O>, void> {
             using node_type = conditions::join_t<T, O>;
-            
+
             template<class L>
             void operator()(const node_type &j, const L &l) const {
                 iterate_ast(j.constraint, l);
             }
         };
-        
+
         template<class T, class O>
         struct ast_iterator<conditions::left_outer_join_t<T, O>, void> {
             using node_type = conditions::left_outer_join_t<T, O>;
-            
+
             template<class L>
             void operator()(const node_type &j, const L &l) const {
                 iterate_ast(j.constraint, l);
             }
         };
-        
+
         template<class T, class O>
         struct ast_iterator<conditions::inner_join_t<T, O>, void> {
             using node_type = conditions::inner_join_t<T, O>;
-            
+
             template<class L>
             void operator()(const node_type &j, const L &l) const {
                 iterate_ast(j.constraint, l);
             }
         };
-        
-        template<class R, class T, class E, class ...Args>
+
+        template<class R, class T, class E, class... Args>
         struct ast_iterator<simple_case_t<R, T, E, Args...>, void> {
             using node_type = simple_case_t<R, T, E, Args...>;
-            
+
             template<class L>
             void operator()(const node_type &c, const L &l) const {
-                c.case_expression.apply([&l](auto &c){
+                c.case_expression.apply([&l](auto &c) {
                     iterate_ast(c, l);
                 });
-                iterate_tuple(c.args, [&l](auto &pair){
+                iterate_tuple(c.args, [&l](auto &pair) {
                     iterate_ast(pair.first, l);
                     iterate_ast(pair.second, l);
                 });
-                c.else_expression.apply([&l](auto &el){
+                c.else_expression.apply([&l](auto &el) {
                     iterate_ast(el, l);
                 });
             }
         };
-        
+
         template<class T, class E>
         struct ast_iterator<as_t<T, E>, void> {
             using node_type = as_t<T, E>;
-            
+
             template<class L>
             void operator()(const node_type &a, const L &l) const {
                 iterate_ast(a.expression, l);
@@ -7168,53 +7237,53 @@ namespace sqlite_orm {
 
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
-        template<class T, class S, class ...Args>
+
+        template<class T, class S, class... Args>
         struct view_t {
             using mapped_type = T;
             using storage_type = S;
             using self = view_t<T, S, Args...>;
-            
+
             storage_type &storage;
             connection_ref connection;
             get_all_t<T, Args...> args;
-            
-            view_t(storage_type &stor, decltype(connection) conn, Args&& ...args_):
-            storage(stor),
-            connection(std::move(conn)),
-            args{std::make_tuple(std::forward<Args>(args_)...)}{}
-            
+
+            view_t(storage_type &stor, decltype(connection) conn, Args &&... args_) :
+                storage(stor), connection(std::move(conn)), args{std::make_tuple(std::forward<Args>(args_)...)} {}
+
             size_t size() {
                 return this->storage.template count<T>();
             }
-            
+
             bool empty() {
                 return !this->size();
             }
-            
+
             iterator_t<self> end() {
                 return {nullptr, *this};
             }
-            
+
             iterator_t<self> begin() {
                 sqlite3_stmt *stmt = nullptr;
                 auto db = this->connection.get();
                 auto query = this->storage.string_from_expression(this->args, false);
                 auto ret = sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr);
-                if(ret == SQLITE_OK){
+                if(ret == SQLITE_OK) {
                     auto index = 1;
-                    iterate_ast(this->args.conditions, [&index, stmt, db](auto &node){
+                    iterate_ast(this->args.conditions, [&index, stmt, db](auto &node) {
                         using node_type = typename std::decay<decltype(node)>::type;
                         conditional_binder<node_type, is_bindable<node_type>> binder{stmt, index};
-                        if(SQLITE_OK != binder(node)){
-                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                        if(SQLITE_OK != binder(node)) {
+                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                    sqlite3_errmsg(db));
                         }
                     });
                     return {stmt, *this};
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
         };
@@ -7226,25 +7295,25 @@ namespace sqlite_orm {
 // #include "storage_base.h"
 
 
-#include <functional>   //  std::function, std::bind
+#include <functional>  //  std::function, std::bind
 #include <sqlite3.h>
-#include <string>   //  std::string
+#include <string>  //  std::string
 #include <sstream>  //  std::stringstream
 #include <utility>  //  std::move
-#include <system_error> //  std::system_error, std::error_code, std::make_error_code
-#include <vector>   //  std::vector
-#include <memory>   //  std::make_shared, std::shared_ptr
+#include <system_error>  //  std::system_error, std::error_code, std::make_error_code
+#include <vector>  //  std::vector
+#include <memory>  //  std::make_shared, std::shared_ptr
 #include <map>  //  std::map
 #include <type_traits>  //  std::decay, std::is_same
-#include <algorithm>    //  std::iter_swap
+#include <algorithm>  //  std::iter_swap
 
 // #include "pragma.h"
 
 
-#include <string>   //  std::string
+#include <string>  //  std::string
 #include <sqlite3.h>
-#include <functional>   //  std::function
-#include <memory> // std::shared_ptr
+#include <functional>  //  std::function
+#include <memory>  // std::shared_ptr
 
 // #include "error_code.h"
 
@@ -7256,82 +7325,86 @@ namespace sqlite_orm {
 
 
 namespace sqlite_orm {
-    
+
     namespace internal {
         struct storage_base;
     }
-    
+
     struct pragma_t {
         using get_connection_t = std::function<internal::connection_ref()>;
-        
-        pragma_t(get_connection_t get_connection_):
-        get_connection(std::move(get_connection_))
-        {}
-        
+
+        pragma_t(get_connection_t get_connection_) : get_connection(std::move(get_connection_)) {}
+
         sqlite_orm::journal_mode journal_mode() {
             return this->get_pragma<sqlite_orm::journal_mode>("journal_mode");
         }
-        
+
         void journal_mode(sqlite_orm::journal_mode value) {
             this->_journal_mode = -1;
             this->set_pragma("journal_mode", value);
             this->_journal_mode = static_cast<decltype(this->_journal_mode)>(value);
         }
-        
+
         int synchronous() {
             return this->get_pragma<int>("synchronous");
         }
-        
+
         void synchronous(int value) {
             this->_synchronous = -1;
             this->set_pragma("synchronous", value);
             this->_synchronous = value;
         }
-        
+
         int user_version() {
             return this->get_pragma<int>("user_version");
         }
-        
+
         void user_version(int value) {
             this->set_pragma("user_version", value);
         }
-        
+
         int auto_vacuum() {
             return this->get_pragma<int>("auto_vacuum");
         }
-        
+
         void auto_vacuum(int value) {
             this->set_pragma("auto_vacuum", value);
         }
-        
-    protected:
+
+      protected:
         friend struct storage_base;
-        
-    public:
+
+      public:
         int _synchronous = -1;
-        signed char _journal_mode = -1; //  if != -1 stores static_cast<sqlite_orm::journal_mode>(journal_mode)
+        signed char _journal_mode = -1;  //  if != -1 stores static_cast<sqlite_orm::journal_mode>(journal_mode)
         get_connection_t get_connection;
-        
+
         template<class T>
         T get_pragma(const std::string &name) {
             auto connection = this->get_connection();
             auto query = "PRAGMA " + name;
             T res;
             auto db = connection.get();
-            auto rc = sqlite3_exec(db, query.c_str(), [](void *data, int argc, char **argv, char **) -> int {
-                                       auto &res = *(T*)data;
-                                       if(argc){
-                                           res = row_extractor<T>().extract(argv[0]);
-                                       }
-                                       return 0;
-                                   }, &res, nullptr);
-            if(rc == SQLITE_OK){
+            auto rc = sqlite3_exec(
+                db,
+                query.c_str(),
+                [](void *data, int argc, char **argv, char **) -> int {
+                    auto &res = *(T *)data;
+                    if(argc) {
+                        res = row_extractor<T>().extract(argv[0]);
+                    }
+                    return 0;
+                },
+                &res,
+                nullptr);
+            if(rc == SQLITE_OK) {
                 return res;
-            }else{
-                throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+            } else {
+                throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                        sqlite3_errmsg(db));
             }
         }
-        
+
         /**
          *  Yevgeniy Zakharov: I wanted to refactore this function with statements and value bindings
          *  but it turns out that bindings in pragma statements are not supported.
@@ -7339,7 +7412,7 @@ namespace sqlite_orm {
         template<class T>
         void set_pragma(const std::string &name, const T &value, sqlite3 *db = nullptr) {
             auto con = this->get_connection();
-            if(!db){
+            if(!db) {
                 db = con.get();
             }
             std::stringstream ss;
@@ -7347,13 +7420,14 @@ namespace sqlite_orm {
             auto query = ss.str();
             auto rc = sqlite3_exec(db, query.c_str(), nullptr, nullptr, nullptr);
             if(rc != SQLITE_OK) {
-                throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                        sqlite3_errmsg(db));
             }
         }
-        
+
         void set_pragma(const std::string &name, const sqlite_orm::journal_mode &value, sqlite3 *db = nullptr) {
             auto con = this->get_connection();
-            if(!db){
+            if(!db) {
                 db = con.get();
             }
             std::stringstream ss;
@@ -7361,7 +7435,8 @@ namespace sqlite_orm {
             auto query = ss.str();
             auto rc = sqlite3_exec(db, query.c_str(), nullptr, nullptr, nullptr);
             if(rc != SQLITE_OK) {
-                throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                        sqlite3_errmsg(db));
             }
         }
     };
@@ -7372,134 +7447,132 @@ namespace sqlite_orm {
 
 #include <sqlite3.h>
 #include <map>  //  std::map
-#include <functional>   //  std::function
-#include <memory>   //  std::shared_ptr
+#include <functional>  //  std::function
+#include <memory>  //  std::shared_ptr
 
 // #include "connection_holder.h"
 
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         struct limit_accesor {
             using get_connection_t = std::function<connection_ref()>;
-            
-            limit_accesor(get_connection_t get_connection_):
-            get_connection(std::move(get_connection_))
-            {}
-            
+
+            limit_accesor(get_connection_t get_connection_) : get_connection(std::move(get_connection_)) {}
+
             int length() {
                 return this->get(SQLITE_LIMIT_LENGTH);
             }
-            
+
             void length(int newValue) {
                 this->set(SQLITE_LIMIT_LENGTH, newValue);
             }
-            
+
             int sql_length() {
                 return this->get(SQLITE_LIMIT_SQL_LENGTH);
             }
-            
+
             void sql_length(int newValue) {
                 this->set(SQLITE_LIMIT_SQL_LENGTH, newValue);
             }
-            
+
             int column() {
                 return this->get(SQLITE_LIMIT_COLUMN);
             }
-            
+
             void column(int newValue) {
                 this->set(SQLITE_LIMIT_COLUMN, newValue);
             }
-            
+
             int expr_depth() {
                 return this->get(SQLITE_LIMIT_EXPR_DEPTH);
             }
-            
+
             void expr_depth(int newValue) {
                 this->set(SQLITE_LIMIT_EXPR_DEPTH, newValue);
             }
-            
+
             int compound_select() {
                 return this->get(SQLITE_LIMIT_COMPOUND_SELECT);
             }
-            
+
             void compound_select(int newValue) {
                 this->set(SQLITE_LIMIT_COMPOUND_SELECT, newValue);
             }
-            
+
             int vdbe_op() {
                 return this->get(SQLITE_LIMIT_VDBE_OP);
             }
-            
+
             void vdbe_op(int newValue) {
                 this->set(SQLITE_LIMIT_VDBE_OP, newValue);
             }
-            
+
             int function_arg() {
                 return this->get(SQLITE_LIMIT_FUNCTION_ARG);
             }
-            
+
             void function_arg(int newValue) {
                 this->set(SQLITE_LIMIT_FUNCTION_ARG, newValue);
             }
-            
+
             int attached() {
                 return this->get(SQLITE_LIMIT_ATTACHED);
             }
-            
+
             void attached(int newValue) {
                 this->set(SQLITE_LIMIT_ATTACHED, newValue);
             }
-            
+
             int like_pattern_length() {
                 return this->get(SQLITE_LIMIT_LIKE_PATTERN_LENGTH);
             }
-            
+
             void like_pattern_length(int newValue) {
                 this->set(SQLITE_LIMIT_LIKE_PATTERN_LENGTH, newValue);
             }
-            
+
             int variable_number() {
                 return this->get(SQLITE_LIMIT_VARIABLE_NUMBER);
             }
-            
+
             void variable_number(int newValue) {
                 this->set(SQLITE_LIMIT_VARIABLE_NUMBER, newValue);
             }
-            
+
             int trigger_depth() {
                 return this->get(SQLITE_LIMIT_TRIGGER_DEPTH);
             }
-            
+
             void trigger_depth(int newValue) {
                 this->set(SQLITE_LIMIT_TRIGGER_DEPTH, newValue);
             }
-            
+
             int worker_threads() {
                 return this->get(SQLITE_LIMIT_WORKER_THREADS);
             }
-            
+
             void worker_threads(int newValue) {
                 this->set(SQLITE_LIMIT_WORKER_THREADS, newValue);
             }
-            
-        protected:
+
+          protected:
             get_connection_t get_connection;
-            
+
             friend struct storage_base;
-            
+
             /**
              *  Stores limit set between connections.
              */
             std::map<int, int> limits;
-            
+
             int get(int id) {
                 auto connection = this->get_connection();
                 return sqlite3_limit(connection.get(), id, -1);
             }
-            
+
             void set(int id, int newValue) {
                 this->limits[id] = newValue;
                 auto connection = this->get_connection();
@@ -7512,15 +7585,15 @@ namespace sqlite_orm {
 // #include "transaction_guard.h"
 
 
-#include <functional>   //  std::function
+#include <functional>  //  std::function
 
 // #include "connection_holder.h"
 
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         /**
          *  Class used as a guard for a transaction. Calls `ROLLBACK` in destructor.
          *  Has explicit `commit()` and `rollback()` functions. After explicit function is fired
@@ -7533,23 +7606,23 @@ namespace sqlite_orm {
              *  if `gotta_fire` is true
              */
             bool commit_on_destroy = false;
-            
-            transaction_guard_t(connection_ref connection_, std::function<void()> commit_func_, std::function<void()> rollback_func_):
-            connection(std::move(connection_)),
-            commit_func(std::move(commit_func_)),
-            rollback_func(std::move(rollback_func_))
-            {}
-            
+
+            transaction_guard_t(connection_ref connection_,
+                                std::function<void()> commit_func_,
+                                std::function<void()> rollback_func_) :
+                connection(std::move(connection_)),
+                commit_func(std::move(commit_func_)), rollback_func(std::move(rollback_func_)) {}
+
             ~transaction_guard_t() {
-                if(this->gotta_fire){
-                    if(!this->commit_on_destroy){
+                if(this->gotta_fire) {
+                    if(!this->commit_on_destroy) {
                         this->rollback_func();
-                    }else{
+                    } else {
                         this->commit_func();
                     }
                 }
             }
-            
+
             /**
              *  Call `COMMIT` explicitly. After this call
              *  guard will not call `COMMIT` or `ROLLBACK`
@@ -7559,7 +7632,7 @@ namespace sqlite_orm {
                 this->commit_func();
                 this->gotta_fire = false;
             }
-            
+
             /**
              *  Call `ROLLBACK` explicitly. After this call
              *  guard will not call `COMMIT` or `ROLLBACK`
@@ -7569,8 +7642,8 @@ namespace sqlite_orm {
                 this->rollback_func();
                 this->gotta_fire = false;
             }
-            
-        protected:
+
+          protected:
             connection_ref connection;
             std::function<void()> commit_func;
             std::function<void()> rollback_func;
@@ -7593,7 +7666,7 @@ namespace sqlite_orm {
 
 
 #include <sqlite3.h>
-#include <string>   //  std::string
+#include <string>  //  std::string
 #include <memory>
 
 // #include "error_code.h"
@@ -7602,9 +7675,9 @@ namespace sqlite_orm {
 
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         /**
          *  A backup class. Don't construct it as is, call storage.make_backup_from or storage.make_backup_to instead.
          *  An instance of this class represents a wrapper around sqlite3_backup pointer. Use this class
@@ -7617,54 +7690,47 @@ namespace sqlite_orm {
                      connection_ref from_,
                      const std::string &zSourceName,
                      std::unique_ptr<connection_holder> holder_) :
-            handle(sqlite3_backup_init(to_.get(), zDestName.c_str(), from_.get(), zSourceName.c_str())),
-            holder(move(holder_)),
-            to(to_),
-            from(from_)
-            {
-                if(!this->handle){
+                handle(sqlite3_backup_init(to_.get(), zDestName.c_str(), from_.get(), zSourceName.c_str())),
+                holder(move(holder_)), to(to_), from(from_) {
+                if(!this->handle) {
                     throw std::system_error(std::make_error_code(orm_error_code::failed_to_init_a_backup));
                 }
             }
-            
+
             backup_t(backup_t &&other) :
-            handle(other.handle),
-            holder(move(other.holder)),
-            to(other.to),
-            from(other.from)
-            {
+                handle(other.handle), holder(move(other.holder)), to(other.to), from(other.from) {
                 other.handle = nullptr;
             }
-            
+
             ~backup_t() {
-                if(this->handle){
+                if(this->handle) {
                     (void)sqlite3_backup_finish(this->handle);
                     this->handle = nullptr;
                 }
             }
-            
+
             /**
              *  Calls sqlite3_backup_step with pages argument
              */
             int step(int pages) {
                 return sqlite3_backup_step(this->handle, pages);
             }
-            
+
             /**
              *  Returns sqlite3_backup_remaining result
              */
             int remaining() const {
                 return sqlite3_backup_remaining(this->handle);
             }
-            
+
             /**
              *  Returns sqlite3_backup_pagecount result
              */
             int pagecount() const {
                 return sqlite3_backup_pagecount(this->handle);
             }
-            
-        protected:
+
+          protected:
             sqlite3_backup *handle = nullptr;
             std::unique_ptr<connection_holder> holder;
             connection_ref to;
@@ -7675,23 +7741,23 @@ namespace sqlite_orm {
 
 
 namespace sqlite_orm {
-    
+
     namespace internal {
-        
+
         struct storage_base {
-            using collating_function = std::function<int(int, const void*, int, const void*)>;
-            
-            std::function<void(sqlite3*)> on_open;
+            using collating_function = std::function<int(int, const void *, int, const void *)>;
+
+            std::function<void(sqlite3 *)> on_open;
             pragma_t pragma;
             limit_accesor limit;
-            
+
             transaction_guard_t transaction_guard() {
                 this->begin_transaction();
-                auto commitFunc = std::bind(static_cast<void(storage_base::*)()>(&storage_base::commit), this);
-                auto rollbackFunc = std::bind(static_cast<void(storage_base::*)()>(&storage_base::rollback), this);
+                auto commitFunc = std::bind(static_cast<void (storage_base::*)()>(&storage_base::commit), this);
+                auto rollbackFunc = std::bind(static_cast<void (storage_base::*)()>(&storage_base::rollback), this);
                 return {this->get_connection(), move(commitFunc), move(rollbackFunc)};
             }
-            
+
             void drop_index(const std::string &indexName) {
                 auto con = this->get_connection();
                 auto db = con.get();
@@ -7699,35 +7765,39 @@ namespace sqlite_orm {
                 ss << "DROP INDEX '" << indexName + "'";
                 auto query = ss.str();
                 sqlite3_stmt *stmt;
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if (sqlite3_step(stmt) == SQLITE_DONE) {
+                    if(sqlite3_step(stmt) == SQLITE_DONE) {
                         //  done..
-                    }else{
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    } else {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
-                }else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             void vacuum() {
                 auto con = this->get_connection();
                 auto db = con.get();
                 std::string query = "VACUUM";
                 sqlite3_stmt *stmt;
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if (sqlite3_step(stmt) == SQLITE_DONE) {
+                    if(sqlite3_step(stmt) == SQLITE_DONE) {
                         //  done..
-                    }else{
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    } else {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
-                }else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             /**
              *  Drops table with given name.
              */
@@ -7735,7 +7805,7 @@ namespace sqlite_orm {
                 auto con = this->get_connection();
                 this->drop_table_internal(tableName, con.get());
             }
-            
+
             /**
              *  sqlite3_changes function.
              */
@@ -7743,7 +7813,7 @@ namespace sqlite_orm {
                 auto con = this->get_connection();
                 return sqlite3_changes(con.get());
             }
-            
+
             /**
              *  sqlite3_total_changes function.
              */
@@ -7751,57 +7821,58 @@ namespace sqlite_orm {
                 auto con = this->get_connection();
                 return sqlite3_total_changes(con.get());
             }
-            
+
             int64 last_insert_rowid() {
                 auto con = this->get_connection();
                 return sqlite3_last_insert_rowid(con.get());
             }
-            
+
             int busy_timeout(int ms) {
                 auto con = this->get_connection();
                 return sqlite3_busy_timeout(con.get(), ms);
             }
-            
+
             /**
              *  Returns libsqltie3 lib version, not sqlite_orm
              */
             std::string libversion() {
                 return sqlite3_libversion();
             }
-            
+
             bool transaction(std::function<bool()> f) {
                 this->begin_transaction();
                 auto con = this->get_connection();
                 auto db = con.get();
                 auto shouldCommit = f();
-                if(shouldCommit){
+                if(shouldCommit) {
                     this->commit(db);
-                }else{
+                } else {
                     this->rollback(db);
                 }
                 return shouldCommit;
             }
-            
+
             std::string current_timestamp() {
                 auto con = this->get_connection();
                 return this->current_timestamp(con.get());
             }
-            
+
 #if SQLITE_VERSION_NUMBER >= 3007010
             /**
              * \fn db_release_memory
-             * \brief Releases freeable memory of database. It is function can/should be called periodically by application,
-             * if application has less memory usage constraint.
-             * \note sqlite3_db_release_memory added in 3.7.10 https://sqlite.org/changes.html
+             * \brief Releases freeable memory of database. It is function can/should be called periodically by
+             * application, if application has less memory usage constraint. \note sqlite3_db_release_memory added
+             * in 3.7.10 https://sqlite.org/changes.html
              */
             int db_release_memory() {
                 auto con = this->get_connection();
                 return sqlite3_db_release_memory(con.get());
             }
 #endif
-            
+
             /**
-             *  Returns existing permanent table names in database. Doesn't check storage itself - works only with actual database.
+             *  Returns existing permanent table names in database. Doesn't check storage itself - works only with
+             * actual database.
              *  @return Returns list of tables in database.
              */
             std::vector<std::string> table_names() {
@@ -7810,201 +7881,205 @@ namespace sqlite_orm {
                 std::string sql = "SELECT name FROM sqlite_master WHERE type='table'";
                 using data_t = std::vector<std::string>;
                 auto db = con.get();
-                int res = sqlite3_exec(db, sql.c_str(),
-                                       [] (void *data, int argc, char **argv, char ** /*columnName*/) -> int {
-                                           auto& tableNames = *(data_t*)data;
-                                           for(int i = 0; i < argc; i++) {
-                                               if(argv[i]){
-                                                   tableNames.push_back(argv[i]);
-                                               }
-                                           }
-                                           return 0;
-                                       }, &tableNames,nullptr);
-                
+                int res = sqlite3_exec(
+                    db,
+                    sql.c_str(),
+                    [](void *data, int argc, char **argv, char * * /*columnName*/) -> int {
+                        auto &tableNames = *(data_t *)data;
+                        for(int i = 0; i < argc; i++) {
+                            if(argv[i]) {
+                                tableNames.push_back(argv[i]);
+                            }
+                        }
+                        return 0;
+                    },
+                    &tableNames,
+                    nullptr);
+
                 if(res != SQLITE_OK) {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
                 return tableNames;
             }
-            
+
             void open_forever() {
                 this->isOpenedForever = true;
                 this->connection->retain();
-                if(1 == this->connection->retain_count()){
+                if(1 == this->connection->retain_count()) {
                     this->on_open_internal(this->connection->get());
                 }
             }
-            
+
             void create_collation(const std::string &name, collating_function f) {
                 collating_function *functionPointer = nullptr;
-                if(f){
+                if(f) {
                     functionPointer = &(collatingFunctions[name] = std::move(f));
-                }else{
+                } else {
                     collatingFunctions.erase(name);
                 }
-                
+
                 //  create collations if db is open
-                if(this->connection->retain_count() > 0){
+                if(this->connection->retain_count() > 0) {
                     auto db = this->connection->get();
                     if(sqlite3_create_collation(db,
                                                 name.c_str(),
                                                 SQLITE_UTF8,
                                                 functionPointer,
-                                                f ? collate_callback : nullptr) != SQLITE_OK)
-                    {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                                                f ? collate_callback : nullptr) != SQLITE_OK) {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
                 }
             }
-            
+
             void begin_transaction() {
                 this->connection->retain();
-                if(1 == this->connection->retain_count()){
+                if(1 == this->connection->retain_count()) {
                     this->on_open_internal(this->connection->get());
                 }
                 auto db = this->connection->get();
                 this->begin_transaction(db);
             }
-            
+
             void commit() {
                 auto db = this->connection->get();
                 this->commit(db);
                 this->connection->release();
-                if(this->connection->retain_count() < 0){
+                if(this->connection->retain_count() < 0) {
                     throw std::system_error(std::make_error_code(orm_error_code::no_active_transaction));
                 }
             }
-            
+
             void rollback() {
                 auto db = this->connection->get();
                 this->rollback(db);
                 this->connection->release();
-                if(this->connection->retain_count() < 0){
+                if(this->connection->retain_count() < 0) {
                     throw std::system_error(std::make_error_code(orm_error_code::no_active_transaction));
                 }
             }
-            
+
             void backup_to(const std::string &filename) {
                 auto backup = this->make_backup_to(filename);
                 backup.step(-1);
             }
-            
+
             void backup_to(storage_base &other) {
                 auto backup = this->make_backup_to(other);
                 backup.step(-1);
             }
-            
+
             void backup_from(const std::string &filename) {
                 auto backup = this->make_backup_from(filename);
                 backup.step(-1);
             }
-            
+
             void backup_from(storage_base &other) {
                 auto backup = this->make_backup_from(other);
                 backup.step(-1);
             }
-            
+
             backup_t make_backup_to(const std::string &filename) {
                 auto holder = std::make_unique<connection_holder>(filename);
                 return {connection_ref{*holder}, "main", this->get_connection(), "main", move(holder)};
             }
-            
+
             backup_t make_backup_to(storage_base &other) {
                 return {other.get_connection(), "main", this->get_connection(), "main", {}};
             }
-            
+
             backup_t make_backup_from(const std::string &filename) {
                 auto holder = std::make_unique<connection_holder>(filename);
                 return {this->get_connection(), "main", connection_ref{*holder}, "main", move(holder)};
             }
-            
+
             backup_t make_backup_from(storage_base &other) {
                 return {this->get_connection(), "main", other.get_connection(), "main", {}};
             }
-            
+
             const std::string &filename() const {
                 return this->connection->filename;
             }
-            
-        protected:
-            
-            storage_base(const std::string &filename_, int foreignKeysCount):
-            pragma(std::bind(&storage_base::get_connection, this)),
-            limit(std::bind(&storage_base::get_connection, this)),
-            inMemory(filename_.empty() || filename_ == ":memory:"),
-            connection(std::make_unique<connection_holder>(filename_)),
-            cachedForeignKeysCount(foreignKeysCount)
-            {
-                if(this->inMemory){
+
+          protected:
+            storage_base(const std::string &filename_, int foreignKeysCount) :
+                pragma(std::bind(&storage_base::get_connection, this)),
+                limit(std::bind(&storage_base::get_connection, this)),
+                inMemory(filename_.empty() || filename_ == ":memory:"),
+                connection(std::make_unique<connection_holder>(filename_)), cachedForeignKeysCount(foreignKeysCount) {
+                if(this->inMemory) {
                     this->connection->retain();
                     this->on_open_internal(this->connection->get());
                 }
             }
-            
-            storage_base(const storage_base &other):
-            on_open(other.on_open),
-            pragma(std::bind(&storage_base::get_connection, this)),
-            limit(std::bind(&storage_base::get_connection, this)),
-            inMemory(other.inMemory),
-            connection(std::make_unique<connection_holder>(other.connection->filename)),
-            cachedForeignKeysCount(other.cachedForeignKeysCount)
-            {}
-            
+
+            storage_base(const storage_base &other) :
+                on_open(other.on_open), pragma(std::bind(&storage_base::get_connection, this)),
+                limit(std::bind(&storage_base::get_connection, this)), inMemory(other.inMemory),
+                connection(std::make_unique<connection_holder>(other.connection->filename)),
+                cachedForeignKeysCount(other.cachedForeignKeysCount) {}
+
             ~storage_base() {
                 if(this->isOpenedForever) {
                     this->connection->release();
                 }
-                if(this->inMemory){
+                if(this->inMemory) {
                     this->connection->release();
                 }
             }
-            
+
             const bool inMemory;
             bool isOpenedForever = false;
             std::unique_ptr<connection_holder> connection;
             std::map<std::string, collating_function> collatingFunctions;
             const int cachedForeignKeysCount;
-            
+
             connection_ref get_connection() {
                 connection_ref res{*this->connection};
-                if(1 == this->connection->retain_count()){
+                if(1 == this->connection->retain_count()) {
                     this->on_open_internal(this->connection->get());
                 }
                 return res;
             }
-            
+
 #if SQLITE_VERSION_NUMBER >= 3006019
-            
+
             void foreign_keys(sqlite3 *db, bool value) {
                 std::stringstream ss;
                 ss << "PRAGMA foreign_keys = " << value;
                 auto query = ss.str();
                 auto rc = sqlite3_exec(db, query.c_str(), nullptr, nullptr, nullptr);
                 if(rc != SQLITE_OK) {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             bool foreign_keys(sqlite3 *db) {
                 std::string query = "PRAGMA foreign_keys";
                 auto res = false;
-                auto rc = sqlite3_exec(db,
-                                       query.c_str(),
-                                       [](void *data, int argc, char **argv,char **) -> int {
-                                           auto &res = *(bool*)data;
-                                           if(argc){
-                                               res = row_extractor<bool>().extract(argv[0]);
-                                           }
-                                           return 0;
-                                       }, &res, nullptr);
+                auto rc = sqlite3_exec(
+                    db,
+                    query.c_str(),
+                    [](void *data, int argc, char **argv, char **) -> int {
+                        auto &res = *(bool *)data;
+                        if(argc) {
+                            res = row_extractor<bool>().extract(argv[0]);
+                        }
+                        return 0;
+                    },
+                    &res,
+                    nullptr);
                 if(rc != SQLITE_OK) {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
                 return res;
             }
-            
-#endif            
-            template<class O, class T, class G, class S, class ...Op>
+
+#endif
+            template<class O, class T, class G, class S, class... Op>
             std::string serialize_column_schema(const internal::column_t<O, T, G, S, Op...> &c) {
                 std::stringstream ss;
                 ss << "'" << c.name << "' ";
@@ -8019,166 +8094,177 @@ namespace sqlite_orm {
                     int primaryKeyIndex = -1;
                     int autoincrementIndex = -1;
                     int tupleIndex = 0;
-                    iterate_tuple(c.constraints, [&constraintsStrings, &primaryKeyIndex, &autoincrementIndex, &tupleIndex](auto &v){
-                        using constraint_type = typename std::decay<decltype(v)>::type;
-                        constraintsStrings.push_back(static_cast<std::string>(v));
-                        if(is_primary_key<constraint_type>::value) {
-                            primaryKeyIndex = tupleIndex;
-                        }else if(std::is_same<constraints::autoincrement_t, constraint_type>::value){
-                            autoincrementIndex = tupleIndex;
-                        }
-                        ++tupleIndex;
-                    });
-                    if(primaryKeyIndex != -1 && autoincrementIndex != -1 && autoincrementIndex < primaryKeyIndex){
-                        iter_swap(constraintsStrings.begin() + primaryKeyIndex, constraintsStrings.begin() + autoincrementIndex);
+                    iterate_tuple(c.constraints,
+                                  [&constraintsStrings, &primaryKeyIndex, &autoincrementIndex, &tupleIndex](auto &v) {
+                                      using constraint_type = typename std::decay<decltype(v)>::type;
+                                      constraintsStrings.push_back(static_cast<std::string>(v));
+                                      if(is_primary_key<constraint_type>::value) {
+                                          primaryKeyIndex = tupleIndex;
+                                      } else if(std::is_same<constraints::autoincrement_t, constraint_type>::value) {
+                                          autoincrementIndex = tupleIndex;
+                                      }
+                                      ++tupleIndex;
+                                  });
+                    if(primaryKeyIndex != -1 && autoincrementIndex != -1 && autoincrementIndex < primaryKeyIndex) {
+                        iter_swap(constraintsStrings.begin() + primaryKeyIndex,
+                                  constraintsStrings.begin() + autoincrementIndex);
                     }
-                    for(auto &str : constraintsStrings) {
+                    for(auto &str: constraintsStrings) {
                         ss << str << ' ';
                     }
                 }
-                if(c.not_null()){
+                if(c.not_null()) {
                     ss << "NOT NULL ";
                 }
                 return ss.str();
             }
-            
+
             void on_open_internal(sqlite3 *db) {
-                
+
 #if SQLITE_VERSION_NUMBER >= 3006019
-                if(this->cachedForeignKeysCount){
+                if(this->cachedForeignKeysCount) {
                     this->foreign_keys(db, true);
                 }
 #endif
                 if(this->pragma._synchronous != -1) {
                     this->pragma.synchronous(this->pragma._synchronous);
                 }
-                
+
                 if(this->pragma._journal_mode != -1) {
                     this->pragma.set_pragma("journal_mode", static_cast<journal_mode>(this->pragma._journal_mode), db);
                 }
-                
-                for(auto &p : this->collatingFunctions){
-                    if(sqlite3_create_collation(db,
-                                                p.first.c_str(),
-                                                SQLITE_UTF8,
-                                                &p.second,
-                                                collate_callback) != SQLITE_OK)
-                    {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+
+                for(auto &p: this->collatingFunctions) {
+                    if(sqlite3_create_collation(db, p.first.c_str(), SQLITE_UTF8, &p.second, collate_callback) !=
+                       SQLITE_OK) {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
                 }
-                
-                for(auto &p : this->limit.limits) {
+
+                for(auto &p: this->limit.limits) {
                     sqlite3_limit(db, p.first, p.second);
                 }
-                
-                if(this->on_open){
+
+                if(this->on_open) {
                     this->on_open(db);
                 }
             }
-            
+
             void begin_transaction(sqlite3 *db) {
                 std::stringstream ss;
                 ss << "BEGIN TRANSACTION";
                 auto query = ss.str();
                 sqlite3_stmt *stmt;
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if (sqlite3_step(stmt) == SQLITE_DONE) {
+                    if(sqlite3_step(stmt) == SQLITE_DONE) {
                         //  done..
-                    }else{
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    } else {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
-                }else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             void commit(sqlite3 *db) {
                 std::stringstream ss;
                 ss << "COMMIT";
                 auto query = ss.str();
                 sqlite3_stmt *stmt;
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if (sqlite3_step(stmt) == SQLITE_DONE) {
+                    if(sqlite3_step(stmt) == SQLITE_DONE) {
                         //  done..
-                    }else{
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    } else {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
-                }else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             void rollback(sqlite3 *db) {
                 std::stringstream ss;
                 ss << "ROLLBACK";
                 auto query = ss.str();
                 sqlite3_stmt *stmt;
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if (sqlite3_step(stmt) == SQLITE_DONE) {
+                    if(sqlite3_step(stmt) == SQLITE_DONE) {
                         //  done..
-                    }else{
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    } else {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
-                }else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             std::string current_timestamp(sqlite3 *db) {
                 std::string res;
                 std::stringstream ss;
                 ss << "SELECT CURRENT_TIMESTAMP";
                 auto query = ss.str();
-                auto rc = sqlite3_exec(db,
-                                       query.c_str(),
-                                       [](void *data, int argc, char **argv, char **) -> int {
-                                           auto &res = *(std::string*)data;
-                                           if(argc){
-                                               if(argv[0]){
-                                                   res = row_extractor<std::string>().extract(argv[0]);
-                                               }
-                                           }
-                                           return 0;
-                                       }, &res, nullptr);
+                auto rc = sqlite3_exec(
+                    db,
+                    query.c_str(),
+                    [](void *data, int argc, char **argv, char **) -> int {
+                        auto &res = *(std::string *)data;
+                        if(argc) {
+                            if(argv[0]) {
+                                res = row_extractor<std::string>().extract(argv[0]);
+                            }
+                        }
+                        return 0;
+                    },
+                    &res,
+                    nullptr);
                 if(rc != SQLITE_OK) {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
                 return res;
             }
-            
+
             void drop_table_internal(const std::string &tableName, sqlite3 *db) {
                 std::stringstream ss;
                 ss << "DROP TABLE '" << tableName + "'";
                 auto query = ss.str();
                 sqlite3_stmt *stmt;
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if (sqlite3_step(stmt) == SQLITE_DONE) {
+                    if(sqlite3_step(stmt) == SQLITE_DONE) {
                         //  done..
-                    }else{
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    } else {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
-                }else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             template<class S>
             std::string process_order_by(const conditions::dynamic_order_by_t<S> &orderBy) const {
                 std::vector<std::string> expressions;
-                for(auto &entry : orderBy){
+                for(auto &entry: orderBy) {
                     std::string entryString;
                     {
                         std::stringstream ss;
                         ss << entry.name << " ";
-                        if(!entry._collate_argument.empty()){
+                        if(!entry._collate_argument.empty()) {
                             ss << "COLLATE " << entry._collate_argument << " ";
                         }
-                        switch(entry.asc_desc){
+                        switch(entry.asc_desc) {
                             case 1:
                                 ss << "ASC";
                                 break;
@@ -8201,17 +8287,17 @@ namespace sqlite_orm {
                 ss << " ";
                 return ss.str();
             }
-            
+
             static int collate_callback(void *arg, int leftLen, const void *lhs, int rightLen, const void *rhs) {
-                auto &f = *(collating_function*)arg;
+                auto &f = *(collating_function *)arg;
                 return f(leftLen, lhs, rightLen, rhs);
             }
-            
+
             //  returns foreign keys count in storage definition
             template<class T>
             static int foreign_keys_count(T &storageImpl) {
                 auto res = 0;
-                storageImpl.for_each([&res](auto impl){
+                storageImpl.for_each([&res](auto impl) {
                     res += impl->foreign_keys_count();
                 });
                 return res;
@@ -8224,57 +8310,53 @@ namespace sqlite_orm {
 
 
 namespace sqlite_orm {
-    
+
     namespace conditions {
-        
+
         template<class S>
         struct dynamic_order_by_t;
     }
-    
+
     namespace internal {
-        
+
         /**
-         *  Storage class itself. Create an instanse to use it as an interfacto to sqlite db by calling `make_storage` function.
+         *  Storage class itself. Create an instanse to use it as an interfacto to sqlite db by calling `make_storage`
+         * function.
          */
-        template<class ...Ts>
+        template<class... Ts>
         struct storage_t : storage_base {
             using self = storage_t<Ts...>;
             using impl_type = storage_impl<Ts...>;
             using storage_base::serialize_column_schema;
-            
+
             /**
              *  @param filename database filename.
              *  @param impl_ storage_impl head
              */
-            storage_t(const std::string &filename, impl_type impl_):
-            storage_base{filename, foreign_keys_count(impl_)},
-            impl(std::move(impl_))
-            {}
-            
-            storage_t(const storage_t &other):
-            storage_base(other),
-            impl(other.impl)
-            {}
-            
-        protected:
+            storage_t(const std::string &filename, impl_type impl_) :
+                storage_base{filename, foreign_keys_count(impl_)}, impl(std::move(impl_)) {}
+
+            storage_t(const storage_t &other) : storage_base(other), impl(other.impl) {}
+
+          protected:
             impl_type impl;
-            
-            template<class T, class S, class ...Args>
+
+            template<class T, class S, class... Args>
             friend struct view_t;
-            
+
             template<class S>
             friend struct conditions::dynamic_order_by_t;
-            
+
             template<class V>
             friend struct iterator_t;
-            
-            template<class ...Cs>
+
+            template<class... Cs>
             std::string serialize_column_schema(const constraints::primary_key_t<Cs...> &fk) {
                 std::stringstream ss;
                 ss << static_cast<std::string>(fk) << " (";
                 std::vector<std::string> columnNames;
                 columnNames.reserve(std::tuple_size<decltype(fk.columns)>::value);
-                iterate_tuple(fk.columns, [&columnNames, this](auto &c){
+                iterate_tuple(fk.columns, [&columnNames, this](auto &c) {
                     columnNames.push_back(this->impl.column_name(c));
                 });
                 for(size_t i = 0; i < columnNames.size(); ++i) {
@@ -8286,23 +8368,24 @@ namespace sqlite_orm {
                 ss << ") ";
                 return ss.str();
             }
-            
+
 #if SQLITE_VERSION_NUMBER >= 3006019
-            
-            template<class ...Cs, class ...Rs>
-            std::string serialize_column_schema(const constraints::foreign_key_t<std::tuple<Cs...>, std::tuple<Rs...>> &fk) {
+
+            template<class... Cs, class... Rs>
+            std::string
+            serialize_column_schema(const constraints::foreign_key_t<std::tuple<Cs...>, std::tuple<Rs...>> &fk) {
                 std::stringstream ss;
                 std::vector<std::string> columnNames;
                 using columns_type_t = typename std::decay<decltype(fk)>::type::columns_type;
                 constexpr const size_t columnsCount = std::tuple_size<columns_type_t>::value;
                 columnNames.reserve(columnsCount);
-                iterate_tuple(fk.columns, [&columnNames, this](auto &v){
+                iterate_tuple(fk.columns, [&columnNames, this](auto &v) {
                     columnNames.push_back(this->impl.column_name(v));
                 });
                 ss << "FOREIGN KEY( ";
                 for(size_t i = 0; i < columnNames.size(); ++i) {
                     ss << columnNames[i];
-                    if(i < columnNames.size() - 1){
+                    if(i < columnNames.size() - 1) {
                         ss << ",";
                     }
                     ss << " ";
@@ -8318,35 +8401,35 @@ namespace sqlite_orm {
                     auto refTableName = this->impl.template find_table_name<first_reference_mapped_type>();
                     ss << refTableName << " ";
                 }
-                iterate_tuple(fk.references, [&referencesNames, this](auto &v){
+                iterate_tuple(fk.references, [&referencesNames, this](auto &v) {
                     referencesNames.push_back(this->impl.column_name(v));
                 });
                 ss << "( ";
-                for(size_t i = 0; i < referencesNames.size(); ++i){
+                for(size_t i = 0; i < referencesNames.size(); ++i) {
                     ss << referencesNames[i];
-                    if(i < referencesNames.size() - 1){
+                    if(i < referencesNames.size() - 1) {
                         ss << ",";
                     }
                     ss << " ";
                 }
                 ss << ") ";
-                if(fk.on_update){
+                if(fk.on_update) {
                     ss << static_cast<std::string>(fk.on_update) << " " << fk.on_update._action << " ";
                 }
-                if(fk.on_delete){
+                if(fk.on_delete) {
                     ss << static_cast<std::string>(fk.on_delete) << " " << fk.on_delete._action << " ";
                 }
                 return ss.str();
             }
 #endif
-            
+
             template<class I>
             void create_table(sqlite3 *db, const std::string &tableName, I *impl) {
                 std::stringstream ss;
                 ss << "CREATE TABLE '" << tableName << "' ( ";
                 auto columnsCount = impl->table.columns_count;
                 auto index = 0;
-                impl->table.for_each_column_with_constraints([columnsCount, &index, &ss, this] (auto &c) {
+                impl->table.for_each_column_with_constraints([columnsCount, &index, &ss, this](auto &c) {
                     ss << this->serialize_column_schema(c);
                     if(index < columnsCount - 1) {
                         ss << ", ";
@@ -8359,186 +8442,192 @@ namespace sqlite_orm {
                 }
                 auto query = ss.str();
                 sqlite3_stmt *stmt;
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if (sqlite3_step(stmt) == SQLITE_DONE) {
+                    if(sqlite3_step(stmt) == SQLITE_DONE) {
                         //  done..
-                    }else{
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    } else {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
-                }else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             template<class I>
             void backup_table(sqlite3 *db, I *impl) {
-                
+
                 //  here we copy source table to another with a name with '_backup' suffix, but in case table with such
                 //  a name already exists we append suffix 1, then 2, etc until we find a free name..
                 auto backupTableName = impl->table.name + "_backup";
-                if(impl->table_exists(backupTableName, db)){
+                if(impl->table_exists(backupTableName, db)) {
                     int suffix = 1;
-                    do{
+                    do {
                         std::stringstream stream;
                         stream << suffix;
                         auto anotherBackupTableName = backupTableName + stream.str();
-                        if(!impl->table_exists(anotherBackupTableName, db)){
+                        if(!impl->table_exists(anotherBackupTableName, db)) {
                             backupTableName = anotherBackupTableName;
                             break;
                         }
                         ++suffix;
-                    }while(true);
+                    } while(true);
                 }
-                
+
                 this->create_table(db, backupTableName, impl);
-                
+
                 impl->copy_table(db, backupTableName);
-                
+
                 this->drop_table_internal(impl->table.name, db);
-                
+
                 impl->rename_table(db, backupTableName, impl->table.name);
             }
-            
+
             template<class O>
             void assert_mapped_type() const {
                 using mapped_types_tuples = std::tuple<typename Ts::object_type...>;
                 static_assert(tuple_helper::has_type<O, mapped_types_tuples>::value, "type is not mapped to a storage");
             }
-            
+
             template<class O>
-            auto& get_impl() const {
+            auto &get_impl() const {
                 return this->impl.template get_impl<O>();
             }
-            
+
             template<class T>
-            typename std::enable_if<is_bindable<T>::value, std::string>::type string_from_expression(const T &, bool) const {
+            typename std::enable_if<is_bindable<T>::value, std::string>::type string_from_expression(const T &,
+                                                                                                     bool) const {
                 return "?";
             }
-            
+
             std::string string_from_expression(std::nullptr_t, bool /*noTableName*/) const {
                 return "?";
             }
-            
+
             template<class T>
             std::string string_from_expression(const alias_holder<T> &, bool /*noTableName*/) const {
                 return T::get();
             }
-            
-            template<class R, class S, class ...Args>
-            std::string string_from_expression(const core_functions::core_function_t<R, S, Args...> &c, bool noTableName) const {
+
+            template<class R, class S, class... Args>
+            std::string string_from_expression(const core_functions::core_function_t<R, S, Args...> &c,
+                                               bool noTableName) const {
                 std::stringstream ss;
                 ss << static_cast<std::string>(c) << "(";
                 std::vector<std::string> args;
                 using args_type = typename std::decay<decltype(c)>::type::args_type;
                 args.reserve(std::tuple_size<args_type>::value);
-                iterate_tuple(c.args, [&args, this, noTableName](auto &v){
+                iterate_tuple(c.args, [&args, this, noTableName](auto &v) {
                     args.push_back(this->string_from_expression(v, noTableName));
                 });
-                for(size_t i = 0; i < args.size(); ++i){
+                for(size_t i = 0; i < args.size(); ++i) {
                     ss << args[i];
-                    if(i < args.size() - 1){
+                    if(i < args.size() - 1) {
                         ss << ", ";
                     }
                 }
                 ss << ")";
                 return ss.str();
             }
-            
+
             template<class T, class E>
             std::string string_from_expression(const as_t<T, E> &als, bool noTableName) const {
                 auto tableAliasString = alias_extractor<T>::get();
                 return this->string_from_expression(als.expression, noTableName) + " AS " + tableAliasString;
             }
-            
+
             template<class T, class C>
             std::string string_from_expression(const alias_column_t<T, C> &als, bool noTableName) const {
                 std::stringstream ss;
-                if(!noTableName){
+                if(!noTableName) {
                     ss << "'" << T::get() << "'.";
                 }
                 ss << this->string_from_expression(als.column, true);
                 return ss.str();
             }
-            
+
             std::string string_from_expression(const std::string &, bool /*noTableName*/) const {
                 return "?";
             }
-            
+
             std::string string_from_expression(const char *, bool /*noTableName*/) const {
                 return "?";
             }
-            
+
             template<class F, class O>
             std::string string_from_expression(F O::*m, bool noTableName) const {
                 std::stringstream ss;
-                if(!noTableName){
+                if(!noTableName) {
                     ss << "'" << this->impl.template find_table_name<O>() << "'.";
                 }
                 ss << "\"" << this->impl.column_name(m) << "\"";
                 return ss.str();
             }
-            
+
             std::string string_from_expression(const rowid_t &rid, bool /*noTableName*/) const {
                 return static_cast<std::string>(rid);
             }
-            
+
             std::string string_from_expression(const oid_t &rid, bool /*noTableName*/) const {
                 return static_cast<std::string>(rid);
             }
-            
+
             std::string string_from_expression(const _rowid_t &rid, bool /*noTableName*/) const {
                 return static_cast<std::string>(rid);
             }
-            
+
             template<class O>
             std::string string_from_expression(const table_rowid_t<O> &rid, bool noTableName) const {
                 std::stringstream ss;
-                if(!noTableName){
+                if(!noTableName) {
                     ss << "'" << this->impl.template find_table_name<O>() << "'.";
                 }
                 ss << static_cast<std::string>(rid);
                 return ss.str();
             }
-            
+
             template<class O>
             std::string string_from_expression(const table_oid_t<O> &rid, bool noTableName) const {
                 std::stringstream ss;
-                if(!noTableName){
+                if(!noTableName) {
                     ss << "'" << this->impl.template find_table_name<O>() << "'.";
                 }
                 ss << static_cast<std::string>(rid);
                 return ss.str();
             }
-            
+
             template<class O>
             std::string string_from_expression(const table__rowid_t<O> &rid, bool noTableName) const {
                 std::stringstream ss;
-                if(!noTableName){
+                if(!noTableName) {
                     ss << "'" << this->impl.template find_table_name<O>() << "'.";
                 }
                 ss << static_cast<std::string>(rid);
                 return ss.str();
             }
-            
+
             template<class T>
-            std::string string_from_expression(const aggregate_functions::group_concat_double_t<T> &f, bool noTableName) const {
+            std::string string_from_expression(const aggregate_functions::group_concat_double_t<T> &f,
+                                               bool noTableName) const {
                 std::stringstream ss;
                 auto expr = this->string_from_expression(f.t, noTableName);
                 auto expr2 = this->string_from_expression(f.y, noTableName);
                 ss << static_cast<std::string>(f) << "(" << expr << ", " << expr2 << ")";
                 return ss.str();
             }
-            
+
             template<class T>
-            std::string string_from_expression(const aggregate_functions::group_concat_single_t<T> &f, bool noTableName) const {
+            std::string string_from_expression(const aggregate_functions::group_concat_single_t<T> &f,
+                                               bool noTableName) const {
                 std::stringstream ss;
                 auto expr = this->string_from_expression(f.t, noTableName);
                 ss << static_cast<std::string>(f) << "(" << expr << ")";
                 return ss.str();
             }
-            
-            template<class L, class R, class ...Ds>
+
+            template<class L, class R, class... Ds>
             std::string string_from_expression(const binary_operator<L, R, Ds...> &f, bool noTableName) const {
                 std::stringstream ss;
                 auto lhs = this->string_from_expression(f.lhs, noTableName);
@@ -8546,7 +8635,7 @@ namespace sqlite_orm {
                 ss << "(" << lhs << " " << static_cast<std::string>(f) << " " << rhs << ")";
                 return ss.str();
             }
-            
+
             template<class T>
             std::string string_from_expression(const aggregate_functions::min_t<T> &f, bool noTableName) const {
                 std::stringstream ss;
@@ -8554,7 +8643,7 @@ namespace sqlite_orm {
                 ss << static_cast<std::string>(f) << "(" << expr << ")";
                 return ss.str();
             }
-            
+
             template<class T>
             std::string string_from_expression(const aggregate_functions::max_t<T> &f, bool noTableName) const {
                 std::stringstream ss;
@@ -8562,7 +8651,7 @@ namespace sqlite_orm {
                 ss << static_cast<std::string>(f) << "(" << expr << ")";
                 return ss.str();
             }
-            
+
             template<class T>
             std::string string_from_expression(const aggregate_functions::total_t<T> &f, bool noTableName) const {
                 std::stringstream ss;
@@ -8570,7 +8659,7 @@ namespace sqlite_orm {
                 ss << static_cast<std::string>(f) << "(" << expr << ")";
                 return ss.str();
             }
-            
+
             template<class T>
             std::string string_from_expression(const aggregate_functions::sum_t<T> &f, bool noTableName) const {
                 std::stringstream ss;
@@ -8578,18 +8667,20 @@ namespace sqlite_orm {
                 ss << static_cast<std::string>(f) << "(" << expr << ")";
                 return ss.str();
             }
-            
+
             template<class T>
-            std::string string_from_expression(const aggregate_functions::count_asterisk_t<T> &, bool noTableName) const {
+            std::string string_from_expression(const aggregate_functions::count_asterisk_t<T> &,
+                                               bool noTableName) const {
                 return this->string_from_expression(aggregate_functions::count_asterisk_without_type{}, noTableName);
             }
-            
-            std::string string_from_expression(const aggregate_functions::count_asterisk_without_type &f, bool /*noTableName*/) const {
+
+            std::string string_from_expression(const aggregate_functions::count_asterisk_without_type &f,
+                                               bool /*noTableName*/) const {
                 std::stringstream ss;
                 ss << static_cast<std::string>(f) << "(*)";
                 return ss.str();
             }
-            
+
             template<class T>
             std::string string_from_expression(const aggregate_functions::count_t<T> &f, bool noTableName) const {
                 std::stringstream ss;
@@ -8597,7 +8688,7 @@ namespace sqlite_orm {
                 ss << static_cast<std::string>(f) << "(" << expr << ")";
                 return ss.str();
             }
-            
+
             template<class T>
             std::string string_from_expression(const aggregate_functions::avg_t<T> &a, bool noTableName) const {
                 std::stringstream ss;
@@ -8605,7 +8696,7 @@ namespace sqlite_orm {
                 ss << static_cast<std::string>(a) << "(" << expr << ") ";
                 return ss.str();
             }
-            
+
             template<class T>
             std::string string_from_expression(const distinct_t<T> &f, bool noTableName) const {
                 std::stringstream ss;
@@ -8613,7 +8704,7 @@ namespace sqlite_orm {
                 ss << static_cast<std::string>(f) << "(" << expr << ") ";
                 return ss.str();
             }
-            
+
             template<class T>
             std::string string_from_expression(const all_t<T> &f, bool noTableName) const {
                 std::stringstream ss;
@@ -8621,58 +8712,58 @@ namespace sqlite_orm {
                 ss << static_cast<std::string>(f) << "(" << expr << ") ";
                 return ss.str();
             }
-            
+
             template<class T, class F>
             std::string string_from_expression(const column_pointer<T, F> &c, bool noTableName) const {
                 std::stringstream ss;
-                if(!noTableName){
+                if(!noTableName) {
                     ss << "'" << this->impl.template find_table_name<T>() << "'.";
                 }
                 auto &impl = this->get_impl<T>();
                 ss << "\"" << impl.column_name_simple(c.field) << "\"";
                 return ss.str();
             }
-            
+
             template<class T>
             std::vector<std::string> get_column_names(const T &t) const {
                 auto columnName = this->string_from_expression(t, false);
-                if(columnName.length()){
+                if(columnName.length()) {
                     return {columnName};
-                }else{
+                } else {
                     throw std::system_error(std::make_error_code(orm_error_code::column_not_found));
                 }
             }
-            
+
             template<class T>
             std::vector<std::string> get_column_names(const internal::asterisk_t<T> &) const {
                 std::vector<std::string> res;
                 res.push_back("*");
                 return res;
             }
-            
-            template<class ...Args>
+
+            template<class... Args>
             std::vector<std::string> get_column_names(const internal::columns_t<Args...> &cols) const {
                 std::vector<std::string> columnNames;
                 columnNames.reserve(static_cast<size_t>(cols.count));
-                iterate_tuple(cols.columns, [&columnNames, this](auto &m){
+                iterate_tuple(cols.columns, [&columnNames, this](auto &m) {
                     auto columnName = this->string_from_expression(m, false);
-                    if(columnName.length()){
+                    if(columnName.length()) {
                         columnNames.push_back(columnName);
-                    }else{
+                    } else {
                         throw std::system_error(std::make_error_code(orm_error_code::column_not_found));
                     }
                 });
                 return columnNames;
             }
-            
+
             /**
              *  Takes select_t object and returns SELECT query string
              */
-            template<class T, class ...Args>
+            template<class T, class... Args>
             std::string string_from_expression(const internal::select_t<T, Args...> &sel, bool /*noTableName*/) const {
                 std::stringstream ss;
-                if(!is_base_of_template<T, compound_operator>::value){
-                    if(!sel.highest_level){
+                if(!is_base_of_template<T, compound_operator>::value) {
+                    if(!sel.highest_level) {
                         ss << "( ";
                     }
                     ss << "SELECT ";
@@ -8689,21 +8780,23 @@ namespace sqlite_orm {
                     ss << " ";
                 }
                 auto tableNamesSet = this->parse_table_name(sel.col);
-                internal::join_iterator<Args...>()([&tableNamesSet, this](const auto &c){
+                internal::join_iterator<Args...>()([&tableNamesSet, this](const auto &c) {
                     using original_join_type = typename std::decay<decltype(c)>::type::join_type::type;
                     using cross_join_type = typename internal::mapped_type_proxy<original_join_type>::type;
                     auto crossJoinedTableName = this->impl.template find_table_name<cross_join_type>();
                     auto tableAliasString = alias_extractor<original_join_type>::get();
-                    std::pair<std::string, std::string> tableNameWithAlias(std::move(crossJoinedTableName), std::move(tableAliasString));
+                    std::pair<std::string, std::string> tableNameWithAlias(std::move(crossJoinedTableName),
+                                                                           std::move(tableAliasString));
                     tableNamesSet.erase(tableNameWithAlias);
                 });
-                if(!tableNamesSet.empty()){
+                if(!tableNamesSet.empty()) {
                     ss << "FROM ";
-                    std::vector<std::pair<std::string, std::string>> tableNames(tableNamesSet.begin(), tableNamesSet.end());
+                    std::vector<std::pair<std::string, std::string>> tableNames(tableNamesSet.begin(),
+                                                                                tableNamesSet.end());
                     for(size_t i = 0; i < tableNames.size(); ++i) {
                         auto &tableNamePair = tableNames[i];
                         ss << "'" << tableNamePair.first << "' ";
-                        if(!tableNamePair.second.empty()){
+                        if(!tableNamePair.second.empty()) {
                             ss << tableNamePair.second << " ";
                         }
                         if(int(i) < int(tableNames.size()) - 1) {
@@ -8712,33 +8805,29 @@ namespace sqlite_orm {
                         ss << " ";
                     }
                 }
-                iterate_tuple(sel.conditions, [&ss, this](auto &v){
+                iterate_tuple(sel.conditions, [&ss, this](auto &v) {
                     this->process_single_condition(ss, v);
                 });
-                if(!is_base_of_template<T, compound_operator>::value){
-                    if(!sel.highest_level){
+                if(!is_base_of_template<T, compound_operator>::value) {
+                    if(!sel.highest_level) {
                         ss << ") ";
                     }
                 }
                 return ss.str();
             }
-            
-            template<class T, class ...Args>
+
+            template<class T, class... Args>
             std::string string_from_expression(const get_all_t<T, Args...> &get, bool /*noTableName*/) const {
                 std::stringstream ss;
                 ss << "SELECT ";
                 auto &impl = this->get_impl<T>();
                 auto columnNames = impl.table.column_names();
                 for(size_t i = 0; i < columnNames.size(); ++i) {
-                    ss
-                    << "\"" << impl.table.name << "\"."
-                    << "\""
-                    << columnNames[i]
-                    << "\""
-                    ;
+                    ss << "\"" << impl.table.name << "\"."
+                       << "\"" << columnNames[i] << "\"";
                     if(i < columnNames.size() - 1) {
                         ss << ", ";
-                    }else{
+                    } else {
                         ss << " ";
                     }
                 }
@@ -8747,22 +8836,18 @@ namespace sqlite_orm {
                 return ss.str();
             }
 
-            template<class T, class ...Args>
+            template<class T, class... Args>
             std::string string_from_expression(const get_all_pointer_t<T, Args...> &get, bool /*noTableName*/) const {
                 std::stringstream ss;
                 ss << "SELECT ";
                 auto &impl = this->get_impl<T>();
                 auto columnNames = impl.table.column_names();
                 for(size_t i = 0; i < columnNames.size(); ++i) {
-                    ss
-                            << "\"" << impl.table.name << "\"."
-                            << "\""
-                            << columnNames[i]
-                            << "\""
-                            ;
+                    ss << "\"" << impl.table.name << "\"."
+                       << "\"" << columnNames[i] << "\"";
                     if(i < columnNames.size() - 1) {
                         ss << ", ";
-                    }else{
+                    } else {
                         ss << " ";
                     }
                 }
@@ -8770,9 +8855,10 @@ namespace sqlite_orm {
                 this->process_conditions(ss, get.conditions);
                 return ss.str();
             }
-            
-            template<class ...Args, class ...Wargs>
-            std::string string_from_expression(const update_all_t<set_t<Args...>, Wargs...> &upd, bool /*noTableName*/) const {
+
+            template<class... Args, class... Wargs>
+            std::string string_from_expression(const update_all_t<set_t<Args...>, Wargs...> &upd,
+                                               bool /*noTableName*/) const {
                 std::stringstream ss;
                 ss << "UPDATE ";
                 std::set<std::pair<std::string, std::string>> tableNamesSet;
@@ -8780,12 +8866,12 @@ namespace sqlite_orm {
                     auto tableName = this->parse_table_name(asgn.lhs);
                     tableNamesSet.insert(tableName.begin(), tableName.end());
                 });
-                if(!tableNamesSet.empty()){
-                    if(tableNamesSet.size() == 1){
+                if(!tableNamesSet.empty()) {
+                    if(tableNamesSet.size() == 1) {
                         ss << " '" << tableNamesSet.begin()->first << "' ";
                         ss << static_cast<std::string>(upd.set) << " ";
                         std::vector<std::string> setPairs;
-                        upd.set.for_each([this, &setPairs](auto &asgn){
+                        upd.set.for_each([this, &setPairs](auto &asgn) {
                             std::stringstream sss;
                             sss << this->string_from_expression(asgn.lhs, true);
                             sss << " " << static_cast<std::string>(asgn) << " ";
@@ -8801,15 +8887,15 @@ namespace sqlite_orm {
                         }
                         this->process_conditions(ss, upd.conditions);
                         return ss.str();
-                    }else{
+                    } else {
                         throw std::system_error(std::make_error_code(orm_error_code::too_many_tables_specified));
                     }
-                }else{
+                } else {
                     throw std::system_error(std::make_error_code(orm_error_code::incorrect_set_fields_specified));
                 }
             }
-            
-            template<class T, class ...Args>
+
+            template<class T, class... Args>
             std::string string_from_expression(const remove_all_t<T, Args...> &rem, bool /*noTableName*/) const {
                 auto &impl = this->get_impl<T>();
                 std::stringstream ss;
@@ -8817,8 +8903,8 @@ namespace sqlite_orm {
                 this->process_conditions(ss, rem.conditions);
                 return ss.str();
             }
-            
-            template<class T, class ...Ids>
+
+            template<class T, class... Ids>
             std::string string_from_expression(const get_t<T, Ids...> &g, bool /*noTableName*/) const {
                 auto &impl = this->get_impl<T>();
                 std::stringstream ss;
@@ -8833,21 +8919,22 @@ namespace sqlite_orm {
                 }
                 ss << "FROM '" << impl.table.name << "' WHERE ";
                 auto primaryKeyColumnNames = impl.table.primary_key_column_names();
-                if(!primaryKeyColumnNames.empty()){
+                if(!primaryKeyColumnNames.empty()) {
                     for(size_t i = 0; i < primaryKeyColumnNames.size(); ++i) {
-                        ss << "\"" << primaryKeyColumnNames[i] << "\"" << " = ? ";
+                        ss << "\"" << primaryKeyColumnNames[i] << "\""
+                           << " = ? ";
                         if(i < primaryKeyColumnNames.size() - 1) {
                             ss << "AND ";
                         }
                         ss << ' ';
                     }
                     return ss.str();
-                }else{
+                } else {
                     throw std::system_error(std::make_error_code(orm_error_code::table_has_no_primary_key_column));
                 }
             }
-            
-            template<class T, class ...Ids>
+
+            template<class T, class... Ids>
             std::string string_from_expression(const get_pointer_t<T, Ids...> &g, bool /*noTableName*/) const {
                 auto &impl = this->get_impl<T>();
                 std::stringstream ss;
@@ -8862,20 +8949,21 @@ namespace sqlite_orm {
                 }
                 ss << "FROM '" << impl.table.name << "' WHERE ";
                 auto primaryKeyColumnNames = impl.table.primary_key_column_names();
-                if(!primaryKeyColumnNames.empty()){
+                if(!primaryKeyColumnNames.empty()) {
                     for(size_t i = 0; i < primaryKeyColumnNames.size(); ++i) {
-                        ss << "\"" << primaryKeyColumnNames[i] << "\"" << " = ? ";
+                        ss << "\"" << primaryKeyColumnNames[i] << "\""
+                           << " = ? ";
                         if(i < primaryKeyColumnNames.size() - 1) {
                             ss << "AND ";
                         }
                         ss << ' ';
                     }
                     return ss.str();
-                }else{
+                } else {
                     throw std::system_error(std::make_error_code(orm_error_code::table_has_no_primary_key_column));
                 }
             }
-            
+
             template<class T, bool by_ref>
             std::string string_from_expression(const update_t<T, by_ref> &upd, bool /*noTableName*/) const {
                 auto &impl = this->get_impl<T>();
@@ -8888,7 +8976,8 @@ namespace sqlite_orm {
                     }
                 });
                 for(size_t i = 0; i < setColumnNames.size(); ++i) {
-                    ss << "\"" << setColumnNames[i] << "\"" << " = ?";
+                    ss << "\"" << setColumnNames[i] << "\""
+                       << " = ?";
                     if(i < setColumnNames.size() - 1) {
                         ss << ",";
                     }
@@ -8897,7 +8986,8 @@ namespace sqlite_orm {
                 ss << "WHERE ";
                 auto primaryKeyColumnNames = impl.table.primary_key_column_names();
                 for(size_t i = 0; i < primaryKeyColumnNames.size(); ++i) {
-                    ss << "\"" << primaryKeyColumnNames[i] << "\"" << " = ?";
+                    ss << "\"" << primaryKeyColumnNames[i] << "\""
+                       << " = ?";
                     if(i < primaryKeyColumnNames.size() - 1) {
                         ss << " AND";
                     }
@@ -8905,8 +8995,8 @@ namespace sqlite_orm {
                 }
                 return ss.str();
             }
-            
-            template<class T, class ...Ids>
+
+            template<class T, class... Ids>
             std::string string_from_expression(const remove_t<T, Ids...> &rem, bool /*noTableName*/) const {
                 auto &impl = this->get_impl<T>();
                 std::stringstream ss;
@@ -8914,16 +9004,18 @@ namespace sqlite_orm {
                 ss << "WHERE ";
                 auto primaryKeyColumnNames = impl.table.primary_key_column_names();
                 for(size_t i = 0; i < primaryKeyColumnNames.size(); ++i) {
-                    ss << "\"" << primaryKeyColumnNames[i] << "\"" << " = ? ";
+                    ss << "\"" << primaryKeyColumnNames[i] << "\""
+                       << " = ? ";
                     if(i < primaryKeyColumnNames.size() - 1) {
                         ss << "AND ";
                     }
                 }
                 return ss.str();
             }
-            
-            template<class T, bool by_ref, class ...Cols>
-            std::string string_from_expression(const insert_explicit<T, by_ref, Cols...> &ins, bool /*noTableName*/) const {
+
+            template<class T, bool by_ref, class... Cols>
+            std::string string_from_expression(const insert_explicit<T, by_ref, Cols...> &ins,
+                                               bool /*noTableName*/) const {
                 constexpr const size_t colsCount = std::tuple_size<std::tuple<Cols...>>::value;
                 static_assert(colsCount > 0, "Use insert or replace with 1 argument instead");
                 this->assert_mapped_type<T>();
@@ -8932,37 +9024,37 @@ namespace sqlite_orm {
                 ss << "INSERT INTO '" << impl.table.name << "' ";
                 std::vector<std::string> columnNames;
                 columnNames.reserve(colsCount);
-                iterate_tuple(ins.columns.columns, [&columnNames, this](auto &m){
+                iterate_tuple(ins.columns.columns, [&columnNames, this](auto &m) {
                     auto columnName = this->string_from_expression(m, true);
-                    if(!columnName.empty()){
+                    if(!columnName.empty()) {
                         columnNames.push_back(columnName);
-                    }else{
+                    } else {
                         throw std::system_error(std::make_error_code(orm_error_code::column_not_found));
                     }
                 });
                 ss << "(";
-                for(size_t i = 0; i < columnNames.size(); ++i){
+                for(size_t i = 0; i < columnNames.size(); ++i) {
                     ss << columnNames[i];
-                    if(i < columnNames.size() - 1){
+                    if(i < columnNames.size() - 1) {
                         ss << ",";
-                    }else{
+                    } else {
                         ss << ")";
                     }
                     ss << " ";
                 }
                 ss << "VALUES (";
-                for(size_t i = 0; i < columnNames.size(); ++i){
+                for(size_t i = 0; i < columnNames.size(); ++i) {
                     ss << "?";
-                    if(i < columnNames.size() - 1){
+                    if(i < columnNames.size() - 1) {
                         ss << ",";
-                    }else{
+                    } else {
                         ss << ")";
                     }
                     ss << " ";
                 }
                 return ss.str();
             }
-            
+
             template<class T, bool by_ref>
             std::string string_from_expression(const insert_t<T, by_ref> &ins, bool /*noTableName*/) const {
                 auto &impl = this->get_impl<T>();
@@ -8970,48 +9062,46 @@ namespace sqlite_orm {
                 ss << "INSERT INTO '" << impl.table.name << "' ";
                 std::vector<std::string> columnNames;
                 auto compositeKeyColumnNames = impl.table.composite_key_columns_names();
-                
-                impl.table.for_each_column([&impl, &columnNames, &compositeKeyColumnNames] (auto &c) {
+
+                impl.table.for_each_column([&impl, &columnNames, &compositeKeyColumnNames](auto &c) {
                     if(impl.table._without_rowid || !c.template has<constraints::primary_key_t<>>()) {
-                        auto it = std::find(compositeKeyColumnNames.begin(),
-                                            compositeKeyColumnNames.end(),
-                                            c.name);
-                        if(it == compositeKeyColumnNames.end()){
+                        auto it = std::find(compositeKeyColumnNames.begin(), compositeKeyColumnNames.end(), c.name);
+                        if(it == compositeKeyColumnNames.end()) {
                             columnNames.emplace_back(c.name);
                         }
                     }
                 });
-                
+
                 auto columnNamesCount = columnNames.size();
-                if(columnNamesCount){
+                if(columnNamesCount) {
                     ss << "( ";
                     for(size_t i = 0; i < columnNamesCount; ++i) {
                         ss << "\"" << columnNames[i] << "\"";
                         if(i < columnNamesCount - 1) {
                             ss << ",";
-                        }else{
+                        } else {
                             ss << ")";
                         }
                         ss << " ";
                     }
-                }else{
+                } else {
                     ss << "DEFAULT ";
                 }
                 ss << "VALUES ";
-                if(columnNamesCount){
+                if(columnNamesCount) {
                     ss << "( ";
                     for(size_t i = 0; i < columnNamesCount; ++i) {
                         ss << "?";
                         if(i < columnNamesCount - 1) {
                             ss << ", ";
-                        }else{
+                        } else {
                             ss << ")";
                         }
                     }
                 }
                 return ss.str();
             }
-            
+
             template<class T, bool by_ref>
             std::string string_from_expression(const replace_t<T, by_ref> &rep, bool /*noTableName*/) const {
                 auto &impl = this->get_impl<T>();
@@ -9023,7 +9113,7 @@ namespace sqlite_orm {
                     ss << "\"" << columnNames[i] << "\"";
                     if(i < columnNamesCount - 1) {
                         ss << ",";
-                    }else{
+                    } else {
                         ss << ")";
                     }
                     ss << " ";
@@ -9033,13 +9123,13 @@ namespace sqlite_orm {
                     ss << "?";
                     if(i < columnNamesCount - 1) {
                         ss << ", ";
-                    }else{
+                    } else {
                         ss << ")";
                     }
                 }
                 return ss.str();
             }
-            
+
             template<class It>
             std::string string_from_expression(const replace_range_t<It> &rep, bool /*noTableName*/) const {
                 using expression_type = typename std::decay<decltype(rep)>::type;
@@ -9053,19 +9143,19 @@ namespace sqlite_orm {
                     ss << "\"" << columnNames[i] << "\"";
                     if(i < columnNamesCount - 1) {
                         ss << ", ";
-                    }else{
+                    } else {
                         ss << ") ";
                     }
                 }
                 ss << "VALUES ";
-                auto valuesString = [columnNamesCount]{
+                auto valuesString = [columnNamesCount] {
                     std::stringstream ss;
                     ss << "(";
                     for(size_t i = 0; i < columnNamesCount; ++i) {
                         ss << "?";
                         if(i < columnNamesCount - 1) {
                             ss << ", ";
-                        }else{
+                        } else {
                             ss << ")";
                         }
                     }
@@ -9081,41 +9171,41 @@ namespace sqlite_orm {
                 }
                 return ss.str();
             }
-            
+
             template<class It>
             std::string string_from_expression(const insert_range_t<It> &ins, bool /*noTableName*/) const {
                 using expression_type = typename std::decay<decltype(ins)>::type;
                 using object_type = typename expression_type::object_type;
                 auto &impl = this->get_impl<object_type>();
-                
+
                 std::stringstream ss;
                 ss << "INSERT INTO '" << impl.table.name << "' (";
                 std::vector<std::string> columnNames;
-                impl.table.for_each_column([&columnNames] (auto &c) {
+                impl.table.for_each_column([&columnNames](auto &c) {
                     if(!c.template has<constraints::primary_key_t<>>()) {
                         columnNames.emplace_back(c.name);
                     }
                 });
-                
+
                 auto columnNamesCount = columnNames.size();
                 for(size_t i = 0; i < columnNamesCount; ++i) {
                     ss << "\"" << columnNames[i] << "\"";
                     if(i < columnNamesCount - 1) {
                         ss << ",";
-                    }else{
+                    } else {
                         ss << ")";
                     }
                     ss << " ";
                 }
                 ss << "VALUES ";
-                auto valuesString = [columnNamesCount]{
+                auto valuesString = [columnNamesCount] {
                     std::stringstream ss;
                     ss << "(";
                     for(size_t i = 0; i < columnNamesCount; ++i) {
                         ss << "?";
                         if(i < columnNamesCount - 1) {
                             ss << ", ";
-                        }else{
+                        } else {
                             ss << ")";
                         }
                     }
@@ -9131,57 +9221,59 @@ namespace sqlite_orm {
                 }
                 return ss.str();
             }
-            
+
             template<class T, class E>
             std::string string_from_expression(const conditions::cast_t<T, E> &c, bool noTableName) const {
                 std::stringstream ss;
                 ss << static_cast<std::string>(c) << " (";
-                ss << this->string_from_expression(c.expression, noTableName) << " AS " << type_printer<T>().print() << ")";
+                ss << this->string_from_expression(c.expression, noTableName) << " AS " << type_printer<T>().print()
+                   << ")";
                 return ss.str();
             }
-            
+
             template<class T>
-            typename std::enable_if<is_base_of_template<T, compound_operator>::value, std::string>::type string_from_expression(const T &op, bool noTableName) const
-            {
+            typename std::enable_if<is_base_of_template<T, compound_operator>::value, std::string>::type
+            string_from_expression(const T &op, bool noTableName) const {
                 std::stringstream ss;
                 ss << this->string_from_expression(op.left, noTableName) << " ";
                 ss << static_cast<std::string>(op) << " ";
                 ss << this->string_from_expression(op.right, noTableName);
                 return ss.str();
             }
-            
-            template<class R, class T, class E, class ...Args>
-            std::string string_from_expression(const internal::simple_case_t<R, T, E, Args...> &c, bool noTableName) const {
+
+            template<class R, class T, class E, class... Args>
+            std::string string_from_expression(const internal::simple_case_t<R, T, E, Args...> &c,
+                                               bool noTableName) const {
                 std::stringstream ss;
                 ss << "CASE ";
-                c.case_expression.apply([&ss, this, noTableName](auto &c){
+                c.case_expression.apply([&ss, this, noTableName](auto &c) {
                     ss << this->string_from_expression(c, noTableName) << " ";
                 });
-                iterate_tuple(c.args, [&ss, this, noTableName](auto &pair){
+                iterate_tuple(c.args, [&ss, this, noTableName](auto &pair) {
                     ss << "WHEN " << this->string_from_expression(pair.first, noTableName) << " ";
                     ss << "THEN " << this->string_from_expression(pair.second, noTableName) << " ";
                 });
-                c.else_expression.apply([&ss, this, noTableName](auto &el){
+                c.else_expression.apply([&ss, this, noTableName](auto &el) {
                     ss << "ELSE " << this->string_from_expression(el, noTableName) << " ";
                 });
                 ss << "END";
                 return ss.str();
             }
-             
+
             template<class T>
             std::string string_from_expression(const conditions::is_null_t<T> &c, bool noTableName) const {
                 std::stringstream ss;
                 ss << this->string_from_expression(c.t, noTableName) << " " << static_cast<std::string>(c) << " ";
                 return ss.str();
             }
-            
+
             template<class T>
             std::string string_from_expression(const conditions::is_not_null_t<T> &c, bool noTableName) const {
                 std::stringstream ss;
                 ss << this->string_from_expression(c.t, noTableName) << " " << static_cast<std::string>(c) << " ";
                 return ss.str();
             }
-            
+
             template<class C>
             std::string string_from_expression(const conditions::negated_condition_t<C> &c, bool noTableName) const {
                 std::stringstream ss;
@@ -9190,7 +9282,7 @@ namespace sqlite_orm {
                 ss << " (" << cString << " ) ";
                 return ss.str();
             }
-            
+
             template<class L, class R>
             std::string string_from_expression(const conditions::is_equal_t<L, R> &c, bool noTableName) const {
                 auto leftString = this->string_from_expression(c.l, noTableName);
@@ -9199,28 +9291,29 @@ namespace sqlite_orm {
                 ss << leftString << " " << static_cast<std::string>(c) << " " << rightString;
                 return ss.str();
             }
-            
+
             template<class C>
-            typename std::enable_if<is_base_of_template<C, conditions::binary_condition>::value, std::string>::type string_from_expression(const C &c, bool noTableName) const {
+            typename std::enable_if<is_base_of_template<C, conditions::binary_condition>::value, std::string>::type
+            string_from_expression(const C &c, bool noTableName) const {
                 auto leftString = this->string_from_expression(c.l, noTableName);
                 auto rightString = this->string_from_expression(c.r, noTableName);
                 std::stringstream ss;
                 ss << "(" << leftString << " " << static_cast<std::string>(c) << " " << rightString << ")";
                 return ss.str();
             }
-            
+
             template<class T>
             std::string string_from_expression(const conditions::named_collate<T> &col, bool noTableName) const {
                 auto res = this->string_from_expression(col.expr, noTableName);
                 return res + " " + static_cast<std::string>(col);
             }
-            
+
             template<class T>
             std::string string_from_expression(const conditions::collate_t<T> &col, bool noTableName) const {
                 auto res = this->string_from_expression(col.expr, noTableName);
                 return res + " " + static_cast<std::string>(col);
             }
-            
+
             template<class L, class A>
             std::string string_from_expression(const conditions::in_t<L, A> &inCondition, bool noTableName) const {
                 std::stringstream ss;
@@ -9229,9 +9322,10 @@ namespace sqlite_orm {
                 ss << this->string_from_expression(inCondition.arg, noTableName);
                 return ss.str();
             }
-            
+
             template<class L, class E>
-            std::string string_from_expression(const conditions::in_t<L, std::vector<E>> &inCondition, bool noTableName) const {
+            std::string string_from_expression(const conditions::in_t<L, std::vector<E>> &inCondition,
+                                               bool noTableName) const {
                 std::stringstream ss;
                 auto leftString = this->string_from_expression(inCondition.l, noTableName);
                 ss << leftString << " " << static_cast<std::string>(inCondition) << " ( ";
@@ -9245,19 +9339,19 @@ namespace sqlite_orm {
                 ss << " )";
                 return ss.str();
             }
-            
+
             template<class A, class T, class E>
             std::string string_from_expression(const conditions::like_t<A, T, E> &l, bool noTableName) const {
                 std::stringstream ss;
                 ss << this->string_from_expression(l.arg, noTableName) << " ";
                 ss << static_cast<std::string>(l) << " ";
                 ss << this->string_from_expression(l.pattern, noTableName);
-                l.arg3.apply([&ss, this, noTableName](auto &value){
+                l.arg3.apply([&ss, this, noTableName](auto &value) {
                     ss << " ESCAPE " << this->string_from_expression(value, noTableName);
                 });
                 return ss.str();
             }
-            
+
             template<class A, class T>
             std::string string_from_expression(const conditions::glob_t<A, T> &l, bool noTableName) const {
                 std::stringstream ss;
@@ -9266,7 +9360,7 @@ namespace sqlite_orm {
                 ss << this->string_from_expression(l.pattern, noTableName);
                 return ss.str();
             }
-            
+
             template<class A, class T>
             std::string string_from_expression(const conditions::between_t<A, T> &bw, bool noTableName) const {
                 std::stringstream ss;
@@ -9277,7 +9371,7 @@ namespace sqlite_orm {
                 ss << this->string_from_expression(bw.b2, noTableName);
                 return ss.str();
             }
-            
+
             template<class T>
             std::string string_from_expression(const conditions::exists_t<T> &e, bool noTableName) const {
                 std::stringstream ss;
@@ -9285,16 +9379,16 @@ namespace sqlite_orm {
                 ss << this->string_from_expression(e.t, noTableName);
                 return ss.str();
             }
-            
+
             template<class O>
             std::string process_order_by(const conditions::order_by_t<O> &orderBy) const {
                 std::stringstream ss;
                 auto columnName = this->string_from_expression(orderBy.o, false);
                 ss << columnName << " ";
-                if(orderBy._collate_argument.length()){
+                if(orderBy._collate_argument.length()) {
                     ss << "COLLATE " << orderBy._collate_argument << " ";
                 }
-                switch(orderBy.asc_desc){
+                switch(orderBy.asc_desc) {
                     case 1:
                         ss << "ASC";
                         break;
@@ -9304,92 +9398,93 @@ namespace sqlite_orm {
                 }
                 return ss.str();
             }
-            
+
             template<class T>
             void process_join_constraint(std::stringstream &ss, const conditions::on_t<T> &t) const {
                 ss << static_cast<std::string>(t) << " " << this->string_from_expression(t.arg, false);
             }
-            
+
             template<class F, class O>
             void process_join_constraint(std::stringstream &ss, const conditions::using_t<F, O> &u) const {
                 ss << static_cast<std::string>(u) << " (" << this->string_from_expression(u.column, true) << " )";
             }
-            
+
             void process_single_condition(std::stringstream &ss, const conditions::limit_t &limt) const {
                 ss << static_cast<std::string>(limt) << " ";
                 if(limt.has_offset) {
-                    if(limt.offset_is_implicit){
+                    if(limt.offset_is_implicit) {
                         ss << limt.off << ", " << limt.lim;
-                    }else{
+                    } else {
                         ss << limt.lim << " OFFSET " << limt.off;
                     }
-                }else{
+                } else {
                     ss << limt.lim;
                 }
             }
-            
+
             template<class O>
             void process_single_condition(std::stringstream &ss, const conditions::cross_join_t<O> &c) const {
                 ss << static_cast<std::string>(c) << " ";
                 ss << " '" << this->impl.template find_table_name<O>() << "'";
             }
-            
+
             template<class O>
             void process_single_condition(std::stringstream &ss, const conditions::natural_join_t<O> &c) const {
                 ss << static_cast<std::string>(c) << " ";
                 ss << " '" << this->impl.template find_table_name<O>() << "'";
             }
-            
+
             template<class T, class O>
             void process_single_condition(std::stringstream &ss, const conditions::inner_join_t<T, O> &l) const {
                 ss << static_cast<std::string>(l) << " ";
                 auto aliasString = alias_extractor<T>::get();
                 ss << " '" << this->impl.template find_table_name<typename mapped_type_proxy<T>::type>() << "' ";
-                if(aliasString.length()){
+                if(aliasString.length()) {
                     ss << "'" << aliasString << "' ";
                 }
                 this->process_join_constraint(ss, l.constraint);
             }
-            
+
             template<class T, class O>
             void process_single_condition(std::stringstream &ss, const conditions::left_outer_join_t<T, O> &l) const {
                 ss << static_cast<std::string>(l) << " ";
                 ss << " '" << this->impl.template find_table_name<T>() << "' ";
                 this->process_join_constraint(ss, l.constraint);
             }
-            
+
             template<class T, class O>
             void process_single_condition(std::stringstream &ss, const conditions::left_join_t<T, O> &l) const {
                 ss << static_cast<std::string>(l) << " ";
                 ss << " '" << this->impl.template find_table_name<T>() << "' ";
                 this->process_join_constraint(ss, l.constraint);
             }
-            
+
             template<class T, class O>
             void process_single_condition(std::stringstream &ss, const conditions::join_t<T, O> &l) const {
                 ss << static_cast<std::string>(l) << " ";
                 ss << " '" << this->impl.template find_table_name<T>() << "' ";
                 this->process_join_constraint(ss, l.constraint);
             }
-            
+
             template<class C>
             void process_single_condition(std::stringstream &ss, const conditions::where_t<C> &w) const {
                 ss << static_cast<std::string>(w) << " ";
                 auto whereString = this->string_from_expression(w.c, false);
                 ss << "( " << whereString << ") ";
             }
-            
+
             template<class O>
             void process_single_condition(std::stringstream &ss, const conditions::order_by_t<O> &orderBy) const {
                 ss << static_cast<std::string>(orderBy) << " ";
                 auto orderByString = this->process_order_by(orderBy);
                 ss << orderByString << " ";
             }
-            
-            template<class ...Args>
-            void process_single_condition(std::stringstream &ss, const conditions::multi_order_by_t<Args...> &orderBy) const {
+
+            template<class... Args>
+            void process_single_condition(std::stringstream &ss,
+                                          const conditions::multi_order_by_t<Args...> &orderBy) const {
                 std::vector<std::string> expressions;
-                iterate_tuple(orderBy.args, [&expressions, this](auto &v){
+                iterate_tuple(orderBy.args, [&expressions, this](auto &v) {
                     auto expression = this->process_order_by(v);
                     expressions.push_back(std::move(expression));
                 });
@@ -9402,16 +9497,17 @@ namespace sqlite_orm {
                 }
                 ss << " ";
             }
-            
+
             template<class S>
-            void process_single_condition(std::stringstream &ss, const conditions::dynamic_order_by_t<S> &orderBy) const {
+            void process_single_condition(std::stringstream &ss,
+                                          const conditions::dynamic_order_by_t<S> &orderBy) const {
                 ss << this->storage_base::process_order_by(orderBy) << " ";
             }
-            
-            template<class ...Args>
+
+            template<class... Args>
             void process_single_condition(std::stringstream &ss, const conditions::group_by_t<Args...> &groupBy) const {
                 std::vector<std::string> expressions;
-                iterate_tuple(groupBy.args, [&expressions, this](auto &v){
+                iterate_tuple(groupBy.args, [&expressions, this](auto &v) {
                     auto expression = this->string_from_expression(v, false);
                     expressions.push_back(expression);
                 });
@@ -9424,49 +9520,48 @@ namespace sqlite_orm {
                 }
                 ss << " ";
             }
-            
+
             template<class T>
             void process_single_condition(std::stringstream &ss, const conditions::having_t<T> &hav) const {
                 ss << static_cast<std::string>(hav) << " ";
                 ss << this->string_from_expression(hav.t, false) << " ";
             }
-            
-            template<class ...Args>
+
+            template<class... Args>
             void process_conditions(std::stringstream &ss, const std::tuple<Args...> &args) const {
-                iterate_tuple(args, [this, &ss](auto &v){
+                iterate_tuple(args, [this, &ss](auto &v) {
                     this->process_single_condition(ss, v);
                 });
             }
-            
-        public:
-            
-            template<class T, class ...Args>
-            view_t<T, self, Args...> iterate(Args&& ...args) {
+
+          public:
+            template<class T, class... Args>
+            view_t<T, self, Args...> iterate(Args &&... args) {
                 this->assert_mapped_type<T>();
-                
+
                 auto con = this->get_connection();
                 return {*this, std::move(con), std::forward<Args>(args)...};
             }
-            
-            template<class O, class ...Args>
-            void remove_all(Args&& ...args) {
+
+            template<class O, class... Args>
+            void remove_all(Args &&... args) {
                 this->assert_mapped_type<O>();
                 auto statement = this->prepare(sqlite_orm::remove_all<O>(std::forward<Args>(args)...));
                 this->execute(statement);
             }
-            
+
             /**
              *  Delete routine.
              *  O is an object's type. Must be specified explicitly.
              *  @param ids ids of object to be removed.
              */
-            template<class O, class ...Ids>
-            void remove(Ids ...ids) {
+            template<class O, class... Ids>
+            void remove(Ids... ids) {
                 this->assert_mapped_type<O>();
                 auto statement = this->prepare(sqlite_orm::remove<O>(std::forward<Ids>(ids)...));
                 this->execute(statement);
             }
-            
+
             /**
              *  Update routine. Sets all non primary key fields where primary key is equal.
              *  O is an object type. May be not specified explicitly cause it can be deduced by
@@ -9479,90 +9574,99 @@ namespace sqlite_orm {
                 auto statement = this->prepare(sqlite_orm::update(o));
                 this->execute(statement);
             }
-            
-            template<class ...Args, class ...Wargs>
-            void update_all(internal::set_t<Args...> set, Wargs ...wh) {
+
+            template<class... Args, class... Wargs>
+            void update_all(internal::set_t<Args...> set, Wargs... wh) {
                 auto statement = this->prepare(sqlite_orm::update_all(std::move(set), std::forward<Wargs>(wh)...));
                 this->execute(statement);
             }
-            
-        protected:
-            
+
+          protected:
             template<class T>
             std::set<std::pair<std::string, std::string>> parse_table_name(const T &) const {
                 return {};
             }
-            
+
             template<class F, class O>
             std::set<std::pair<std::string, std::string>> parse_table_name(F O::*, std::string alias = {}) const {
                 return {std::make_pair(this->impl.template find_table_name<O>(), std::move(alias))};
             }
-            
+
             template<class T>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const aggregate_functions::min_t<T> &f) const {
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const aggregate_functions::min_t<T> &f) const {
                 return this->parse_table_name(f.t);
             }
-            
+
             template<class T>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const aggregate_functions::max_t<T> &f) const {
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const aggregate_functions::max_t<T> &f) const {
                 return this->parse_table_name(f.t);
             }
-            
+
             template<class T>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const aggregate_functions::sum_t<T> &f) const {
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const aggregate_functions::sum_t<T> &f) const {
                 return this->parse_table_name(f.t);
             }
-            
+
             template<class T>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const aggregate_functions::total_t<T> &f) const {
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const aggregate_functions::total_t<T> &f) const {
                 return this->parse_table_name(f.t);
             }
-            
+
             template<class T>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const aggregate_functions::group_concat_double_t<T> &f) const {
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const aggregate_functions::group_concat_double_t<T> &f) const {
                 auto res = this->parse_table_name(f.t);
                 auto secondSet = this->parse_table_name(f.y);
                 res.insert(secondSet.begin(), secondSet.end());
                 return res;
             }
-            
+
             template<class T>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const aggregate_functions::group_concat_single_t<T> &f) const {
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const aggregate_functions::group_concat_single_t<T> &f) const {
                 return this->parse_table_name(f.t);
             }
-            
+
             template<class T>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const aggregate_functions::count_t<T> &f) const {
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const aggregate_functions::count_t<T> &f) const {
                 return this->parse_table_name(f.t);
             }
-            
+
             template<class T>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const aggregate_functions::avg_t<T> &a) const {
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const aggregate_functions::avg_t<T> &a) const {
                 return this->parse_table_name(a.t);
             }
-            
-            template<class R, class S, class ...Args>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const core_functions::core_function_t<R, S, Args...> &f) const {
+
+            template<class R, class S, class... Args>
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const core_functions::core_function_t<R, S, Args...> &f) const {
                 std::set<std::pair<std::string, std::string>> res;
-                iterate_tuple(f.args, [&res, this](auto &v){
+                iterate_tuple(f.args, [&res, this](auto &v) {
                     auto tableNames = this->parse_table_name(v);
                     res.insert(tableNames.begin(), tableNames.end());
                 });
                 return res;
             }
-            
+
             template<class T>
             std::set<std::pair<std::string, std::string>> parse_table_name(const distinct_t<T> &f) const {
                 return this->parse_table_name(f.t);
             }
-            
+
             template<class T>
             std::set<std::pair<std::string, std::string>> parse_table_name(const all_t<T> &f) const {
                 return this->parse_table_name(f.t);
             }
-            
-            template<class L, class R, class ...Ds>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const binary_operator<L, R, Ds...> &f) const {
+
+            template<class L, class R, class... Ds>
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const binary_operator<L, R, Ds...> &f) const {
                 std::set<std::pair<std::string, std::string>> res;
                 auto leftSet = this->parse_table_name(f.lhs);
                 res.insert(leftSet.begin(), leftSet.end());
@@ -9570,66 +9674,70 @@ namespace sqlite_orm {
                 res.insert(rightSet.begin(), rightSet.end());
                 return res;
             }
-            
+
             template<class T, class F>
             std::set<std::pair<std::string, std::string>> parse_table_name(const column_pointer<T, F> &) const {
                 std::set<std::pair<std::string, std::string>> res;
                 res.insert({this->impl.template find_table_name<T>(), ""});
                 return res;
             }
-            
+
             template<class T, class C>
             std::set<std::pair<std::string, std::string>> parse_table_name(const alias_column_t<T, C> &a) const {
                 return this->parse_table_name(a.column, alias_extractor<T>::get());
             }
-            
+
             template<class T>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const aggregate_functions::count_asterisk_t<T> &) const {
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const aggregate_functions::count_asterisk_t<T> &) const {
                 auto tableName = this->impl.template find_table_name<T>();
-                if(!tableName.empty()){
+                if(!tableName.empty()) {
                     return {std::make_pair(std::move(tableName), "")};
-                }else{
+                } else {
                     return {};
                 }
             }
-            
-            std::set<std::pair<std::string, std::string>> parse_table_name(const aggregate_functions::count_asterisk_without_type &) const {
+
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const aggregate_functions::count_asterisk_without_type &) const {
                 return {};
             }
-            
+
             template<class T>
             std::set<std::pair<std::string, std::string>> parse_table_name(const asterisk_t<T> &) const {
                 auto tableName = this->impl.template find_table_name<T>();
                 return {std::make_pair(std::move(tableName), "")};
             }
-            
+
             template<class T, class E>
             std::set<std::pair<std::string, std::string>> parse_table_name(const conditions::cast_t<T, E> &c) const {
                 return this->parse_table_name(c.expression);
             }
-            
-            template<class R, class T, class E, class ...Args>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const simple_case_t<R, T, E, Args...> &c) const {
+
+            template<class R, class T, class E, class... Args>
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const simple_case_t<R, T, E, Args...> &c) const {
                 std::set<std::pair<std::string, std::string>> res;
-                c.case_expression.apply([this, &res](auto &c){
+                c.case_expression.apply([this, &res](auto &c) {
                     auto caseExpressionSet = this->parse_table_name(c);
                     res.insert(caseExpressionSet.begin(), caseExpressionSet.end());
                 });
-                iterate_tuple(c.args, [this, &res](auto &pair){
+                iterate_tuple(c.args, [this, &res](auto &pair) {
                     auto leftSet = this->parse_table_name(pair.first);
                     res.insert(leftSet.begin(), leftSet.end());
                     auto rightSet = this->parse_table_name(pair.second);
                     res.insert(rightSet.begin(), rightSet.end());
                 });
-                c.else_expression.apply([this, &res](auto &el){
+                c.else_expression.apply([this, &res](auto &el) {
                     auto tableNames = this->parse_table_name(el);
                     res.insert(tableNames.begin(), tableNames.end());
                 });
                 return res;
             }
-            
+
             template<class L, class R>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const conditions::and_condition_t<L, R> &c) const {
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const conditions::and_condition_t<L, R> &c) const {
                 std::set<std::pair<std::string, std::string>> res;
                 auto leftTableNames = this->parse_table_name(c.l);
                 res.insert(leftTableNames.begin(), leftTableNames.end());
@@ -9637,9 +9745,10 @@ namespace sqlite_orm {
                 res.insert(rightTableNames.begin(), rightTableNames.end());
                 return res;
             }
-            
+
             template<class L, class R>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const conditions::or_condition_t<L, R> &c) const {
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const conditions::or_condition_t<L, R> &c) const {
                 std::set<std::pair<std::string, std::string>> res;
                 auto leftTableNames = this->parse_table_name(c.l);
                 res.insert(leftTableNames.begin(), leftTableNames.end());
@@ -9647,9 +9756,10 @@ namespace sqlite_orm {
                 res.insert(rightTableNames.begin(), rightTableNames.end());
                 return res;
             }
-            
+
             template<class L, class R>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const conditions::is_equal_t<L, R> &c) const {
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const conditions::is_equal_t<L, R> &c) const {
                 std::set<std::pair<std::string, std::string>> res;
                 auto leftTableNames = this->parse_table_name(c.l);
                 res.insert(leftTableNames.begin(), leftTableNames.end());
@@ -9657,9 +9767,10 @@ namespace sqlite_orm {
                 res.insert(rightTableNames.begin(), rightTableNames.end());
                 return res;
             }
-            
+
             template<class L, class R>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const conditions::is_not_equal_t<L, R> &c) const {
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const conditions::is_not_equal_t<L, R> &c) const {
                 std::set<std::pair<std::string, std::string>> res;
                 auto leftTableNames = this->parse_table_name(c.l);
                 res.insert(leftTableNames.begin(), leftTableNames.end());
@@ -9667,9 +9778,10 @@ namespace sqlite_orm {
                 res.insert(rightTableNames.begin(), rightTableNames.end());
                 return res;
             }
-            
+
             template<class L, class R>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const conditions::greater_than_t<L, R> &c) const {
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const conditions::greater_than_t<L, R> &c) const {
                 std::set<std::pair<std::string, std::string>> res;
                 auto leftTableNames = this->parse_table_name(c.l);
                 res.insert(leftTableNames.begin(), leftTableNames.end());
@@ -9677,9 +9789,10 @@ namespace sqlite_orm {
                 res.insert(rightTableNames.begin(), rightTableNames.end());
                 return res;
             }
-            
+
             template<class L, class R>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const conditions::greater_or_equal_t<L, R> &c) const {
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const conditions::greater_or_equal_t<L, R> &c) const {
                 std::set<std::pair<std::string, std::string>> res;
                 auto leftTableNames = this->parse_table_name(c.l);
                 res.insert(leftTableNames.begin(), leftTableNames.end());
@@ -9687,9 +9800,10 @@ namespace sqlite_orm {
                 res.insert(rightTableNames.begin(), rightTableNames.end());
                 return res;
             }
-            
+
             template<class L, class R>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const conditions::lesser_than_t<L, R> &c) const {
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const conditions::lesser_than_t<L, R> &c) const {
                 std::set<std::pair<std::string, std::string>> res;
                 auto leftTableNames = this->parse_table_name(c.l);
                 res.insert(leftTableNames.begin(), leftTableNames.end());
@@ -9697,9 +9811,10 @@ namespace sqlite_orm {
                 res.insert(rightTableNames.begin(), rightTableNames.end());
                 return res;
             }
-            
+
             template<class L, class R>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const conditions::lesser_or_equal_t<L, R> &c) const {
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const conditions::lesser_or_equal_t<L, R> &c) const {
                 std::set<std::pair<std::string, std::string>> res;
                 auto leftTableNames = this->parse_table_name(c.l);
                 res.insert(leftTableNames.begin(), leftTableNames.end());
@@ -9707,7 +9822,7 @@ namespace sqlite_orm {
                 res.insert(rightTableNames.begin(), rightTableNames.end());
                 return res;
             }
-            
+
             template<class A, class T, class E>
             std::set<std::pair<std::string, std::string>> parse_table_name(const conditions::like_t<A, T, E> &l) const {
                 std::set<std::pair<std::string, std::string>> res;
@@ -9715,13 +9830,13 @@ namespace sqlite_orm {
                 res.insert(argTableNames.begin(), argTableNames.end());
                 auto patternTableNames = this->parse_table_name(l.pattern);
                 res.insert(patternTableNames.begin(), patternTableNames.end());
-                l.arg3.apply([&res, this](auto &value){
+                l.arg3.apply([&res, this](auto &value) {
                     auto escapeTableNames = this->parse_table_name(value);
                     res.insert(escapeTableNames.begin(), escapeTableNames.end());
                 });
                 return res;
             }
-            
+
             template<class A, class T>
             std::set<std::pair<std::string, std::string>> parse_table_name(const conditions::glob_t<A, T> &l) const {
                 std::set<std::pair<std::string, std::string>> res;
@@ -9731,52 +9846,53 @@ namespace sqlite_orm {
                 res.insert(patternTableNames.begin(), patternTableNames.end());
                 return res;
             }
-            
+
             template<class C>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const conditions::negated_condition_t<C> &c) const {
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const conditions::negated_condition_t<C> &c) const {
                 return this->parse_table_name(c.c);
             }
-            
+
             template<class T, class E>
             std::set<std::pair<std::string, std::string>> parse_table_name(const as_t<T, E> &a) const {
                 return this->parse_table_name(a.expression);
             }
-            
-            template<class ...Args>
-            std::set<std::pair<std::string, std::string>> parse_table_name(const internal::columns_t<Args...> &cols) const {
+
+            template<class... Args>
+            std::set<std::pair<std::string, std::string>>
+            parse_table_name(const internal::columns_t<Args...> &cols) const {
                 std::set<std::pair<std::string, std::string>> res;
-                iterate_tuple(cols.columns, [&res, this](auto &m){
+                iterate_tuple(cols.columns, [&res, this](auto &m) {
                     auto tableName = this->parse_table_name(m);
                     res.insert(tableName.begin(), tableName.end());
                 });
                 return res;
             }
-            
-            template<class F, class O, class ...Args>
-            std::string group_concat_internal(F O::*m, std::unique_ptr<std::string> y, Args&& ...args) {
+
+            template<class F, class O, class... Args>
+            std::string group_concat_internal(F O::*m, std::unique_ptr<std::string> y, Args &&... args) {
                 this->assert_mapped_type<O>();
                 std::vector<std::string> rows;
-                if(y){
+                if(y) {
                     rows = this->select(sqlite_orm::group_concat(m, move(*y)), std::forward<Args>(args)...);
-                }else{
+                } else {
                     rows = this->select(sqlite_orm::group_concat(m), std::forward<Args>(args)...);
                 }
-                if(!rows.empty()){
+                if(!rows.empty()) {
                     return move(rows.front());
-                }else{
+                } else {
                     return {};
                 }
             }
-            
-        public:
-            
+
+          public:
             /**
              *  Select * with no conditions routine.
              *  O is an object type to be extracted. Must be specified explicitly.
              *  @return All objects of type O stored in database at the moment.
              */
-            template<class O, class C = std::vector<O>, class ...Args>
-            C get_all(Args&& ...args) {
+            template<class O, class C = std::vector<O>, class... Args>
+            C get_all(Args &&... args) {
                 this->assert_mapped_type<O>();
                 auto statement = this->prepare(sqlite_orm::get_all<O>(std::forward<Args>(args)...));
                 return this->execute(statement);
@@ -9787,8 +9903,8 @@ namespace sqlite_orm {
              *  O is an object type to be extracted. Must be specified explicitly.
              *  @return All objects of type O as std::unique_ptr<O> stored in database at the moment.
              */
-            template<class O, class C = std::vector<std::unique_ptr<O>>, class ...Args>
-            C get_all_pointer(Args&& ...args) {
+            template<class O, class C = std::vector<std::unique_ptr<O>>, class... Args>
+            C get_all_pointer(Args &&... args) {
                 this->assert_mapped_type<O>();
                 auto statement = this->prepare(sqlite_orm::get_all_pointer<O>(std::forward<Args>(args)...));
                 return this->execute(statement);
@@ -9796,25 +9912,25 @@ namespace sqlite_orm {
 
             /**
              *  Select * by id routine.
-             *  throws std::system_error(orm_error_code::not_found, orm_error_category) if object not found with given id.
-             *  throws std::system_error with orm_error_category in case of db error.
-             *  O is an object type to be extracted. Must be specified explicitly.
-             *  @return Object of type O where id is equal parameter passed or throws `std::system_error(orm_error_code::not_found, orm_error_category)`
-             *  if there is no object with such id.
+             *  throws std::system_error(orm_error_code::not_found, orm_error_category) if object not found with given
+             * id. throws std::system_error with orm_error_category in case of db error. O is an object type to be
+             * extracted. Must be specified explicitly.
+             *  @return Object of type O where id is equal parameter passed or throws
+             * `std::system_error(orm_error_code::not_found, orm_error_category)` if there is no object with such id.
              */
-            template<class O, class ...Ids>
-            O get(Ids ...ids) {
+            template<class O, class... Ids>
+            O get(Ids... ids) {
                 this->assert_mapped_type<O>();
                 auto statement = this->prepare(sqlite_orm::get<O>(std::forward<Ids>(ids)...));
                 return this->execute(statement);
             }
-            
+
             /**
-             *  The same as `get` function but doesn't throw an exception if noting found but returns std::unique_ptr with null value.
-             *  throws std::system_error in case of db error.
+             *  The same as `get` function but doesn't throw an exception if noting found but returns std::unique_ptr
+             * with null value. throws std::system_error in case of db error.
              */
-            template<class O, class ...Ids>
-            std::unique_ptr<O> get_pointer(Ids ...ids) {
+            template<class O, class... Ids>
+            std::unique_ptr<O> get_pointer(Ids... ids) {
                 this->assert_mapped_type<O>();
                 auto statement = this->prepare(sqlite_orm::get_pointer<O>(std::forward<Ids>(ids)...));
                 return this->execute(statement);
@@ -9833,8 +9949,8 @@ namespace sqlite_orm {
              * shared_ptr, exactly like we're doing here.
              * (Conversely, you _can't_ go from shared back to unique.)
              */
-            template<class O, class ...Ids>
-            std::shared_ptr<O> get_no_throw(Ids ...ids) {
+            template<class O, class... Ids>
+            std::shared_ptr<O> get_no_throw(Ids... ids) {
                 return std::shared_ptr<O>(get_pointer<O>(std::forward<Ids>(ids)...));
             }
 
@@ -9842,171 +9958,174 @@ namespace sqlite_orm {
              *  SELECT COUNT(*) https://www.sqlite.org/lang_aggfunc.html#count
              *  @return Number of O object in table.
              */
-            template<class O, class ...Args, class R = typename mapped_type_proxy<O>::type>
-            int count(Args&& ...args) {
+            template<class O, class... Args, class R = typename mapped_type_proxy<O>::type>
+            int count(Args &&... args) {
                 this->assert_mapped_type<R>();
                 auto rows = this->select(sqlite_orm::count<R>(), std::forward<Args>(args)...);
-                if(!rows.empty()){
+                if(!rows.empty()) {
                     return rows.front();
-                }else{
+                } else {
                     return 0;
                 }
             }
-            
+
             /**
              *  SELECT COUNT(X) https://www.sqlite.org/lang_aggfunc.html#count
              *  @param m member pointer to class mapped to the storage.
              */
-            template<class F, class O, class ...Args>
-            int count(F O::*m, Args&& ...args) {
+            template<class F, class O, class... Args>
+            int count(F O::*m, Args &&... args) {
                 this->assert_mapped_type<O>();
                 auto rows = this->select(sqlite_orm::count(m), std::forward<Args>(args)...);
-                if(!rows.empty()){
+                if(!rows.empty()) {
                     return rows.front();
-                }else{
+                } else {
                     return 0;
                 }
             }
-            
+
             /**
              *  AVG(X) query.   https://www.sqlite.org/lang_aggfunc.html#avg
              *  @param m is a class member pointer (the same you passed into make_column).
              *  @return average value from db.
              */
-            template<class F, class O, class ...Args>
-            double avg(F O::*m, Args&& ...args) {
+            template<class F, class O, class... Args>
+            double avg(F O::*m, Args &&... args) {
                 this->assert_mapped_type<O>();
                 auto rows = this->select(sqlite_orm::avg(m), std::forward<Args>(args)...);
-                if(!rows.empty()){
+                if(!rows.empty()) {
                     return rows.front();
-                }else{
+                } else {
                     return 0;
                 }
             }
-            
+
             template<class F, class O>
             std::string group_concat(F O::*m) {
                 return this->group_concat_internal(m, {});
             }
-            
+
             /**
              *  GROUP_CONCAT(X) query.  https://www.sqlite.org/lang_aggfunc.html#groupconcat
              *  @param m is a class member pointer (the same you passed into make_column).
              *  @return group_concat query result.
              */
-            template<class F, class O, class ...Args,
-            class Tuple = std::tuple<Args...>,
-            typename sfinae = typename std::enable_if<std::tuple_size<Tuple>::value >= 1>::type
-            >
-            std::string group_concat(F O::*m, Args&& ...args) {
+            template<class F,
+                     class O,
+                     class... Args,
+                     class Tuple = std::tuple<Args...>,
+                     typename sfinae = typename std::enable_if<std::tuple_size<Tuple>::value >= 1>::type>
+            std::string group_concat(F O::*m, Args &&... args) {
                 return this->group_concat_internal(m, {}, std::forward<Args>(args)...);
             }
-            
+
             /**
              *  GROUP_CONCAT(X, Y) query.   https://www.sqlite.org/lang_aggfunc.html#groupconcat
              *  @param m is a class member pointer (the same you passed into make_column).
              *  @return group_concat query result.
              */
-            template<class F, class O, class ...Args>
-            std::string group_concat(F O::*m, std::string y, Args&& ...args) {
-                return this->group_concat_internal(m, std::make_unique<std::string>(move(y)), std::forward<Args>(args)...);
+            template<class F, class O, class... Args>
+            std::string group_concat(F O::*m, std::string y, Args &&... args) {
+                return this->group_concat_internal(m,
+                                                   std::make_unique<std::string>(move(y)),
+                                                   std::forward<Args>(args)...);
             }
-            
-            template<class F, class O, class ...Args>
-            std::string group_concat(F O::*m, const char *y, Args&& ...args) {
+
+            template<class F, class O, class... Args>
+            std::string group_concat(F O::*m, const char *y, Args &&... args) {
                 std::unique_ptr<std::string> str;
-                if(y){
+                if(y) {
                     str = std::make_unique<std::string>(y);
-                }else{
+                } else {
                     str = std::make_unique<std::string>();
                 }
                 return this->group_concat_internal(m, move(str), std::forward<Args>(args)...);
             }
-            
+
             /**
              *  MAX(x) query.
              *  @param m is a class member pointer (the same you passed into make_column).
              *  @return std::unique_ptr with max value or null if sqlite engine returned null.
              */
-            template<class F, class O, class ...Args, class Ret = typename column_result_t<self, F O::*>::type>
-            std::unique_ptr<Ret> max(F O::*m, Args&& ...args) {
+            template<class F, class O, class... Args, class Ret = typename column_result_t<self, F O::*>::type>
+            std::unique_ptr<Ret> max(F O::*m, Args &&... args) {
                 this->assert_mapped_type<O>();
                 auto rows = this->select(sqlite_orm::max(m), std::forward<Args>(args)...);
-                if(!rows.empty()){
+                if(!rows.empty()) {
                     return std::move(rows.front());
-                }else{
+                } else {
                     return {};
                 }
             }
-            
+
             /**
              *  MIN(x) query.
              *  @param m is a class member pointer (the same you passed into make_column).
              *  @return std::unique_ptr with min value or null if sqlite engine returned null.
              */
-            template<class F, class O, class ...Args, class Ret = typename column_result_t<self, F O::*>::type>
-            std::unique_ptr<Ret> min(F O::*m, Args&& ...args) {
+            template<class F, class O, class... Args, class Ret = typename column_result_t<self, F O::*>::type>
+            std::unique_ptr<Ret> min(F O::*m, Args &&... args) {
                 this->assert_mapped_type<O>();
                 auto rows = this->select(sqlite_orm::min(m), std::forward<Args>(args)...);
-                if(!rows.empty()){
+                if(!rows.empty()) {
                     return std::move(rows.front());
-                }else{
+                } else {
                     return {};
                 }
             }
-            
+
             /**
              *  SUM(x) query.
              *  @param m is a class member pointer (the same you passed into make_column).
              *  @return std::unique_ptr with sum value or null if sqlite engine returned null.
              */
-            template<class F, class O, class ...Args, class Ret = typename column_result_t<self, F O::*>::type>
-            std::unique_ptr<Ret> sum(F O::*m, Args&& ...args) {
+            template<class F, class O, class... Args, class Ret = typename column_result_t<self, F O::*>::type>
+            std::unique_ptr<Ret> sum(F O::*m, Args &&... args) {
                 this->assert_mapped_type<O>();
-                std::vector<std::unique_ptr<double>> rows = this->select(sqlite_orm::sum(m), std::forward<Args>(args)...);
-                if(!rows.empty()){
-                    if(rows.front()){
+                std::vector<std::unique_ptr<double>> rows =
+                    this->select(sqlite_orm::sum(m), std::forward<Args>(args)...);
+                if(!rows.empty()) {
+                    if(rows.front()) {
                         return std::make_unique<Ret>(std::move(*rows.front()));
-                    }else{
+                    } else {
                         return {};
                     }
-                }else{
+                } else {
                     return {};
                 }
             }
-            
+
             /**
              *  TOTAL(x) query.
              *  @param m is a class member pointer (the same you passed into make_column).
-             *  @return total value (the same as SUM but not nullable. More details here https://www.sqlite.org/lang_aggfunc.html)
+             *  @return total value (the same as SUM but not nullable. More details here
+             * https://www.sqlite.org/lang_aggfunc.html)
              */
-            template<class F, class O, class ...Args>
-            double total(F O::*m, Args&& ...args) {
+            template<class F, class O, class... Args>
+            double total(F O::*m, Args &&... args) {
                 this->assert_mapped_type<O>();
                 auto rows = this->select(sqlite_orm::total(m), std::forward<Args>(args)...);
-                if(!rows.empty()){
+                if(!rows.empty()) {
                     return std::move(rows.front());
-                }else{
+                } else {
                     return {};
                 }
             }
-            
+
             /**
              *  Select a single column into std::vector<T> or multiple columns into std::vector<std::tuple<...>>.
              *  For a single column use `auto rows = storage.select(&User::id, where(...));
              *  For multicolumns use `auto rows = storage.select(columns(&User::id, &User::name), where(...));
              */
-            template<
-            class T,
-            class ...Args,
-            class R = typename column_result_t<self, T>::type>
-            std::vector<R> select(T m, Args ...args) {
-                static_assert(!is_base_of_template<T, compound_operator>::value || std::tuple_size<std::tuple<Args...>>::value == 0,
+            template<class T, class... Args, class R = typename column_result_t<self, T>::type>
+            std::vector<R> select(T m, Args... args) {
+                static_assert(!is_base_of_template<T, compound_operator>::value ||
+                                  std::tuple_size<std::tuple<Args...>>::value == 0,
                               "Cannot use args with a compound operator");
                 auto statement = this->prepare(sqlite_orm::select(std::move(m), std::forward<Args>(args)...));
                 return this->execute(statement);
             }
-            
+
             /**
              *  Returns a string representation of object of a class mapped to the storage.
              *  Type of string has json-like style.
@@ -10016,7 +10135,7 @@ namespace sqlite_orm {
                 this->assert_mapped_type<O>();
                 return this->impl.dump(o);
             }
-            
+
             /**
              *  This is REPLACE (INSERT OR REPLACE) function.
              *  Also if you need to insert value with knows id you should
@@ -10029,7 +10148,7 @@ namespace sqlite_orm {
                 auto statement = this->prepare(sqlite_orm::replace(o));
                 this->execute(statement);
             }
-            
+
             template<class It>
             void replace_range(It from, It to) {
                 using O = typename std::iterator_traits<It>::value_type;
@@ -10037,12 +10156,12 @@ namespace sqlite_orm {
                 if(from == to) {
                     return;
                 }
-                
+
                 auto statement = this->prepare(sqlite_orm::replace_range(from, to));
                 this->execute(statement);
             }
-            
-            template<class O, class ...Cols>
+
+            template<class O, class... Cols>
             int insert(const O &o, columns_t<Cols...> cols) {
                 constexpr const size_t colsCount = std::tuple_size<std::tuple<Cols...>>::value;
                 static_assert(colsCount > 0, "Use insert or replace with 1 argument instead");
@@ -10050,7 +10169,7 @@ namespace sqlite_orm {
                 auto statement = this->prepare(sqlite_orm::insert(o, std::move(cols)));
                 return int(this->execute(statement));
             }
-            
+
             /**
              *  Insert routine. Inserts object with all non primary key fields in passed object. Id of passed
              *  object doesn't matter.
@@ -10062,7 +10181,7 @@ namespace sqlite_orm {
                 auto statement = this->prepare(sqlite_orm::insert(o));
                 return int(this->execute(statement));
             }
-            
+
             template<class It>
             void insert_range(It from, It to) {
                 using O = typename std::iterator_traits<It>::value_type;
@@ -10070,27 +10189,27 @@ namespace sqlite_orm {
                 if(from == to) {
                     return;
                 }
-                
+
                 auto statement = this->prepare(sqlite_orm::insert_range(from, to));
                 this->execute(statement);
             }
-            
-        protected:
-            
-            template<class ...Tss, class ...Cols>
+
+          protected:
+            template<class... Tss, class... Cols>
             sync_schema_result sync_table(storage_impl<internal::index_t<Cols...>, Tss...> *impl, sqlite3 *db, bool) {
                 auto res = sync_schema_result::already_in_sync;
                 std::stringstream ss;
                 ss << "CREATE ";
-                if(impl->table.unique){
+                if(impl->table.unique) {
                     ss << "UNIQUE ";
                 }
                 using columns_type = typename decltype(impl->table)::columns_type;
                 using head_t = typename std::tuple_element<0, columns_type>::type;
                 using indexed_type = typename internal::table_type<head_t>::type;
-                ss << "INDEX IF NOT EXISTS '" << impl->table.name << "' ON '" << this->impl.template find_table_name<indexed_type>() << "' ( ";
+                ss << "INDEX IF NOT EXISTS '" << impl->table.name << "' ON '"
+                   << this->impl.template find_table_name<indexed_type>() << "' ( ";
                 std::vector<std::string> columnNames;
-                iterate_tuple(impl->table.columns, [&columnNames, this](auto &v){
+                iterate_tuple(impl->table.columns, [&columnNames, this](auto &v) {
                     columnNames.push_back(this->impl.column_name(v));
                 });
                 for(size_t i = 0; i < columnNames.size(); ++i) {
@@ -10104,56 +10223,56 @@ namespace sqlite_orm {
                 auto query = ss.str();
                 auto rc = sqlite3_exec(db, query.c_str(), nullptr, nullptr, nullptr);
                 if(rc != SQLITE_OK) {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
                 return res;
             }
-            
-            template<class ...Tss, class ...Cs>
+
+            template<class... Tss, class... Cs>
             sync_schema_result sync_table(storage_impl<table_t<Cs...>, Tss...> *impl, sqlite3 *db, bool preserve) {
                 auto res = sync_schema_result::already_in_sync;
-                
+
                 auto schema_stat = impl->schema_status(db, preserve);
                 if(schema_stat != decltype(schema_stat)::already_in_sync) {
                     if(schema_stat == decltype(schema_stat)::new_table_created) {
                         this->create_table(db, impl->table.name, impl);
                         res = decltype(res)::new_table_created;
-                    }else{
-                        if(schema_stat == sync_schema_result::old_columns_removed
-                           || schema_stat == sync_schema_result::new_columns_added
-                           || schema_stat == sync_schema_result::new_columns_added_and_old_columns_removed)
-                        {
-                            
+                    } else {
+                        if(schema_stat == sync_schema_result::old_columns_removed ||
+                           schema_stat == sync_schema_result::new_columns_added ||
+                           schema_stat == sync_schema_result::new_columns_added_and_old_columns_removed) {
+
                             //  get table info provided in `make_table` call..
                             auto storageTableInfo = impl->table.get_table_info();
-                            
+
                             //  now get current table info from db using `PRAGMA table_info` query..
                             auto dbTableInfo = impl->get_table_info(impl->table.name, db);
-                            
+
                             //  this vector will contain pointers to columns that gotta be added..
-                            std::vector<table_info*> columnsToAdd;
-                            
+                            std::vector<table_info *> columnsToAdd;
+
                             impl->get_remove_add_columns(columnsToAdd, storageTableInfo, dbTableInfo);
-                            
+
                             if(schema_stat == sync_schema_result::old_columns_removed) {
-                                
+
                                 //  extra table columns than storage columns
                                 this->backup_table(db, impl);
                                 res = decltype(res)::old_columns_removed;
                             }
-                            
+
                             if(schema_stat == sync_schema_result::new_columns_added) {
-                                for(auto columnPointer : columnsToAdd) {
+                                for(auto columnPointer: columnsToAdd) {
                                     impl->add_column(*columnPointer, db);
                                 }
                                 res = decltype(res)::new_columns_added;
                             }
-                            
+
                             if(schema_stat == sync_schema_result::new_columns_added_and_old_columns_removed) {
-                                
-                                //remove extra columns
+
+                                // remove extra columns
                                 this->backup_table(db, impl);
-                                for(auto columnPointer : columnsToAdd) {
+                                for(auto columnPointer: columnsToAdd) {
                                     impl->add_column(*columnPointer, db);
                                 }
                                 res = decltype(res)::new_columns_added_and_old_columns_removed;
@@ -10167,9 +10286,8 @@ namespace sqlite_orm {
                 }
                 return res;
             }
-            
-        public:
-            
+
+          public:
             /**
              *  This is a cute function used to replace migration up/down functionality.
              *  It performs check storage schema with actual db schema and:
@@ -10177,31 +10295,37 @@ namespace sqlite_orm {
              *  * every table from storage is compared with it's db analog and
              *      * if table doesn't exist it is being created
              *      * if table exists its colums are being compared with table_info from db and
-             *          * if there are columns in db that do not exist in storage (excess) table will be dropped and recreated
-             *          * if there are columns in storage that do not exist in db they will be added using `ALTER TABLE ... ADD COLUMN ...' command
-             *          * if there is any column existing in both db and storage but differs by any of properties/constraints (type, pk, notnull, dflt_value) table will be dropped and recreated
-             *  Be aware that `sync_schema` doesn't guarantee that data will not be dropped. It guarantees only that it will make db schema the same
-             *  as you specified in `make_storage` function call. A good point is that if you have no db file at all it will be created and
-             *  all tables also will be created with exact tables and columns you specified in `make_storage`, `make_table` and `make_column` call.
-             *  The best practice is to call this function right after storage creation.
-             *  @param preserve affects on function behaviour in case it is needed to remove a column. If it is `false` so table will be dropped
-             *  if there is column to remove, if `true` -  table is being copied into another table, dropped and copied table is renamed with source table name.
-             *  Warning: sync_schema doesn't check foreign keys cause it is unable to do so in sqlite3. If you know how to get foreign key info
-             *  please submit an issue https://github.com/fnc12/sqlite_orm/issues
-             *  @return std::map with std::string key equal table name and `sync_schema_result` as value. `sync_schema_result` is a enum value that stores
-             *  table state after syncing a schema. `sync_schema_result` can be printed out on std::ostream with `operator<<`.
+             *          * if there are columns in db that do not exist in storage (excess) table will be dropped and
+             * recreated
+             *          * if there are columns in storage that do not exist in db they will be added using `ALTER TABLE
+             * ... ADD COLUMN ...' command
+             *          * if there is any column existing in both db and storage but differs by any of
+             * properties/constraints (type, pk, notnull, dflt_value) table will be dropped and recreated Be aware that
+             * `sync_schema` doesn't guarantee that data will not be dropped. It guarantees only that it will make db
+             * schema the same as you specified in `make_storage` function call. A good point is that if you have no db
+             * file at all it will be created and all tables also will be created with exact tables and columns you
+             * specified in `make_storage`, `make_table` and `make_column` call. The best practice is to call this
+             * function right after storage creation.
+             *  @param preserve affects on function behaviour in case it is needed to remove a column. If it is `false`
+             * so table will be dropped if there is column to remove, if `true` -  table is being copied into another
+             * table, dropped and copied table is renamed with source table name. Warning: sync_schema doesn't check
+             * foreign keys cause it is unable to do so in sqlite3. If you know how to get foreign key info please
+             * submit an issue https://github.com/fnc12/sqlite_orm/issues
+             *  @return std::map with std::string key equal table name and `sync_schema_result` as value.
+             * `sync_schema_result` is a enum value that stores table state after syncing a schema. `sync_schema_result`
+             * can be printed out on std::ostream with `operator<<`.
              */
             std::map<std::string, sync_schema_result> sync_schema(bool preserve = false) {
                 auto con = this->get_connection();
                 std::map<std::string, sync_schema_result> result;
                 auto db = con.get();
-                this->impl.for_each([&result, db, preserve, this](auto impl){
+                this->impl.for_each([&result, db, preserve, this](auto impl) {
                     auto res = this->sync_table(impl, db, preserve);
                     result.insert({impl->table.name, res});
                 });
                 return result;
             }
-            
+
             /**
              *  This function returns the same map that `sync_schema` returns but it
              *  doesn't perform `sync_schema` actually - just simulates it in case you want to know
@@ -10211,12 +10335,12 @@ namespace sqlite_orm {
                 auto con = this->get_connection();
                 std::map<std::string, sync_schema_result> result;
                 auto db = con.get();
-                this->impl.for_each([&result, db, preserve](auto impl){
+                this->impl.for_each([&result, db, preserve](auto impl) {
                     result.insert({impl->table.name, impl->schema_status(db, preserve)});
                 });
                 return result;
             }
-            
+
             /**
              *  Checks whether table exists in db. Doesn't check storage itself - works only with actual database.
              *  Note: table can be not mapped to a storage
@@ -10226,191 +10350,206 @@ namespace sqlite_orm {
                 auto con = this->get_connection();
                 return this->impl.table_exists(tableName, con.get());
             }
-            
-            template<class T, class ...Args>
+
+            template<class T, class... Args>
             prepared_statement_t<select_t<T, Args...>> prepare(select_t<T, Args...> sel) {
                 sel.highest_level = true;
                 auto con = this->get_connection();
                 sqlite3_stmt *stmt;
                 auto db = con.get();
                 auto query = this->string_from_expression(sel, false);
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     return {std::move(sel), stmt, con};
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
-            template<class T, class ...Args>
+
+            template<class T, class... Args>
             prepared_statement_t<get_all_t<T, Args...>> prepare(get_all_t<T, Args...> get) {
                 auto con = this->get_connection();
                 sqlite3_stmt *stmt;
                 auto db = con.get();
                 auto query = this->string_from_expression(get, false);
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     return {std::move(get), stmt, con};
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
 
-            template<class T, class ...Args>
+            template<class T, class... Args>
             prepared_statement_t<get_all_pointer_t<T, Args...>> prepare(get_all_pointer_t<T, Args...> get) {
                 auto con = this->get_connection();
                 sqlite3_stmt *stmt;
                 auto db = con.get();
                 auto query = this->string_from_expression(get, false);
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     return {std::move(get), stmt, con};
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
-            template<class ...Args, class ...Wargs>
-            prepared_statement_t<update_all_t<set_t<Args...>, Wargs...>> prepare(update_all_t<set_t<Args...>, Wargs...> upd) {
+
+            template<class... Args, class... Wargs>
+            prepared_statement_t<update_all_t<set_t<Args...>, Wargs...>>
+            prepare(update_all_t<set_t<Args...>, Wargs...> upd) {
                 auto con = this->get_connection();
                 sqlite3_stmt *stmt;
                 auto db = con.get();
                 auto query = this->string_from_expression(upd, false);
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     return {std::move(upd), stmt, con};
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
-            template<class T, class ...Args>
+
+            template<class T, class... Args>
             prepared_statement_t<remove_all_t<T, Args...>> prepare(remove_all_t<T, Args...> rem) {
                 auto con = this->get_connection();
                 sqlite3_stmt *stmt;
                 auto db = con.get();
                 auto query = this->string_from_expression(rem, false);
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     return {std::move(rem), stmt, std::move(con)};
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
-            template<class T, class ...Ids>
+
+            template<class T, class... Ids>
             prepared_statement_t<get_t<T, Ids...>> prepare(get_t<T, Ids...> g) {
                 auto con = this->get_connection();
                 sqlite3_stmt *stmt;
                 auto db = con.get();
                 auto query = this->string_from_expression(g, false);
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     return {std::move(g), stmt, con};
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
-            template<class T, class ...Ids>
+
+            template<class T, class... Ids>
             prepared_statement_t<get_pointer_t<T, Ids...>> prepare(get_pointer_t<T, Ids...> g) {
                 auto con = this->get_connection();
                 sqlite3_stmt *stmt;
                 auto db = con.get();
                 auto query = this->string_from_expression(g, false);
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     return {std::move(g), stmt, con};
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             template<class T, bool by_ref>
             prepared_statement_t<update_t<T, by_ref>> prepare(update_t<T, by_ref> upd) {
                 auto con = this->get_connection();
                 sqlite3_stmt *stmt;
                 auto db = con.get();
                 auto query = this->string_from_expression(upd, false);
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     return {std::move(upd), stmt, con};
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
-            template<class T, class ...Ids>
+
+            template<class T, class... Ids>
             prepared_statement_t<remove_t<T, Ids...>> prepare(remove_t<T, Ids...> rem) {
                 auto con = this->get_connection();
                 sqlite3_stmt *stmt;
                 auto db = con.get();
                 auto query = this->string_from_expression(rem, false);
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     return {std::move(rem), stmt, con};
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             template<class T, bool by_ref>
             prepared_statement_t<insert_t<T, by_ref>> prepare(insert_t<T, by_ref> ins) {
                 auto con = this->get_connection();
                 sqlite3_stmt *stmt;
                 auto db = con.get();
                 auto query = this->string_from_expression(ins, false);
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     return {std::move(ins), stmt, con};
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             template<class T, bool by_ref>
             prepared_statement_t<replace_t<T, by_ref>> prepare(replace_t<T, by_ref> rep) {
                 auto con = this->get_connection();
                 sqlite3_stmt *stmt;
                 auto db = con.get();
                 auto query = this->string_from_expression(rep, false);
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     return {std::move(rep), stmt, con};
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             template<class It>
             prepared_statement_t<insert_range_t<It>> prepare(insert_range_t<It> ins) {
                 auto con = this->get_connection();
                 sqlite3_stmt *stmt;
                 auto db = con.get();
                 auto query = this->string_from_expression(ins, false);
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     return {std::move(ins), stmt, con};
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             template<class It>
             prepared_statement_t<replace_range_t<It>> prepare(replace_range_t<It> rep) {
                 auto con = this->get_connection();
                 sqlite3_stmt *stmt;
                 auto db = con.get();
                 auto query = this->string_from_expression(rep, false);
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     return {std::move(rep), stmt, con};
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
-            template<class T, bool by_ref, class ...Cols>
+
+            template<class T, bool by_ref, class... Cols>
             prepared_statement_t<insert_explicit<T, by_ref, Cols...>> prepare(insert_explicit<T, by_ref, Cols...> ins) {
                 auto con = this->get_connection();
                 sqlite3_stmt *stmt;
                 auto db = con.get();
                 auto query = this->string_from_expression(ins, false);
-                if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     return {std::move(ins), stmt, con};
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
-            template<class T, bool by_ref, class ...Cols>
+
+            template<class T, bool by_ref, class... Cols>
             int64 execute(const prepared_statement_t<insert_explicit<T, by_ref, Cols...>> &statement) {
                 auto index = 1;
                 auto con = this->get_connection();
@@ -10419,21 +10558,23 @@ namespace sqlite_orm {
                 auto &impl = this->get_impl<T>();
                 auto &o = statement.t.obj;
                 sqlite3_reset(stmt);
-                iterate_tuple(statement.t.columns.columns, [&o, &index, &stmt, &impl, db] (auto &m) {
+                iterate_tuple(statement.t.columns.columns, [&o, &index, &stmt, &impl, db](auto &m) {
                     using column_type = typename std::decay<decltype(m)>::type;
                     using field_type = typename column_result_t<self, column_type>::type;
                     const field_type *value = impl.table.template get_object_field_pointer<field_type>(o, m);
-                    if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, *value)){
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, *value)) {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
                 });
-                if (sqlite3_step(stmt) == SQLITE_DONE) {
+                if(sqlite3_step(stmt) == SQLITE_DONE) {
                     return sqlite3_last_insert_rowid(db);
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             template<class It>
             void execute(const prepared_statement_t<replace_range_t<It>> &statement) {
                 using statement_type = typename std::decay<decltype(statement)>::type;
@@ -10447,29 +10588,34 @@ namespace sqlite_orm {
                 sqlite3_reset(stmt);
                 for(auto it = statement.t.from; it != statement.t.to; ++it) {
                     auto &o = *it;
-                    impl.table.for_each_column([&o, &index, &stmt, db] (auto &c) {
+                    impl.table.for_each_column([&o, &index, &stmt, db](auto &c) {
                         using column_type = typename std::decay<decltype(c)>::type;
                         using field_type = typename column_type::field_type;
-                        if(c.member_pointer){
-                            if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, o.*c.member_pointer)){
-                                throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                        if(c.member_pointer) {
+                            if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, o.*c.member_pointer)) {
+                                throw std::system_error(
+                                    std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                    sqlite3_errmsg(db));
                             }
-                        }else{
+                        } else {
                             using getter_type = typename column_type::getter_type;
                             field_value_holder<getter_type> valueHolder{((o).*(c.getter))()};
-                            if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, valueHolder.value)){
-                                throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                            if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, valueHolder.value)) {
+                                throw std::system_error(
+                                    std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                    sqlite3_errmsg(db));
                             }
                         }
                     });
                 }
-                if (sqlite3_step(stmt) == SQLITE_DONE) {
+                if(sqlite3_step(stmt) == SQLITE_DONE) {
                     //..
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             template<class It>
             void execute(const prepared_statement_t<insert_range_t<It>> &statement) {
                 using statement_type = typename std::decay<decltype(statement)>::type;
@@ -10483,31 +10629,37 @@ namespace sqlite_orm {
                 sqlite3_reset(stmt);
                 for(auto it = statement.t.from; it != statement.t.to; ++it) {
                     auto &o = *it;
-                    impl.table.for_each_column([&o, &index, &stmt, db] (auto &c) {
-                        if(!c.template has<constraints::primary_key_t<>>()){
+                    impl.table.for_each_column([&o, &index, &stmt, db](auto &c) {
+                        if(!c.template has<constraints::primary_key_t<>>()) {
                             using column_type = typename std::decay<decltype(c)>::type;
                             using field_type = typename column_type::field_type;
-                            if(c.member_pointer){
-                                if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, o.*c.member_pointer)){
-                                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                            if(c.member_pointer) {
+                                if(SQLITE_OK !=
+                                   statement_binder<field_type>().bind(stmt, index++, o.*c.member_pointer)) {
+                                    throw std::system_error(
+                                        std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                        sqlite3_errmsg(db));
                                 }
-                            }else{
+                            } else {
                                 using getter_type = typename column_type::getter_type;
                                 field_value_holder<getter_type> valueHolder{((o).*(c.getter))()};
-                                if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, valueHolder.value)){
-                                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                                if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, valueHolder.value)) {
+                                    throw std::system_error(
+                                        std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                        sqlite3_errmsg(db));
                                 }
                             }
                         }
                     });
                 }
-                if (sqlite3_step(stmt) == SQLITE_DONE) {
+                if(sqlite3_step(stmt) == SQLITE_DONE) {
                     //..
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             template<class T, bool by_ref>
             void execute(const prepared_statement_t<replace_t<T, by_ref>> &statement) {
                 auto con = this->get_connection();
@@ -10517,28 +10669,31 @@ namespace sqlite_orm {
                 auto &o = statement.t.obj;
                 auto &impl = this->get_impl<T>();
                 sqlite3_reset(stmt);
-                impl.table.for_each_column([&o, &index, &stmt, db] (auto &c) {
+                impl.table.for_each_column([&o, &index, &stmt, db](auto &c) {
                     using column_type = typename std::decay<decltype(c)>::type;
                     using field_type = typename column_type::field_type;
-                    if(c.member_pointer){
-                        if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, o.*c.member_pointer)){
-                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    if(c.member_pointer) {
+                        if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, o.*c.member_pointer)) {
+                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                    sqlite3_errmsg(db));
                         }
-                    }else{
+                    } else {
                         using getter_type = typename column_type::getter_type;
                         field_value_holder<getter_type> valueHolder{((o).*(c.getter))()};
-                        if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, valueHolder.value)){
-                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                        if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, valueHolder.value)) {
+                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                    sqlite3_errmsg(db));
                         }
                     }
                 });
-                if (sqlite3_step(stmt) == SQLITE_DONE) {
+                if(sqlite3_step(stmt) == SQLITE_DONE) {
                     //..
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             template<class T, bool by_ref>
             int64 execute(const prepared_statement_t<insert_t<T, by_ref>> &statement) {
                 int64 res = 0;
@@ -10550,56 +10705,62 @@ namespace sqlite_orm {
                 auto &o = statement.t.obj;
                 auto compositeKeyColumnNames = impl.table.composite_key_columns_names();
                 sqlite3_reset(stmt);
-                impl.table.for_each_column([&o, &index, &stmt, &impl, &compositeKeyColumnNames, db] (auto &c) {
-                    if(impl.table._without_rowid || !c.template has<constraints::primary_key_t<>>()){
-                        auto it = std::find(compositeKeyColumnNames.begin(),
-                                            compositeKeyColumnNames.end(),
-                                            c.name);
-                        if(it == compositeKeyColumnNames.end()){
+                impl.table.for_each_column([&o, &index, &stmt, &impl, &compositeKeyColumnNames, db](auto &c) {
+                    if(impl.table._without_rowid || !c.template has<constraints::primary_key_t<>>()) {
+                        auto it = std::find(compositeKeyColumnNames.begin(), compositeKeyColumnNames.end(), c.name);
+                        if(it == compositeKeyColumnNames.end()) {
                             using column_type = typename std::decay<decltype(c)>::type;
                             using field_type = typename column_type::field_type;
-                            if(c.member_pointer){
-                                if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, o.*c.member_pointer)){
-                                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                            if(c.member_pointer) {
+                                if(SQLITE_OK !=
+                                   statement_binder<field_type>().bind(stmt, index++, o.*c.member_pointer)) {
+                                    throw std::system_error(
+                                        std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                        sqlite3_errmsg(db));
                                 }
-                            }else{
+                            } else {
                                 using getter_type = typename column_type::getter_type;
                                 field_value_holder<getter_type> valueHolder{((o).*(c.getter))()};
-                                if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, valueHolder.value)){
-                                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                                if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, valueHolder.value)) {
+                                    throw std::system_error(
+                                        std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                        sqlite3_errmsg(db));
                                 }
                             }
                         }
                     }
                 });
-                if (sqlite3_step(stmt) == SQLITE_DONE) {
+                if(sqlite3_step(stmt) == SQLITE_DONE) {
                     res = sqlite3_last_insert_rowid(db);
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
                 return res;
             }
-            
-            template<class T, class ...Ids>
+
+            template<class T, class... Ids>
             void execute(const prepared_statement_t<remove_t<T, Ids...>> &statement) {
                 auto con = this->get_connection();
                 auto db = con.get();
                 auto stmt = statement.stmt;
                 auto index = 1;
                 sqlite3_reset(stmt);
-                iterate_tuple(statement.t.ids, [stmt, &index, db](auto &v){
+                iterate_tuple(statement.t.ids, [stmt, &index, db](auto &v) {
                     using field_type = typename std::decay<decltype(v)>::type;
-                    if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, v)){
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, v)) {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
                 });
-                if (sqlite3_step(stmt) == SQLITE_DONE) {
+                if(sqlite3_step(stmt) == SQLITE_DONE) {
                     //  done..
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
+
             template<class T, bool by_ref>
             void execute(const prepared_statement_t<update_t<T, by_ref>> &statement) {
                 auto con = this->get_connection();
@@ -10609,49 +10770,58 @@ namespace sqlite_orm {
                 auto index = 1;
                 auto &o = statement.t.obj;
                 sqlite3_reset(stmt);
-                impl.table.for_each_column([&o, stmt, &index, db] (auto &c) {
+                impl.table.for_each_column([&o, stmt, &index, db](auto &c) {
                     if(!c.template has<constraints::primary_key_t<>>()) {
                         using column_type = typename std::decay<decltype(c)>::type;
                         using field_type = typename column_type::field_type;
-                        if(c.member_pointer){
+                        if(c.member_pointer) {
                             auto bind_res = statement_binder<field_type>().bind(stmt, index++, o.*c.member_pointer);
-                            if(SQLITE_OK != bind_res){
-                                throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                            if(SQLITE_OK != bind_res) {
+                                throw std::system_error(
+                                    std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                    sqlite3_errmsg(db));
                             }
-                        }else{
+                        } else {
                             using getter_type = typename column_type::getter_type;
                             field_value_holder<getter_type> valueHolder{((o).*(c.getter))()};
-                            if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, valueHolder.value)){
-                                throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                            if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, valueHolder.value)) {
+                                throw std::system_error(
+                                    std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                    sqlite3_errmsg(db));
                             }
                         }
                     }
                 });
-                impl.table.for_each_column([&o, stmt, &index, db] (auto &c) {
+                impl.table.for_each_column([&o, stmt, &index, db](auto &c) {
                     if(c.template has<constraints::primary_key_t<>>()) {
                         using column_type = typename std::decay<decltype(c)>::type;
                         using field_type = typename column_type::field_type;
-                        if(c.member_pointer){
-                            if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, o.*c.member_pointer)){
-                                throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                        if(c.member_pointer) {
+                            if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, o.*c.member_pointer)) {
+                                throw std::system_error(
+                                    std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                    sqlite3_errmsg(db));
                             }
-                        }else{
+                        } else {
                             using getter_type = typename column_type::getter_type;
                             field_value_holder<getter_type> valueHolder{((o).*(c.getter))()};
-                            if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, valueHolder.value)){
-                                throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                            if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, valueHolder.value)) {
+                                throw std::system_error(
+                                    std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                    sqlite3_errmsg(db));
                             }
                         }
                     }
                 });
-                if (sqlite3_step(stmt) == SQLITE_DONE) {
+                if(sqlite3_step(stmt) == SQLITE_DONE) {
                     //  done..
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
-            template<class T, class ...Ids>
+
+            template<class T, class... Ids>
             std::unique_ptr<T> execute(const prepared_statement_t<get_pointer_t<T, Ids...>> &statement) {
                 auto &impl = this->get_impl<T>();
                 auto con = this->get_connection();
@@ -10659,38 +10829,40 @@ namespace sqlite_orm {
                 auto stmt = statement.stmt;
                 auto index = 1;
                 sqlite3_reset(stmt);
-                iterate_tuple(statement.t.ids, [stmt, &index, db](auto &v){
+                iterate_tuple(statement.t.ids, [stmt, &index, db](auto &v) {
                     using field_type = typename std::decay<decltype(v)>::type;
-                    if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, v)){
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, v)) {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
                 });
                 auto stepRes = sqlite3_step(stmt);
-                switch(stepRes){
-                    case SQLITE_ROW:{
+                switch(stepRes) {
+                    case SQLITE_ROW: {
                         auto res = std::make_unique<T>();
                         index = 0;
-                        impl.table.for_each_column([&index, &res, stmt] (auto c) {
+                        impl.table.for_each_column([&index, &res, stmt](auto c) {
                             using field_type = typename decltype(c)::field_type;
                             auto value = row_extractor<field_type>().extract(stmt, index++);
-                            if(c.member_pointer){
+                            if(c.member_pointer) {
                                 (*res).*c.member_pointer = std::move(value);
-                            }else{
+                            } else {
                                 ((*res).*(c.setter))(std::move(value));
                             }
                         });
                         return res;
-                    }break;
-                    case SQLITE_DONE:{
+                    } break;
+                    case SQLITE_DONE: {
                         return {};
-                    }break;
-                    default:{
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    } break;
+                    default: {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
                 }
             }
-            
-            template<class T, class ...Ids>
+
+            template<class T, class... Ids>
             T execute(const prepared_statement_t<get_t<T, Ids...>> &statement) {
                 auto &impl = this->get_impl<T>();
                 auto con = this->get_connection();
@@ -10698,121 +10870,131 @@ namespace sqlite_orm {
                 auto stmt = statement.stmt;
                 auto index = 1;
                 sqlite3_reset(stmt);
-                iterate_tuple(statement.t.ids, [stmt, &index, db](auto &v){
+                iterate_tuple(statement.t.ids, [stmt, &index, db](auto &v) {
                     using field_type = typename std::decay<decltype(v)>::type;
-                    if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, v)){
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, v)) {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
                 });
                 auto stepRes = sqlite3_step(stmt);
-                switch(stepRes){
-                    case SQLITE_ROW:{
+                switch(stepRes) {
+                    case SQLITE_ROW: {
                         T res;
                         index = 0;
-                        impl.table.for_each_column([&index, &res, stmt] (auto &c) {
+                        impl.table.for_each_column([&index, &res, stmt](auto &c) {
                             using column_type = typename std::decay<decltype(c)>::type;
                             using field_type = typename column_type::field_type;
                             auto value = row_extractor<field_type>().extract(stmt, index++);
-                            if(c.member_pointer){
+                            if(c.member_pointer) {
                                 res.*c.member_pointer = std::move(value);
-                            }else{
+                            } else {
                                 ((res).*(c.setter))(std::move(value));
                             }
                         });
                         return res;
-                    }break;
-                    case SQLITE_DONE:{
+                    } break;
+                    case SQLITE_DONE: {
                         throw std::system_error(std::make_error_code(sqlite_orm::orm_error_code::not_found));
-                    }break;
-                    default:{
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    } break;
+                    default: {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
                 }
             }
-            
-            template<class T, class ...Args>
+
+            template<class T, class... Args>
             void execute(const prepared_statement_t<remove_all_t<T, Args...>> &statement) {
                 auto con = this->get_connection();
                 auto db = con.get();
                 auto stmt = statement.stmt;
                 auto index = 1;
                 sqlite3_reset(stmt);
-                iterate_ast(statement.t.conditions, [stmt, &index, db](auto &node){
+                iterate_ast(statement.t.conditions, [stmt, &index, db](auto &node) {
                     using node_type = typename std::decay<decltype(node)>::type;
                     conditional_binder<node_type, is_bindable<node_type>> binder{stmt, index};
-                    if(SQLITE_OK != binder(node)){
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    if(SQLITE_OK != binder(node)) {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
                 });
-                if (sqlite3_step(stmt) == SQLITE_DONE) {
+                if(sqlite3_step(stmt) == SQLITE_DONE) {
                     //  done..
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
-            template<class ...Args, class ...Wargs>
+
+            template<class... Args, class... Wargs>
             void execute(const prepared_statement_t<update_all_t<set_t<Args...>, Wargs...>> &statement) {
                 auto con = this->get_connection();
                 auto db = con.get();
                 auto stmt = statement.stmt;
                 auto index = 1;
                 sqlite3_reset(stmt);
-                statement.t.set.for_each([&index, stmt, db](auto &setArg){
-                    iterate_ast(setArg, [&index, stmt, db](auto &node){
+                statement.t.set.for_each([&index, stmt, db](auto &setArg) {
+                    iterate_ast(setArg, [&index, stmt, db](auto &node) {
                         using node_type = typename std::decay<decltype(node)>::type;
                         conditional_binder<node_type, is_bindable<node_type>> binder{stmt, index};
-                        if(SQLITE_OK != binder(node)){
-                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                        if(SQLITE_OK != binder(node)) {
+                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                    sqlite3_errmsg(db));
                         }
                     });
                 });
-                iterate_ast(statement.t.conditions, [stmt, &index, db](auto &node){
+                iterate_ast(statement.t.conditions, [stmt, &index, db](auto &node) {
                     using node_type = typename std::decay<decltype(node)>::type;
                     conditional_binder<node_type, is_bindable<node_type>> binder{stmt, index};
-                    if(SQLITE_OK != binder(node)){
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    if(SQLITE_OK != binder(node)) {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
                 });
-                if (sqlite3_step(stmt) == SQLITE_DONE) {
+                if(sqlite3_step(stmt) == SQLITE_DONE) {
                     //  done..
-                }else{
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                } else {
+                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                            sqlite3_errmsg(db));
                 }
             }
-            
-            template<class T, class ...Args, class R = typename column_result_t<self, T>::type>
+
+            template<class T, class... Args, class R = typename column_result_t<self, T>::type>
             std::vector<R> execute(const prepared_statement_t<select_t<T, Args...>> &statement) {
                 auto con = this->get_connection();
                 auto db = con.get();
                 auto stmt = statement.stmt;
                 auto index = 1;
                 sqlite3_reset(stmt);
-                iterate_ast(statement.t, [stmt, &index, db](auto &node){
+                iterate_ast(statement.t, [stmt, &index, db](auto &node) {
                     using node_type = typename std::decay<decltype(node)>::type;
                     conditional_binder<node_type, is_bindable<node_type>> binder{stmt, index};
-                    if(SQLITE_OK != binder(node)){
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    if(SQLITE_OK != binder(node)) {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
                 });
                 std::vector<R> res;
                 int stepRes;
-                do{
+                do {
                     stepRes = sqlite3_step(stmt);
-                    switch(stepRes){
-                        case SQLITE_ROW:{
+                    switch(stepRes) {
+                        case SQLITE_ROW: {
                             res.push_back(row_extractor<R>().extract(stmt, 0));
-                        }break;
-                        case SQLITE_DONE: break;
-                        default:{
-                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                        } break;
+                        case SQLITE_DONE:
+                            break;
+                        default: {
+                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                    sqlite3_errmsg(db));
                         }
                     }
-                }while(stepRes != SQLITE_DONE);
+                } while(stepRes != SQLITE_DONE);
                 return res;
             }
-            
-            template<class T, class ...Args>
+
+            template<class T, class... Args>
             std::vector<T> execute(const prepared_statement_t<get_all_t<T, Args...>> &statement) {
                 auto &impl = this->get_impl<T>();
                 auto con = this->get_connection();
@@ -10820,96 +11002,103 @@ namespace sqlite_orm {
                 auto stmt = statement.stmt;
                 auto index = 1;
                 sqlite3_reset(stmt);
-                iterate_ast(statement.t, [stmt, &index, db](auto &node){
+                iterate_ast(statement.t, [stmt, &index, db](auto &node) {
                     using node_type = typename std::decay<decltype(node)>::type;
                     conditional_binder<node_type, is_bindable<node_type>> binder{stmt, index};
-                    if(SQLITE_OK != binder(node)){
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    if(SQLITE_OK != binder(node)) {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
                 });
                 std::vector<T> res;
                 int stepRes;
-                do{
+                do {
                     stepRes = sqlite3_step(stmt);
-                    switch(stepRes){
-                        case SQLITE_ROW:{
+                    switch(stepRes) {
+                        case SQLITE_ROW: {
                             T obj;
                             auto index = 0;
-                            impl.table.for_each_column([&index, &obj, stmt] (auto &c) {
+                            impl.table.for_each_column([&index, &obj, stmt](auto &c) {
                                 using field_type = typename std::decay<decltype(c)>::type::field_type;
                                 auto value = row_extractor<field_type>().extract(stmt, index++);
-                                if(c.member_pointer){
+                                if(c.member_pointer) {
                                     obj.*c.member_pointer = std::move(value);
-                                }else{
+                                } else {
                                     ((obj).*(c.setter))(std::move(value));
                                 }
                             });
                             res.push_back(std::move(obj));
-                        }break;
-                        case SQLITE_DONE: break;
-                        default:{
-                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                        } break;
+                        case SQLITE_DONE:
+                            break;
+                        default: {
+                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                    sqlite3_errmsg(db));
                         }
                     }
-                }while(stepRes != SQLITE_DONE);
+                } while(stepRes != SQLITE_DONE);
                 return res;
             }
-            template<class T, class ...Args>
-            std::vector<std::unique_ptr<T>> execute(const prepared_statement_t<get_all_pointer_t<T, Args...>> &statement) {
+            template<class T, class... Args>
+            std::vector<std::unique_ptr<T>>
+            execute(const prepared_statement_t<get_all_pointer_t<T, Args...>> &statement) {
                 auto &impl = this->get_impl<T>();
                 auto con = this->get_connection();
                 auto db = con.get();
                 auto stmt = statement.stmt;
                 auto index = 1;
                 sqlite3_reset(stmt);
-                iterate_ast(statement.t, [stmt, &index, db](auto &node){
+                iterate_ast(statement.t, [stmt, &index, db](auto &node) {
                     using node_type = typename std::decay<decltype(node)>::type;
                     conditional_binder<node_type, is_bindable<node_type>> binder{stmt, index};
-                    if(SQLITE_OK != binder(node)){
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                    if(SQLITE_OK != binder(node)) {
+                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                sqlite3_errmsg(db));
                     }
                 });
                 std::vector<std::unique_ptr<T>> res;
                 int stepRes;
-                do{
+                do {
                     stepRes = sqlite3_step(stmt);
-                    switch(stepRes){
-                        case SQLITE_ROW:{
+                    switch(stepRes) {
+                        case SQLITE_ROW: {
                             auto obj = std::make_unique<T>();
                             auto index = 0;
-                            impl.table.for_each_column([&index, &obj, stmt] (auto &c) {
+                            impl.table.for_each_column([&index, &obj, stmt](auto &c) {
                                 using field_type = typename std::decay<decltype(c)>::type::field_type;
                                 auto value = row_extractor<field_type>().extract(stmt, index++);
-                                if(c.member_pointer){
+                                if(c.member_pointer) {
                                     (*obj).*c.member_pointer = std::move(value);
-                                }else{
+                                } else {
                                     ((*obj).*(c.setter))(std::move(value));
                                 }
                             });
                             res.push_back(std::move(obj));
-                        }break;
-                        case SQLITE_DONE: break;
-                        default:{
-                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), sqlite3_errmsg(db));
+                        } break;
+                        case SQLITE_DONE:
+                            break;
+                        default: {
+                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                                    sqlite3_errmsg(db));
                         }
                     }
-                }while(stepRes != SQLITE_DONE);
+                } while(stepRes != SQLITE_DONE);
                 return res;
             }
         };
-        
+
         template<class T>
         struct is_storage : std::false_type {};
-        
-        template<class ...Ts>
+
+        template<class... Ts>
         struct is_storage<storage_t<Ts...>> : std::true_type {};
     }
-    
-    template<class ...Ts>
-    internal::storage_t<Ts...> make_storage(const std::string &filename, Ts ...tables) {
+
+    template<class... Ts>
+    internal::storage_t<Ts...> make_storage(const std::string &filename, Ts... tables) {
         return {filename, internal::storage_impl<Ts...>(tables...)};
     }
-    
+
     /**
      *  sqlite3_threadsafe() interface.
      */
@@ -10920,12 +11109,12 @@ namespace sqlite_orm {
 #pragma once
 
 #if defined(_MSC_VER)
-# if defined(__RESTORE_MIN__)
+#if defined(__RESTORE_MIN__)
 __pragma(pop_macro("min"))
-# undef __RESTORE_MIN__
-# endif
-# if defined(__RESTORE_MAX__)
-__pragma(pop_macro("max"))
-# undef __RESTORE_MAX__
-# endif
-#endif // defined(_MSC_VER)
+#undef __RESTORE_MIN__
+#endif
+#if defined(__RESTORE_MAX__)
+    __pragma(pop_macro("max"))
+#undef __RESTORE_MAX__
+#endif
+#endif  // defined(_MSC_VER)

--- a/tests/backup_tests.cpp
+++ b/tests/backup_tests.cpp
@@ -1,6 +1,6 @@
 #include <sqlite_orm/sqlite_orm.h>
 #include <catch2/catch.hpp>
-#include <cstdio>   //  remove
+#include <cstdio>  //  remove
 
 using namespace sqlite_orm;
 
@@ -9,7 +9,7 @@ namespace BackupTests {
         int id = 0;
         std::string name;
     };
-    
+
     bool operator==(const User &lhs, const User &rhs) {
         return lhs.id == rhs.id && lhs.name == rhs.name;
     }
@@ -19,11 +19,10 @@ TEST_CASE("backup") {
     using namespace BackupTests;
     using Catch::Matchers::UnorderedEquals;
     const std::string usersTableName = "users";
-    auto makeStorage = [&usersTableName](const std::string &filename){
-        return make_storage(filename,
-                            make_table(usersTableName,
-                                       make_column("id", &User::id, primary_key()),
-                                       make_column("name", &User::name)));
+    auto makeStorage = [&usersTableName](const std::string &filename) {
+        return make_storage(
+            filename,
+            make_table(usersTableName, make_column("id", &User::id, primary_key()), make_column("name", &User::name)));
     };
     const std::string backupFilename = "backup.sqlite";
     SECTION("to") {
@@ -47,9 +46,9 @@ TEST_CASE("backup") {
         }
         SECTION("filename step 1") {
             auto backup = storage.make_backup_to(backupFilename);
-            do{
+            do {
                 backup.step(1);
-            }while(backup.remaining() > 0);
+            } while(backup.remaining() > 0);
         }
         SECTION("storage step -1") {
             auto backup = storage.make_backup_to(storage2);
@@ -57,9 +56,9 @@ TEST_CASE("backup") {
         }
         SECTION("storage step 1") {
             auto backup = storage.make_backup_to(storage2);
-            do{
+            do {
                 backup.step(1);
-            }while(backup.remaining() > 0);
+            } while(backup.remaining() > 0);
         }
         REQUIRE(storage2.table_exists(usersTableName));
         auto rowsFromBackup = storage2.get_all<User>();
@@ -83,9 +82,9 @@ TEST_CASE("backup") {
         }
         SECTION("filename step 1") {
             auto backup = storage2.make_backup_from(backupFilename);
-            do{
+            do {
                 backup.step(1);
-            }while(backup.remaining() > 0);
+            } while(backup.remaining() > 0);
         }
         SECTION("storage") {
             storage2.backup_from(storage);
@@ -96,9 +95,9 @@ TEST_CASE("backup") {
         }
         SECTION("storage step -1") {
             auto backup = storage2.make_backup_from(storage);
-            do{
+            do {
                 backup.step(1);
-            }while(backup.remaining() > 0);
+            } while(backup.remaining() > 0);
         }
         REQUIRE(storage2.table_exists(usersTableName));
         auto rowsFromBackup = storage2.get_all<User>();

--- a/tests/composite_key.cpp
+++ b/tests/composite_key.cpp
@@ -3,13 +3,13 @@
 
 using namespace sqlite_orm;
 
-TEST_CASE("Composite key"){
+TEST_CASE("Composite key") {
     struct Record {
         int year = 0;
         int month = 0;
         int amount = 0;
     };
-    
+
     auto recordsTableName = "records";
     auto storage = make_storage({},
                                 make_table(recordsTableName,
@@ -17,10 +17,10 @@ TEST_CASE("Composite key"){
                                            make_column("month", &Record::month),
                                            make_column("amount", &Record::amount),
                                            primary_key(&Record::year, &Record::month)));
-    
+
     storage.sync_schema();
     REQUIRE(storage.sync_schema().at(recordsTableName) == sqlite_orm::sync_schema_result::already_in_sync);
-    
+
     //  after #18
     SECTION("Repeat sync") {
         auto storage2 = make_storage("",
@@ -31,7 +31,7 @@ TEST_CASE("Composite key"){
                                                 primary_key(&Record::month, &Record::year)));
         storage2.sync_schema();
         REQUIRE(storage2.sync_schema().at(recordsTableName) == sqlite_orm::sync_schema_result::already_in_sync);
-        
+
         auto storage3 = make_storage("",
                                      make_table(recordsTableName,
                                                 make_column("year", &Record::year),
@@ -41,18 +41,18 @@ TEST_CASE("Composite key"){
         storage3.sync_schema();
         REQUIRE(storage3.sync_schema().at(recordsTableName) == sqlite_orm::sync_schema_result::already_in_sync);
     }
-    
+
     //  after #348
     SECTION("get & get_pointer") {
         storage.replace(Record{1, 2, 3});
-        
+
         REQUIRE(storage.count<Record>() == 1);
-        
+
         auto record = storage.get<Record>(1, 2);
         REQUIRE(record.year == 1);
         REQUIRE(record.month == 2);
         REQUIRE(record.amount == 3);
-        
+
         auto recordPointer = storage.get_pointer<Record>(1, 2);
         REQUIRE(recordPointer);
     }

--- a/tests/core_functions_tests.cpp
+++ b/tests/core_functions_tests.cpp
@@ -3,19 +3,17 @@
 
 using namespace sqlite_orm;
 
-TEST_CASE("substr"){
+TEST_CASE("substr") {
     struct Test {
         std::string text;
         int x = 0;
         int y = 0;
     };
-    auto storage = make_storage({},
-                                make_table("test",
-                                           make_column("text", &Test::text),
-                                           make_column("x", &Test::x),
-                                           make_column("y", &Test::y)));
+    auto storage = make_storage(
+        {},
+        make_table("test", make_column("text", &Test::text), make_column("x", &Test::x), make_column("y", &Test::y)));
     storage.sync_schema();
-    
+
     {
         auto rows = storage.select(substr("SQLite substr", 8));
         REQUIRE(rows.size() == 1);
@@ -34,7 +32,7 @@ TEST_CASE("substr"){
         REQUIRE(rows.front() == "SQLite");
     }
     {
-        
+
         storage.remove_all<Test>();
         storage.insert(Test{"SQLite substr", 1, 6});
         REQUIRE(storage.count<Test>() == 1);
@@ -44,16 +42,14 @@ TEST_CASE("substr"){
     }
 }
 
-TEST_CASE("zeroblob"){
+TEST_CASE("zeroblob") {
     struct Test {
         int value = 0;
     };
-    
-    auto storage = make_storage({},
-                                make_table("test",
-                                           make_column("value", &Test::value)));
+
+    auto storage = make_storage({}, make_table("test", make_column("value", &Test::value)));
     storage.sync_schema();
-    
+
     {
         auto rows = storage.select(zeroblob(10));
         REQUIRE(rows.size() == 1);
@@ -65,7 +61,7 @@ TEST_CASE("zeroblob"){
     }
     {
         storage.insert(Test{100});
-        
+
         auto rows = storage.select(zeroblob(&Test::value));
         REQUIRE(rows.size() == 1);
         auto &row = rows.front();
@@ -76,20 +72,18 @@ TEST_CASE("zeroblob"){
     }
 }
 
-TEST_CASE("julianday"){
+TEST_CASE("julianday") {
     struct Test {
         std::string text;
     };
-    
-    auto storage = make_storage({},
-                                make_table("test",
-                                           make_column("text", &Test::text)));
+
+    auto storage = make_storage({}, make_table("test", make_column("text", &Test::text)));
     storage.sync_schema();
-    auto singleTestCase = [&storage](const std::string &arg, double expected){
+    auto singleTestCase = [&storage](const std::string &arg, double expected) {
         {
             auto rows = storage.select(julianday(arg));
             REQUIRE(rows.size() == 1);
-            REQUIRE((rows.front() - expected) < 0.001); //  too much precision
+            REQUIRE((rows.front() - expected) < 0.001);  //  too much precision
         }
         {
             storage.insert(Test{arg});
@@ -104,14 +98,14 @@ TEST_CASE("julianday"){
     singleTestCase("2016-10-18 16:45:30", 2457680.19826389);
 }
 
-TEST_CASE("datetime"){
+TEST_CASE("datetime") {
     auto storage = make_storage({});
     auto rows = storage.select(datetime("now"));
     REQUIRE(rows.size() == 1);
     REQUIRE(!rows.front().empty());
 }
 
-TEST_CASE("date"){
+TEST_CASE("date") {
     auto storage = make_storage({});
     auto rows = storage.select(date("now", "start of month", "+1 month", "-1 day"));
     REQUIRE(rows.size() == 1);
@@ -119,73 +113,72 @@ TEST_CASE("date"){
 }
 
 #if SQLITE_VERSION_NUMBER >= 3007016
-TEST_CASE("char"){
+TEST_CASE("char") {
     auto storage = make_storage({});
-    auto rows = storage.select(char_(67,72,65,82));
+    auto rows = storage.select(char_(67, 72, 65, 82));
     REQUIRE(rows.size() == 1);
     REQUIRE(rows.front() == "CHAR");
 }
 #endif
 
-TEST_CASE("rtrim"){
+TEST_CASE("rtrim") {
     auto storage = make_storage({});
     auto rows = storage.select(rtrim("ototo   "));
     REQUIRE(rows.size() == 1);
     REQUIRE(rows.front() == "ototo");
-    
+
     rows = storage.select(rtrim("ototo   ", " "));
     REQUIRE(rows.size() == 1);
     REQUIRE(rows.front() == "ototo");
 }
 
-TEST_CASE("ltrim"){
+TEST_CASE("ltrim") {
     auto storage = make_storage({});
     auto rows = storage.select(ltrim("  ototo"));
     REQUIRE(rows.size() == 1);
     REQUIRE(rows.front() == "ototo");
-    
+
     rows = storage.select(ltrim("  ototo", " "));
     REQUIRE(rows.size() == 1);
     REQUIRE(rows.front() == "ototo");
 }
 
-TEST_CASE("trim"){
+TEST_CASE("trim") {
     auto storage = make_storage({});
     auto rows = storage.select(trim("   ototo   "));
     REQUIRE(rows.size() == 1);
     REQUIRE(rows.front() == "ototo");
-    
+
     rows = storage.select(trim("   ototo   ", " "));
     REQUIRE(rows.size() == 1);
     REQUIRE(rows.front() == "ototo");
 }
 
-TEST_CASE("upper"){
+TEST_CASE("upper") {
     auto storage = make_storage({});
     auto rows = storage.select(upper("ototo"));
     REQUIRE(rows.size() == 1);
     REQUIRE(rows.front() == "OTOTO");
 }
 
-TEST_CASE("lower"){
+TEST_CASE("lower") {
     auto storage = make_storage({});
     auto rows = storage.select(lower("OTOTO"));
     REQUIRE(rows.size() == 1);
     REQUIRE(rows.front() == "ototo");
 }
 
-TEST_CASE("length"){
+TEST_CASE("length") {
     auto storage = make_storage({});
     auto rows = storage.select(length("ototo"));
     REQUIRE(rows.size() == 1);
     REQUIRE(rows.front() == 5);
 }
 
-TEST_CASE("abs"){
+TEST_CASE("abs") {
     auto storage = make_storage({});
     auto rows = storage.select(sqlite_orm::abs(-10));
     REQUIRE(rows.size() == 1);
     REQUIRE(rows.front());
     REQUIRE(*rows.front() == 10);
 }
-

--- a/tests/dynamic_order_by.cpp
+++ b/tests/dynamic_order_by.cpp
@@ -10,7 +10,7 @@ TEST_CASE("Dynamic order by") {
         std::string lastName;
         long registerTime = 0;
     };
-    
+
     auto storage = make_storage({},
                                 make_table("users",
                                            make_column("id", &User::id, primary_key()),
@@ -18,76 +18,100 @@ TEST_CASE("Dynamic order by") {
                                            make_column("last_name", &User::lastName),
                                            make_column("register_time", &User::registerTime)));
     storage.sync_schema();
-    
+
     storage.replace(User{1, "Jack", "Johnson", 100});
     storage.replace(User{2, "John", "Jackson", 90});
     storage.replace(User{3, "Elena", "Alexandra", 80});
     storage.replace(User{4, "Kaye", "Styles", 70});
-    
+
     auto orderBy = dynamic_order_by(storage);
     std::vector<decltype(User::id)> expectedIds;
-    
+
     SECTION("id") {
         orderBy.push_back(order_by(&User::id));
         expectedIds = {
-            1, 2, 3, 4,
+            1,
+            2,
+            3,
+            4,
         };
     }
-    
+
     SECTION("id desc") {
         orderBy.push_back(order_by(&User::id).desc());
         expectedIds = {
-            4, 3, 2, 1,
+            4,
+            3,
+            2,
+            1,
         };
     }
-    
+
     SECTION("firstName") {
         orderBy.push_back(order_by(&User::firstName));
         expectedIds = {
-            3, 1, 2, 4,
+            3,
+            1,
+            2,
+            4,
         };
     }
-    
+
     SECTION("firstName asc") {
         orderBy.push_back(order_by(&User::firstName).asc());
         expectedIds = {
-            3, 1, 2, 4,
+            3,
+            1,
+            2,
+            4,
         };
     }
-    
+
     SECTION("firstName desc") {
         orderBy.push_back(order_by(&User::firstName).desc());
         expectedIds = {
-            4, 2, 1, 3,
+            4,
+            2,
+            1,
+            3,
         };
     }
-    
+
     SECTION("firstName asc + id desc") {
         orderBy.push_back(order_by(&User::firstName).asc());
         orderBy.push_back(order_by(&User::id).desc());
         expectedIds = {
-            3, 1, 2, 4,
+            3,
+            1,
+            2,
+            4,
         };
     }
-    
+
     SECTION("lastName + firstName + id") {
         orderBy.push_back(order_by(&User::lastName));
         orderBy.push_back(order_by(&User::firstName));
         orderBy.push_back(order_by(&User::id));
         expectedIds = {
-            3, 2, 1, 4,
+            3,
+            2,
+            1,
+            4,
         };
     }
-    
+
     SECTION("lastName + firstName desc + id") {
         orderBy.push_back(order_by(&User::lastName));
         orderBy.push_back(order_by(&User::firstName).desc());
         orderBy.push_back(order_by(&User::id));
         expectedIds = {
-            3, 2, 1, 4,
+            3,
+            2,
+            1,
+            4,
         };
     }
-    
+
     auto rows = storage.get_all<User>(orderBy);
     REQUIRE(rows.size() == 4);
     for(auto i = 0; i < int(rows.size()); ++i) {

--- a/tests/explicit_columns.cpp
+++ b/tests/explicit_columns.cpp
@@ -3,80 +3,80 @@
 
 using namespace sqlite_orm;
 
-TEST_CASE("Explicit colums"){
+TEST_CASE("Explicit colums") {
     struct Object {
         int id;
     };
-    
+
     struct User : Object {
         std::string name;
-        
-        User(decltype(id) id_, decltype(name) name_): Object{id_}, name(std::move(name_)) {}
+
+        User(decltype(id) id_, decltype(name) name_) : Object{id_}, name(std::move(name_)) {}
     };
-    
+
     struct Token : Object {
         std::string token;
         int usedId;
-        
-        Token(decltype(id) id_, decltype(token) token_, decltype(usedId) usedId_): Object{id_}, token(std::move(token_)), usedId(usedId_) {}
+
+        Token(decltype(id) id_, decltype(token) token_, decltype(usedId) usedId_) :
+            Object{id_}, token(std::move(token_)), usedId(usedId_) {}
     };
-    
-    auto storage = make_storage("column_pointer.sqlite",
-                                make_table<User>("users",
-                                                 make_column("id", &User::id, primary_key()),
-                                                 make_column("name", &User::name)),
-                                make_table<Token>("tokens",
-                                                  make_column("id", &Token::id, primary_key()),
-                                                  make_column("token", &Token::token),
-                                                  make_column("used_id", &Token::usedId),
-                                                  foreign_key(&Token::usedId).references(column<User>(&User::id))));
+
+    auto storage = make_storage(
+        "column_pointer.sqlite",
+        make_table<User>("users", make_column("id", &User::id, primary_key()), make_column("name", &User::name)),
+        make_table<Token>("tokens",
+                          make_column("id", &Token::id, primary_key()),
+                          make_column("token", &Token::token),
+                          make_column("used_id", &Token::usedId),
+                          foreign_key(&Token::usedId).references(column<User>(&User::id))));
     storage.sync_schema();
     REQUIRE(storage.table_exists("users"));
     REQUIRE(storage.table_exists("tokens"));
-    
+
     storage.remove_all<Token>();
     storage.remove_all<User>();
-    
+
     auto brunoId = storage.insert(User{0, "Bruno"});
     auto zeddId = storage.insert(User{0, "Zedd"});
-    
+
     REQUIRE(storage.count<User>() == 2);
-    
+
     {
         auto w = where(is_equal(&User::name, "Bruno"));
-        
+
         {
             auto rows = storage.select(column<User>(&User::id), w);
             REQUIRE(rows.size() == 1);
             REQUIRE(rows.front() == brunoId);
         }
-        
+
         {
             auto rows2 = storage.select(columns(column<User>(&User::id)), w);
             REQUIRE(rows2.size() == 1);
             REQUIRE(std::get<0>(rows2.front()) == brunoId);
-            
+
             auto rows3 = storage.select(columns(column<User>(&Object::id)), w);
             REQUIRE(rows3 == rows2);
         }
     }
-    
+
     {
         auto rows = storage.select(column<User>(&User::id), where(is_equal(&User::name, "Zedd")));
         REQUIRE(rows.size() == 1);
         REQUIRE(rows.front() == zeddId);
     }
-    
+
     {
         auto abcId = storage.insert(Token(0, "abc", brunoId));
-        
+
         auto w = where(is_equal(&Token::token, "abc"));
         {
             auto rows = storage.select(column<Token>(&Token::id), w);
             REQUIRE(rows.size() == 1);
             REQUIRE(rows.front() == abcId);
         }
-        
+
         {
             auto rows2 = storage.select(columns(column<Token>(&Token::id), &Token::usedId), w);
             REQUIRE(rows2.size() == 1);
@@ -84,7 +84,7 @@ TEST_CASE("Explicit colums"){
             REQUIRE(std::get<1>(rows2.front()) == brunoId);
         }
     }
-    
+
     {
         auto joinedRows = storage.select(columns(&User::name, &Token::token),
                                          join<Token>(on(is_equal(&Token::usedId, column<User>(&User::id)))));

--- a/tests/operators.cpp
+++ b/tests/operators.cpp
@@ -3,30 +3,32 @@
 
 using namespace sqlite_orm;
 
-TEST_CASE("Operators"){
+TEST_CASE("Operators") {
     struct Object {
         std::string name;
         int nameLen;
         int number;
     };
-    
+
     auto storage = make_storage("",
                                 make_table("objects",
                                            make_column("name", &Object::name),
                                            make_column("name_len", &Object::nameLen),
                                            make_column("number", &Object::number)));
     storage.sync_schema();
-    
-    std::vector<std::string> names {
-        "Zombie", "Eminem", "Upside down",
+
+    std::vector<std::string> names{
+        "Zombie",
+        "Eminem",
+        "Upside down",
     };
     auto number = 10;
-    for(auto &name : names) {
-        storage.insert(Object{ name , int(name.length()), number });
+    for(auto &name: names) {
+        storage.insert(Object{name, int(name.length()), number});
     }
     {
         auto rows = storage.select(c(&Object::nameLen) + 1000);
-        for(size_t i = 0; i < rows.size(); ++i){
+        for(size_t i = 0; i < rows.size(); ++i) {
             auto &row = rows[i];
             auto &name = names[i];
             REQUIRE(int(row) == name.length() + 1000);
@@ -34,7 +36,7 @@ TEST_CASE("Operators"){
     }
     {
         auto rows = storage.select(columns(c(&Object::nameLen) + 1000));
-        for(size_t i = 0; i < rows.size(); ++i){
+        for(size_t i = 0; i < rows.size(); ++i) {
             auto &row = rows[i];
             auto &name = names[i];
             REQUIRE(int(std::get<0>(row)) == name.length() + 1000);
@@ -43,7 +45,7 @@ TEST_CASE("Operators"){
     {
         std::string suffix = "ototo";
         auto rows = storage.select(c(&Object::name) || suffix);
-        for(size_t i = 0; i < rows.size(); ++i){
+        for(size_t i = 0; i < rows.size(); ++i) {
             auto &row = rows[i];
             auto &name = names[i];
             REQUIRE(row == name + suffix);
@@ -51,8 +53,8 @@ TEST_CASE("Operators"){
     }
     {
         std::string suffix = "ototo";
-        auto rows = storage.select(columns(conc(&Object::name,  suffix)));
-        for(size_t i = 0; i < rows.size(); ++i){
+        auto rows = storage.select(columns(conc(&Object::name, suffix)));
+        for(size_t i = 0; i < rows.size(); ++i) {
             auto &row = rows[i];
             auto &name = names[i];
             REQUIRE(std::get<0>(row) == name + suffix);
@@ -64,31 +66,31 @@ TEST_CASE("Operators"){
                                            c(&Object::name) || suffix,
                                            &Object::name || c(suffix),
                                            c(&Object::name) || c(suffix),
-                                           
+
                                            add(&Object::nameLen, &Object::number),
                                            c(&Object::nameLen) + &Object::number,
                                            &Object::nameLen + c(&Object::number),
                                            c(&Object::nameLen) + c(&Object::number),
                                            c(&Object::nameLen) + 1000,
-                                           
+
                                            sub(&Object::nameLen, &Object::number),
                                            c(&Object::nameLen) - &Object::number,
                                            &Object::nameLen - c(&Object::number),
                                            c(&Object::nameLen) - c(&Object::number),
                                            c(&Object::nameLen) - 1000,
-                                           
+
                                            mul(&Object::nameLen, &Object::number),
                                            c(&Object::nameLen) * &Object::number,
                                            &Object::nameLen * c(&Object::number),
                                            c(&Object::nameLen) * c(&Object::number),
                                            c(&Object::nameLen) * 1000,
-                                           
+
                                            div(&Object::nameLen, &Object::number),
                                            c(&Object::nameLen) / &Object::number,
                                            &Object::nameLen / c(&Object::number),
                                            c(&Object::nameLen) / c(&Object::number),
                                            c(&Object::nameLen) / 2));
-        
+
         for(size_t i = 0; i < rows.size(); ++i) {
             auto &row = rows[i];
             auto &name = names[i];
@@ -96,7 +98,7 @@ TEST_CASE("Operators"){
             REQUIRE(std::get<1>(row) == std::get<0>(row));
             REQUIRE(std::get<2>(row) == std::get<1>(row));
             REQUIRE(std::get<3>(row) == std::get<2>(row));
-            
+
             auto expectedAddNumber = int(name.length()) + number;
             REQUIRE(std::get<4>(row) == expectedAddNumber);
             REQUIRE(std::get<5>(row) == std::get<4>(row));
@@ -106,21 +108,21 @@ TEST_CASE("Operators"){
                 auto &rowValue = std::get<8>(row);
                 REQUIRE(rowValue == int(name.length()) + 1000);
             }
-            
+
             auto expectedSubNumber = int(name.length()) - number;
             REQUIRE(std::get<9>(row) == expectedSubNumber);
             REQUIRE(std::get<10>(row) == std::get<9>(row));
             REQUIRE(std::get<11>(row) == std::get<10>(row));
             REQUIRE(std::get<12>(row) == std::get<11>(row));
             REQUIRE(std::get<13>(row) == int(name.length()) - 1000);
-            
+
             auto expectedMulNumber = int(name.length()) * number;
             REQUIRE(std::get<14>(row) == expectedMulNumber);
             REQUIRE(std::get<15>(row) == std::get<14>(row));
             REQUIRE(std::get<16>(row) == std::get<15>(row));
             REQUIRE(std::get<17>(row) == std::get<16>(row));
             REQUIRE(std::get<18>(row) == int(name.length()) * 1000);
-            
+
             auto expectedDivNumber = int(name.length()) / number;
             REQUIRE(std::get<19>(row) == expectedDivNumber);
             REQUIRE(std::get<20>(row) == std::get<19>(row));

--- a/tests/operators/cast.cpp
+++ b/tests/operators/cast.cpp
@@ -3,22 +3,22 @@
 
 using namespace sqlite_orm;
 
-TEST_CASE("Cast"){
+TEST_CASE("Cast") {
     struct Student {
         int id;
         float scoreFloat;
         std::string scoreString;
     };
-    
+
     auto storage = make_storage("",
                                 make_table("students",
                                            make_column("id", &Student::id, primary_key()),
                                            make_column("score_float", &Student::scoreFloat),
                                            make_column("score_str", &Student::scoreString)));
     storage.sync_schema();
-    
+
     storage.replace(Student{1, 10.1f, "14.5"});
-    
+
     {
         auto rows = storage.select(columns(cast<int>(&Student::scoreFloat), cast<int>(&Student::scoreString)));
         REQUIRE(rows.size() == 1);

--- a/tests/operators/glob.cpp
+++ b/tests/operators/glob.cpp
@@ -3,8 +3,8 @@
  */
 #include <sqlite_orm/sqlite_orm.h>
 #include <catch2/catch.hpp>
-#include <vector>   //  std::vector
-#include <algorithm>    //  std::find_if, std::count
+#include <vector>  //  std::vector
+#include <algorithm>  //  std::find_if, std::count
 
 using namespace sqlite_orm;
 
@@ -16,7 +16,7 @@ TEST_CASE("Glob") {
         float salary = 0;
         int deptId = 0;
     };
-    
+
     auto storage = make_storage({},
                                 make_table("emp_master",
                                            make_column("emp_id", &Employee::id, primary_key(), autoincrement()),
@@ -25,7 +25,7 @@ TEST_CASE("Glob") {
                                            make_column("salary", &Employee::salary),
                                            make_column("dept_id", &Employee::deptId)));
     storage.sync_schema();
-    
+
     std::vector<Employee> employees = {
         Employee{1, "Honey", "Patel", 10100, 1},
         Employee{2, "Shweta", "Jariwala", 19300, 2},
@@ -38,34 +38,34 @@ TEST_CASE("Glob") {
         Employee{9, "Shwets", "Jariwala", 19400, 2},
     };
     storage.replace_range(employees.begin(), employees.end());
-    
+
     auto expectIds = [](const std::vector<Employee> &employees, const std::vector<decltype(Employee::id)> ids) {
-        for(auto expectedId : ids) {
-            REQUIRE(find_if(employees.begin(), employees.end(), [expectedId](auto &employee){
-                return employee.id == expectedId;
-            }) != employees.end());
+        for(auto expectedId: ids) {
+            REQUIRE(find_if(employees.begin(), employees.end(), [expectedId](auto &employee) {
+                        return employee.id == expectedId;
+                    }) != employees.end());
         }
         return false;
     };
     {
         auto employees = storage.get_all<Employee>(where(glob(&Employee::salary, "1*")));
         REQUIRE(employees.size() == 6);
-        expectIds(employees, { 1, 2, 5, 6, 7, 9 });
+        expectIds(employees, {1, 2, 5, 6, 7, 9});
     }
     {
         auto employees = storage.get_all<Employee>(where(glob(&Employee::firstName, "Shwet?")));
         REQUIRE(employees.size() == 3);
-        expectIds(employees, { 2, 5, 9 });
+        expectIds(employees, {2, 5, 9});
     }
     {
         auto employees = storage.get_all<Employee>(where(glob(&Employee::lastName, "[A-J]*")));
         REQUIRE(employees.size() == 3);
-        expectIds(employees, { 2, 3, 9 });
+        expectIds(employees, {2, 3, 9});
     }
     {
         auto employees = storage.get_all<Employee>(where(glob(&Employee::lastName, "[^A-J]*")));
         REQUIRE(employees.size() == 6);
-        expectIds(employees, { 1, 4, 5, 6, 7, 8 });
+        expectIds(employees, {1, 4, 5, 6, 7, 8});
     }
     {
         auto rows = storage.select(glob(&Employee::firstName, "S*"));

--- a/tests/operators/in.cpp
+++ b/tests/operators/in.cpp
@@ -3,20 +3,18 @@
 
 using namespace sqlite_orm;
 
-TEST_CASE("In"){
+TEST_CASE("In") {
     {
         struct User {
             int id;
         };
-        
-        auto storage = make_storage("",
-                                    make_table("users",
-                                               make_column("id", &User::id, primary_key())));
+
+        auto storage = make_storage("", make_table("users", make_column("id", &User::id, primary_key())));
         storage.sync_schema();
-        storage.replace(User{ 1 });
-        storage.replace(User{ 2 });
-        storage.replace(User{ 3 });
-        
+        storage.replace(User{1});
+        storage.replace(User{2});
+        storage.replace(User{3});
+
         {
             auto rows = storage.get_all<User>(where(in(&User::id, {1, 2, 3})));
             REQUIRE(rows.size() == 3);
@@ -35,16 +33,15 @@ TEST_CASE("In"){
             int id;
             std::string name;
         };
-        auto storage = make_storage("",
-                                    make_table("letters",
-                                               make_column("id", &Letter::id, primary_key()),
-                                               make_column("name", &Letter::name)));
+        auto storage = make_storage(
+            "",
+            make_table("letters", make_column("id", &Letter::id, primary_key()), make_column("name", &Letter::name)));
         storage.sync_schema();
-        
+
         storage.replace(Letter{1, "A"});
         storage.replace(Letter{2, "B"});
         storage.replace(Letter{3, "C"});
-        
+
         {
             auto letters = storage.get_all<Letter>(where(in(&Letter::id, {1, 2, 3})));
             REQUIRE(letters.size() == 3);

--- a/tests/operators/like.cpp
+++ b/tests/operators/like.cpp
@@ -3,7 +3,7 @@
 
 using namespace sqlite_orm;
 
-TEST_CASE("Like operator"){
+TEST_CASE("Like operator") {
     struct User {
         int id = 0;
         std::string name;
@@ -11,19 +11,18 @@ TEST_CASE("Like operator"){
     struct Pattern {
         std::string value;
     };
-    
+
     auto storage = make_storage("",
                                 make_table("users",
                                            make_column("id", &User::id, autoincrement(), primary_key()),
                                            make_column("name", &User::name)),
-                                make_table("patterns",
-                                           make_column("value", &Pattern::value)));
+                                make_table("patterns", make_column("value", &Pattern::value)));
     storage.sync_schema();
-    
+
     storage.insert(User{0, "Sia"});
     storage.insert(User{0, "Stark"});
     storage.insert(User{0, "Index"});
-    
+
     auto whereCondition = where(like(&User::name, "S%"));
     {
         auto users = storage.get_all<User>(whereCondition);
@@ -46,11 +45,11 @@ TEST_CASE("Like operator"){
     {
         auto rows = storage.select(like(&User::name, "S%a"));
         REQUIRE(rows.size() == 3);
-        REQUIRE(count_if(rows.begin(), rows.end(), [](bool arg){
-            return arg == true;
-        }) == 1);
+        REQUIRE(count_if(rows.begin(), rows.end(), [](bool arg) {
+                    return arg == true;
+                }) == 1);
     }
-    
+
     storage.insert(Pattern{"o%o"});
     {
         auto rows = storage.select(like("ototo", &Pattern::value));

--- a/tests/pragma_tests.cpp
+++ b/tests/pragma_tests.cpp
@@ -1,10 +1,10 @@
 #include <sqlite_orm/sqlite_orm.h>
-#include <cstdio>   //  ::remove
+#include <cstdio>  //  ::remove
 #include <catch2/catch.hpp>
 
 using namespace sqlite_orm;
 
-TEST_CASE("Journal mode"){
+TEST_CASE("Journal mode") {
     auto filename = "journal_mode.sqlite";
     ::remove(filename);
     auto storage = make_storage(filename);
@@ -18,84 +18,84 @@ TEST_CASE("Journal mode"){
     }
     auto jm = stor->pragma.journal_mode();
     REQUIRE(jm == decltype(jm)::DELETE);
-    
-    for(auto i = 0; i < 2; ++i){
+
+    for(auto i = 0; i < 2; ++i) {
         if(i == 0) {
             stor->begin_transaction();
         }
         stor->pragma.journal_mode(journal_mode::MEMORY);
         jm = stor->pragma.journal_mode();
         REQUIRE(jm == decltype(jm)::MEMORY);
-        
-        if(i == 1) {    //  WAL cannot be set within a transaction
+
+        if(i == 1) {  //  WAL cannot be set within a transaction
             stor->pragma.journal_mode(journal_mode::WAL);
             jm = stor->pragma.journal_mode();
             REQUIRE(jm == decltype(jm)::WAL);
         }
-        
+
         stor->pragma.journal_mode(journal_mode::OFF);
         jm = stor->pragma.journal_mode();
         REQUIRE(jm == decltype(jm)::OFF);
-        
+
         stor->pragma.journal_mode(journal_mode::PERSIST);
         jm = stor->pragma.journal_mode();
         REQUIRE(jm == decltype(jm)::PERSIST);
-        
+
         stor->pragma.journal_mode(journal_mode::TRUNCATE);
         jm = stor->pragma.journal_mode();
         REQUIRE(jm == decltype(jm)::TRUNCATE);
-        
+
         if(i == 0) {
             stor->rollback();
         }
     }
 }
 
-TEST_CASE("Synchronous"){
+TEST_CASE("Synchronous") {
     auto storage = make_storage("");
     const auto value = 1;
     storage.pragma.synchronous(value);
     REQUIRE(storage.pragma.synchronous() == value);
-    
+
     storage.begin_transaction();
-    
+
     const auto newValue = 2;
-    try{
+    try {
         storage.pragma.synchronous(newValue);
         throw std::runtime_error("Must not fire");
-    }catch(const std::system_error&) {
+    } catch(const std::system_error &) {
         //  Safety level may not be changed inside a transaction
         REQUIRE(storage.pragma.synchronous() == value);
     }
-    
+
     storage.commit();
 }
 
-TEST_CASE("User version"){
+TEST_CASE("User version") {
     auto storage = make_storage("");
     auto version = storage.pragma.user_version();
-    
+
     storage.pragma.user_version(version + 1);
     REQUIRE(storage.pragma.user_version() == version + 1);
-    
+
     storage.begin_transaction();
     storage.pragma.user_version(version + 2);
     REQUIRE(storage.pragma.user_version() == version + 2);
     storage.commit();
 }
 
-TEST_CASE("Auto vacuum"){
+TEST_CASE("Auto vacuum") {
     auto filename = "autovacuum.sqlite";
     ::remove(filename);
-    
+
     auto storage = make_storage(filename);
-    
+
     storage.pragma.auto_vacuum(0);
     REQUIRE(storage.pragma.auto_vacuum() == 0);
-    
+
     storage.pragma.auto_vacuum(1);
     REQUIRE(storage.pragma.auto_vacuum() == 1);
-    
+
     storage.pragma.auto_vacuum(2);
     REQUIRE(storage.pragma.auto_vacuum() == 2);
 }

--- a/tests/prepared_statement_tests.cpp
+++ b/tests/prepared_statement_tests.cpp
@@ -1,6 +1,6 @@
 #include <sqlite_orm/sqlite_orm.h>
 #include <catch2/catch.hpp>
-#include <tuple>    //  std::ignore
+#include <tuple>  //  std::ignore
 
 using namespace sqlite_orm;
 
@@ -9,21 +9,21 @@ namespace PreparedStatementTests {
         int id = 0;
         std::string name;
     };
-    
+
     struct Visit {
         int id = 0;
         decltype(User::id) userId;
         long time = 0;
     };
-    
+
     bool operator==(const User &lhs, const User &rhs) {
         return lhs.id == rhs.id && lhs.name == rhs.name;
     }
-    
+
     bool operator!=(const User &lhs, const User &rhs) {
         return !(lhs == rhs);
     }
-    
+
     void testSerializing(const internal::prepared_statement_base &statement) {
         auto sql = statement.sql();
         std::ignore = sql;
@@ -39,9 +39,9 @@ namespace PreparedStatementTests {
 TEST_CASE("Prepared") {
     using namespace PreparedStatementTests;
     using Catch::Matchers::UnorderedEquals;
-    
+
     const int defaultVisitTime = 50;
-    
+
     remove("prepared.sqlite");
     auto storage = make_storage("prepared.sqlite",
                                 make_index("user_id_index", &User::id),
@@ -55,11 +55,11 @@ TEST_CASE("Prepared") {
                                            foreign_key(&Visit::userId).references(&User::id)));
     storage.sync_schema();
     storage.remove_all<User>();
-    
+
     storage.replace(User{1, "Team BS"});
     storage.replace(User{2, "Shy'm"});
     storage.replace(User{3, "Maître Gims"});
-    
+
     SECTION("select") {
         {
             for(auto i = 0; i < 2; ++i) {
@@ -99,7 +99,8 @@ TEST_CASE("Prepared") {
             }
         }
         {
-            auto statement = storage.prepare(select(&User::id, where(length(&User::name) > 5 and like(&User::name, "T%"))));
+            auto statement =
+                storage.prepare(select(&User::id, where(length(&User::name) > 5 and like(&User::name, "T%"))));
             testSerializing(statement);
             SECTION("nothing") {
                 //..
@@ -125,8 +126,8 @@ TEST_CASE("Prepared") {
             }
         }
         {
-            auto statement = storage.prepare(select(columns(&User::name, &User::id), where(is_equal(mod(&User::id, 2), 0)),
-                                                    order_by(&User::name)));
+            auto statement = storage.prepare(
+                select(columns(&User::name, &User::id), where(is_equal(mod(&User::id, 2), 0)), order_by(&User::name)));
             testSerializing(statement);
             SECTION("nothing") {
                 //..
@@ -240,7 +241,8 @@ TEST_CASE("Prepared") {
             storage.execute(statement);
         }
         SECTION("Two conditions") {
-            auto statement = storage.prepare(remove_all<User>(where(is_equal(&User::name, "Shy'm") and lesser_than(&User::id, 10))));
+            auto statement =
+                storage.prepare(remove_all<User>(where(is_equal(&User::name, "Shy'm") and lesser_than(&User::id, 10))));
             testSerializing(statement);
             storage.execute(statement);
         }
@@ -294,7 +296,7 @@ TEST_CASE("Prepared") {
                 try {
                     auto user = storage.execute(statement);
                     REQUIRE(false);
-                } catch (const std::system_error &e) {
+                } catch(const std::system_error &e) {
                     //..
                 }
             }
@@ -518,7 +520,7 @@ TEST_CASE("Prepared") {
             storage.execute(statement);
             auto rows = storage.get_all<User>();
             REQUIRE_THAT(rows, UnorderedEquals(expected));
-            
+
             user = {5, "LP"};
             expected.push_back(user);
             storage.execute(statement);
@@ -541,7 +543,7 @@ TEST_CASE("Prepared") {
             storage.execute(statement);
             auto rows = storage.get_all<User>();
             REQUIRE_THAT(rows, UnorderedEquals(expected));
-            
+
             user = {5, "LP"};
             storage.execute(statement);
         }
@@ -554,11 +556,11 @@ TEST_CASE("Prepared") {
         expected.push_back(User{1, "Team BS"});
         expected.push_back(User{2, "Shy'm"});
         expected.push_back(User{3, "Maître Gims"});
-        SECTION("empty"){
+        SECTION("empty") {
             try {
                 auto statement = storage.prepare(insert_range(users.begin(), users.end()));
                 REQUIRE(false);
-            } catch (const std::system_error &e) {
+            } catch(const std::system_error &e) {
                 //..
             }
         }
@@ -592,7 +594,7 @@ TEST_CASE("Prepared") {
             try {
                 auto statement = storage.prepare(replace_range(users.begin(), users.end()));
                 REQUIRE(false);
-            } catch (const std::system_error &e) {
+            } catch(const std::system_error &e) {
                 //..
             }
         }
@@ -656,12 +658,12 @@ TEST_CASE("Prepared") {
                 {
                     user.id = 6;
                     user.name = "Nate Dogg";
-                    try{
+                    try {
                         storage.execute(statement);
                         REQUIRE(false);
-                    }catch(const std::system_error &e) {
+                    } catch(const std::system_error &e) {
                         //..
-                    }catch(...){
+                    } catch(...) {
                         REQUIRE(false);
                     }
                 }
@@ -681,7 +683,7 @@ TEST_CASE("Prepared") {
                 REQUIRE(insertedId == visit.id);
             }
             {
-                Visit visit{2, 1, defaultVisitTime + 1};    //  time must differ
+                Visit visit{2, 1, defaultVisitTime + 1};  //  time must differ
                 auto statement = storage.prepare(insert(visit, columns(&Visit::id, &Visit::userId)));
                 auto insertedId = storage.execute(statement);
                 REQUIRE(insertedId == visit.id);

--- a/tests/private_getters_tests.cpp
+++ b/tests/private_getters_tests.cpp
@@ -4,48 +4,47 @@
 
 using namespace sqlite_orm;
 
-TEST_CASE("Issue 343"){
-    
+TEST_CASE("Issue 343") {
+
     class A {
-    public:
+      public:
         A() = default;
-        
+
         A(int id_, std::string name_) : name(move(name_)), id(id_) {}
-        
+
         int getId() const {
             return this->id;
         }
-        
+
         void setId(int id) {
             this->id = id;
         }
-        
+
         std::string name;
-    private:
+
+      private:
         int id = 0;
     };
-    
-    auto storage = make_storage({},
-                                make_table("a",
-                                           make_column("role", &A::getId, &A::setId, primary_key()),
-                                           make_column("name", &A::name)));
+
+    auto storage = make_storage(
+        {},
+        make_table("a", make_column("role", &A::getId, &A::setId, primary_key()), make_column("name", &A::name)));
     storage.sync_schema();
-    
+
     A object(1, "Ototo");
     storage.insert(object);
-    
+
     storage.replace(object);
-    
+
     storage.update(object);
-    
+
     storage.remove<A>(object.getId());
-    
+
     std::vector<A> vec{object};
     storage.insert_range(vec.begin(), vec.end());
-    
+
     storage.replace_range(vec.begin(), vec.end());
-    
+
     auto all = storage.get_all<A>();
     std::ignore = all;
-    
 }

--- a/tests/simple_query.cpp
+++ b/tests/simple_query.cpp
@@ -3,7 +3,7 @@
 
 using namespace sqlite_orm;
 
-TEST_CASE("Simple query"){
+TEST_CASE("Simple query") {
     auto storage = make_storage("");
     {
         //  SELECT 1
@@ -22,7 +22,7 @@ TEST_CASE("Simple query"){
         auto two = storage.select(c(1) + 1);
         REQUIRE(two.size() == 1);
         REQUIRE(two.front() == 2);
-        
+
         auto twoAgain = storage.select(add(1, 1));
         REQUIRE(two == twoAgain);
     }

--- a/tests/static_tests.cpp
+++ b/tests/static_tests.cpp
@@ -8,27 +8,27 @@ using namespace sqlite_orm;
 
 struct User {
     int id;
-    
-    const int& getIdByRefConst() const {
+
+    const int &getIdByRefConst() const {
         return this->id;
     }
-    
-    const int& getIdByRef() {
+
+    const int &getIdByRef() {
         return this->id;
     }
-    
+
     int getIdByValConst() const {
         return this->id;
     }
-    
+
     void setIdByVal(int id) {
         this->id = id;
     }
-    
+
     void setIdByConstRef(const int &id) {
         this->id = id;
     }
-    
+
     void setIdByRef(int &id) {
         this->id = id;
     }
@@ -38,9 +38,7 @@ struct Object {
     int id;
 };
 
-struct Token : Object {
-    
-};
+struct Token : Object {};
 
 TEST_CASE("Column") {
     {
@@ -49,8 +47,9 @@ TEST_CASE("Column") {
         static_assert(std::is_same<column_type::object_type, User>::value, "Incorrect object_type");
         static_assert(std::is_same<column_type::field_type, int>::value, "Incorrect field_type");
         static_assert(std::is_same<column_type::member_pointer_t, int User::*>::value, "Incorrect member pointer type");
-        static_assert(std::is_same<column_type::getter_type, const int&(User::*)() const>::value, "Incorrect getter_type");
-        static_assert(std::is_same<column_type::setter_type, void(User::*)(int)>::value, "Incorrect setter_type");
+        static_assert(std::is_same<column_type::getter_type, const int &(User::*)() const>::value,
+                      "Incorrect getter_type");
+        static_assert(std::is_same<column_type::setter_type, void (User::*)(int)>::value, "Incorrect setter_type");
     }
     {
         using column_type = decltype(make_column("id", &User::getIdByRefConst, &User::setIdByVal));
@@ -58,8 +57,9 @@ TEST_CASE("Column") {
         static_assert(std::is_same<column_type::object_type, User>::value, "Incorrect object_type");
         static_assert(std::is_same<column_type::field_type, int>::value, "Incorrect field_type");
         static_assert(std::is_same<column_type::member_pointer_t, int User::*>::value, "Incorrect member pointer type");
-        static_assert(std::is_same<column_type::getter_type, const int&(User::*)() const>::value, "Incorrect getter_type");
-        static_assert(std::is_same<column_type::setter_type, void(User::*)(int)>::value, "Incorrect setter_type");
+        static_assert(std::is_same<column_type::getter_type, const int &(User::*)() const>::value,
+                      "Incorrect getter_type");
+        static_assert(std::is_same<column_type::setter_type, void (User::*)(int)>::value, "Incorrect setter_type");
     }
     {
         using column_type = decltype(make_column("id", &User::setIdByVal, &User::getIdByRefConst));
@@ -67,8 +67,9 @@ TEST_CASE("Column") {
         static_assert(std::is_same<column_type::object_type, User>::value, "Incorrect object_type");
         static_assert(std::is_same<column_type::field_type, int>::value, "Incorrect field_type");
         static_assert(std::is_same<column_type::member_pointer_t, int User::*>::value, "Incorrect member pointer type");
-        static_assert(std::is_same<column_type::getter_type, const int&(User::*)() const>::value, "Incorrect getter_type");
-        static_assert(std::is_same<column_type::setter_type, void(User::*)(int)>::value, "Incorrect setter_type");
+        static_assert(std::is_same<column_type::getter_type, const int &(User::*)() const>::value,
+                      "Incorrect getter_type");
+        static_assert(std::is_same<column_type::setter_type, void (User::*)(int)>::value, "Incorrect setter_type");
     }
     {
         using column_type = decltype(make_column("id", &User::getIdByRef, &User::setIdByConstRef));
@@ -76,8 +77,9 @@ TEST_CASE("Column") {
         static_assert(std::is_same<column_type::object_type, User>::value, "Incorrect object_type");
         static_assert(std::is_same<column_type::field_type, int>::value, "Incorrect field_type");
         static_assert(std::is_same<column_type::member_pointer_t, int User::*>::value, "Incorrect member pointer type");
-        static_assert(std::is_same<column_type::getter_type, const int&(User::*)()>::value, "Incorrect getter_type");
-        static_assert(std::is_same<column_type::setter_type, void(User::*)(const int&)>::value, "Incorrect setter_type");
+        static_assert(std::is_same<column_type::getter_type, const int &(User::*)()>::value, "Incorrect getter_type");
+        static_assert(std::is_same<column_type::setter_type, void (User::*)(const int &)>::value,
+                      "Incorrect setter_type");
     }
     {
         using column_type = decltype(make_column("id", &User::setIdByConstRef, &User::getIdByRef));
@@ -85,8 +87,9 @@ TEST_CASE("Column") {
         static_assert(std::is_same<column_type::object_type, User>::value, "Incorrect object_type");
         static_assert(std::is_same<column_type::field_type, int>::value, "Incorrect field_type");
         static_assert(std::is_same<column_type::member_pointer_t, int User::*>::value, "Incorrect member pointer type");
-        static_assert(std::is_same<column_type::getter_type, const int&(User::*)()>::value, "Incorrect getter_type");
-        static_assert(std::is_same<column_type::setter_type, void(User::*)(const int&)>::value, "Incorrect setter_type");
+        static_assert(std::is_same<column_type::getter_type, const int &(User::*)()>::value, "Incorrect getter_type");
+        static_assert(std::is_same<column_type::setter_type, void (User::*)(const int &)>::value,
+                      "Incorrect setter_type");
     }
     {
         using column_type = decltype(make_column("id", &User::getIdByValConst, &User::setIdByRef));
@@ -94,8 +97,8 @@ TEST_CASE("Column") {
         static_assert(std::is_same<column_type::object_type, User>::value, "Incorrect object_type");
         static_assert(std::is_same<column_type::field_type, int>::value, "Incorrect field_type");
         static_assert(std::is_same<column_type::member_pointer_t, int User::*>::value, "Incorrect member pointer type");
-        static_assert(std::is_same<column_type::getter_type, int(User::*)() const>::value, "Incorrect getter_type");
-        static_assert(std::is_same<column_type::setter_type, void(User::*)(int&)>::value, "Incorrect setter_type");
+        static_assert(std::is_same<column_type::getter_type, int (User::*)() const>::value, "Incorrect getter_type");
+        static_assert(std::is_same<column_type::setter_type, void (User::*)(int &)>::value, "Incorrect setter_type");
     }
     {
         using column_type = decltype(make_column("id", &User::setIdByRef, &User::getIdByValConst));
@@ -103,8 +106,8 @@ TEST_CASE("Column") {
         static_assert(std::is_same<column_type::object_type, User>::value, "Incorrect object_type");
         static_assert(std::is_same<column_type::field_type, int>::value, "Incorrect field_type");
         static_assert(std::is_same<column_type::member_pointer_t, int User::*>::value, "Incorrect member pointer type");
-        static_assert(std::is_same<column_type::getter_type, int(User::*)() const>::value, "Incorrect getter_type");
-        static_assert(std::is_same<column_type::setter_type, void(User::*)(int&)>::value, "Incorrect setter_type");
+        static_assert(std::is_same<column_type::getter_type, int (User::*)() const>::value, "Incorrect getter_type");
+        static_assert(std::is_same<column_type::setter_type, void (User::*)(int &)>::value, "Incorrect setter_type");
     }
     {
         using column_type = decltype(column<Token>(&Token::id));
@@ -112,7 +115,8 @@ TEST_CASE("Column") {
         using field_type = column_type::field_type;
         static_assert(std::is_same<field_type, decltype(&Object::id)>::value, "Incorrect field type");
         static_assert(std::is_same<internal::table_type<field_type>::type, Object>::value, "Incorrect mapped type");
-        static_assert(std::is_same<internal::column_result_t<internal::storage_t<>, field_type>::type, int>::value, "Incorrect field type");
+        static_assert(std::is_same<internal::column_result_t<internal::storage_t<>, field_type>::type, int>::value,
+                      "Incorrect field type");
         static_assert(std::is_member_pointer<field_type>::value, "Field type is not a member pointer");
         static_assert(!std::is_member_function_pointer<field_type>::value, "Field type is not a member pointer");
     }
@@ -122,125 +126,165 @@ TEST_CASE("Aggregate function return types") {
     struct User {
         int id;
         std::string name;
-        
+
         int getIdByValConst() const {
             return this->id;
         }
-        
+
         void setIdByVal(int id) {
             this->id = id;
         }
-        
+
         std::string getNameByVal() {
             return this->name;
         }
-        
+
         void setNameByConstRef(const std::string &name) {
             this->name = name;
         }
-        
-        const int& getConstIdByRefConst() const {
+
+        const int &getConstIdByRefConst() const {
             return this->id;
         }
-        
+
         void setIdByRef(int &id) {
             this->id = id;
         }
-        
-        const std::string& getConstNameByRefConst() const {
+
+        const std::string &getConstNameByRefConst() const {
             return this->name;
         }
-        
+
         void setNameByRef(std::string &name) {
             this->name = std::move(name);
         }
     };
     const std::string filename = "static_tests.sqlite";
-    auto storage0 = make_storage(filename,
-                                 make_table("users",
-                                            make_column("id", &User::id, primary_key()),
-                                            make_column("name", &User::name)));
+    auto storage0 = make_storage(
+        filename,
+        make_table("users", make_column("id", &User::id, primary_key()), make_column("name", &User::name)));
     auto storage1 = make_storage(filename,
                                  make_table("users",
                                             make_column("id", &User::getIdByValConst, &User::setIdByVal, primary_key()),
                                             make_column("name", &User::setNameByConstRef, &User::getNameByVal)));
-    auto storage2 = make_storage(filename,
-                                 make_table("users",
-                                            make_column("id", &User::getConstIdByRefConst, &User::setIdByRef, primary_key()),
-                                            make_column("name", &User::getConstNameByRefConst, &User::setNameByRef)));
+    auto storage2 =
+        make_storage(filename,
+                     make_table("users",
+                                make_column("id", &User::getConstIdByRefConst, &User::setIdByRef, primary_key()),
+                                make_column("name", &User::getConstNameByRefConst, &User::setNameByRef)));
     static_assert(std::is_same<decltype(storage0.max(&User::id))::element_type, int>::value, "Incorrect max value");
-    static_assert(std::is_same<decltype(storage1.max(&User::getIdByValConst))::element_type, int>::value, "Incorrect max value");
-    static_assert(std::is_same<decltype(storage1.max(&User::setIdByVal))::element_type, int>::value, "Incorrect max value");
-    static_assert(std::is_same<decltype(storage2.max(&User::getConstIdByRefConst))::element_type, int>::value, "Incorrect max value");
-    static_assert(std::is_same<decltype(storage2.max(&User::setIdByRef))::element_type, int>::value, "Incorrect max value");
-    
-    static_assert(std::is_same<decltype(storage0.max(&User::id, where(lesser_than(&User::id, 10))))::element_type, int>::value,
+    static_assert(std::is_same<decltype(storage1.max(&User::getIdByValConst))::element_type, int>::value,
                   "Incorrect max value");
-    static_assert(std::is_same<decltype(storage1.max(&User::getIdByValConst, where(lesser_than(&User::id, 10))))::element_type, int>::value,
+    static_assert(std::is_same<decltype(storage1.max(&User::setIdByVal))::element_type, int>::value,
                   "Incorrect max value");
-    static_assert(std::is_same<decltype(storage1.max(&User::setIdByVal, where(lesser_than(&User::id, 10))))::element_type, int>::value,
+    static_assert(std::is_same<decltype(storage2.max(&User::getConstIdByRefConst))::element_type, int>::value,
                   "Incorrect max value");
-    static_assert(std::is_same<decltype(storage2.max(&User::getConstIdByRefConst, where(lesser_than(&User::id, 10))))::element_type, int>::value,
+    static_assert(std::is_same<decltype(storage2.max(&User::setIdByRef))::element_type, int>::value,
                   "Incorrect max value");
-    static_assert(std::is_same<decltype(storage2.max(&User::setIdByRef, where(lesser_than(&User::id, 10))))::element_type, int>::value,
+
+    static_assert(
+        std::is_same<decltype(storage0.max(&User::id, where(lesser_than(&User::id, 10))))::element_type, int>::value,
+        "Incorrect max value");
+    static_assert(
+        std::is_same<decltype(storage1.max(&User::getIdByValConst, where(lesser_than(&User::id, 10))))::element_type,
+                     int>::value,
+        "Incorrect max value");
+    static_assert(
+        std::is_same<decltype(storage1.max(&User::setIdByVal, where(lesser_than(&User::id, 10))))::element_type,
+                     int>::value,
+        "Incorrect max value");
+    static_assert(std::is_same<decltype(storage2.max(&User::getConstIdByRefConst,
+                                                     where(lesser_than(&User::id, 10))))::element_type,
+                               int>::value,
                   "Incorrect max value");
-    
+    static_assert(
+        std::is_same<decltype(storage2.max(&User::setIdByRef, where(lesser_than(&User::id, 10))))::element_type,
+                     int>::value,
+        "Incorrect max value");
+
     static_assert(std::is_same<decltype(storage0.min(&User::id))::element_type, int>::value, "Incorrect min value");
-    static_assert(std::is_same<decltype(storage1.min(&User::getIdByValConst))::element_type, int>::value, "Incorrect min value");
-    static_assert(std::is_same<decltype(storage1.min(&User::setIdByVal))::element_type, int>::value, "Incorrect min value");
-    static_assert(std::is_same<decltype(storage2.min(&User::getConstIdByRefConst))::element_type, int>::value, "Incorrect min value");
-    static_assert(std::is_same<decltype(storage2.min(&User::setIdByRef))::element_type, int>::value, "Incorrect min value");
-    
-    static_assert(std::is_same<decltype(storage0.min(&User::id, where(lesser_than(&User::id, 10))))::element_type, int>::value,
+    static_assert(std::is_same<decltype(storage1.min(&User::getIdByValConst))::element_type, int>::value,
                   "Incorrect min value");
-    static_assert(std::is_same<decltype(storage1.min(&User::getIdByValConst, where(lesser_than(&User::id, 10))))::element_type, int>::value,
+    static_assert(std::is_same<decltype(storage1.min(&User::setIdByVal))::element_type, int>::value,
                   "Incorrect min value");
-    static_assert(std::is_same<decltype(storage1.min(&User::setIdByVal, where(lesser_than(&User::id, 10))))::element_type, int>::value,
+    static_assert(std::is_same<decltype(storage2.min(&User::getConstIdByRefConst))::element_type, int>::value,
                   "Incorrect min value");
-    static_assert(std::is_same<decltype(storage2.min(&User::getConstIdByRefConst, where(lesser_than(&User::id, 10))))::element_type, int>::value,
+    static_assert(std::is_same<decltype(storage2.min(&User::setIdByRef))::element_type, int>::value,
                   "Incorrect min value");
-    static_assert(std::is_same<decltype(storage2.min(&User::setIdByRef, where(lesser_than(&User::id, 10))))::element_type, int>::value,
+
+    static_assert(
+        std::is_same<decltype(storage0.min(&User::id, where(lesser_than(&User::id, 10))))::element_type, int>::value,
+        "Incorrect min value");
+    static_assert(
+        std::is_same<decltype(storage1.min(&User::getIdByValConst, where(lesser_than(&User::id, 10))))::element_type,
+                     int>::value,
+        "Incorrect min value");
+    static_assert(
+        std::is_same<decltype(storage1.min(&User::setIdByVal, where(lesser_than(&User::id, 10))))::element_type,
+                     int>::value,
+        "Incorrect min value");
+    static_assert(std::is_same<decltype(storage2.min(&User::getConstIdByRefConst,
+                                                     where(lesser_than(&User::id, 10))))::element_type,
+                               int>::value,
                   "Incorrect min value");
-    
+    static_assert(
+        std::is_same<decltype(storage2.min(&User::setIdByRef, where(lesser_than(&User::id, 10))))::element_type,
+                     int>::value,
+        "Incorrect min value");
+
     static_assert(std::is_same<decltype(storage0.sum(&User::id))::element_type, int>::value, "Incorrect sum value");
-    static_assert(std::is_same<decltype(storage1.sum(&User::getIdByValConst))::element_type, int>::value, "Incorrect sum value");
-    static_assert(std::is_same<decltype(storage1.sum(&User::setIdByVal))::element_type, int>::value, "Incorrect sum value");
-    static_assert(std::is_same<decltype(storage2.sum(&User::getConstIdByRefConst))::element_type, int>::value, "Incorrect sum value");
-    static_assert(std::is_same<decltype(storage2.sum(&User::setIdByRef))::element_type, int>::value, "Incorrect sum value");
-    
-    static_assert(std::is_same<decltype(storage0.sum(&User::id, where(lesser_than(&User::id, 10))))::element_type, int>::value,
+    static_assert(std::is_same<decltype(storage1.sum(&User::getIdByValConst))::element_type, int>::value,
                   "Incorrect sum value");
-    static_assert(std::is_same<decltype(storage1.sum(&User::getIdByValConst, where(lesser_than(&User::id, 10))))::element_type, int>::value,
+    static_assert(std::is_same<decltype(storage1.sum(&User::setIdByVal))::element_type, int>::value,
                   "Incorrect sum value");
-    static_assert(std::is_same<decltype(storage1.sum(&User::setIdByVal, where(lesser_than(&User::id, 10))))::element_type, int>::value,
+    static_assert(std::is_same<decltype(storage2.sum(&User::getConstIdByRefConst))::element_type, int>::value,
                   "Incorrect sum value");
-    static_assert(std::is_same<decltype(storage2.sum(&User::getConstIdByRefConst, where(lesser_than(&User::id, 10))))::element_type, int>::value,
+    static_assert(std::is_same<decltype(storage2.sum(&User::setIdByRef))::element_type, int>::value,
                   "Incorrect sum value");
-    static_assert(std::is_same<decltype(storage2.sum(&User::setIdByRef, where(lesser_than(&User::id, 10))))::element_type, int>::value,
+
+    static_assert(
+        std::is_same<decltype(storage0.sum(&User::id, where(lesser_than(&User::id, 10))))::element_type, int>::value,
+        "Incorrect sum value");
+    static_assert(
+        std::is_same<decltype(storage1.sum(&User::getIdByValConst, where(lesser_than(&User::id, 10))))::element_type,
+                     int>::value,
+        "Incorrect sum value");
+    static_assert(
+        std::is_same<decltype(storage1.sum(&User::setIdByVal, where(lesser_than(&User::id, 10))))::element_type,
+                     int>::value,
+        "Incorrect sum value");
+    static_assert(std::is_same<decltype(storage2.sum(&User::getConstIdByRefConst,
+                                                     where(lesser_than(&User::id, 10))))::element_type,
+                               int>::value,
                   "Incorrect sum value");
+    static_assert(
+        std::is_same<decltype(storage2.sum(&User::setIdByRef, where(lesser_than(&User::id, 10))))::element_type,
+                     int>::value,
+        "Incorrect sum value");
 }
 
 TEST_CASE("Compound operators") {
     auto unionValue = union_(select(&User::id), select(&Token::id));
-    static_assert(internal::is_base_of_template<decltype(unionValue), internal::compound_operator>::value, "union must be base of compound_operator");
+    static_assert(internal::is_base_of_template<decltype(unionValue), internal::compound_operator>::value,
+                  "union must be base of compound_operator");
     auto exceptValue = except(select(&User::id), select(&Token::id));
-    static_assert(internal::is_base_of_template<decltype(exceptValue), internal::compound_operator>::value, "except must be base of compound_operator");
+    static_assert(internal::is_base_of_template<decltype(exceptValue), internal::compound_operator>::value,
+                  "except must be base of compound_operator");
 }
 
 TEST_CASE("Select return types") {
-    auto storage = make_storage("",
-                                make_table("users",
-                                           make_column("id", &User::id)));
+    auto storage = make_storage("", make_table("users", make_column("id", &User::id)));
     //  this call is important - it tests compilation in inner storage_t::serialize_column_schema function
     storage.sync_schema();
     {
         using SelectVectorInt = decltype(storage.select(&User::id));
         static_assert(std::is_same<SelectVectorInt, std::vector<int>>::value, "Incorrect select id vector type");
-        
+
         using SelectVectorTuple = decltype(storage.select(columns(&User::id)));
         auto ids = storage.select(columns(&User::id));
         static_assert(std::is_same<decltype(ids), SelectVectorTuple>::value, "");
-        static_assert(std::is_same<SelectVectorTuple, std::vector<std::tuple<int>>>::value, "Incorrect select id vector type");
+        static_assert(std::is_same<SelectVectorTuple, std::vector<std::tuple<int>>>::value,
+                      "Incorrect select id vector type");
         using IdsTuple = SelectVectorTuple::value_type;
         static_assert(std::tuple_size<IdsTuple>::value == 1, "Incorrect tuple size");
     }
@@ -251,44 +295,57 @@ TEST_CASE("Select return types") {
             std::string date;
         };
         using namespace sqlite_orm::internal::storage_traits;
-        
+
         //  test type_is_mapped
         static_assert(type_is_mapped<decltype(storage), User>::value, "User must be mapped to a storage");
         static_assert(!type_is_mapped<decltype(storage), Visit>::value, "User must be mapped to a storage");
-        
+
         //  test is_storage
         static_assert(internal::is_storage<decltype(storage)>::value, "is_storage works incorrectly");
         static_assert(!internal::is_storage<User>::value, "is_storage works incorrectly");
         static_assert(!internal::is_storage<int>::value, "is_storage works incorrectly");
         static_assert(!internal::is_storage<void>::value, "is_storage works incorrectly");
-        
-        auto storage2 = make_storage("",
-                                     make_table("visits",
-                                                make_column("id", &Visit::id, primary_key()),
-                                                make_column("date", &Visit::date)));
-        
+
+        auto storage2 = make_storage(
+            "",
+            make_table("visits", make_column("id", &Visit::id, primary_key()), make_column("date", &Visit::date)));
+
         //  test storage_columns_count
-        static_assert(storage_columns_count<decltype(storage), User>::value == 1, "Incorrect storage columns count value");
-        static_assert(storage_columns_count<decltype(storage), Visit>::value == 0, "Incorrect storage columns count value");
-        static_assert(storage_columns_count<decltype(storage2), Visit>::value == 2, "Incorrect storage columns count value");
-        
+        static_assert(storage_columns_count<decltype(storage), User>::value == 1,
+                      "Incorrect storage columns count value");
+        static_assert(storage_columns_count<decltype(storage), Visit>::value == 0,
+                      "Incorrect storage columns count value");
+        static_assert(storage_columns_count<decltype(storage2), Visit>::value == 2,
+                      "Incorrect storage columns count value");
+
         //  test storage mapped columns
         using UserColumnsTuple = storage_mapped_columns<decltype(storage), User>::type;
-        static_assert(std::is_same<UserColumnsTuple, std::tuple<int>>::value, "Incorrect storage_mapped_columns result");
-        
+        static_assert(std::is_same<UserColumnsTuple, std::tuple<int>>::value,
+                      "Incorrect storage_mapped_columns result");
+
         using VisitColumsEmptyType = storage_mapped_columns<decltype(storage), Visit>::type;
-        static_assert(std::is_same<VisitColumsEmptyType, std::tuple<>>::value, "Incorrect storage_mapped_columns result");
-        
+        static_assert(std::is_same<VisitColumsEmptyType, std::tuple<>>::value,
+                      "Incorrect storage_mapped_columns result");
+
         using VisitColumnTypes = storage_mapped_columns<decltype(storage2), Visit>::type;
-        static_assert(std::is_same<VisitColumnTypes, std::tuple<int, std::string>>::value, "Incorrect storage_mapped_columns result");
+        static_assert(std::is_same<VisitColumnTypes, std::tuple<int, std::string>>::value,
+                      "Incorrect storage_mapped_columns result");
     }
 }
 
 TEST_CASE("Arithmetic operators result type") {
-    static_assert(std::is_same<internal::column_result_t<internal::storage_t<>, decltype(add(1, 2))>::type, double>::value, "Incorrect add result");
-    static_assert(std::is_same<internal::column_result_t<internal::storage_t<>, decltype(sub(2, 1))>::type, double>::value, "Incorrect sub result");
-    static_assert(std::is_same<internal::column_result_t<internal::storage_t<>, decltype(mul(2, 3))>::type, double>::value, "Incorrect mul result");
-    static_assert(std::is_same<internal::column_result_t<internal::storage_t<>, decltype(sqlite_orm::div(2, 3))>::type, double>::value, "Incorrect div result");
+    static_assert(
+        std::is_same<internal::column_result_t<internal::storage_t<>, decltype(add(1, 2))>::type, double>::value,
+        "Incorrect add result");
+    static_assert(
+        std::is_same<internal::column_result_t<internal::storage_t<>, decltype(sub(2, 1))>::type, double>::value,
+        "Incorrect sub result");
+    static_assert(
+        std::is_same<internal::column_result_t<internal::storage_t<>, decltype(mul(2, 3))>::type, double>::value,
+        "Incorrect mul result");
+    static_assert(std::is_same<internal::column_result_t<internal::storage_t<>, decltype(sqlite_orm::div(2, 3))>::type,
+                               double>::value,
+                  "Incorrect div result");
 }
 
 TEST_CASE("is_bindable") {
@@ -301,7 +358,7 @@ TEST_CASE("is_bindable") {
     static_assert(internal::is_bindable<std::nullptr_t>::value, "null must be bindable");
     static_assert(internal::is_bindable<std::unique_ptr<int>>::value, "unique_ptr must be bindable");
     static_assert(internal::is_bindable<std::shared_ptr<int>>::value, "shared_ptr must be bindable");
-    
+
     static_assert(!internal::is_bindable<void>::value, "void cannot be bindable");
     auto isEqual = is_equal(&User::id, 5);
     static_assert(!internal::is_bindable<decltype(isEqual)>::value, "is_equal cannot be bindable");

--- a/tests/sync_schema_tests.cpp
+++ b/tests/sync_schema_tests.cpp
@@ -8,11 +8,12 @@ using namespace sqlite_orm;
  *  this is the deal: assume we have a `users` table with schema
  *  `CREATE TABLE users (id INTEGER NOT NULL PRIMARY KEY, name TEXT NOT NULL, category_id INTEGER, surname TEXT)`.
  *  We create a storage and insert several objects. Next we simulate schema changing (app update for example): create
- *  another storage with a new schema partial of the previous one: `CREATE TABLE users (id INTEGER NOT NULL PRIMARY KEY, name TEXT NOT NULL)`.
- *  Next we call `sync_schema(true)` and assert that all users are saved. This test tests whether REMOVE COLUMN imitation works well.
+ *  another storage with a new schema partial of the previous one: `CREATE TABLE users (id INTEGER NOT NULL PRIMARY KEY,
+ * name TEXT NOT NULL)`. Next we call `sync_schema(true)` and assert that all users are saved. This test tests whether
+ * REMOVE COLUMN imitation works well.
  */
-TEST_CASE("Sync schema"){
-    
+TEST_CASE("Sync schema") {
+
     //  this is an old version of user..
     struct UserBefore {
         int id;
@@ -20,13 +21,13 @@ TEST_CASE("Sync schema"){
         std::unique_ptr<int> categoryId;
         std::unique_ptr<std::string> surname;
     };
-    
+
     //  this is a new version of user
     struct UserAfter {
         int id;
         std::string name;
     };
-    
+
     //  create an old storage
     auto filename = "sync_schema_text.sqlite";
     auto storage = make_storage(filename,
@@ -35,16 +36,16 @@ TEST_CASE("Sync schema"){
                                            make_column("name", &UserBefore::name),
                                            make_column("category_id", &UserBefore::categoryId),
                                            make_column("surname", &UserBefore::surname)));
-    
+
     //  sync in case if it is first launch
     auto syncSchemaSimulationRes = storage.sync_schema_simulate();
     auto syncSchemaRes = storage.sync_schema();
-    
+
     REQUIRE(syncSchemaRes == syncSchemaSimulationRes);
-    
+
     //  remove old users in case the test was launched before
     storage.remove_all<UserBefore>();
-    
+
     //  create c++ objects to insert into table
     std::vector<UserBefore> usersToInsert;
     usersToInsert.push_back({-1, "Michael", nullptr, std::make_unique<std::string>("Scofield")});
@@ -54,64 +55,57 @@ TEST_CASE("Sync schema"){
     usersToInsert.push_back({-1, "John", std::make_unique<int>(100500), std::make_unique<std::string>("Abruzzi")});
     usersToInsert.push_back({-1, "Brad", std::make_unique<int>(65), nullptr});
     usersToInsert.push_back({-1, "Paul", std::make_unique<int>(65), nullptr});
-    
-    for(auto &user : usersToInsert) {
+
+    for(auto &user: usersToInsert) {
         auto insertedId = storage.insert(user);
         user.id = insertedId;
     }
-    
+
     //  assert count first cause we shall be asserting row by row next
     REQUIRE(static_cast<size_t>(storage.count<UserBefore>()) == usersToInsert.size());
-    
+
     //  now we create a new storage with a partial schema
-    auto newStorage = make_storage(filename,
-                                   make_table("users",
-                                              make_column("id", &UserAfter::id, primary_key()),
-                                              make_column("name", &UserAfter::name)));
-    
+    auto newStorage = make_storage(
+        filename,
+        make_table("users", make_column("id", &UserAfter::id, primary_key()), make_column("name", &UserAfter::name)));
+
     syncSchemaSimulationRes = newStorage.sync_schema_simulate(true);
-    
-    //  now call `sync_schema` with argument `preserve` as `true`. It will retain the data in case `sqlite_orm` needs to remove a column
+
+    //  now call `sync_schema` with argument `preserve` as `true`. It will retain the data in case `sqlite_orm` needs to
+    //  remove a column
     syncSchemaRes = newStorage.sync_schema(true);
     REQUIRE(syncSchemaRes.size() == 1);
     REQUIRE(syncSchemaRes.begin()->second == sync_schema_result::old_columns_removed);
     REQUIRE(syncSchemaSimulationRes == syncSchemaRes);
-    
+
     //  get all users after syncing the schema
     auto usersFromDb = newStorage.get_all<UserAfter>(order_by(&UserAfter::id));
-    
+
     REQUIRE(usersFromDb.size() == usersToInsert.size());
-    
+
     for(size_t i = 0; i < usersFromDb.size(); ++i) {
         auto &userFromDb = usersFromDb[i];
         auto &oldUser = usersToInsert[i];
         REQUIRE(userFromDb.id == oldUser.id);
         REQUIRE(userFromDb.name == oldUser.name);
     }
-    
+
     auto usersCountBefore = newStorage.count<UserAfter>();
-    
+
     syncSchemaSimulationRes = newStorage.sync_schema_simulate();
     syncSchemaRes = newStorage.sync_schema();
     REQUIRE(syncSchemaRes == syncSchemaSimulationRes);
-    
+
     auto usersCountAfter = newStorage.count<UserAfter>();
     REQUIRE(usersCountBefore == usersCountAfter);
-    
+
     //  test select..
     auto ids = newStorage.select(&UserAfter::id);
     auto users = newStorage.get_all<UserAfter>();
     decltype(ids) idsFromGetAll;
     idsFromGetAll.reserve(users.size());
-    std::transform(users.begin(),
-                   users.end(),
-                   std::back_inserter(idsFromGetAll),
-                   [=](auto &user) {
-                       return user.id;
-                   });
-    REQUIRE(std::equal(ids.begin(),
-                       ids.end(),
-                       idsFromGetAll.begin(),
-                       idsFromGetAll.end()));
-    
+    std::transform(users.begin(), users.end(), std::back_inserter(idsFromGetAll), [=](auto &user) {
+        return user.id;
+    });
+    REQUIRE(std::equal(ids.begin(), ids.end(), idsFromGetAll.begin(), idsFromGetAll.end()));
 }

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -5,12 +5,12 @@
 #include <catch2/catch.hpp>
 
 #include <cassert>  //  assert
-#include <vector>   //  std::vector
-#include <string>   //  std::string
-#include <memory>   //  std::unique_ptr
-#include <cstdio>   //  remove
+#include <vector>  //  std::vector
+#include <string>  //  std::string
+#include <memory>  //  std::unique_ptr
+#include <cstdio>  //  remove
 #include <numeric>  //  std::iota
-#include <algorithm>    //  std::fill
+#include <algorithm>  //  std::fill
 
 using namespace sqlite_orm;
 
@@ -20,13 +20,12 @@ TEST_CASE("Join iterator ctor compilation error") {
         int objectId;
         std::string text;
     };
-    
-    auto storage = make_storage("join_error.sqlite",
-                                make_table("tags",
-                                           make_column("object_id", &Tag::objectId),
-                                           make_column("text", &Tag::text)));
+
+    auto storage =
+        make_storage("join_error.sqlite",
+                     make_table("tags", make_column("object_id", &Tag::objectId), make_column("text", &Tag::text)));
     storage.sync_schema();
-    
+
     auto offs = 0;
     auto lim = 5;
     storage.select(columns(&Tag::text, count(&Tag::text)),
@@ -35,7 +34,7 @@ TEST_CASE("Join iterator ctor compilation error") {
                    limit(offs, lim));
 }
 
-TEST_CASE("limits"){
+TEST_CASE("limits") {
     auto storage2 = make_storage("limits.sqlite");
     auto storage = storage2;
     storage.sync_schema();
@@ -126,305 +125,304 @@ TEST_CASE("limits"){
     }
 }
 
-TEST_CASE("Explicit insert"){
+TEST_CASE("Explicit insert") {
     struct User {
         int id;
         std::string name;
         int age;
         std::string email;
     };
-    
+
     class Visit {
-    public:
-        const int& id() const {
+      public:
+        const int &id() const {
             return _id;
         }
-        
+
         void setId(int newValue) {
             _id = newValue;
         }
-        
-        const time_t& createdAt() const {
+
+        const time_t &createdAt() const {
             return _createdAt;
         }
-        
+
         void setCreatedAt(time_t newValue) {
             _createdAt = newValue;
         }
-        
-        const int& usedId() const {
+
+        const int &usedId() const {
             return _usedId;
         }
-        
+
         void setUsedId(int newValue) {
             _usedId = newValue;
         }
-        
-    private:
+
+      private:
         int _id;
         time_t _createdAt;
         int _usedId;
     };
-    
-    auto storage = make_storage("explicitinsert.sqlite",
-                                make_table("users",
-                                           make_column("id", &User::id, primary_key()),
-                                           make_column("name", &User::name),
-                                           make_column("age", &User::age),
-                                           make_column("email", &User::email, default_value("dummy@email.com"))),
-                                make_table("visits",
-                                           make_column("id", &Visit::setId, &Visit::id, primary_key()),
-                                           make_column("created_at", &Visit::createdAt, &Visit::setCreatedAt, default_value(10)),
-                                           make_column("used_id", &Visit::usedId, &Visit::setUsedId)));
-    
+
+    auto storage =
+        make_storage("explicitinsert.sqlite",
+                     make_table("users",
+                                make_column("id", &User::id, primary_key()),
+                                make_column("name", &User::name),
+                                make_column("age", &User::age),
+                                make_column("email", &User::email, default_value("dummy@email.com"))),
+                     make_table("visits",
+                                make_column("id", &Visit::setId, &Visit::id, primary_key()),
+                                make_column("created_at", &Visit::createdAt, &Visit::setCreatedAt, default_value(10)),
+                                make_column("used_id", &Visit::usedId, &Visit::setUsedId)));
+
     storage.sync_schema();
     storage.remove_all<User>();
     storage.remove_all<Visit>();
-    
+
     {
-        
-        {
-            User user{};
-            user.name = "Juan";
-            user.age = 57;
-            auto id = storage.insert(user, columns(&User::name, &User::age));
-            REQUIRE(storage.get<User>(id).email == "dummy@email.com");
-        }
-        
-        {
-            User user2;
-            user2.id = 2;
-            user2.name = "Kevin";
-            user2.age = 27;
-            REQUIRE(user2.id == storage.insert(user2, columns(&User::id, &User::name, &User::age)));
-            REQUIRE(storage.get<User>(user2.id).email == "dummy@email.com");
-        }
-        
-        {
-            User user3;
-            user3.id = 3;
-            user3.name = "Sia";
-            user3.age = 42;
-            user3.email = "sia@gmail.com";
-            auto insertedId = storage.insert(user3, columns(&User::id, &User::name, &User::age, &User::email));
-            REQUIRE(user3.id == insertedId);
-            auto insertedUser3 = storage.get<User>(user3.id);
-            REQUIRE(insertedUser3.email == user3.email);
-            REQUIRE(insertedUser3.age == user3.age);
-            REQUIRE(insertedUser3.name == user3.name);
-        }
-        
-        {
-            User user4;
-            user4.name = "Egor";
-            try {
-                storage.insert(user4, columns(&User::name));
-                REQUIRE(false);
-//                throw std::runtime_error("Must not fire");
-            } catch (const std::system_error&) {
-                //        cout << e.what() << endl;
-             }
-        }
+
+        {User user{};
+    user.name = "Juan";
+    user.age = 57;
+    auto id = storage.insert(user, columns(&User::name, &User::age));
+    REQUIRE(storage.get<User>(id).email == "dummy@email.com");
+}
+
+{
+    User user2;
+    user2.id = 2;
+    user2.name = "Kevin";
+    user2.age = 27;
+    REQUIRE(user2.id == storage.insert(user2, columns(&User::id, &User::name, &User::age)));
+    REQUIRE(storage.get<User>(user2.id).email == "dummy@email.com");
+}
+
+{
+    User user3;
+    user3.id = 3;
+    user3.name = "Sia";
+    user3.age = 42;
+    user3.email = "sia@gmail.com";
+    auto insertedId = storage.insert(user3, columns(&User::id, &User::name, &User::age, &User::email));
+    REQUIRE(user3.id == insertedId);
+    auto insertedUser3 = storage.get<User>(user3.id);
+    REQUIRE(insertedUser3.email == user3.email);
+    REQUIRE(insertedUser3.age == user3.age);
+    REQUIRE(insertedUser3.name == user3.name);
+}
+
+{
+    User user4;
+    user4.name = "Egor";
+    try {
+        storage.insert(user4, columns(&User::name));
+        REQUIRE(false);
+        //                throw std::runtime_error("Must not fire");
+    } catch(const std::system_error &) {
+        //        cout << e.what() << endl;
     }
+}
+}
+{
+
     {
-        
+        Visit visit;
+
         {
-            Visit visit;
-            
+            visit.setUsedId(1);
+            visit.setId(storage.insert(visit, columns(&Visit::usedId)));
+
+            auto visitFromStorage = storage.get<Visit>(visit.id());
+            REQUIRE(visitFromStorage.createdAt() == 10);
+            REQUIRE(visitFromStorage.usedId() == visit.usedId());
+            storage.remove<Visit>(visitFromStorage.usedId());
+        }
+
+        {
+            visit.setId(storage.insert(visit, columns(&Visit::setUsedId)));
+            auto visitFromStorage = storage.get<Visit>(visit.id());
+            REQUIRE(visitFromStorage.createdAt() == 10);
+            REQUIRE(visitFromStorage.usedId() == visit.usedId());
+            storage.remove<Visit>(visitFromStorage.usedId());
+        }
+
+        {
+            Visit visit2;
+            visit2.setId(2);
+            visit2.setUsedId(1);
             {
-                visit.setUsedId(1);
-                visit.setId(storage.insert(visit, columns(&Visit::usedId)));
-                
-                auto visitFromStorage = storage.get<Visit>(visit.id());
-                REQUIRE(visitFromStorage.createdAt() == 10);
-                REQUIRE(visitFromStorage.usedId() == visit.usedId());
-                storage.remove<Visit>(visitFromStorage.usedId());
+                auto insertedId = storage.insert(visit2, columns(&Visit::id, &Visit::usedId));
+                REQUIRE(visit2.id() == insertedId);
+                auto visitFromStorage = storage.get<Visit>(visit2.id());
+                REQUIRE(visitFromStorage.usedId() == visit2.usedId());
+                storage.remove<Visit>(visit2.id());
             }
-            
             {
-                visit.setId(storage.insert(visit, columns(&Visit::setUsedId)));
-                auto visitFromStorage = storage.get<Visit>(visit.id());
-                REQUIRE(visitFromStorage.createdAt() == 10);
-                REQUIRE(visitFromStorage.usedId() == visit.usedId());
-                storage.remove<Visit>(visitFromStorage.usedId());
+                auto insertedId = storage.insert(visit2, columns(&Visit::setId, &Visit::setUsedId));
+                REQUIRE(visit2.id() == insertedId);
+                auto visitFromStorage = storage.get<Visit>(visit2.id());
+                REQUIRE(visitFromStorage.usedId() == visit2.usedId());
+                storage.remove<Visit>(visit2.id());
             }
-            
-            {
-                Visit visit2;
-                visit2.setId(2);
-                visit2.setUsedId(1);
-                {
-                    auto insertedId = storage.insert(visit2, columns(&Visit::id, &Visit::usedId));
-                    REQUIRE(visit2.id() == insertedId);
-                    auto visitFromStorage = storage.get<Visit>(visit2.id());
-                    REQUIRE(visitFromStorage.usedId() == visit2.usedId());
-                    storage.remove<Visit>(visit2.id());
-                }
-                {
-                    auto insertedId = storage.insert(visit2, columns(&Visit::setId, &Visit::setUsedId));
-                    REQUIRE(visit2.id() == insertedId);
-                    auto visitFromStorage = storage.get<Visit>(visit2.id());
-                    REQUIRE(visitFromStorage.usedId() == visit2.usedId());
-                    storage.remove<Visit>(visit2.id());
-                }
+        }
+
+        {
+            Visit visit3;
+            visit3.setId(10);
+            try {
+                storage.insert(visit3, columns(&Visit::id));
+                REQUIRE(false);
+            } catch(const std::system_error &) {
+                //        cout << e.what() << endl;
             }
-            
-            {
-                Visit visit3;
-                visit3.setId(10);
-                try {
-                    storage.insert(visit3, columns(&Visit::id));
-                    REQUIRE(false);
-                } catch (const std::system_error&) {
-                    //        cout << e.what() << endl;
-                }
-                
-                try {
-                    storage.insert(visit3, columns(&Visit::setId));
-                    REQUIRE(false);
-                } catch (const std::system_error&) {
-                    //        cout << e.what() << endl;
-                }
+
+            try {
+                storage.insert(visit3, columns(&Visit::setId));
+                REQUIRE(false);
+            } catch(const std::system_error &) {
+                //        cout << e.what() << endl;
             }
         }
     }
 }
+}
 
-TEST_CASE("Custom collate"){
+TEST_CASE("Custom collate") {
     struct Item {
         int id;
         std::string name;
     };
-    
-    auto storage = make_storage("custom_collate.sqlite",
-                                make_table("items",
-                                           make_column("id", &Item::id, primary_key()),
-                                           make_column("name", &Item::name)));
-//    storage.open_forever();
+
+    auto storage = make_storage(
+        "custom_collate.sqlite",
+        make_table("items", make_column("id", &Item::id, primary_key()), make_column("name", &Item::name)));
+    //    storage.open_forever();
     storage.sync_schema();
     storage.remove_all<Item>();
-    storage.insert(Item{ 0, "Mercury" });
-    storage.insert(Item{ 0, "Mars" });
-    storage.create_collation("ototo", [](int, const void *lhs, int, const void *rhs){
-        return strcmp((const char*)lhs, (const char*)rhs);
+    storage.insert(Item{0, "Mercury"});
+    storage.insert(Item{0, "Mars"});
+    storage.create_collation("ototo", [](int, const void *lhs, int, const void *rhs) {
+        return strcmp((const char *)lhs, (const char *)rhs);
     });
-    storage.create_collation("alwaysequal", [](int, const void *, int, const void *){
+    storage.create_collation("alwaysequal", [](int, const void *, int, const void *) {
         return 0;
     });
     auto rows = storage.select(&Item::name, where(is_equal(&Item::name, "Mercury").collate("ototo")));
     REQUIRE(rows.size() == 1);
     REQUIRE(rows.front() == "Mercury");
-    
-    rows = storage.select(&Item::name, where(is_equal(&Item::name, "Mercury").collate("alwaysequal")),
+
+    rows = storage.select(&Item::name,
+                          where(is_equal(&Item::name, "Mercury").collate("alwaysequal")),
                           order_by(&Item::name).collate("ototo"));
-    
+
     storage.create_collation("ototo", {});
     try {
         rows = storage.select(&Item::name, where(is_equal(&Item::name, "Mercury").collate("ototo")));
         REQUIRE(false);
-    } catch (const std::system_error& e) {
-//        cout << e.what() << endl;
+    } catch(const std::system_error &e) {
+        //        cout << e.what() << endl;
     }
     try {
         rows = storage.select(&Item::name, where(is_equal(&Item::name, "Mercury").collate("ototo2")));
         REQUIRE(false);
-    } catch (const std::system_error& e) {
-//        cout << e.what() << endl;
+    } catch(const std::system_error &e) {
+        //        cout << e.what() << endl;
     }
-    rows = storage.select(&Item::name, where(is_equal(&Item::name, "Mercury").collate("alwaysequal")),
-                                             order_by(&Item::name).collate_rtrim());
-    
-    rows = storage.select(&Item::name, where(is_equal(&Item::name, "Mercury").collate("alwaysequal")),
+    rows = storage.select(&Item::name,
+                          where(is_equal(&Item::name, "Mercury").collate("alwaysequal")),
+                          order_by(&Item::name).collate_rtrim());
+
+    rows = storage.select(&Item::name,
+                          where(is_equal(&Item::name, "Mercury").collate("alwaysequal")),
                           order_by(&Item::name).collate("alwaysequal"));
     REQUIRE(rows.size() == static_cast<size_t>(storage.count<Item>()));
 }
 
-TEST_CASE("Vacuum"){
+TEST_CASE("Vacuum") {
     struct Item {
         int id;
         std::string name;
     };
-    
-    auto storage = make_storage("vacuum.sqlite",
-                                make_table("items",
-                                           make_column("id", &Item::id, primary_key()),
-                                           make_column("name", &Item::name)));
+
+    auto storage = make_storage(
+        "vacuum.sqlite",
+        make_table("items", make_column("id", &Item::id, primary_key()), make_column("name", &Item::name)));
     storage.sync_schema();
-    storage.insert(Item{ 0, "One" });
-    storage.insert(Item{ 0, "Two" });
-    storage.insert(Item{ 0, "Three" });
-    storage.insert(Item{ 0, "Four" });
-    storage.insert(Item{ 0, "Five" });
+    storage.insert(Item{0, "One"});
+    storage.insert(Item{0, "Two"});
+    storage.insert(Item{0, "Three"});
+    storage.insert(Item{0, "Four"});
+    storage.insert(Item{0, "Five"});
     storage.remove_all<Item>();
     storage.vacuum();
 }
 
-TEST_CASE("Remove all"){
+TEST_CASE("Remove all") {
     struct Object {
         int id;
         std::string name;
     };
-    
-    auto storage = make_storage("",
-                                make_table("objects",
-                                           make_column("id", &Object::id, primary_key()),
-                                           make_column("name", &Object::name)));
+
+    auto storage = make_storage(
+        "",
+        make_table("objects", make_column("id", &Object::id, primary_key()), make_column("name", &Object::name)));
     storage.sync_schema();
-    
-    storage.replace(Object{ 1, "Ototo" });
-    storage.replace(Object{ 2, "Contigo" });
-    
+
+    storage.replace(Object{1, "Ototo"});
+    storage.replace(Object{2, "Contigo"});
+
     REQUIRE(storage.count<Object>() == 2);
-    
+
     storage.remove_all<Object>(where(c(&Object::id) == 1));
-    
+
     REQUIRE(storage.count<Object>() == 1);
 }
 
-TEST_CASE("Escaped index name"){
-    struct User{
+TEST_CASE("Escaped index name") {
+    struct User {
         std::string group;
     };
     auto storage = make_storage("index_group.sqlite",
                                 make_index("index", &User::group),
-                                make_table("users",
-                                           make_column("group", &User::group)));
+                                make_table("users", make_column("group", &User::group)));
     storage.sync_schema();
 }
 
-TEST_CASE("Where"){
-    struct User{
+TEST_CASE("Where") {
+    struct User {
         int id = 0;
         int age = 0;
         std::string name;
     };
-    
+
     auto storage = make_storage("",
                                 make_table("users",
                                            make_column("id", &User::id, primary_key()),
                                            make_column("age", &User::age),
                                            make_column("name", &User::name)));
     storage.sync_schema();
-    
-    storage.replace(User{ 1, 4, "Jeremy" });
-    storage.replace(User{ 2, 18, "Nataly" });
-    
+
+    storage.replace(User{1, 4, "Jeremy"});
+    storage.replace(User{2, 18, "Nataly"});
+
     auto users = storage.get_all<User>();
     REQUIRE(users.size() == 2);
-    
+
     auto users2 = storage.get_all<User>(where(true));
     REQUIRE(users2.size() == 2);
-    
+
     auto users3 = storage.get_all<User>(where(false));
     REQUIRE(users3.size() == 0);
-    
+
     auto users4 = storage.get_all<User>(where(true and c(&User::id) == 1));
     REQUIRE(users4.size() == 1);
     REQUIRE(users4.front().id == 1);
-    
+
     auto users5 = storage.get_all<User>(where(false and c(&User::id) == 1));
     REQUIRE(users5.size() == 0);
-    
+
     auto users6 = storage.get_all<User>(where((false or c(&User::id) == 4) and (false or c(&User::age) == 18)));
     REQUIRE(users6.empty());
 }

--- a/tests/tests2.cpp
+++ b/tests/tests2.cpp
@@ -3,27 +3,26 @@
 
 using namespace sqlite_orm;
 
-TEST_CASE("Empty storage"){
+TEST_CASE("Empty storage") {
     auto storage = make_storage("empty.sqlite");
     storage.table_exists("table");
 }
 
-TEST_CASE("Remove"){
+TEST_CASE("Remove") {
     struct Object {
         int id;
         std::string name;
     };
-    
+
     {
-        auto storage = make_storage("test_remove.sqlite",
-                                    make_table("objects",
-                                               make_column("id", &Object::id, primary_key()),
-                                               make_column("name", &Object::name)));
-        
+        auto storage = make_storage(
+            "test_remove.sqlite",
+            make_table("objects", make_column("id", &Object::id, primary_key()), make_column("name", &Object::name)));
+
         storage.sync_schema();
         storage.remove_all<Object>();
-        
-        auto id1 = storage.insert(Object{ 0, "Skillet"});
+
+        auto id1 = storage.insert(Object{0, "Skillet"});
         REQUIRE(storage.count<Object>() == 1);
         storage.remove<Object>(id1);
         REQUIRE(storage.count<Object>() == 0);
@@ -36,8 +35,8 @@ TEST_CASE("Remove"){
                                                primary_key(&Object::id)));
         storage.sync_schema();
         storage.remove_all<Object>();
-        
-        auto id1 = storage.insert(Object{ 0, "Skillet"});
+
+        auto id1 = storage.insert(Object{0, "Skillet"});
         REQUIRE(storage.count<Object>() == 1);
         storage.remove<Object>(id1);
         REQUIRE(storage.count<Object>() == 0);
@@ -53,68 +52,67 @@ TEST_CASE("Remove"){
         assert(storage.count<Object>() == 1);
         storage.remove<Object>(1, "Skillet");
         REQUIRE(storage.count<Object>() == 0);
-        
+
         storage.replace(Object{1, "Skillet"});
         storage.replace(Object{2, "Paul Cless"});
         REQUIRE(storage.count<Object>() == 2);
         storage.remove<Object>(1, "Skillet");
         REQUIRE(storage.count<Object>() == 1);
-        
     }
 }
 
-TEST_CASE("Select"){
+TEST_CASE("Select") {
     sqlite3 *db;
     auto dbFileName = "test.db";
     auto rc = sqlite3_open(dbFileName, &db);
     assert(rc == SQLITE_OK);
     auto sql = "CREATE TABLE IF NOT EXISTS WORDS("
-    "ID INTEGER PRIMARY        KEY AUTOINCREMENT      NOT NULL,"
-    "CURRENT_WORD          TEXT     NOT NULL,"
-    "BEFORE_WORD           TEXT     NOT NULL,"
-    "AFTER_WORD            TEXT     NOT NULL,"
-    "OCCURANCES            INT      NOT NULL);";
-    
+               "ID INTEGER PRIMARY        KEY AUTOINCREMENT      NOT NULL,"
+               "CURRENT_WORD          TEXT     NOT NULL,"
+               "BEFORE_WORD           TEXT     NOT NULL,"
+               "AFTER_WORD            TEXT     NOT NULL,"
+               "OCCURANCES            INT      NOT NULL);";
+
     char *errMsg = nullptr;
     rc = sqlite3_exec(db, sql, nullptr, nullptr, &errMsg);
     REQUIRE(rc == SQLITE_OK);
-    
+
     sqlite3_stmt *stmt;
-    
+
     //  delete previous words. This command is excess in travis or other docker based CI tools
     //  but it is required on local machine
     sql = "DELETE FROM WORDS";
     rc = sqlite3_prepare_v2(db, sql, -1, &stmt, nullptr);
     REQUIRE(rc == SQLITE_OK);
-    
+
     rc = sqlite3_step(stmt);
-    if(rc != SQLITE_DONE){
-//        cout << sqlite3_errmsg(db) << endl;
+    if(rc != SQLITE_DONE) {
+        //        cout << sqlite3_errmsg(db) << endl;
         throw std::runtime_error(sqlite3_errmsg(db));
     }
     sqlite3_finalize(stmt);
-    
+
     sql = "INSERT INTO WORDS (CURRENT_WORD, BEFORE_WORD, AFTER_WORD, OCCURANCES) VALUES(?, ?, ?, ?)";
     rc = sqlite3_prepare_v2(db, sql, -1, &stmt, nullptr);
     REQUIRE(rc == SQLITE_OK);
-    
+
     //  INSERT [ ID, 'best', 'behaviour', 'hey', 5 ]
-    
+
     sqlite3_bind_text(stmt, 1, "best", -1, nullptr);
     sqlite3_bind_text(stmt, 2, "behaviour", -1, nullptr);
     sqlite3_bind_text(stmt, 3, "hey", -1, nullptr);
     sqlite3_bind_int(stmt, 4, 5);
     rc = sqlite3_step(stmt);
-    if(rc != SQLITE_DONE){
-//        cout << sqlite3_errmsg(db) << endl;
+    if(rc != SQLITE_DONE) {
+        //        cout << sqlite3_errmsg(db) << endl;
         throw std::runtime_error(sqlite3_errmsg(db));
     }
     sqlite3_finalize(stmt);
-    
+
     auto firstId = sqlite3_last_insert_rowid(db);
-    
+
     //  INSERT [ ID, 'corruption', 'blood', 'brothers', 15 ]
-    
+
     rc = sqlite3_prepare_v2(db, sql, -1, &stmt, nullptr);
     REQUIRE(rc == SQLITE_OK);
     sqlite3_bind_text(stmt, 1, "corruption", -1, nullptr);
@@ -122,27 +120,27 @@ TEST_CASE("Select"){
     sqlite3_bind_text(stmt, 3, "brothers", -1, nullptr);
     sqlite3_bind_int(stmt, 4, 15);
     rc = sqlite3_step(stmt);
-    if(rc != SQLITE_DONE){
-//        cout << sqlite3_errmsg(db) << endl;
+    if(rc != SQLITE_DONE) {
+        //        cout << sqlite3_errmsg(db) << endl;
         throw std::runtime_error(sqlite3_errmsg(db));
     }
     sqlite3_finalize(stmt);
-    
+
     auto secondId = sqlite3_last_insert_rowid(db);
-    
+
     {
         //  SELECT ID, CURRENT_WORD, BEFORE_WORD, AFTER_WORD, OCCURANCES
         //  FROM WORDS
         //  WHERE ID = firstId
-        
+
         sql = "SELECT ID, CURRENT_WORD, BEFORE_WORD, AFTER_WORD, OCCURANCES FROM WORDS WHERE ID = ?";
         rc = sqlite3_prepare_v2(db, sql, -1, &stmt, nullptr);
         REQUIRE(rc == SQLITE_OK);
-        
+
         sqlite3_bind_int64(stmt, 1, firstId);
         rc = sqlite3_step(stmt);
-        if(rc != SQLITE_ROW){
-//            cout << sqlite3_errmsg(db) << endl;
+        if(rc != SQLITE_ROW) {
+            //            cout << sqlite3_errmsg(db) << endl;
             throw std::runtime_error(sqlite3_errmsg(db));
         }
         REQUIRE(sqlite3_column_int(stmt, 0) == firstId);
@@ -152,9 +150,9 @@ TEST_CASE("Select"){
         REQUIRE(sqlite3_column_int(stmt, 4) == 5);
         sqlite3_finalize(stmt);
     }
-    
+
     sqlite3_close(db);
-    
+
     struct Word {
         int id;
         std::string currentWord;
@@ -162,7 +160,7 @@ TEST_CASE("Select"){
         std::string afterWord;
         int occurances;
     };
-    
+
     auto storage = make_storage(dbFileName,
                                 make_table("WORDS",
                                            make_column("ID", &Word::id, primary_key(), autoincrement()),
@@ -170,33 +168,29 @@ TEST_CASE("Select"){
                                            make_column("BEFORE_WORD", &Word::beforeWord),
                                            make_column("AFTER_WORD", &Word::afterWord),
                                            make_column("OCCURANCES", &Word::occurances)));
-    
+
     storage.sync_schema();  //  sync schema must not alter any data cause schemas are the same
-    
+
     REQUIRE(storage.count<Word>() == 2);
-    
+
     auto firstRow = storage.get_no_throw<Word>(firstId);
     REQUIRE(firstRow);
     REQUIRE(firstRow->currentWord == "best");
     REQUIRE(firstRow->beforeWord == "behaviour");
     REQUIRE(firstRow->afterWord == "hey");
     REQUIRE(firstRow->occurances == 5);
-    
+
     auto secondRow = storage.get_pointer<Word>(secondId);
     REQUIRE(secondRow);
     REQUIRE(secondRow->currentWord == "corruption");
     REQUIRE(secondRow->beforeWord == "blood");
     REQUIRE(secondRow->afterWord == "brothers");
     REQUIRE(secondRow->occurances == 15);
-    
-    auto cols = columns(&Word::id,
-                        &Word::currentWord,
-                        &Word::beforeWord,
-                        &Word::afterWord,
-                        &Word::occurances);
+
+    auto cols = columns(&Word::id, &Word::currentWord, &Word::beforeWord, &Word::afterWord, &Word::occurances);
     auto rawTuples = storage.select(cols, where(eq(&Word::id, firstId)));
     REQUIRE(rawTuples.size() == 1);
-    
+
     {
         auto &firstTuple = rawTuples.front();
         REQUIRE(std::get<0>(firstTuple) == firstId);
@@ -205,10 +199,10 @@ TEST_CASE("Select"){
         REQUIRE(std::get<3>(firstTuple) == "hey");
         REQUIRE(std::get<4>(firstTuple) == 5);
     }
-    
+
     rawTuples = storage.select(cols, where(eq(&Word::id, secondId)));
     REQUIRE(rawTuples.size() == 1);
-    
+
     {
         auto &secondTuple = rawTuples.front();
         REQUIRE(std::get<0>(secondTuple) == secondId);
@@ -217,91 +211,88 @@ TEST_CASE("Select"){
         REQUIRE(std::get<3>(secondTuple) == "brothers");
         REQUIRE(std::get<4>(secondTuple) == 15);
     }
-    
+
     auto ordr = order_by(&Word::id);
-    
+
     auto idsOnly = storage.select(&Word::id, ordr);
     REQUIRE(idsOnly.size() == 2);
-    
+
     REQUIRE(idsOnly[0] == firstId);
     REQUIRE(idsOnly[1] == secondId);
-    
+
     auto currentWordsOnly = storage.select(&Word::currentWord, ordr);
     REQUIRE(currentWordsOnly.size() == 2);
-    
+
     REQUIRE(currentWordsOnly[0] == "best");
     REQUIRE(currentWordsOnly[1] == "corruption");
-    
+
     auto beforeWordsOnly = storage.select(&Word::beforeWord, ordr);
     REQUIRE(beforeWordsOnly.size() == 2);
-    
+
     REQUIRE(beforeWordsOnly[0] == "behaviour");
     REQUIRE(beforeWordsOnly[1] == "blood");
-    
+
     auto afterWordsOnly = storage.select(&Word::afterWord, ordr);
     REQUIRE(afterWordsOnly.size() == 2);
-    
+
     REQUIRE(afterWordsOnly[0] == "hey");
     REQUIRE(afterWordsOnly[1] == "brothers");
-    
+
     auto occurencesOnly = storage.select(&Word::occurances, ordr);
     REQUIRE(occurencesOnly.size() == 2);
-    
+
     REQUIRE(occurencesOnly[0] == 5);
     REQUIRE(occurencesOnly[1] == 15);
-    
+
     //  test update_all with the same storage
-    
-    storage.update_all(set(assign(&Word::currentWord, "ototo")),
-                       where(is_equal(&Word::id, firstId)));
-    
+
+    storage.update_all(set(assign(&Word::currentWord, "ototo")), where(is_equal(&Word::id, firstId)));
+
     REQUIRE(storage.get<Word>(firstId).currentWord == "ototo");
-    
 }
 
-TEST_CASE("Replace"){
+TEST_CASE("Replace") {
     struct Object {
         int id;
         std::string name;
     };
-    
+
     struct User {
-        
-        User(int id_, std::string name_): id(id_), name(move(name_)) {}
-        
+
+        User(int id_, std::string name_) : id(id_), name(move(name_)) {}
+
         int getId() const {
             return this->id;
         }
-        
+
         void setId(int id) {
             this->id = id;
         }
-        
+
         std::string getName() const {
             return this->name;
         }
-        
+
         void setName(std::string name) {
             this->name = move(name);
         }
-        
-    private:
+
+      private:
         int id = 0;
         std::string name;
     };
-    
-    auto storage = make_storage("test_replace.sqlite",
-                                make_table("objects",
-                                           make_column("id", &Object::id, primary_key()),
-                                           make_column("name", &Object::name)),
-                                make_table("users",
-                                           make_column("id", &User::getId, &User::setId, primary_key()),
-                                           make_column("name", &User::setName, &User::getName)));
-    
+
+    auto storage = make_storage(
+        "test_replace.sqlite",
+        make_table("objects", make_column("id", &Object::id, primary_key()), make_column("name", &Object::name)),
+        make_table("users",
+                   make_column("id", &User::getId, &User::setId, primary_key()),
+                   make_column("name", &User::setName, &User::getName)));
+
     storage.sync_schema();
     storage.remove_all<Object>();
     storage.remove_all<User>();
-    
+
     storage.replace(Object{
         100,
         "Baby",
@@ -310,7 +301,7 @@ TEST_CASE("Replace"){
     auto baby = storage.get<Object>(100);
     REQUIRE(baby.id == 100);
     REQUIRE(baby.name == "Baby");
-    
+
     storage.replace(Object{
         200,
         "Time",
@@ -327,7 +318,7 @@ TEST_CASE("Replace"){
     auto ototo = storage.get<Object>(100);
     REQUIRE(ototo.id == 100);
     REQUIRE(ototo.name == "Ototo");
-    
+
     auto initList = {
         Object{
             300,
@@ -340,40 +331,38 @@ TEST_CASE("Replace"){
     };
     storage.replace_range(initList.begin(), initList.end());
     REQUIRE(storage.count<Object>() == 4);
-    
+
     //  test empty container
     std::vector<Object> emptyVector;
-    storage.replace_range(emptyVector.begin(),
-                          emptyVector.end());
-    
-    
+    storage.replace_range(emptyVector.begin(), emptyVector.end());
+
     REQUIRE(storage.count<User>() == 0);
     storage.replace(User{10, "Daddy Yankee"});
 }
 
-TEST_CASE("Insert"){
+TEST_CASE("Insert") {
     struct Object {
         int id;
         std::string name;
     };
-    
+
     struct ObjectWithoutRowid {
         int id;
         std::string name;
     };
-    
-    auto storage = make_storage("test_insert.sqlite",
-                                make_table("objects",
-                                           make_column("id", &Object::id, primary_key()),
-                                           make_column("name", &Object::name)),
-                                make_table("objects_without_rowid",
-                                           make_column("id", &ObjectWithoutRowid::id, primary_key()),
-                                           make_column("name", &ObjectWithoutRowid::name)).without_rowid());
-    
+
+    auto storage = make_storage(
+        "test_insert.sqlite",
+        make_table("objects", make_column("id", &Object::id, primary_key()), make_column("name", &Object::name)),
+        make_table("objects_without_rowid",
+                   make_column("id", &ObjectWithoutRowid::id, primary_key()),
+                   make_column("name", &ObjectWithoutRowid::name))
+            .without_rowid());
+
     storage.sync_schema();
     storage.remove_all<Object>();
     storage.remove_all<ObjectWithoutRowid>();
-    
+
     for(auto i = 0; i < 100; ++i) {
         storage.insert(Object{
             0,
@@ -381,7 +370,7 @@ TEST_CASE("Insert"){
         });
         REQUIRE(storage.count<Object>() == i + 1);
     }
-    
+
     auto initList = {
         Object{
             0,
@@ -396,29 +385,26 @@ TEST_CASE("Insert"){
             "Sun",
         },
     };
-    
-//    cout << "inserting range" << endl;
+
+    //    cout << "inserting range" << endl;
     auto countBefore = storage.count<Object>();
-    storage.insert_range(initList.begin(),
-                         initList.end());
+    storage.insert_range(initList.begin(), initList.end());
     REQUIRE(storage.count<Object>() == countBefore + static_cast<int>(initList.size()));
-    
-    
+
     //  test empty container
     std::vector<Object> emptyVector;
-    storage.insert_range(emptyVector.begin(),
-                         emptyVector.end());
-    
+    storage.insert_range(emptyVector.begin(), emptyVector.end());
+
     //  test insert without rowid
-    storage.insert(ObjectWithoutRowid{ 10, "Life" });
+    storage.insert(ObjectWithoutRowid{10, "Life"});
     REQUIRE(storage.get<ObjectWithoutRowid>(10).name == "Life");
-    storage.insert(ObjectWithoutRowid{ 20, "Death" });
+    storage.insert(ObjectWithoutRowid{20, "Death"});
     REQUIRE(storage.get<ObjectWithoutRowid>(20).name == "Death");
 }
 
-TEST_CASE("Type parsing"){
+TEST_CASE("Type parsing") {
     using namespace sqlite_orm::internal;
-    
+
     //  int
     REQUIRE(*to_sqlite_type("INT") == sqlite_type::INTEGER);
     REQUIRE(*to_sqlite_type("integeer") == sqlite_type::INTEGER);
@@ -430,11 +416,11 @@ TEST_CASE("Type parsing"){
     REQUIRE(*to_sqlite_type("UNSIGNED BIG INT") == sqlite_type::INTEGER);
     REQUIRE(*to_sqlite_type("INT2") == sqlite_type::INTEGER);
     REQUIRE(*to_sqlite_type("INT8") == sqlite_type::INTEGER);
-    
+
     //  text
     REQUIRE(*to_sqlite_type("TEXT") == sqlite_type::TEXT);
     REQUIRE(*to_sqlite_type("CLOB") == sqlite_type::TEXT);
-    for(auto i = 0; i< 255; ++i) {
+    for(auto i = 0; i < 255; ++i) {
         REQUIRE(*to_sqlite_type("CHARACTER(" + std::to_string(i) + ")") == sqlite_type::TEXT);
         REQUIRE(*to_sqlite_type("VARCHAR(" + std::to_string(i) + ")") == sqlite_type::TEXT);
         REQUIRE(*to_sqlite_type("VARYING CHARACTER(" + std::to_string(i) + ")") == sqlite_type::TEXT);
@@ -442,28 +428,27 @@ TEST_CASE("Type parsing"){
         REQUIRE(*to_sqlite_type("NATIVE CHARACTER(" + std::to_string(i) + ")") == sqlite_type::TEXT);
         REQUIRE(*to_sqlite_type("NVARCHAR(" + std::to_string(i) + ")") == sqlite_type::TEXT);
     }
-    
+
     //  blob..
     REQUIRE(*to_sqlite_type("BLOB") == sqlite_type::BLOB);
-    
+
     //  real
     REQUIRE(*to_sqlite_type("REAL") == sqlite_type::REAL);
     REQUIRE(*to_sqlite_type("DOUBLE") == sqlite_type::REAL);
     REQUIRE(*to_sqlite_type("DOUBLE PRECISION") == sqlite_type::REAL);
     REQUIRE(*to_sqlite_type("FLOAT") == sqlite_type::REAL);
-    
+
     REQUIRE(*to_sqlite_type("NUMERIC") == sqlite_type::REAL);
     for(auto i = 0; i < 255; ++i) {
         for(auto j = 0; j < 10; ++j) {
-            REQUIRE(*to_sqlite_type("DECIMAL(" + std::to_string(i) + "," + std::to_string(j) + ")") == sqlite_type::REAL);
+            REQUIRE(*to_sqlite_type("DECIMAL(" + std::to_string(i) + "," + std::to_string(j) + ")") ==
+                    sqlite_type::REAL);
         }
     }
     REQUIRE(*to_sqlite_type("BOOLEAN") == sqlite_type::REAL);
     REQUIRE(*to_sqlite_type("DATE") == sqlite_type::REAL);
     REQUIRE(*to_sqlite_type("DATETIME") == sqlite_type::REAL);
-    
-    
-    
+
     REQUIRE(type_is_nullable<bool>::value == false);
     REQUIRE(type_is_nullable<char>::value == false);
     REQUIRE(type_is_nullable<unsigned char>::value == false);
@@ -485,5 +470,4 @@ TEST_CASE("Type parsing"){
     REQUIRE(type_is_nullable<std::unique_ptr<std::string>>::value == true);
     REQUIRE(type_is_nullable<std::unique_ptr<int>>::value == true);
     REQUIRE(type_is_nullable<std::unique_ptr<std::string>>::value == true);
-    
 }

--- a/tests/tests3.cpp
+++ b/tests/tests3.cpp
@@ -3,30 +3,31 @@
 
 using namespace sqlite_orm;
 
-TEST_CASE("Multi order by"){
+TEST_CASE("Multi order by") {
     struct Singer {
         int id;
         std::string name;
         std::string gender;
     };
-    
+
     auto storage = make_storage("",
                                 make_table("singers",
                                            make_column("id", &Singer::id, primary_key()),
                                            make_column("name", &Singer::name, unique()),
                                            make_column("gender", &Singer::gender)));
     storage.sync_schema();
-    
-    storage.insert(Singer{ 0, "Alexandra Stan", "female" });
-    storage.insert(Singer{ 0, "Inna", "female" });
-    storage.insert(Singer{ 0, "Krewella", "female" });
-    storage.insert(Singer{ 0, "Sting", "male" });
-    storage.insert(Singer{ 0, "Lady Gaga", "female" });
-    storage.insert(Singer{ 0, "Rameez", "male" });
-    
+
+    storage.insert(Singer{0, "Alexandra Stan", "female"});
+    storage.insert(Singer{0, "Inna", "female"});
+    storage.insert(Singer{0, "Krewella", "female"});
+    storage.insert(Singer{0, "Sting", "male"});
+    storage.insert(Singer{0, "Lady Gaga", "female"});
+    storage.insert(Singer{0, "Rameez", "male"});
+
     {
         //  test double ORDER BY
-        auto singers = storage.get_all<Singer>(multi_order_by(order_by(&Singer::name).asc().collate_nocase(), order_by(&Singer::gender).desc()));
+        auto singers = storage.get_all<Singer>(
+            multi_order_by(order_by(&Singer::name).asc().collate_nocase(), order_by(&Singer::gender).desc()));
         auto expectedIds = {1, 2, 3, 5, 6, 4};
         REQUIRE(expectedIds.size() == singers.size());
         auto it = expectedIds.begin();
@@ -35,7 +36,7 @@ TEST_CASE("Multi order by"){
             ++it;
         }
     }
-    
+
     //  test multi ORDER BY ith singl column with single ORDER BY
     {
         auto singers = storage.get_all<Singer>(order_by(&Singer::id).asc());
@@ -45,41 +46,37 @@ TEST_CASE("Multi order by"){
             REQUIRE(singers[i].id == singers2[i].id);
         }
     }
-    
 }
 
-TEST_CASE("Issue 105"){
+TEST_CASE("Issue 105") {
     struct Data {
         int str;
     };
-    
-    auto storage = make_storage("",
-                                make_table("data",
-                                           make_column("str", &Data::str, primary_key())));
-    
+
+    auto storage = make_storage("", make_table("data", make_column("str", &Data::str, primary_key())));
+
     storage.sync_schema();
-    
+
     Data d{0};
     storage.insert(d);
 }
 
-TEST_CASE("Row id"){
+TEST_CASE("Row id") {
     struct SimpleTable {
         std::string letter;
         std::string desc;
     };
-    
-    auto storage = make_storage("rowid.sqlite",
-                                make_table("tbl1",
-                                           make_column("letter", &SimpleTable::letter),
-                                           make_column("desc", &SimpleTable::desc)));
+
+    auto storage = make_storage(
+        "rowid.sqlite",
+        make_table("tbl1", make_column("letter", &SimpleTable::letter), make_column("desc", &SimpleTable::desc)));
     storage.sync_schema();
     storage.remove_all<SimpleTable>();
-    
+
     storage.insert(SimpleTable{"A", "first letter"});
     storage.insert(SimpleTable{"B", "second letter"});
     storage.insert(SimpleTable{"C", "third letter"});
-    
+
     auto rows = storage.select(columns(rowid(),
                                        oid(),
                                        _rowid_(),
@@ -99,19 +96,19 @@ TEST_CASE("Row id"){
     }
 }
 
-TEST_CASE("Issue 87"){
+TEST_CASE("Issue 87") {
     struct Data {
-        uint8_t  mDefault; /**< 0=User or 1=Default*/
-        uint8_t     mAppLang; //en_GB
-        uint8_t     mContentLang1; //de_DE
-        uint8_t     mContentLang2; //en_GB
-        uint8_t     mContentLang3;
-        uint8_t     mContentLang4;
-        uint8_t     mContentLang5;
+        uint8_t mDefault; /**< 0=User or 1=Default*/
+        uint8_t mAppLang;  // en_GB
+        uint8_t mContentLang1;  // de_DE
+        uint8_t mContentLang2;  // en_GB
+        uint8_t mContentLang3;
+        uint8_t mContentLang4;
+        uint8_t mContentLang5;
     };
-    
+
     Data data;
-    
+
     auto storage = make_storage("",
                                 make_table("data",
                                            make_column("IsDef", &Data::mDefault, primary_key()),
@@ -122,7 +119,7 @@ TEST_CASE("Issue 87"){
                                            make_column("CL4", &Data::mContentLang4),
                                            make_column("CL5", &Data::mContentLang5)));
     storage.sync_schema();
-    
+
     storage.update_all(set(c(&Data::mContentLang1) = data.mContentLang1,
                            c(&Data::mContentLang2) = data.mContentLang2,
                            c(&Data::mContentLang3) = data.mContentLang3,
@@ -132,47 +129,43 @@ TEST_CASE("Issue 87"){
 }
 
 #ifndef SQLITE_ORM_OMITS_CODECVT
-TEST_CASE("Wide string"){
-    
+TEST_CASE("Wide string") {
+
     struct Alphabet {
         int id;
         std::wstring letters;
     };
-    
+
     auto storage = make_storage("wideStrings.sqlite",
                                 make_table("alphabets",
-                                           make_column("id",
-                                                       &Alphabet::id,
-                                                       primary_key()),
-                                           make_column("letters",
-                                                       &Alphabet::letters)));
+                                           make_column("id", &Alphabet::id, primary_key()),
+                                           make_column("letters", &Alphabet::letters)));
     storage.sync_schema();
     storage.remove_all<Alphabet>();
-    
+
     std::vector<std::wstring> expectedStrings = {
-        L"ﻌﺾﺒﺑﺏﺖﺘﺗﺕﺚﺜﺛﺙﺞﺠﺟﺝﺢﺤﺣﺡﺦﺨﺧﺥﺪﺩﺬﺫﺮﺭﺰﺯﺲﺴﺳﺱﺶﺸﺷﺵﺺﺼﺻﺹﻀﺿﺽﻂﻄﻃﻁﻆﻈﻇﻅﻊﻋﻉﻎﻐﻏﻍﻒﻔﻓﻑﻖﻘﻗﻕﻚﻜﻛﻙﻞﻠﻟﻝﻢﻤﻣﻡﻦﻨﻧﻥﻪﻬﻫﻩﻮﻭﻲﻴﻳﻱ",   //  arabic
-        L"ԱաԲբԳգԴդԵեԶզԷէԸըԹթԺժԻիԼլԽխԾծԿկՀհՁձՂղՃճՄմՅյՆնՇշՈոՉչՊպՋջՌռՍսՎվՏտՐրՑցՒւՓփՔքՕօՖֆ",    //  armenian
+        L"ﻌﺾﺒﺑﺏﺖﺘﺗﺕﺚﺜﺛﺙﺞﺠﺟﺝﺢﺤﺣﺡﺦﺨﺧﺥﺪﺩﺬﺫﺮﺭﺰﺯﺲﺴﺳﺱﺶﺸﺷﺵﺺﺼﺻﺹﻀﺿﺽﻂﻄﻃﻁﻆﻈﻇﻅﻊﻋﻉﻎﻐﻏﻍﻒﻔﻓﻑﻖﻘﻗﻕﻚﻜﻛﻙﻞﻠﻟﻝﻢﻤﻣﻡﻦﻨﻧﻥﻪﻬﻫﻩﻮﻭﻲﻴﻳ"
+        L"ﻱ",  //  arabic
+        L"ԱաԲբԳգԴդԵեԶզԷէԸըԹթԺժԻիԼլԽխԾծԿկՀհՁձՂղՃճՄմՅյՆնՇշՈոՉչՊպՋջՌռՍսՎվՏտՐրՑցՒւՓփՔքՕօՖֆ",  //  armenian
         L"АаБбВвГгДдЕеЁёЖжЗзИиЙйКкЛлМмНнОоППРрСсТтУуФфХхЦцЧчШшЩщЪъЫыЬьЭэЮюЯя",  //  russian
         L"AaBbCcÇçDdEeFFGgĞğHhIıİiJjKkLlMmNnOoÖöPpRrSsŞşTtUuÜüVvYyZz",  //  turkish
     };
-    for(auto &expectedString : expectedStrings) {
+    for(auto &expectedString: expectedStrings) {
         auto id = storage.insert(Alphabet{0, expectedString});
         REQUIRE(storage.get<Alphabet>(id).letters == expectedString);
     }
-    
 }
 #endif  //  SQLITE_ORM_OMITS_CODECVT
 
-TEST_CASE("Issue 86"){
-    struct Data
-    {
-        uint8_t mUsed=0;
+TEST_CASE("Issue 86") {
+    struct Data {
+        uint8_t mUsed = 0;
         int mId = 0;
         int mCountryId = 0;
         int mLangId = 0;
         std::string mName;
     };
-    
+
     auto storage = make_storage("",
                                 make_table("cities",
                                            make_column("U", &Data::mUsed),
@@ -182,46 +175,45 @@ TEST_CASE("Issue 86"){
                                            make_column("N", &Data::mName)));
     storage.sync_schema();
     std::string CurrCity = "ototo";
-    auto vms = storage.select(columns(&Data::mId, &Data::mLangId),
-                              where(like(&Data::mName, CurrCity)));
+    auto vms = storage.select(columns(&Data::mId, &Data::mLangId), where(like(&Data::mName, CurrCity)));
 }
 
-TEST_CASE("Busy timeout"){
+TEST_CASE("Busy timeout") {
     auto storage = make_storage("testBusyTimeout.sqlite");
     storage.busy_timeout(500);
 }
 
-TEST_CASE("Aggregate functions"){
+TEST_CASE("Aggregate functions") {
     struct User {
         int id;
         std::string name;
         int age;
-        
+
         void setId(int newValue) {
             this->id = newValue;
         }
-        
-        const int& getId() const {
+
+        const int &getId() const {
             return this->id;
         }
-        
+
         void setName(std::string newValue) {
             this->name = newValue;
         }
-        
-        const std::string& getName() const {
+
+        const std::string &getName() const {
             return this->name;
         }
-        
+
         void setAge(int newValue) {
             this->age = newValue;
         }
-        
-        const int& getAge() const {
+
+        const int &getAge() const {
             return this->age;
         }
     };
-    
+
     auto storage = make_storage("test_aggregate.sqlite",
                                 make_table("users",
                                            make_column("id", &User::id, primary_key()),
@@ -234,47 +226,47 @@ TEST_CASE("Aggregate functions"){
                                             make_column("age", &User::getAge, &User::setAge)));
     storage.sync_schema();
     storage.remove_all<User>();
-    
-    storage.replace(User{ 1, "Bebe Rexha", 28});
-    storage.replace(User{ 2, "Rihanna", 29 });
-    storage.replace(User{ 3, "Cheryl Cole", 34 });
-    
+
+    storage.replace(User{1, "Bebe Rexha", 28});
+    storage.replace(User{2, "Rihanna", 29});
+    storage.replace(User{3, "Cheryl Cole", 34});
+
     auto avgId = storage.avg(&User::id);
     REQUIRE(avgId == 2);
-    
+
     auto avgId2 = storage2.avg(&User::getId);
     REQUIRE(avgId2 == avgId);
-    
+
     auto avgId3 = storage2.avg(&User::setId);
     REQUIRE(avgId3 == avgId2);
-    
+
     auto avgRaw = storage.select(avg(&User::id)).front();
     REQUIRE(avgRaw == avgId);
-    
+
     auto distinctAvg = storage.select(distinct(avg(&User::id))).front();
     REQUIRE(distinctAvg == avgId);
-    
+
     auto allAvg = storage.select(all(avg(&User::id))).front();
     REQUIRE(allAvg == avgId);
-    
+
     auto avgRaw2 = storage2.select(avg(&User::getId)).front();
     REQUIRE(avgRaw2 == avgId);
-    
+
     auto avgRaw3 = storage2.select(avg(&User::setId)).front();
     REQUIRE(avgRaw3 == avgRaw2);
-    
+
     auto distinctAvg2 = storage2.select(distinct(avg(&User::setId))).front();
     REQUIRE(distinctAvg2 == avgId);
-    
+
     auto distinctAvg3 = storage2.select(distinct(avg(&User::getId))).front();
     REQUIRE(distinctAvg3 == distinctAvg2);
-    
+
     auto allAvg2 = storage2.select(all(avg(&User::getId))).front();
     REQUIRE(allAvg2 == avgId);
-    
+
     auto allAvg3 = storage2.select(all(avg(&User::setId))).front();
     REQUIRE(allAvg3 == allAvg2);
-    
+
     //  next we test that all aggregate functions support arguments bindings.
     //  This is why id = 1 condition is important here
     {
@@ -310,55 +302,54 @@ TEST_CASE("Aggregate functions"){
     }
 }
 
-TEST_CASE("Current timestamp"){
+TEST_CASE("Current timestamp") {
     auto storage = make_storage("");
     REQUIRE(storage.current_timestamp().size());
-    
+
     storage.begin_transaction();
     REQUIRE(storage.current_timestamp().size());
     storage.commit();
 }
 
-TEST_CASE("Open forever"){
+TEST_CASE("Open forever") {
     struct User {
         int id;
         std::string name;
     };
-    
-    auto storage = make_storage("open_forever.sqlite",
-                                make_table("users",
-                                           make_column("id", &User::id, primary_key()),
-                                           make_column("name", &User::name)));
+
+    auto storage = make_storage(
+        "open_forever.sqlite",
+        make_table("users", make_column("id", &User::id, primary_key()), make_column("name", &User::name)));
     storage.sync_schema();
-    
+
     storage.remove_all<User>();
-    
+
     storage.open_forever();
-    
-    storage.insert(User{ 1, "Demi" });
-    storage.insert(User{ 2, "Luis" });
-    storage.insert(User{ 3, "Shakira" });
-    
+
+    storage.insert(User{1, "Demi"});
+    storage.insert(User{2, "Luis"});
+    storage.insert(User{3, "Shakira"});
+
     storage.open_forever();
-    
+
     REQUIRE(storage.count<User>() == 3);
-    
+
     storage.begin_transaction();
-    storage.insert(User{ 4, "Calvin" });
+    storage.insert(User{4, "Calvin"});
     storage.commit();
-    
+
     REQUIRE(storage.count<User>() == 4);
 }
 
 //  appeared after #55
-TEST_CASE("Default value"){
+TEST_CASE("Default value") {
     struct User {
         int userId;
         std::string name;
         int age;
         std::string email;
     };
-    
+
     auto storage1 = make_storage("test_db.sqlite",
                                  make_table("User",
                                             make_column("Id", &User::userId, primary_key()),
@@ -366,9 +357,9 @@ TEST_CASE("Default value"){
                                             make_column("Age", &User::age)));
     storage1.sync_schema();
     storage1.remove_all<User>();
-    
+
     auto emailColumn = make_column("Email", &User::email, default_value("example@email.com"));
-    
+
     auto storage2 = make_storage("test_db.sqlite",
                                  make_table("User",
                                             make_column("Id", &User::userId, primary_key()),
@@ -377,23 +368,23 @@ TEST_CASE("Default value"){
                                             emailColumn));
     storage2.sync_schema();
     storage2.insert(User{0, "Tom", 15, ""});
-    
+
     auto emailDefault = emailColumn.default_value();
     REQUIRE(emailDefault);
     REQUIRE(*emailDefault == "example@email.com");
 }
 
 //  appeared after #54
-TEST_CASE("Blob"){
+TEST_CASE("Blob") {
     struct BlobData {
         std::vector<char> data;
     };
     using byte = char;
-    
-    auto generateData = [](size_t size) -> byte* {
-        auto data = (byte*)::malloc(size * sizeof(byte));
-        for (int i = 0; i < static_cast<int>(size); ++i) {
-            if ((i+1) % 10 == 0) {
+
+    auto generateData = [](size_t size) -> byte * {
+        auto data = (byte *)::malloc(size * sizeof(byte));
+        for(int i = 0; i < static_cast<int>(size); ++i) {
+            if((i + 1) % 10 == 0) {
                 data[i] = 0;
             } else {
                 data[i] = static_cast<byte>((rand() % 100) + 1);
@@ -401,22 +392,20 @@ TEST_CASE("Blob"){
         }
         return data;
     };
-    
-    auto storage = make_storage("blob.db",
-                                make_table("blob",
-                                           make_column("data", &BlobData::data)));
+
+    auto storage = make_storage("blob.db", make_table("blob", make_column("data", &BlobData::data)));
     storage.sync_schema();
     storage.remove_all<BlobData>();
-    
+
     size_t size = 100;
     auto data = generateData(size);
-    
+
     //  write data
     BlobData d;
     std::vector<char> v(data, data + size);
     d.data = v;
     storage.insert(d);
-    
+
     //  read data with get_all
     {
         auto vd = storage.get_all<BlobData>();
@@ -425,7 +414,7 @@ TEST_CASE("Blob"){
         REQUIRE(blob.data.size() == size);
         REQUIRE(std::equal(data, data + size, blob.data.begin()));
     }
-    
+
     //  read data with select (single column)
     {
         auto blobData = storage.select(&BlobData::data);
@@ -434,99 +423,93 @@ TEST_CASE("Blob"){
         REQUIRE(blob.size() == size);
         REQUIRE(std::equal(data, data + size, blob.begin()));
     }
-    
+
     //  read data with select (multi column)
     {
         auto blobData = storage.select(columns(&BlobData::data));
         REQUIRE(blobData.size() == 1);
         auto &blob = std::get<0>(blobData.front());
         REQUIRE(blob.size() == size);
-        REQUIRE(std::equal(data,
-                           data + size,
-                           blob.begin()));
+        REQUIRE(std::equal(data, data + size, blob.begin()));
     }
-    
+
     storage.insert(BlobData{});
-    
+
     free(data);
 }
 
 //  appeared after #57
-TEST_CASE("Foreign key 2"){
+TEST_CASE("Foreign key 2") {
     class test1 {
-    public:
+      public:
         // Constructors
-        test1() {};
-        
+        test1(){};
+
         // Variables
         int id;
         std::string val1;
         std::string val2;
     };
-    
+
     class test2 {
-    public:
+      public:
         // Constructors
-        test2() {};
-        
+        test2(){};
+
         // Variables
         int id;
         int fk_id;
         std::string val1;
         std::string val2;
     };
-    
+
     auto table1 = make_table("test_1",
                              make_column("id", &test1::id, primary_key()),
                              make_column("val1", &test1::val1),
                              make_column("val2", &test1::val2));
-    
+
     auto table2 = make_table("test_2",
                              make_column("id", &test2::id, primary_key()),
                              make_column("fk_id", &test2::fk_id),
                              make_column("val1", &test2::val1),
                              make_column("val2", &test2::val2),
                              foreign_key(&test2::fk_id).references(&test1::id));
-    
-    auto storage = make_storage("test.sqlite",
-                                table1,
-                                table2);
-    
+
+    auto storage = make_storage("test.sqlite", table1, table2);
+
     storage.sync_schema();
-    
-    
+
     test1 t1;
     t1.val1 = "test";
     t1.val2 = "test";
     storage.insert(t1);
-    
+
     test1 t1_copy;
     t1_copy.val1 = "test";
     t1_copy.val2 = "test";
     storage.insert(t1_copy);
-    
+
     test2 t2;
     t2.fk_id = 1;
     t2.val1 = "test";
     t2.val2 = "test";
     storage.insert(t2);
-    
+
     t2.fk_id = 2;
-    
+
     storage.update(t2);
 }
 
-TEST_CASE("Foreign key"){
-    
+TEST_CASE("Foreign key") {
+
     struct Location {
         int id;
         std::string place;
         std::string country;
         std::string city;
         int distance;
-        
     };
-    
+
     struct Visit {
         int id;
         std::unique_ptr<int> location;
@@ -534,7 +517,7 @@ TEST_CASE("Foreign key"){
         int visited_at;
         uint8_t mark;
     };
-    
+
     //  this case didn't compile on linux until `typedef constraints_type` was added to `foreign_key_t`
     auto storage = make_storage("test_fk.sqlite",
                                 make_table("location",
@@ -551,24 +534,22 @@ TEST_CASE("Foreign key"){
                                            make_column("mark", &Visit::mark),
                                            foreign_key(&Visit::location).references(&Location::id)));
     storage.sync_schema();
-    
+
     int fromDate = int(time(nullptr));
     int toDate = int(time(nullptr));
     int toDistance = 100;
     auto id = 10;
     storage.select(columns(&Visit::mark, &Visit::visited_at, &Location::place),
                    inner_join<Location>(on(is_equal(&Visit::location, &Location::id))),
-                   where(is_equal(&Visit::user, id) and
-                         greater_than(&Visit::visited_at, fromDate) and
-                         lesser_than(&Visit::visited_at, toDate) and
-                         lesser_than(&Location::distance, toDistance)),
+                   where(is_equal(&Visit::user, id) and greater_than(&Visit::visited_at, fromDate) and
+                         lesser_than(&Visit::visited_at, toDate) and lesser_than(&Location::distance, toDistance)),
                    order_by(&Visit::visited_at));
 }
 
 /**
  *  Created by fixing https://github.com/fnc12/sqlite_orm/issues/42
  */
-TEST_CASE("Escape chars"){
+TEST_CASE("Escape chars") {
     struct Employee {
         int id;
         std::string name;
@@ -576,16 +557,16 @@ TEST_CASE("Escape chars"){
         std::string address;
         double salary;
     };
-    auto storage =  make_storage("test_escape_chars.sqlite",
-                                 make_table("COMPANY",
-                                            make_column("INDEX", &Employee::id, primary_key()),
-                                            make_column("NAME", &Employee::name),
-                                            make_column("AGE", &Employee::age),
-                                            make_column("ADDRESS", &Employee::address),
-                                            make_column("SALARY", &Employee::salary)));
+    auto storage = make_storage("test_escape_chars.sqlite",
+                                make_table("COMPANY",
+                                           make_column("INDEX", &Employee::id, primary_key()),
+                                           make_column("NAME", &Employee::name),
+                                           make_column("AGE", &Employee::age),
+                                           make_column("ADDRESS", &Employee::address),
+                                           make_column("SALARY", &Employee::salary)));
     storage.sync_schema();
     storage.remove_all<Employee>();
-    
+
     storage.insert(Employee{
         0,
         "Paul'l",
@@ -593,9 +574,9 @@ TEST_CASE("Escape chars"){
         "Sacramento 20",
         40000,
     });
-    
+
     auto paulL = storage.get_all<Employee>(where(is_equal(&Employee::name, "Paul'l")));
-    
+
     storage.replace(Employee{
         10,
         "Selena",
@@ -603,7 +584,7 @@ TEST_CASE("Escape chars"){
         "Florida",
         500000,
     });
-    
+
     auto selena = storage.get<Employee>(10);
     auto selenaMaybe = storage.get_no_throw<Employee>(10);
     selena.name = "Gomez";
@@ -611,89 +592,90 @@ TEST_CASE("Escape chars"){
     storage.remove<Employee>(10);
 }
 
-TEST_CASE("Transaction guard"){
+TEST_CASE("Transaction guard") {
     struct Object {
         int id;
         std::string name;
     };
-    
-    auto storage = make_storage("test_transaction_guard.sqlite",
-                                make_table("objects",
-                                           make_column("id", &Object::id, primary_key()),
-                                           make_column("name", &Object::name)));
-    
+
+    auto storage = make_storage(
+        "test_transaction_guard.sqlite",
+        make_table("objects", make_column("id", &Object::id, primary_key()), make_column("name", &Object::name)));
+
     storage.sync_schema();
     storage.remove_all<Object>();
-    
+
     storage.insert(Object{0, "Jack"});
-    
+
     //  insert, call make a storage to cakk an exception and check that rollback was fired
     auto countBefore = storage.count<Object>();
-    try{
+    try {
         auto guard = storage.transaction_guard();
-        
+
         storage.insert(Object{0, "John"});
-        
+
         storage.get<Object>(-1);
-        
+
         REQUIRE(false);
-    }catch(...){
+    } catch(...) {
         auto countNow = storage.count<Object>();
-        
+
         REQUIRE(countBefore == countNow);
     }
-    
+
     //  check that one can call other transaction functions without exceptions
-    storage.transaction([&]{return false;});
-    
+    storage.transaction([&] {
+        return false;
+    });
+
     //  commit explicitly and check that after exception data was saved
     countBefore = storage.count<Object>();
-    try{
+    try {
         auto guard = storage.transaction_guard();
         storage.insert(Object{0, "John"});
         guard.commit();
         storage.get<Object>(-1);
         REQUIRE(false);
-    }catch(...){
+    } catch(...) {
         auto countNow = storage.count<Object>();
-        
+
         REQUIRE(countNow == countBefore + 1);
     }
-    
+
     //  rollback explicitly
     countBefore = storage.count<Object>();
-    try{
+    try {
         auto guard = storage.transaction_guard();
         storage.insert(Object{0, "Michael"});
         guard.rollback();
         storage.get<Object>(-1);
         REQUIRE(false);
-    }catch(...){
+    } catch(...) {
         auto countNow = storage.count<Object>();
         REQUIRE(countNow == countBefore);
     }
-    
+
     //  commit on exception
     countBefore = storage.count<Object>();
-    try{
+    try {
         auto guard = storage.transaction_guard();
         guard.commit_on_destroy = true;
         storage.insert(Object{0, "Michael"});
         storage.get<Object>(-1);
         REQUIRE(false);
-    }catch(...){
+    } catch(...) {
         auto countNow = storage.count<Object>();
         REQUIRE(countNow == countBefore + 1);
     }
-    
+
     //  work witout exception
     countBefore = storage.count<Object>();
-    try{
+    try {
         auto guard = storage.transaction_guard();
         guard.commit_on_destroy = true;
         storage.insert(Object{0, "Lincoln"});
-        
-    }catch(...){
+
+    } catch(...) {
         throw std::runtime_error("Must not fire");
     }
     auto countNow = storage.count<Object>();


### PR DESCRIPTION
Added clang-format that I tried to match to your style but not all styles could be the same. I also applied the style formatting to all files that can be done with the following command: `find -name '*.cpp' -o -name '*.h' | xargs clang-format -i`
All the style options can be found on https://clang.llvm.org/docs/ClangFormatStyleOptions.html
You can replace the style with some already predefined styles as used for LLVM, Google, Chromium, Mozilla, WebKit with `clang-format -style=llvm -dump-config > .clang-format` as described in https://clang.llvm.org/docs/ClangFormat.html and then format the code again for all files.
Usually, most editors offer format on save or similar so everyone can use the same style without the need for manual checking.