### PR TITLE
Compile error due to insufficient braces.

### DIFF
--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -4979,14 +4979,14 @@ namespace sqlite_orm {
             std::transform(str.begin(), str.end(), std::back_inserter(upper_str), [](char c) {
                 return static_cast<char>(std::toupper(static_cast<int>(c)));
             });
-            static std::array<journal_mode, 6> all = {
+            static std::array<journal_mode, 6> all = {{
                 journal_mode::DELETE,
                 journal_mode::TRUNCATE,
                 journal_mode::PERSIST,
                 journal_mode::MEMORY,
                 journal_mode::WAL,
                 journal_mode::OFF,
-            };
+            }};
             for(auto j: all) {
                 if(to_string(j) == upper_str) {
                     return std::make_unique<journal_mode>(j);


### PR DESCRIPTION
When compiling in Ubuntu 18 with GCC 7.5 and 9.3 (tested both) and with the C++17 flag on, GCC complains that there are missing braces, and fails compilation.

The issue stems from the `-Wmissing-braces` warning, which gets elevated into an error when compiling under stricter modes.

An investigation leads to [discussions such as this](https://stackoverflow.com/questions/11734861/when-can-outer-braces-be-omitted-in-an-initializer-list).

After adding the braces I find that GCC happily compiles the code.