### PR TITLE
import stdlib.h instead of cstdlib

### DIFF
--- a/dev/row_extractor.h
+++ b/dev/row_extractor.h
@@ -2,7 +2,7 @@
 
 #include <sqlite3.h>
 #include <type_traits>  //  std::enable_if_t, std::is_arithmetic, std::is_same, std::enable_if
-#include <cstdlib>  //  atof, atoi, atoll
+#include <stdlib.h>  //  atof, atoi, atoll
 #include <string>  //  std::string, std::wstring
 #ifndef SQLITE_ORM_OMITS_CODECVT
 #include <codecvt>  //  std::wstring_convert, std::codecvt_utf8_utf16

--- a/dev/storage_impl.h
+++ b/dev/storage_impl.h
@@ -5,7 +5,7 @@
 #include <cstddef>  //  std::nullptr_t
 #include <system_error>  //  std::system_error, std::error_code
 #include <sstream>  //  std::stringstream
-#include <cstdlib>  //  std::atoi
+#include <stdlib.h>  //  std::atoi
 #include <type_traits>  //  std::forward, std::enable_if, std::is_same, std::remove_reference, std::false_type, std::true_type
 #include <utility>  //  std::pair, std::make_pair
 #include <vector>  //  std::vector

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -5397,7 +5397,7 @@ namespace sqlite_orm {
 
 #include <sqlite3.h>
 #include <type_traits>  //  std::enable_if_t, std::is_arithmetic, std::is_same, std::enable_if
-#include <cstdlib>  //  atof, atoi, atoll
+#include <stdlib.h>  //  atof, atoi, atoll
 #include <string>  //  std::string, std::wstring
 #ifndef SQLITE_ORM_OMITS_CODECVT
 #include <codecvt>  //  std::wstring_convert, std::codecvt_utf8_utf16
@@ -6792,7 +6792,7 @@ namespace sqlite_orm {
 #include <cstddef>  //  std::nullptr_t
 #include <system_error>  //  std::system_error, std::error_code
 #include <sstream>  //  std::stringstream
-#include <cstdlib>  //  std::atoi
+#include <stdlib.h>  //  std::atoi
 #include <type_traits>  //  std::forward, std::enable_if, std::is_same, std::remove_reference, std::false_type, std::true_type
 #include <utility>  //  std::pair, std::make_pair
 #include <vector>  //  std::vector


### PR DESCRIPTION
More details in the issue: https://github.com/fnc12/sqlite_orm/issues/716

Technically the headers in `cstdlib` define utilities like `atoi` under the std namespace, so they should be referenced as `std::atoi`. Most compilers don't care about this, but something changed recently in XCode 12.5 and it started complaining on our project.

I generated the amalgamated file by running `third_party/amalgamate/amalgamate.py -c third_party/amalgamate/config.json -s .`, but let me know if this is supposed to be handled by some build process instead and I can remove it.