### PR TITLE
Use constant references when iterating over ranges in replace_range

### DIFF
--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -12399,7 +12399,7 @@ namespace sqlite_orm {
                 auto &tImpl = this->get_impl<object_type>();
                 sqlite3_reset(stmt);
                 for(auto it = statement.t.range.first; it != statement.t.range.second; ++it) {
-                    const auto &o = *it;
+                    auto &o = *it;
                     tImpl.table.for_each_column([&o, &index, &stmt, db](auto &c) {
                         if(!c.template has<constraints::primary_key_t<>>()) {
                             using column_type = typename std::decay<decltype(c)>::type;

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -12358,7 +12358,7 @@ namespace sqlite_orm {
                 auto stmt = statement.stmt;
                 sqlite3_reset(stmt);
                 for(auto it = statement.t.range.first; it != statement.t.range.second; ++it) {
-                    auto &o = *it;
+                    const auto &o = *it;
                     tImpl.table.for_each_column([&o, &index, &stmt, db](auto &c) {
                         using column_type = typename std::decay<decltype(c)>::type;
                         using field_type = typename column_type::field_type;
@@ -12399,7 +12399,7 @@ namespace sqlite_orm {
                 auto &tImpl = this->get_impl<object_type>();
                 sqlite3_reset(stmt);
                 for(auto it = statement.t.range.first; it != statement.t.range.second; ++it) {
-                    auto &o = *it;
+                    const auto &o = *it;
                     tImpl.table.for_each_column([&o, &index, &stmt, db](auto &c) {
                         if(!c.template has<constraints::primary_key_t<>>()) {
                             using column_type = typename std::decay<decltype(c)>::type;


### PR DESCRIPTION
This is required if one wants to use iterators that do not return references when are dereferenced.
Usually, this will happen whenever using something from `std::ranges`. Eg:

```c++
struct Message {
    int id;
    int code;
}
std::vector<int> messageCodes = {....};
int id = 0;
auto messages = messageCodes | std::views::transform([&id](int code) mutable { return Message {.id = id++, .code = code};});
storage.replace_range(messages.begin(), messages.end());

```