### PR TITLE
clang-format lint action not active

### DIFF
--- a/.github/workflows/clang-format-lint.yaml
+++ b/.github/workflows/clang-format-lint.yaml
@@ -4,7 +4,6 @@ on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Tried updating the action, currently, it is not triggering the workflow.