### PR TITLE
sqlite3_busy_handler

### DIFF
--- a/dev/storage_base.h
+++ b/dev/storage_base.h
@@ -124,6 +124,25 @@ namespace sqlite_orm {
                 return sqlite3_busy_timeout(con.get(), ms);
             }
 
+            /*
+             * Ownership is NOT transferred, i.e. data
+             * must not go out of scope for the lifetime of the database.
+             */
+            template<typename T = void>
+            int busy_handler(std::function<int(T *, int)> f, T &data) {
+                handler = {[f{move(f)}](void *ptr, int times) -> int {
+                               return f(reinterpret_cast<T *>(ptr), times);
+                           },
+                           (void *)&data};
+                return sqlite3_busy_handler(
+                    this->get_connection().get(),
+                    [](void *ptr, int times) -> int {
+                        auto h = *reinterpret_cast<handler_t *>(ptr);
+                        return h.fn(reinterpret_cast<T *>(h.ptr), times);
+                    },
+                    &handler);
+            }
+
             /**
              *  Returns libsqlite3 lib version, not sqlite_orm
              */
@@ -339,6 +358,11 @@ namespace sqlite_orm {
             std::unique_ptr<connection_holder> connection;
             std::map<std::string, collating_function> collatingFunctions;
             const int cachedForeignKeysCount;
+
+            struct handler_t final {
+                std::function<int(void *, int)> fn;
+                void *ptr;
+            } handler;
 
             connection_ref get_connection() {
                 connection_ref res{*this->connection};

--- a/dev/storage_base.h
+++ b/dev/storage_base.h
@@ -125,7 +125,7 @@ namespace sqlite_orm {
             }
 
             /**
-             *  Returns libsqltie3 lib version, not sqlite_orm
+             *  Returns libsqlite3 lib version, not sqlite_orm
              */
             std::string libversion() {
                 return sqlite3_libversion();

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -8702,7 +8702,7 @@ namespace sqlite_orm {
             }
 
             /**
-             *  Returns libsqltie3 lib version, not sqlite_orm
+             *  Returns libsqlite3 lib version, not sqlite_orm
              */
             std::string libversion() {
                 return sqlite3_libversion();

--- a/tests/tests3.cpp
+++ b/tests/tests3.cpp
@@ -183,6 +183,25 @@ TEST_CASE("Busy timeout") {
     storage.busy_timeout(500);
 }
 
+TEST_CASE("Busy handler") {
+    auto storage = make_storage("testBusyHandler.sqlite");
+    int value = 42;
+    storage.busy_handler<int>(
+        [](int *ptr, int times) -> int {
+            int ptr_value = *ptr;
+            return (ptr_value == 42) ? 1 : 0;
+        },
+        value);
+
+    // Test if lambda captures compile successfully
+    storage.busy_handler<int>(
+        [&value](int *ptr, int times) -> int {
+            int ptr_value = *ptr;
+            return (ptr_value == value) ? 1 : 0;
+        },
+        value);
+}
+
 TEST_CASE("Aggregate functions") {
     struct User {
         int id;


### PR DESCRIPTION
I propose a possible implementation of a busy_handler function.

As sqlite3 has a pure C interface, it is not possible to simply pass `std::function` or lambdas into `sqlite3_busy_handler()`.
My solution is to shove a `std::function` and the user pointer into a struct, pass it into the C interface as a void pointer, and unpack it from the inside.
This way, we get to also expose a strongly typed interface to the user, through the template.
It can accept lambda captures too.

Warning: I don't really have a way to unit test this. The tests written are to ensure compile-ability only.