### PR TITLE
Added the get table info function.

### DIFF
--- a/dev/statement_serializator.h
+++ b/dev/statement_serializator.h
@@ -553,42 +553,22 @@ namespace sqlite_orm {
             template<class C>
             std::string operator()(const statement_type& c, const C& context) const {
                 std::stringstream ss;
-                auto leftString = serialize(c.left, context);
-                ss << leftString << " " << static_cast<std::string>(c) << " (";
-                for(size_t index = 0; index < c.argument.size(); ++index) {
-                    auto& value = c.argument[index];
-                    ss << serialize(value, context);
-                    if(index < c.argument.size() - 1) {
+                auto leftString = serialize(c.l, context);
+                if(context.use_parentheses) {
+                    ss << '(';
+                }
+                ss << leftString << " " << static_cast<std::string>(c) << " ( ";
+                for(size_t index = 0; index < c.arg.size(); ++index) {
+                    auto &value = c.arg[index];
+                    ss << " " << serialize(value, context);
+                    if(index < c.arg.size() - 1) {
                         ss << ", ";
                     }
                 }
-                ss << ")";
-                return ss.str();
-            }
-        };
-
-        template<class L, class... Args>
-        struct statement_serializator<in_t<L, Args...>, void> {
-            using statement_type = in_t<L, Args...>;
-
-            template<class C>
-            std::string operator()(const statement_type& c, const C& context) const {
-                std::stringstream ss;
-                auto leftString = serialize(c.left, context);
-                ss << leftString << " " << static_cast<std::string>(c) << " (";
-                std::vector<std::string> args;
-                using args_type = std::tuple<Args...>;
-                args.reserve(std::tuple_size<args_type>::value);
-                iterate_tuple(c.argument, [&args, &context](auto& v) {
-                    args.push_back(serialize(v, context));
-                });
-                for(size_t i = 0; i < args.size(); ++i) {
-                    ss << args[i];
-                    if(i < args.size() - 1) {
-                        ss << ", ";
-                    }
+                ss << " )";
+                if(context.use_parentheses) {
+                    ss << ')';
                 }
-                ss << ")";
                 return ss.str();
             }
         };

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -14634,7 +14634,7 @@ namespace sqlite_orm {
                 auto &tImpl = this->get_impl<object_type>();
                 sqlite3_reset(stmt);
                 for(auto it = statement.t.range.first; it != statement.t.range.second; ++it) {
-                    const auto &o = *it;
+                    auto &o = *it;
                     tImpl.table.for_each_column([&o, &index, &stmt, db](auto &c) {
                         if(!c.template has<constraints::primary_key_t<>>()) {
                             using column_type = typename std::decay<decltype(c)>::type;

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -12260,42 +12260,22 @@ namespace sqlite_orm {
             template<class C>
             std::string operator()(const statement_type& c, const C& context) const {
                 std::stringstream ss;
-                auto leftString = serialize(c.left, context);
-                ss << leftString << " " << static_cast<std::string>(c) << " (";
-                for(size_t index = 0; index < c.argument.size(); ++index) {
-                    auto& value = c.argument[index];
-                    ss << serialize(value, context);
-                    if(index < c.argument.size() - 1) {
+                auto leftString = serialize(c.l, context);
+                if(context.use_parentheses) {
+                    ss << '(';
+                }
+                ss << leftString << " " << static_cast<std::string>(c) << " ( ";
+                for(size_t index = 0; index < c.arg.size(); ++index) {
+                    auto &value = c.arg[index];
+                    ss << " " << serialize(value, context);
+                    if(index < c.arg.size() - 1) {
                         ss << ", ";
                     }
                 }
-                ss << ")";
-                return ss.str();
-            }
-        };
-
-        template<class L, class... Args>
-        struct statement_serializator<in_t<L, Args...>, void> {
-            using statement_type = in_t<L, Args...>;
-
-            template<class C>
-            std::string operator()(const statement_type& c, const C& context) const {
-                std::stringstream ss;
-                auto leftString = serialize(c.left, context);
-                ss << leftString << " " << static_cast<std::string>(c) << " (";
-                std::vector<std::string> args;
-                using args_type = std::tuple<Args...>;
-                args.reserve(std::tuple_size<args_type>::value);
-                iterate_tuple(c.argument, [&args, &context](auto& v) {
-                    args.push_back(serialize(v, context));
-                });
-                for(size_t i = 0; i < args.size(); ++i) {
-                    ss << args[i];
-                    if(i < args.size() - 1) {
-                        ss << ", ";
-                    }
+                ss << " )";
+                if(context.use_parentheses) {
+                    ss << ')';
                 }
-                ss << ")";
                 return ss.str();
             }
         };

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -14617,7 +14617,7 @@ namespace sqlite_orm {
                 auto stmt = statement.stmt;
                 sqlite3_reset(stmt);
                 for(auto it = statement.t.range.first; it != statement.t.range.second; ++it) {
-                    auto &o = *it;
+                    const auto &o = *it;
                     tImpl.table.for_each_column([&o, &index, &stmt, db](auto &c) {
                         using column_type = typename std::decay<decltype(c)>::type;
                         using field_type = typename column_type::field_type;
@@ -14651,7 +14651,7 @@ namespace sqlite_orm {
                 auto &tImpl = this->get_impl<object_type>();
                 sqlite3_reset(stmt);
                 for(auto it = statement.t.range.first; it != statement.t.range.second; ++it) {
-                    auto &o = *it;
+                    const auto &o = *it;
                     tImpl.table.for_each_column([&o, &index, &stmt, db](auto &c) {
                         if(!c.template has<constraints::primary_key_t<>>()) {
                             using column_type = typename std::decay<decltype(c)>::type;

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -14617,7 +14617,7 @@ namespace sqlite_orm {
                 auto stmt = statement.stmt;
                 sqlite3_reset(stmt);
                 for(auto it = statement.t.range.first; it != statement.t.range.second; ++it) {
-                    const auto &o = *it;
+                    auto &o = *it;
                     tImpl.table.for_each_column([&o, &index, &stmt, db](auto &c) {
                         using column_type = typename std::decay<decltype(c)>::type;
                         using field_type = typename column_type::field_type;

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -14600,7 +14600,7 @@ namespace sqlite_orm {
                 auto stmt = statement.stmt;
                 sqlite3_reset(stmt);
                 for(auto it = statement.t.range.first; it != statement.t.range.second; ++it) {
-                    const auto &o = *it;
+                    auto &o = *it;
                     tImpl.table.for_each_column([&o, &index, &stmt, db](auto &c) {
                         using column_type = typename std::decay<decltype(c)>::type;
                         using field_type = typename column_type::field_type;

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -8761,6 +8761,12 @@ namespace sqlite_orm {
 
             prepared_statement_t(T t_, sqlite3_stmt* stmt_, connection_ref con_) :
                 prepared_statement_base{stmt_, std::move(con_)}, t(std::move(t_)) {}
+
+            prepared_statement_t(prepared_statement_t && prepared_stmt) :
+                prepared_statement_base{prepared_stmt.stmt, std::move(prepared_stmt.con)}, t(std::move(prepared_stmt.t))
+            {
+                prepared_stmt.stmt = nullptr;
+            }
         };
 
         template<class T>
@@ -13724,6 +13730,17 @@ namespace sqlite_orm {
             }
 
           public:
+
+            template<class T>
+            std::vector<table_info> get_table_info() const
+            {
+                this->assert_mapped_type<T>();
+
+                auto & tInfo = this->get_impl<T>();
+
+                return tInfo.table.get_table_info();
+            }
+
             template<class T, class... Args>
             view_t<T, self, Args...> iterate(Args&&... args) {
                 this->assert_mapped_type<T>();

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -14651,7 +14651,7 @@ namespace sqlite_orm {
                 auto &tImpl = this->get_impl<object_type>();
                 sqlite3_reset(stmt);
                 for(auto it = statement.t.range.first; it != statement.t.range.second; ++it) {
-                    const auto &o = *it;
+                    auto &o = *it;
                     tImpl.table.for_each_column([&o, &index, &stmt, db](auto &c) {
                         if(!c.template has<constraints::primary_key_t<>>()) {
                             using column_type = typename std::decay<decltype(c)>::type;


### PR DESCRIPTION
I needed to query table information from some code I wrote for a project, and namely needed the number of columns present in a given mapped table. This was to populate a bulk insert statement from a template function. This code makes the `table_info` struct accessible from the storage object if needed.

I also added a move constructor to the prepared statement class as I wanted a way to cache PreparedStatements in a map, so I could create them just once. This wasn't working unless I did a move operation on the underlying connection and statement.