### PR TITLE
Ensure that CHECK's expressions are wrapped in parentheses

### DIFF
--- a/dev/statement_serializator.h
+++ b/dev/statement_serializator.h
@@ -498,6 +498,9 @@ namespace sqlite_orm {
             std::string operator()(const statement_type &c, const C &context) const {
                 std::stringstream ss;
                 auto leftString = serialize(c.l, context);
+                if(context.use_parentheses) {
+                    ss << '(';
+                }
                 ss << leftString << " " << static_cast<std::string>(c) << " ( ";
                 for(size_t index = 0; index < c.arg.size(); ++index) {
                     auto &value = c.arg[index];
@@ -507,6 +510,9 @@ namespace sqlite_orm {
                     }
                 }
                 ss << " )";
+                if(context.use_parentheses) {
+                    ss << ')';
+                }
                 return ss.str();
             }
         };

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -10048,6 +10048,9 @@ namespace sqlite_orm {
             std::string operator()(const statement_type &c, const C &context) const {
                 std::stringstream ss;
                 auto leftString = serialize(c.l, context);
+                if(context.use_parentheses) {
+                    ss << '(';
+                }
                 ss << leftString << " " << static_cast<std::string>(c) << " ( ";
                 for(size_t index = 0; index < c.arg.size(); ++index) {
                     auto &value = c.arg[index];
@@ -10057,6 +10060,9 @@ namespace sqlite_orm {
                     }
                 }
                 ss << " )";
+                if(context.use_parentheses) {
+                    ss << ')';
+                }
                 return ss.str();
             }
         };


### PR DESCRIPTION
An example table creation:

```cpp
sqlite_orm::make_table(
	"user",
	sqlite_orm::make_column(
		"id",
		&core::entities::User::id,
		sqlite_orm::autoincrement(),
		sqlite_orm::primary_key()
	),
	sqlite_orm::make_column("main", &core::entities::User::is_main),
	sqlite_orm::check(sqlite_orm::in(&core::entities::User::is_main, {0, 1}))
)
```

Creates a CHECK statement which expression is not wrapped properly in parentheses, i.e. 

```sql
CREATE TABLE 'user' ( 
	'id' INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL , 
	'main' INTEGER NOT NULL , 
	CHECK "main" IN (  0,  1 )
)
```

Proper CHECK syntax in this example would be `CHECK ("main" IN (  0,  1 ))`. 

The following pull request makes a small change to fix this. As I'm not a regular here, the required change may be more sophisticated than what I'm proposing. Nevertheless, the fix should solve the issue for the mentioned case scenario.