### PR TITLE
add clang-format lint on pull requests

### DIFF
--- a/.github/workflows/clang-format-lint.yaml
+++ b/.github/workflows/clang-format-lint.yaml
@@ -1,6 +1,6 @@
 name: clang-format lint
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
This pull request adds running clang-format lint workflow on pull requests.