### PR TITLE
 Avoid -Wmissing-field-initializers

### DIFF
--- a/dev/statement_serializator.h
+++ b/dev/statement_serializator.h
@@ -910,7 +910,7 @@ namespace sqlite_orm {
                 ss << "UPDATE ";
                 table_name_collector collector{[&context](std::type_index ti) {
                     return context.impl.find_table_name(ti);
-                }};
+                }, {}};
                 iterate_ast(upd.set.assigns, collector);
                 if(!collector.table_names.empty()) {
                     if(collector.table_names.size() == 1) {
@@ -1266,7 +1266,7 @@ namespace sqlite_orm {
                 }
                 table_name_collector collector{[&context](std::type_index ti) {
                     return context.impl.find_table_name(ti);
-                }};
+                }, {}};
                 iterate_ast(sel.col, collector);
                 iterate_ast(sel.conditions, collector);
                 internal::join_iterator<Args...>()([&collector, &context](const auto& c) {

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -10855,7 +10855,7 @@ namespace sqlite_orm {
                 ss << "UPDATE ";
                 table_name_collector collector{[&context](std::type_index ti) {
                     return context.impl.find_table_name(ti);
-                }};
+                }, {}};
                 iterate_ast(upd.set.assigns, collector);
                 if(!collector.table_names.empty()) {
                     if(collector.table_names.size() == 1) {
@@ -11211,7 +11211,7 @@ namespace sqlite_orm {
                 }
                 table_name_collector collector{[&context](std::type_index ti) {
                     return context.impl.find_table_name(ti);
-                }};
+                }, {}};
                 iterate_ast(sel.col, collector);
                 iterate_ast(sel.conditions, collector);
                 internal::join_iterator<Args...>()([&collector, &context](const auto& c) {


### PR DESCRIPTION
Getting the warnings with clang12 using `-Wall`.

Please merge with squash (selectable in the GitHub merge button).