### PR TITLE
Extra info when failing to open a database

### DIFF
--- a/dev/database_connection.h
+++ b/dev/database_connection.h
@@ -5,26 +5,23 @@
 #include <system_error> //  std::error_code, std::system_error
 
 #include "error_code.h"
-
 namespace sqlite_orm {
     
     namespace internal {
 
         inline sqlite3 *open_db(std::string const&filename)
-    	{
-    		sqlite3 *result {nullptr};
-			if(sqlite3_open(filename.c_str(), &result) != SQLITE_OK){
-				
-				throw std::system_error(std::error_code(sqlite3_errcode(result), get_sqlite_error_category()), get_error_message(result, "opening '", filename, "'. "));
+        {
+            sqlite3 *result {nullptr};
+            if(sqlite3_open(filename.c_str(), &result) != SQLITE_OK){
+                throw_error(result, "opening '", filename, "'. ");
             }
-			return result;
-    	}
+            return result;
+        }
     	
         struct database_connection {
             explicit database_connection(const std::string &filename):
-				db {open_db(filename) }
-    		{
-            }
+               db {open_db(filename) }
+            {}
             
             ~database_connection() {
                 sqlite3_close(this->db);

--- a/dev/database_connection.h
+++ b/dev/database_connection.h
@@ -9,14 +9,21 @@
 namespace sqlite_orm {
     
     namespace internal {
-        
+
+        inline sqlite3 *open_db(std::string const&filename)
+    	{
+    		sqlite3 *result {nullptr};
+			if(sqlite3_open(filename.c_str(), &result) != SQLITE_OK){
+				
+				throw std::system_error(std::error_code(sqlite3_errcode(result), get_sqlite_error_category()), get_error_message(result, "opening '", filename, "'. "));
+            }
+			return result;
+    	}
+    	
         struct database_connection {
-            
-            database_connection(const std::string &filename) {
-                auto rc = sqlite3_open(filename.c_str(), &this->db);
-                if(rc != SQLITE_OK){
-                    throw std::system_error(std::error_code(sqlite3_errcode(this->db), get_sqlite_error_category()), sqlite3_errmsg(this->db));
-                }
+            explicit database_connection(const std::string &filename):
+				db {open_db(filename) }
+    		{
             }
             
             ~database_connection() {
@@ -28,7 +35,7 @@ namespace sqlite_orm {
             }
             
         protected:
-            sqlite3 *db = nullptr;
+            sqlite3 *db;
         };
     }
 }

--- a/dev/error_code.h
+++ b/dev/error_code.h
@@ -81,6 +81,21 @@ namespace sqlite_orm {
         static sqlite_error_category res;
         return res;
     }
+    
+    template<typename ... T>
+	std::string get_error_message(sqlite3 *db, T&& ... args)
+	{
+		std::ostringstream stream;
+		using unpack = int[];
+		static_cast<void>(unpack{
+			0, (static_cast<void>(stream << args) , 0) ...
+		});
+    	stream << sqlite3_errmsg(db);
+		//in visual studio 2019:
+		//stream << ... << std::forward<T>(args);
+		return stream.str();
+	}
+
 }
 
 namespace std

--- a/dev/error_code.h
+++ b/dev/error_code.h
@@ -83,19 +83,22 @@ namespace sqlite_orm {
     }
     
     template<typename ... T>
-	std::string get_error_message(sqlite3 *db, T&& ... args)
-	{
-		std::ostringstream stream;
-		using unpack = int[];
-		static_cast<void>(unpack{
-			0, (static_cast<void>(stream << args) , 0) ...
-		});
-    	stream << sqlite3_errmsg(db);
-		//in visual studio 2019:
-		//stream << ... << std::forward<T>(args);
-		return stream.str();
-	}
+    std::string get_error_message(sqlite3 *db, T&& ... args)
+    {
+            std::ostringstream stream;
+            using unpack = int[];
+            static_cast<void>(unpack{
+                0, (static_cast<void>(stream << args) , 0) ...
+        });
+        stream << sqlite3_errmsg(db);
+	return stream.str();
+    }
 
+    template<typename ... T>
+    [[noresult]] void throw_error(sqlite3 *db, T&& ... args)
+    {
+        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()), get_error_message(db, std::forward<T>(args)...));
+    }
 }
 
 namespace std


### PR DESCRIPTION
Added a throw_error and get_error_message function to easy add extra information when errors occur, and to deduplicate the error code generation. This is used in the open database to add info about which file cannot be opened and can be used on lot of other places.