### PR TITLE
Extract sqlite3_exec

### DIFF
--- a/dev/pragma.h
+++ b/dev/pragma.h
@@ -6,6 +6,7 @@
 #include <memory>  // std::shared_ptr
 
 #include "error_code.h"
+#include "util.h"
 #include "row_extractor.h"
 #include "journal_mode.h"
 #include "connection_holder.h"
@@ -111,12 +112,7 @@ namespace sqlite_orm {
             }
             std::stringstream ss;
             ss << "PRAGMA " << name << " = " << value;
-            auto query = ss.str();
-            auto rc = sqlite3_exec(db, query.c_str(), nullptr, nullptr, nullptr);
-            if(rc != SQLITE_OK) {
-                throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                        sqlite3_errmsg(db));
-            }
+            internal::perform_void_exec(db, ss.str());
         }
 
         void set_pragma(const std::string &name, const sqlite_orm::journal_mode &value, sqlite3 *db = nullptr) {
@@ -126,12 +122,7 @@ namespace sqlite_orm {
             }
             std::stringstream ss;
             ss << "PRAGMA " << name << " = " << internal::to_string(value);
-            auto query = ss.str();
-            auto rc = sqlite3_exec(db, query.c_str(), nullptr, nullptr, nullptr);
-            if(rc != SQLITE_OK) {
-                throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                        sqlite3_errmsg(db));
-            }
+            internal::perform_void_exec(db, ss.str());
         }
     };
 }

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -104,15 +104,7 @@ namespace sqlite_orm {
                 if(tableImpl.table._without_rowid) {
                     ss << "WITHOUT ROWID ";
                 }
-                auto query = ss.str();
-                sqlite3_stmt *stmt;
-                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
-                    statement_finalizer finalizer{stmt};
-                    perform_step(db, stmt);
-                } else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                            sqlite3_errmsg(db));
-                }
+                perform_void_exec(db, ss.str());
             }
 
             template<class I>
@@ -655,11 +647,7 @@ namespace sqlite_orm {
                 using context_t = serializator_context<impl_type>;
                 context_t context{this->impl};
                 auto query = serialize(tableImpl.table, context);
-                auto rc = sqlite3_exec(db, query.c_str(), nullptr, nullptr, nullptr);
-                if(rc != SQLITE_OK) {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                            sqlite3_errmsg(db));
-                }
+                perform_void_exec(db, query);
                 return res;
             }
 

--- a/dev/storage_impl.h
+++ b/dev/storage_impl.h
@@ -58,15 +58,7 @@ namespace sqlite_orm {
             void rename_table(sqlite3 *db, const std::string &oldName, const std::string &newName) const {
                 std::stringstream ss;
                 ss << "ALTER TABLE " << oldName << " RENAME TO " << newName;
-                auto query = ss.str();
-                sqlite3_stmt *stmt;
-                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
-                    statement_finalizer finalizer{stmt};
-                    perform_step(db, stmt);
-                } else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                            sqlite3_errmsg(db));
-                }
+                perform_void_exec(db, ss.str());
             }
 
             static bool get_remove_add_columns(std::vector<table_info *> &columnsToAdd,
@@ -270,16 +262,7 @@ namespace sqlite_orm {
                 if(ti.dflt_value.length()) {
                     ss << "DEFAULT " << ti.dflt_value << " ";
                 }
-                auto query = ss.str();
-                sqlite3_stmt *stmt;
-                auto prepareResult = sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr);
-                if(prepareResult == SQLITE_OK) {
-                    statement_finalizer finalizer{stmt};
-                    perform_step(db, stmt);
-                } else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                            sqlite3_errmsg(db));
-                }
+                perform_void_exec(db, ss.str());
             }
 
             /**
@@ -322,15 +305,7 @@ namespace sqlite_orm {
                     ss << " ";
                 }
                 ss << "FROM '" << this->table.name << "' ";
-                auto query = ss.str();
-                sqlite3_stmt *stmt;
-                if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
-                    statement_finalizer finalizer{stmt};
-                    perform_step(db, stmt);
-                } else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                            sqlite3_errmsg(db));
-                }
+                perform_void_exec(db, ss.str());
             }
 
             sync_schema_result schema_status(sqlite3 *db, bool preserve) const {

--- a/dev/util.h
+++ b/dev/util.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <sqlite3.h>
+#include <string>  //  std::string
 #include <system_error>  //  std::system_error, std::error_code
 
 namespace sqlite_orm {
@@ -10,6 +11,14 @@ namespace sqlite_orm {
             if(sqlite3_step(stmt) == SQLITE_DONE) {
                 //  done..
             } else {
+                throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                        sqlite3_errmsg(db));
+            }
+        }
+
+        static void perform_void_exec(sqlite3 *db, const std::string &query) {
+            int rc = sqlite3_exec(db, query.c_str(), nullptr, nullptr, nullptr);
+            if(rc != SQLITE_OK) {
                 throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
                                         sqlite3_errmsg(db));
             }


### PR DESCRIPTION
Many of the function blocks that do `sqlite3_prepare_v2`, `statement_finalizer`, and `perform_step`/`sqlite3_step` are essentially `sqlite3_exec` calls, especially if no results are returned.