### PR TITLE
Maybe it's easier to use if we fetch sqlite3 as sub-module of this repo with cmake ?

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,8 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 include(CTest)
 
+option(SqliteOrm_SysSqlite "Use system version of sqlite library" OFF)
+
 ### Dependencies
 add_subdirectory(dependencies)
 
@@ -39,7 +41,6 @@ set(SqliteOrm_INCLUDE "${CMAKE_CURRENT_SOURCE_DIR}/include")
 add_library(sqlite_orm INTERFACE)
 add_library(sqlite_orm::sqlite_orm ALIAS sqlite_orm)
 
-find_package(SQLite3 REQUIRED)
 target_link_libraries(sqlite_orm INTERFACE SQLite::SQLite3)
 
 target_sources(sqlite_orm INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/sqlite_orm/sqlite_orm.h>)
@@ -75,4 +76,4 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_EXAMPLES)
 endif()
 
 ### Packaging
-add_subdirectory(packaging)
+# add_subdirectory(packaging)

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ auto storage = make_storage("db.sqlite",
                             make_table("user_types",
                                        make_column("id", &UserType::id, autoincrement(), primary_key()),
                                        make_column("name", &UserType::name, default_value("name_placeholder"))));
+storage.sync_schema();
 ```
 
 Too easy isn't it? You do not have to specify mapped type explicitly - it is deduced from your member pointers you pass during making a column (for example: `&User::id`). To create a column you have to pass two arguments at least: its name in the table and your mapped class member pointer. You can also add extra arguments to tell your storage about column's constraints like `primary_key`, `autoincrement`, `default_value` or `unique`(order isn't important; `not_null` is deduced from type automatically).

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -4,10 +4,16 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
     FetchContent_Declare(
         catch2
         GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+        GIT_TAG        v2.13.3
     )
 endif()
 
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
     add_subdirectory(catch2)
 endif()
-add_subdirectory(sqlite3)
+
+if(SqliteOrm_SysSqlite)
+    find_package(SQLite3 REQUIRED)
+else()
+    add_subdirectory(sqlite3)
+endif()

--- a/dependencies/sqlite3/CMakeLists.txt
+++ b/dependencies/sqlite3/CMakeLists.txt
@@ -1,2 +1,15 @@
-# find_package exposes targets only globally, but caches them. So call find_package again in the directory of usage
-find_package(SQLite3 REQUIRED)
+include(FetchContent)
+
+FetchContent_Declare(
+  sqlite3
+  URL      https://www.sqlite.org/2020/sqlite-amalgamation-3340000.zip
+)
+
+FetchContent_GetProperties(sqlite3)
+if(NOT sqlite3_POPULATED)
+  FetchContent_Populate(sqlite3)
+  add_library(sqlite3 ${sqlite3_SOURCE_DIR}/sqlite3.c)
+  add_library(SQLite::SQLite3 ALIAS sqlite3)
+  target_include_directories(sqlite3 INTERFACE $<BUILD_INTERFACE:${sqlite3_SOURCE_DIR}>)
+  target_link_libraries(sqlite3 PRIVATE ${CMAKE_DL_LIBS})
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,14 +2,6 @@ cmake_minimum_required (VERSION 3.2)
 
 option(SQLITE_ORM_OMITS_CODECVT "Omits codec testing" OFF)
 
-option(SqliteOrm_SysSqlite "Use system version of sqlite library" OFF)
-
-if(SqliteOrm_SysSqlite)
-    message(FATAL_ERROR "WIP: please, disable the SqliteOrm_SysSqlite option.")
-else()
-    add_subdirectory(third_party/sqlite)
-endif()
-
 add_executable(unit_tests tests.cpp tests2.cpp tests3.cpp tests4.cpp tests5.cpp private_getters_tests.cpp pragma_tests.cpp explicit_columns.cpp core_functions_tests.cpp index_tests.cpp constraints/composite_key.cpp static_tests.cpp operators/arithmetic_operators.cpp operators/like.cpp operators/glob.cpp operators/in.cpp operators/cast.cpp operators/is_null.cpp operators/not_operator.cpp operators/bitwise.cpp dynamic_order_by.cpp prepared_statement_tests/select.cpp prepared_statement_tests/get_all.cpp prepared_statement_tests/get_all_pointer.cpp prepared_statement_tests/get_all_optional.cpp prepared_statement_tests/update_all.cpp prepared_statement_tests/remove_all.cpp prepared_statement_tests/get.cpp prepared_statement_tests/get_pointer.cpp prepared_statement_tests/get_optional.cpp prepared_statement_tests/update.cpp prepared_statement_tests/remove.cpp prepared_statement_tests/insert.cpp prepared_statement_tests/replace.cpp prepared_statement_tests/insert_range.cpp prepared_statement_tests/replace_range.cpp prepared_statement_tests/insert_explicit.cpp pragma_tests.cpp simple_query.cpp static_tests/is_bindable.cpp static_tests/arithmetic_operators_result_type.cpp static_tests/tuple_conc.cpp static_tests/node_tuple.cpp static_tests/bindable_filter.cpp static_tests/count_tuple.cpp static_tests/member_traits_tests.cpp static_tests/select_return_type.cpp constraints/default.cpp constraints/unique.cpp constraints/foreign_key.cpp constraints/check.cpp table_tests.cpp statement_serializator_tests/primary_key.cpp statement_serializator_tests/column_names.cpp statement_serializator_tests/autoincrement.cpp statement_serializator_tests/arithmetic_operators.cpp statement_serializator_tests/core_functions.cpp statement_serializator_tests/comparison_operators.cpp statement_serializator_tests/unique.cpp statement_serializator_tests/foreign_key.cpp statement_serializator_tests/collate.cpp statement_serializator_tests/check.cpp statement_serializator_tests/index.cpp statement_serializator_tests/indexed_column.cpp unique_cases/get_all_with_two_tables.cpp unique_cases/prepare_get_all_with_case.cpp unique_cases/index_named_table_with_fk.cpp unique_cases/issue525.cpp unique_cases/delete_with_two_fields.cpp unique_cases/join_iterator_ctor_compilation_error.cpp get_all_custom_containers.cpp select_asterisk.cpp backup_tests.cpp transaction_tests.cpp)
 
 


### PR DESCRIPTION
sqlite3 lib is not convenient enough as it can not be build and include with cmake. So we have to build an install it in our develop environment before use it. and 'find_package()' of cmake is not always works well. Maybe it's easier to use If sqlite3 can be imported automatically when this repo is imported.

I made some changes in CMakeLists to achieve this goal, and now we can import this repo in other project without pre-install sqlite3, just need:
```cmake

FetchContent_Declare(
  sqlite_orm
  GIT_REPOSITORY https://github.com/dhmemi/sqlite_orm
  GIT_TAG        master
)

FetchContent_MakeAvailable(sqlite_orm)
```

But If we config this repo independently, some error in packaging like below will be encountered:
```
CMake Error: install(EXPORT "SqliteOrmTargets" ...) includes target "sqlite_orm" which requires target "sqlite3" that is not in any export set.
```
I do not know how to deal with this as I'm not familiar with cmake-install. Do you or anyone have any idea about this?