### PR TITLE
Extract sqlite3 step

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required (VERSION 3.14.0)
 # PACKAGE_VERSION is used by cpack scripts currently
 # Both sqlite_orm_VERSION and PACKAGE_VERSION should be the same for now
 
-set(sqlite_orm_VERSION "1.3.0")
+set(sqlite_orm_VERSION "1.6.0")
 set(PACKAGE_VERSION ${sqlite_orm_VERSION})
 
 project("sqlite_orm" VERSION ${PACKAGE_VERSION})

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -108,12 +108,7 @@ namespace sqlite_orm {
                 sqlite3_stmt *stmt;
                 if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if(sqlite3_step(stmt) == SQLITE_DONE) {
-                        //  done..
-                    } else {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
-                    }
+                    perform_step(db, stmt);
                 } else {
                     throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
                                             sqlite3_errmsg(db));
@@ -1109,12 +1104,8 @@ namespace sqlite_orm {
                                                 sqlite3_errmsg(db));
                     }
                 });
-                if(sqlite3_step(stmt) == SQLITE_DONE) {
-                    return sqlite3_last_insert_rowid(db);
-                } else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                            sqlite3_errmsg(db));
-                }
+                perform_step(db, stmt);
+                return sqlite3_last_insert_rowid(db);
             }
 
             template<class It>
@@ -1150,12 +1141,7 @@ namespace sqlite_orm {
                         }
                     });
                 }
-                if(sqlite3_step(stmt) == SQLITE_DONE) {
-                    //..
-                } else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                            sqlite3_errmsg(db));
-                }
+                perform_step(db, stmt);
             }
 
             template<class It>
@@ -1194,12 +1180,7 @@ namespace sqlite_orm {
                         }
                     });
                 }
-                if(sqlite3_step(stmt) == SQLITE_DONE) {
-                    //..
-                } else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                            sqlite3_errmsg(db));
-                }
+                perform_step(db, stmt);
             }
 
             template<class T>
@@ -1231,12 +1212,7 @@ namespace sqlite_orm {
                         }
                     }
                 });
-                if(sqlite3_step(stmt) == SQLITE_DONE) {
-                    //..
-                } else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                            sqlite3_errmsg(db));
-                }
+                perform_step(db, stmt);
             }
 
             template<class T>
@@ -1278,13 +1254,8 @@ namespace sqlite_orm {
                         }
                     }
                 });
-                if(sqlite3_step(stmt) == SQLITE_DONE) {
-                    res = sqlite3_last_insert_rowid(db);
-                } else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                            sqlite3_errmsg(db));
-                }
-                return res;
+                perform_step(db, stmt);
+                return sqlite3_last_insert_rowid(db);
             }
 
             template<class T, class... Ids>
@@ -1301,12 +1272,7 @@ namespace sqlite_orm {
                                                 sqlite3_errmsg(db));
                     }
                 });
-                if(sqlite3_step(stmt) == SQLITE_DONE) {
-                    //  done..
-                } else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                            sqlite3_errmsg(db));
-                }
+                perform_step(db, stmt);
             }
 
             template<class T>
@@ -1364,12 +1330,7 @@ namespace sqlite_orm {
                         }
                     }
                 });
-                if(sqlite3_step(stmt) == SQLITE_DONE) {
-                    //  done..
-                } else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                            sqlite3_errmsg(db));
-                }
+                perform_step(db, stmt);
             }
 
             template<class T, class... Ids>
@@ -1488,12 +1449,7 @@ namespace sqlite_orm {
                                                 sqlite3_errmsg(db));
                     }
                 });
-                if(sqlite3_step(stmt) == SQLITE_DONE) {
-                    //  done..
-                } else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                            sqlite3_errmsg(db));
-                }
+                perform_step(db, stmt);
             }
 
             template<class... Args, class... Wargs>
@@ -1521,12 +1477,7 @@ namespace sqlite_orm {
                                                 sqlite3_errmsg(db));
                     }
                 });
-                if(sqlite3_step(stmt) == SQLITE_DONE) {
-                    //  done..
-                } else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                            sqlite3_errmsg(db));
-                }
+                perform_step(db, stmt);
             }
 
             template<class T, class... Args, class R = typename column_result_t<self, T>::type>

--- a/dev/storage_base.h
+++ b/dev/storage_base.h
@@ -19,6 +19,7 @@
 #include "type_printer.h"
 #include "tuple_helper.h"
 #include "row_extractor.h"
+#include "util.h"
 #include "connection_holder.h"
 #include "backup.h"
 
@@ -49,12 +50,7 @@ namespace sqlite_orm {
                 sqlite3_stmt *stmt;
                 if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if(sqlite3_step(stmt) == SQLITE_DONE) {
-                        //  done..
-                    } else {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
-                    }
+                    perform_step(db, stmt);
                 } else {
                     throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
                                             sqlite3_errmsg(db));
@@ -68,12 +64,7 @@ namespace sqlite_orm {
                 sqlite3_stmt *stmt;
                 if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if(sqlite3_step(stmt) == SQLITE_DONE) {
-                        //  done..
-                    } else {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
-                    }
+                    perform_step(db, stmt);
                 } else {
                     throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
                                             sqlite3_errmsg(db));
@@ -441,12 +432,7 @@ namespace sqlite_orm {
                 sqlite3_stmt *stmt;
                 if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if(sqlite3_step(stmt) == SQLITE_DONE) {
-                        //  done..
-                    } else {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
-                    }
+                    perform_step(db, stmt);
                 } else {
                     throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
                                             sqlite3_errmsg(db));
@@ -460,12 +446,7 @@ namespace sqlite_orm {
                 sqlite3_stmt *stmt;
                 if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if(sqlite3_step(stmt) == SQLITE_DONE) {
-                        //  done..
-                    } else {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
-                    }
+                    perform_step(db, stmt);
                 } else {
                     throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
                                             sqlite3_errmsg(db));
@@ -479,12 +460,7 @@ namespace sqlite_orm {
                 sqlite3_stmt *stmt;
                 if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if(sqlite3_step(stmt) == SQLITE_DONE) {
-                        //  done..
-                    } else {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
-                    }
+                    perform_step(db, stmt);
                 } else {
                     throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
                                             sqlite3_errmsg(db));
@@ -527,12 +503,7 @@ namespace sqlite_orm {
                 sqlite3_stmt *stmt;
                 if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if(sqlite3_step(stmt) == SQLITE_DONE) {
-                        //  done..
-                    } else {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
-                    }
+                    perform_step(db, stmt);
                 } else {
                     throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
                                             sqlite3_errmsg(db));

--- a/dev/storage_impl.h
+++ b/dev/storage_impl.h
@@ -15,6 +15,7 @@
 #include "error_code.h"
 #include "statement_finalizer.h"
 #include "row_extractor.h"
+#include "util.h"
 #include "constraints.h"
 #include "select_constraints.h"
 #include "field_printer.h"
@@ -61,12 +62,7 @@ namespace sqlite_orm {
                 sqlite3_stmt *stmt;
                 if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if(sqlite3_step(stmt) == SQLITE_DONE) {
-                        //  done..
-                    } else {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
-                    }
+                    perform_step(db, stmt);
                 } else {
                     throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
                                             sqlite3_errmsg(db));
@@ -279,12 +275,7 @@ namespace sqlite_orm {
                 auto prepareResult = sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr);
                 if(prepareResult == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if(sqlite3_step(stmt) == SQLITE_DONE) {
-                        //..
-                    } else {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
-                    }
+                    perform_step(db, stmt);
                 } else {
                     throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
                                             sqlite3_errmsg(db));
@@ -335,12 +326,7 @@ namespace sqlite_orm {
                 sqlite3_stmt *stmt;
                 if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if(sqlite3_step(stmt) == SQLITE_DONE) {
-                        //..
-                    } else {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
-                    }
+                    perform_step(db, stmt);
                 } else {
                     throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
                                             sqlite3_errmsg(db));

--- a/dev/util.h
+++ b/dev/util.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <sqlite3.h>
+#include <system_error>  //  std::system_error, std::error_code
+
+namespace sqlite_orm {
+
+    namespace internal {
+        static void perform_step(sqlite3 *db, sqlite3_stmt *stmt) {
+            if(sqlite3_step(stmt) == SQLITE_DONE) {
+                //  done..
+            } else {
+                throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                        sqlite3_errmsg(db));
+            }
+        }
+    }
+}

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -5249,6 +5249,24 @@ namespace sqlite_orm {
 }
 #pragma once
 
+#include <sqlite3.h>
+#include <system_error>  //  std::system_error, std::error_code
+
+namespace sqlite_orm {
+
+    namespace internal {
+        static void perform_step(sqlite3 *db, sqlite3_stmt *stmt) {
+            if(sqlite3_step(stmt) == SQLITE_DONE) {
+                //  done..
+            } else {
+                throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                        sqlite3_errmsg(db));
+            }
+        }
+    }
+}
+#pragma once
+
 #include <ostream>
 
 namespace sqlite_orm {
@@ -6226,6 +6244,8 @@ namespace sqlite_orm {
 
 // #include "row_extractor.h"
 
+// #include "util.h"
+
 // #include "constraints.h"
 
 // #include "select_constraints.h"
@@ -6303,12 +6323,7 @@ namespace sqlite_orm {
                 sqlite3_stmt *stmt;
                 if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if(sqlite3_step(stmt) == SQLITE_DONE) {
-                        //  done..
-                    } else {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
-                    }
+                    perform_step(db, stmt);
                 } else {
                     throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
                                             sqlite3_errmsg(db));
@@ -6521,12 +6536,7 @@ namespace sqlite_orm {
                 auto prepareResult = sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr);
                 if(prepareResult == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if(sqlite3_step(stmt) == SQLITE_DONE) {
-                        //..
-                    } else {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
-                    }
+                    perform_step(db, stmt);
                 } else {
                     throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
                                             sqlite3_errmsg(db));
@@ -6577,12 +6587,7 @@ namespace sqlite_orm {
                 sqlite3_stmt *stmt;
                 if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if(sqlite3_step(stmt) == SQLITE_DONE) {
-                        //..
-                    } else {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
-                    }
+                    perform_step(db, stmt);
                 } else {
                     throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
                                             sqlite3_errmsg(db));
@@ -8530,6 +8535,8 @@ namespace sqlite_orm {
 
 // #include "row_extractor.h"
 
+// #include "util.h"
+
 // #include "connection_holder.h"
 
 // #include "backup.h"
@@ -8634,12 +8641,7 @@ namespace sqlite_orm {
                 sqlite3_stmt *stmt;
                 if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if(sqlite3_step(stmt) == SQLITE_DONE) {
-                        //  done..
-                    } else {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
-                    }
+                    perform_step(db, stmt);
                 } else {
                     throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
                                             sqlite3_errmsg(db));
@@ -8653,12 +8655,7 @@ namespace sqlite_orm {
                 sqlite3_stmt *stmt;
                 if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if(sqlite3_step(stmt) == SQLITE_DONE) {
-                        //  done..
-                    } else {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
-                    }
+                    perform_step(db, stmt);
                 } else {
                     throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
                                             sqlite3_errmsg(db));
@@ -9026,12 +9023,7 @@ namespace sqlite_orm {
                 sqlite3_stmt *stmt;
                 if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if(sqlite3_step(stmt) == SQLITE_DONE) {
-                        //  done..
-                    } else {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
-                    }
+                    perform_step(db, stmt);
                 } else {
                     throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
                                             sqlite3_errmsg(db));
@@ -9045,12 +9037,7 @@ namespace sqlite_orm {
                 sqlite3_stmt *stmt;
                 if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if(sqlite3_step(stmt) == SQLITE_DONE) {
-                        //  done..
-                    } else {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
-                    }
+                    perform_step(db, stmt);
                 } else {
                     throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
                                             sqlite3_errmsg(db));
@@ -9064,12 +9051,7 @@ namespace sqlite_orm {
                 sqlite3_stmt *stmt;
                 if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if(sqlite3_step(stmt) == SQLITE_DONE) {
-                        //  done..
-                    } else {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
-                    }
+                    perform_step(db, stmt);
                 } else {
                     throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
                                             sqlite3_errmsg(db));
@@ -9112,12 +9094,7 @@ namespace sqlite_orm {
                 sqlite3_stmt *stmt;
                 if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if(sqlite3_step(stmt) == SQLITE_DONE) {
-                        //  done..
-                    } else {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
-                    }
+                    perform_step(db, stmt);
                 } else {
                     throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
                                             sqlite3_errmsg(db));
@@ -11331,12 +11308,7 @@ namespace sqlite_orm {
                 sqlite3_stmt *stmt;
                 if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     statement_finalizer finalizer{stmt};
-                    if(sqlite3_step(stmt) == SQLITE_DONE) {
-                        //  done..
-                    } else {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
-                    }
+                    perform_step(db, stmt);
                 } else {
                     throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
                                             sqlite3_errmsg(db));
@@ -12332,12 +12304,8 @@ namespace sqlite_orm {
                                                 sqlite3_errmsg(db));
                     }
                 });
-                if(sqlite3_step(stmt) == SQLITE_DONE) {
-                    return sqlite3_last_insert_rowid(db);
-                } else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                            sqlite3_errmsg(db));
-                }
+                perform_step(db, stmt);
+                return sqlite3_last_insert_rowid(db);
             }
 
             template<class It>
@@ -12373,12 +12341,7 @@ namespace sqlite_orm {
                         }
                     });
                 }
-                if(sqlite3_step(stmt) == SQLITE_DONE) {
-                    //..
-                } else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                            sqlite3_errmsg(db));
-                }
+                perform_step(db, stmt);
             }
 
             template<class It>
@@ -12417,12 +12380,7 @@ namespace sqlite_orm {
                         }
                     });
                 }
-                if(sqlite3_step(stmt) == SQLITE_DONE) {
-                    //..
-                } else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                            sqlite3_errmsg(db));
-                }
+                perform_step(db, stmt);
             }
 
             template<class T>
@@ -12454,12 +12412,7 @@ namespace sqlite_orm {
                         }
                     }
                 });
-                if(sqlite3_step(stmt) == SQLITE_DONE) {
-                    //..
-                } else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                            sqlite3_errmsg(db));
-                }
+                perform_step(db, stmt);
             }
 
             template<class T>
@@ -12501,13 +12454,8 @@ namespace sqlite_orm {
                         }
                     }
                 });
-                if(sqlite3_step(stmt) == SQLITE_DONE) {
-                    res = sqlite3_last_insert_rowid(db);
-                } else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                            sqlite3_errmsg(db));
-                }
-                return res;
+                perform_step(db, stmt);
+                return sqlite3_last_insert_rowid(db);
             }
 
             template<class T, class... Ids>
@@ -12524,12 +12472,7 @@ namespace sqlite_orm {
                                                 sqlite3_errmsg(db));
                     }
                 });
-                if(sqlite3_step(stmt) == SQLITE_DONE) {
-                    //  done..
-                } else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                            sqlite3_errmsg(db));
-                }
+                perform_step(db, stmt);
             }
 
             template<class T>
@@ -12587,12 +12530,7 @@ namespace sqlite_orm {
                         }
                     }
                 });
-                if(sqlite3_step(stmt) == SQLITE_DONE) {
-                    //  done..
-                } else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                            sqlite3_errmsg(db));
-                }
+                perform_step(db, stmt);
             }
 
             template<class T, class... Ids>
@@ -12711,12 +12649,7 @@ namespace sqlite_orm {
                                                 sqlite3_errmsg(db));
                     }
                 });
-                if(sqlite3_step(stmt) == SQLITE_DONE) {
-                    //  done..
-                } else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                            sqlite3_errmsg(db));
-                }
+                perform_step(db, stmt);
             }
 
             template<class... Args, class... Wargs>
@@ -12744,12 +12677,7 @@ namespace sqlite_orm {
                                                 sqlite3_errmsg(db));
                     }
                 });
-                if(sqlite3_step(stmt) == SQLITE_DONE) {
-                    //  done..
-                } else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                            sqlite3_errmsg(db));
-                }
+                perform_step(db, stmt);
             }
 
             template<class T, class... Args, class R = typename column_result_t<self, T>::type>

--- a/third_party/amalgamate/config.json
+++ b/third_party/amalgamate/config.json
@@ -25,6 +25,7 @@
 		"dev/arithmetic_tag.h",
 		"dev/statement_binder.h",
 		"dev/row_extractor.h",
+		"dev/util.h",
 		"dev/sync_schema_result.h",
 		"dev/index.h",
 		"dev/mapped_type_proxy.h",
@@ -34,8 +35,8 @@
 		"dev/storage_impl.h",
 		"dev/storage.h",
 		"dev/finish_macros.h",
-        "dev/node_tuple.h",
-        "dev/get_prepared_statement.h"
+		"dev/node_tuple.h",
+		"dev/get_prepared_statement.h"
 	],
 	"include_paths": ["dev"]
 }


### PR DESCRIPTION
First commit: Update the version, which hasn't been updated since 1.3.0

Second commit: Extract out `sqlite3_step`, in order to prepare for possible implementations of the retry logic.

Note that there are still some `sqlite3_step`s in `storage_impl.h`. However, that header does not `#include` from `storage_base.h`, so `perform_step()` is not visible in that header.

I'm not sure how to resolve this, please advise.

(Also, I don't see any `static asserts` lost here - can you point them out to me so I can take a look?)