### PR TITLE
Add clang-format lint action

### DIFF
--- a/.github/workflows/clang-format-lint.yaml
+++ b/.github/workflows/clang-format-lint.yaml
@@ -1,0 +1,15 @@
+name: clang-format lint
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: clang-format lint
+      uses: DoozyX/clang-format-lint-action@v0.3.1
+      with:
+        exclude: ./include


### PR DESCRIPTION
This pull request adds clang-format lint action that checks if the code matches the .clang-format file.
It ignores the sqlite_orm.h header because it is generated from the python script and the formatting is not exactly the same.
I can't see the actions tab on your repo, if it doesn't work here you may need to sign up on the beta here https://github.com/features/actions . The GitHub actions will be generally available on November 13.