### PR TITLE
Support for 'pointer-passing interface'

### DIFF
--- a/dev/arithmetic_tag.h
+++ b/dev/arithmetic_tag.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <type_traits>
 
 namespace sqlite_orm {
 

--- a/dev/carray.h
+++ b/dev/carray.h
@@ -14,15 +14,15 @@ namespace sqlite_orm {
     using carray_trule = pointer_trule<P, carray_pvt, D>;
 
     /**
-     *  SQL function that is a pass-through
-     *  for values (it returns a copy of its argument) but also saves the
+     *  SQL function that is a pass-through for values
+     *  (it returns its argument unchanged using move semantics) but also saves the
      *  value that is passed through into a C-language variable.
      */
     template<typename P>
     struct note_value_fn {
         using pointer_value_t = carray_value<P>;
 
-        P operator()(P value, pointer_value_t pv) const {
+        P operator()(P&& value, pointer_value_t pv) const {
             if (P* p = pv) {
                 *p = value;
             }

--- a/dev/carray.h
+++ b/dev/carray.h
@@ -9,23 +9,50 @@ namespace sqlite_orm {
 
     SQLITE_ORM_INLINE_VAR constexpr const char carray_pvt_name[] = "carray";
     using carray_pvt = std::integral_constant<const char*, carray_pvt_name>;
+
     template<typename P>
-    using carray_value = pointer_value<P, carray_pvt>;
+    using carray_pointer_arg = pointer_arg<P, carray_pvt>;
     template<typename P, typename D>
-    using carray_trule = pointer_trule<P, carray_pvt, D>;
+    using carray_pointer_binding = pointer_binding<P, carray_pvt, D>;
+    template<typename P>
+    using static_carray_pointer_binding = static_pointer_binding<P, carray_pvt>;
 
     /**
-     *  SQL function that is a pass-through for values
+     *  Wrap a pointer of type 'carray' and its deleter function for binding it to a statement.
+     *  
+     *  Unless the deleter carries a nullptr function the ownership
+     *  will be transferred to sqlite, which will delete it through
+     *  the the deleter function when the statement finishes.
+     */
+    template<class P, class D>
+    auto bindable_carray_pointer(P* p, D d) -> pointer_binding<P, carray_pvt, D> {
+        return bindable_pointer<carray_pvt>(p, d);
+    }
+
+    /**
+     *  Wrap a pointer of type 'carray' for binding it to a statement.
+     *  
+     *  Note: 'Static' means that ownership won't be transferred to
+     *  sqlite and sqlite assumes the object pointed to is valid throughout
+     *  the lifetime of a statement.
+     */
+    template<class P>
+    auto statically_bindable_carray_pointer(P* p) -> static_pointer_binding<P, carray_pvt> {
+        return statically_bindable_pointer<carray_pvt>(p);
+    }
+
+    /**
+     *  Generalized form of the 'remember' SQL function that is a pass-through for values
      *  (it returns its argument unchanged using move semantics) but also saves the
-     *  value that is passed through into a C-language variable.
+     *  value that is passed through into a bound variable.
      */
     template<typename P>
     struct note_value_fn {
-        using pointer_value_t = carray_value<P>;
+        using pointer_arg_t = carray_pointer_arg<P>;
 
-        P operator()(P&& value, pointer_value_t pv) const {
-            if(P* p = pv) {
-                *p = value;
+        P operator()(P&& value, pointer_arg_t pv) const {
+            if(P* observer = pv) {
+                *observer = value;
             }
             return std::move(value);
         }

--- a/dev/carray.h
+++ b/dev/carray.h
@@ -2,11 +2,12 @@
 
 #include <type_traits>
 
+#include "start_macros.h"
 #include "pointer_value.h"
 
 namespace sqlite_orm {
 
-    inline constexpr const char carray_pvt_name[] = "carray";
+    SQLITE_ORM_INLINE_VAR constexpr const char carray_pvt_name[] = "carray";
     using carray_pvt = std::integral_constant<const char*, carray_pvt_name>;
     template<typename P>
     using carray_value = pointer_value<P, carray_pvt>;

--- a/dev/carray.h
+++ b/dev/carray.h
@@ -23,7 +23,7 @@ namespace sqlite_orm {
         using pointer_value_t = carray_value<P>;
 
         P operator()(P&& value, pointer_value_t pv) const {
-            if (P* p = pv) {
+            if(P* p = pv) {
                 *p = value;
             }
             return std::move(value);

--- a/dev/carray.h
+++ b/dev/carray.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <type_traits>
+
+#include "pointer_value.h"
+
+namespace sqlite_orm {
+
+    inline constexpr const char carray_pvt_name[] = "carray";
+    using carray_pvt = std::integral_constant<const char*, carray_pvt_name>;
+    template<typename P>
+    using carray_value = pointer_value<P, carray_pvt>;
+    template<typename P, typename D>
+    using carray_trule = pointer_trule<P, carray_pvt, D>;
+
+    /**
+     *  SQL function that is a pass-through
+     *  for values (it returns a copy of its argument) but also saves the
+     *  value that is passed through into a C-language variable.
+     */
+    template<typename P>
+    struct note_value_fn {
+        using pointer_value_t = carray_value<P>;
+
+        P operator()(P value, pointer_value_t pv) const {
+            if (P* p = pv) {
+                *p = value;
+            }
+            return std::move(value);
+        }
+
+        static constexpr const char* name() {
+            return "note_value";
+        }
+    };
+
+    /**
+     *  remember(V, $PTR) extension function https://sqlite.org/src/file/ext/misc/remember.c
+     */
+    struct remember_fn : note_value_fn<int64> {
+        static constexpr const char* name() {
+            return "remember";
+        }
+    };
+}

--- a/dev/pointer_value.h
+++ b/dev/pointer_value.h
@@ -74,9 +74,8 @@ namespace sqlite_orm {
         using fn_t = internal::fp_type_t<D>;
 
         // constraint: xDestroy function must be invocable: D(P*)
-        constexpr xdestroy_fn_t get_deleter() const
-            requires std::invocable<fn_t, std::remove_cv_t<P>*>
-        {
+        constexpr xdestroy_fn_t get_deleter() const requires std::invocable < fn_t, std::remove_cv_t<P>
+        * > {
             fn_t destroy = d_;
             return xdestroy_fn_t(void_fn_t(destroy));
         }
@@ -90,10 +89,7 @@ namespace sqlite_orm {
         using fn_t = internal::fp_type_t<D>;
 
         // constraint: xDestroy function must be invocable: D(P*)
-        constexpr std::enable_if_t<
-            std::is_invocable_v<fn_t, std::remove_cv_t<P>*>,
-            xdestroy_fn_t
-        > get_deleter() const {
+        constexpr std::enable_if_t<std::is_invocable_v<fn_t, std::remove_cv_t<P>*>, xdestroy_fn_t> get_deleter() const {
             fn_t destroy = d_;
             return xdestroy_fn_t(void_fn_t(destroy));
         }

--- a/dev/pointer_value.h
+++ b/dev/pointer_value.h
@@ -100,7 +100,9 @@ namespace sqlite_orm {
     template<typename P, typename T, typename D>
     struct pointer_trule : pointer_value<P, T> {
 
-        D d_{};
+        D d_;
+
+        pointer_trule(P* p, D d = D{}) : pointer_value<P, T>{p}, d_{d} {}
 
         // constraint: xDestroy function must be void(*)(void*)
         constexpr xdestroy_fn_t get_deleter() const {

--- a/dev/pointer_value.h
+++ b/dev/pointer_value.h
@@ -80,7 +80,7 @@ namespace sqlite_orm {
             return xdestroy_fn_t(void_fn_t(destroy));
         }
     };
-#else
+#elif __cplusplus >= 201703L  // use of C++17 or higher
     template<typename P, typename T, typename D>
     struct pointer_trule : pointer_value<P, T> {
 
@@ -92,6 +92,18 @@ namespace sqlite_orm {
         constexpr std::enable_if_t<std::is_invocable_v<fn_t, std::remove_cv_t<P>*>, xdestroy_fn_t> get_deleter() const {
             fn_t destroy = d_;
             return xdestroy_fn_t(void_fn_t(destroy));
+        }
+    };
+#else
+    template<typename P, typename T, typename D>
+    struct pointer_trule : pointer_value<P, T> {
+
+        D d_{};
+
+        // constraint: xDestroy function must be void(*)(void*)
+        constexpr xdestroy_fn_t get_deleter() const {
+            xdestroy_fn_t destroy = d_;
+            return destroy;
         }
     };
 #endif

--- a/dev/pointer_value.h
+++ b/dev/pointer_value.h
@@ -5,6 +5,8 @@
 #include <concepts>
 #endif
 
+#include "start_macros.h"
+
 namespace sqlite_orm {
 
     namespace internal {

--- a/dev/pointer_value.h
+++ b/dev/pointer_value.h
@@ -1,0 +1,102 @@
+#pragma once
+
+#include <type_traits>
+#ifdef __cpp_lib_concepts
+#include <concepts>
+#endif
+
+namespace sqlite_orm {
+
+    namespace internal {
+
+        template<typename T>
+        struct fp_type {
+            using type = typename T::value_type;
+        };
+        template<typename R, typename... Args>
+        struct fp_type<R (*)(Args...)> {
+            using type = R (*)(Args...);
+        };
+        template<typename T>
+        using fp_type_t = typename fp_type<T>::type;
+    }
+
+    /**
+     *  Wraps a pointer and tags it with a pointer type,
+     *  used for accepting function parameters,
+     *  facilitating the 'pointer-passing interface'.
+     * 
+     *  Template parameters:
+     *    - P: The value type, possibly const-qualified.
+     *    - T: An integral constant string denoting the pointer type, e.g. carray_pvt_name.
+     *
+     */
+    template<typename P, typename T>
+    struct pointer_value {
+
+        static_assert(std::is_convertible_v<T::value_type, const char*>,
+                      "`std::integral_constant<>` must be convertible to `const char*`");
+
+        using tag = T;
+        P* ptr = nullptr;
+
+        constexpr operator P*() const {
+            return ptr;
+        }
+    };
+
+    /**
+     *  Pointer value with associated deleter function,
+     *  used for returning or binding pointer values
+     *  as part of facilitating the 'pointer-passing interface'.
+     * 
+     *  The term "trule" is the short form of "TRansport capsULE" and is a carrier
+     *  object used for moving wrapped types from one place to another.
+     *
+     *  Template parameters:
+     *    - D: The deleter function for the pointer value;
+     *         must be either a function pointer type,
+     *         integral constant or structure returning a function pointer.
+     *
+     *  @example
+     *  ```
+     *  int64 rememberedId;
+     *  storage.select(func<remember_fn>(&Object::id, carray_trule<int64, null_xdetroy>{&rememberedId}));
+     *  ```
+     */
+#ifdef __cpp_lib_concepts
+    template<typename P, typename T, typename D>
+    struct pointer_trule : pointer_value<P, T> {
+
+        SQLITE_ORM_NOUNIQUEADDRESS
+        D d_{};
+
+        using fn_t = internal::fp_type_t<D>;
+
+        // constraint: xDestroy function must be invocable: D(P*)
+        constexpr xdestroy_fn_t get_deleter() const
+            requires std::invocable<fn_t, std::remove_cv_t<P>*>
+        {
+            fn_t destroy = d_;
+            return xdestroy_fn_t(void_fn_t(destroy));
+        }
+    };
+#else
+    template<typename P, typename T, typename D>
+    struct pointer_trule : pointer_value<P, T> {
+
+        D d_{};
+
+        using fn_t = internal::fp_type_t<D>;
+
+        // constraint: xDestroy function must be invocable: D(P*)
+        constexpr std::enable_if_t<
+            std::is_invocable_v<fn_t, std::remove_cv_t<P>*>,
+            xdestroy_fn_t
+        > get_deleter() const {
+            fn_t destroy = d_;
+            return xdestroy_fn_t(void_fn_t(destroy));
+        }
+    };
+#endif
+}

--- a/dev/row_extractor.h
+++ b/dev/row_extractor.h
@@ -44,8 +44,8 @@ namespace sqlite_orm {
      *  extracting pointers from columns.
      */
     template<class P, class T>
-    struct row_extractor<pointer_value<P, T>, void> {
-        using V = pointer_value<P, T>;
+    struct row_extractor<pointer_arg<P, T>, void> {
+        using V = pointer_arg<P, T>;
 
         V extract(sqlite3_value* value) const {
             return {static_cast<P*>(sqlite3_value_pointer(value, T::value))};

--- a/dev/row_extractor.h
+++ b/dev/row_extractor.h
@@ -14,6 +14,7 @@
 #include <tuple>  //  std::tuple, std::tuple_size, std::tuple_element
 
 #include "arithmetic_tag.h"
+#include "pointer_value.h"
 #include "journal_mode.h"
 #include "error_code.h"
 
@@ -34,6 +35,21 @@ namespace sqlite_orm {
 
         //  used in user defined functions
         V extract(sqlite3_value* value) const;
+    };
+
+    /**
+     *  Specialization for the 'pointer-passing interface'.
+     * 
+     *  @note The 'pointer-passing' interface doesn't support (and in fact prohibits)
+     *  extracting pointers from columns.
+     */
+    template<class P, class T>
+    struct row_extractor<pointer_value<P, T>, void> {
+        using V = pointer_value<P, T>;
+
+        V extract(sqlite3_value* value) const {
+            return {static_cast<P*>(sqlite3_value_pointer(value, T::value))};
+        }
     };
 
     /**

--- a/dev/start_macros.h
+++ b/dev/start_macros.h
@@ -20,4 +20,8 @@ __pragma(push_macro("min"))
 #define SQLITE_ORM_OPTIONAL_SUPPORTED
 #define SQLITE_ORM_STRING_VIEW_SUPPORTED
 #define SQLITE_ORM_NOTHROW_ALIASES_SUPPORTED
+// note: a C++17 conforming compiler ignores unknown attributes
+#define SQLITE_ORM_NOUNIQUEADDRESS [[no_unique_address]]
+#else
+#define SQLITE_ORM_NOUNIQUEADDRESS 
 #endif

--- a/dev/start_macros.h
+++ b/dev/start_macros.h
@@ -23,5 +23,5 @@ __pragma(push_macro("min"))
 // note: a C++17 conforming compiler ignores unknown attributes
 #define SQLITE_ORM_NOUNIQUEADDRESS [[no_unique_address]]
 #else
-#define SQLITE_ORM_NOUNIQUEADDRESS 
+#define SQLITE_ORM_NOUNIQUEADDRESS
 #endif

--- a/dev/start_macros.h
+++ b/dev/start_macros.h
@@ -20,8 +20,10 @@ __pragma(push_macro("min"))
 #define SQLITE_ORM_OPTIONAL_SUPPORTED
 #define SQLITE_ORM_STRING_VIEW_SUPPORTED
 #define SQLITE_ORM_NOTHROW_ALIASES_SUPPORTED
+#define SQLITE_ORM_INLINE_VAR inline
 // note: a C++17 conforming compiler ignores unknown attributes
 #define SQLITE_ORM_NOUNIQUEADDRESS [[no_unique_address]]
 #else
+#define SQLITE_ORM_INLINE_VAR
 #define SQLITE_ORM_NOUNIQUEADDRESS
 #endif

--- a/dev/statement_binder.h
+++ b/dev/statement_binder.h
@@ -14,6 +14,7 @@
 
 #include "is_std_ptr.h"
 #include "arithmetic_tag.h"
+#include "pointer_value.h"
 
 namespace sqlite_orm {
 
@@ -22,6 +23,23 @@ namespace sqlite_orm {
      */
     template<class V, typename Enable = void>
     struct statement_binder : std::false_type {};
+
+    /**
+     *  Specialization for 'pointer-passing interface'.
+     */
+    template<class P, class T, class D>
+    struct statement_binder<pointer_trule<P, T, D>, void> {
+
+        using V = pointer_trule<P, T, D>;
+
+        int bind(sqlite3_stmt* stmt, int index, const V& value) const {
+            return sqlite3_bind_pointer(stmt, index, (void*)value.ptr, T::value, value.get_deleter());
+        }
+
+        void result(sqlite3_context* context, const V& value) const {
+            sqlite3_result_pointer(context, (void*)value.ptr, T::value, value.get_deleter());
+        }
+    };
 
     /**
      *  Specialization for arithmetic types.

--- a/dev/statement_binder.h
+++ b/dev/statement_binder.h
@@ -28,9 +28,9 @@ namespace sqlite_orm {
      *  Specialization for 'pointer-passing interface'.
      */
     template<class P, class T, class D>
-    struct statement_binder<pointer_trule<P, T, D>, void> {
+    struct statement_binder<pointer_binding<P, T, D>, void> {
 
-        using V = pointer_trule<P, T, D>;
+        using V = pointer_binding<P, T, D>;
 
         int bind(sqlite3_stmt* stmt, int index, const V& value) const {
             return sqlite3_bind_pointer(stmt, index, (void*)value.ptr, T::value, value.get_deleter());

--- a/dev/statement_binder.h
+++ b/dev/statement_binder.h
@@ -13,6 +13,7 @@
 #include <cstring>  //  ::strncpy, ::strlen
 
 #include "is_std_ptr.h"
+#include "arithmetic_tag.h"
 
 namespace sqlite_orm {
 

--- a/dev/statement_finalizer.h
+++ b/dev/statement_finalizer.h
@@ -4,6 +4,8 @@
 #include <sqlite3.h>
 #include <type_traits>  // std::integral_constant
 
+#include "start_macros.h"
+
 namespace sqlite_orm {
 
     /**
@@ -14,6 +16,6 @@ namespace sqlite_orm {
 
     using void_fn_t = void (*)();
     using xdestroy_fn_t = void (*)(void*);
-    using null_xdestroy = std::integral_constant<xdestroy_fn_t, nullptr>;
-
+    using null_xdestroy_t = std::integral_constant<xdestroy_fn_t, nullptr>;
+    SQLITE_ORM_INLINE_VAR constexpr null_xdestroy_t null_xdestroy{};
 }

--- a/dev/statement_finalizer.h
+++ b/dev/statement_finalizer.h
@@ -12,4 +12,8 @@ namespace sqlite_orm {
     using statement_finalizer =
         std::unique_ptr<sqlite3_stmt, std::integral_constant<decltype(&sqlite3_finalize), sqlite3_finalize>>;
 
+    using void_fn_t = void (*)();
+    using xdestroy_fn_t = void (*)(void*);
+    using null_xdestroy = std::integral_constant<xdestroy_fn_t, nullptr>;
+
 }

--- a/dev/tuple_helper/tuple_helper.h
+++ b/dev/tuple_helper/tuple_helper.h
@@ -135,7 +135,7 @@ namespace sqlite_orm {
         //  got it form here https://stackoverflow.com/questions/7858817/unpacking-a-tuple-to-call-a-matching-function-pointer
         template<class Function, class FunctionPointer, class Tuple, size_t... I>
         auto call_impl(Function& f, FunctionPointer functionPointer, Tuple t, std::index_sequence<I...>) {
-            return (f.*functionPointer)(std::get<I>(t)...);
+            return (f.*functionPointer)(std::get<I>(move(t))...);
         }
 
         template<class Function, class FunctionPointer, class Tuple>

--- a/dev/tuple_helper/tuple_helper.h
+++ b/dev/tuple_helper/tuple_helper.h
@@ -3,7 +3,7 @@
 #include <tuple>  //  std::tuple, std::get, std::tuple_element, std::tuple_size
 #include <type_traits>  //  std::false_type, std::true_type
 
-#include "static_magic.h"
+#include "../static_magic.h"
 
 namespace sqlite_orm {
 

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -20,9 +20,11 @@ __pragma(push_macro("min"))
 #define SQLITE_ORM_OPTIONAL_SUPPORTED
 #define SQLITE_ORM_STRING_VIEW_SUPPORTED
 #define SQLITE_ORM_NOTHROW_ALIASES_SUPPORTED
+#define SQLITE_ORM_INLINE_VAR inline
 // note: a C++17 conforming compiler ignores unknown attributes
 #define SQLITE_ORM_NOUNIQUEADDRESS [[no_unique_address]]
 #else
+#define SQLITE_ORM_INLINE_VAR
 #define SQLITE_ORM_NOUNIQUEADDRESS
 #endif
 #pragma once
@@ -6723,6 +6725,8 @@ namespace sqlite_orm {
 #ifdef __cpp_lib_concepts
 #include <concepts>
 #endif
+
+// #include "start_macros.h"
 
 namespace sqlite_orm {
 
@@ -17497,11 +17501,13 @@ namespace sqlite_orm {
 
 #include <type_traits>
 
+// #include "start_macros.h"
+
 // #include "pointer_value.h"
 
 namespace sqlite_orm {
 
-    inline constexpr const char carray_pvt_name[] = "carray";
+    SQLITE_ORM_INLINE_VAR constexpr const char carray_pvt_name[] = "carray";
     using carray_pvt = std::integral_constant<const char*, carray_pvt_name>;
     template<typename P>
     using carray_value = pointer_value<P, carray_pvt>;

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -6821,7 +6821,9 @@ namespace sqlite_orm {
     template<typename P, typename T, typename D>
     struct pointer_trule : pointer_value<P, T> {
 
-        D d_{};
+        D d_;
+
+        pointer_trule(P* p, D d = D{}) : pointer_value<P, T>{p}, d_{d} {}
 
         // constraint: xDestroy function must be void(*)(void*)
         constexpr xdestroy_fn_t get_deleter() const {

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -324,7 +324,7 @@ namespace sqlite_orm {
         //  got it form here https://stackoverflow.com/questions/7858817/unpacking-a-tuple-to-call-a-matching-function-pointer
         template<class Function, class FunctionPointer, class Tuple, size_t... I>
         auto call_impl(Function& f, FunctionPointer functionPointer, Tuple t, std::index_sequence<I...>) {
-            return (f.*functionPointer)(std::get<I>(t)...);
+            return (f.*functionPointer)(std::get<I>(move(t))...);
         }
 
         template<class Function, class FunctionPointer, class Tuple>

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -6686,6 +6686,7 @@ namespace sqlite_orm {
 
 }
 #pragma once
+#include <type_traits>
 
 namespace sqlite_orm {
 
@@ -6750,6 +6751,8 @@ namespace sqlite_orm {
         }
     };
 }
+
+// #include "arithmetic_tag.h"
 
 namespace sqlite_orm {
 

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -6799,7 +6799,7 @@ namespace sqlite_orm {
             return xdestroy_fn_t(void_fn_t(destroy));
         }
     };
-#else
+#elif __cplusplus >= 201703L  // use of C++17 or higher
     template<typename P, typename T, typename D>
     struct pointer_trule : pointer_value<P, T> {
 
@@ -6811,6 +6811,18 @@ namespace sqlite_orm {
         constexpr std::enable_if_t<std::is_invocable_v<fn_t, std::remove_cv_t<P>*>, xdestroy_fn_t> get_deleter() const {
             fn_t destroy = d_;
             return xdestroy_fn_t(void_fn_t(destroy));
+        }
+    };
+#else
+    template<typename P, typename T, typename D>
+    struct pointer_trule : pointer_value<P, T> {
+
+        D d_{};
+
+        // constraint: xDestroy function must be void(*)(void*)
+        constexpr xdestroy_fn_t get_deleter() const {
+            xdestroy_fn_t destroy = d_;
+            return destroy;
         }
     };
 #endif

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -153,7 +153,7 @@ namespace std {
 #include <tuple>  //  std::tuple, std::get, std::tuple_element, std::tuple_size
 #include <type_traits>  //  std::false_type, std::true_type
 
-// #include "static_magic.h"
+// #include "../static_magic.h"
 
 #include <type_traits>  //  std::false_type, std::true_type, std::integral_constant
 
@@ -6160,22 +6160,6 @@ namespace sqlite_orm {
 // #include "ast/where.h"
 
 // #include "../serialize_result_type.h"
-
-#ifdef SQLITE_ORM_STRING_VIEW_SUPPORTED
-#include <string_view>  //  string_view
-#else
-#include <string>  //  std::string
-#endif
-
-namespace sqlite_orm {
-    namespace internal {
-#ifdef SQLITE_ORM_STRING_VIEW_SUPPORTED
-        using serialize_result_type = std::string_view;
-#else
-        using serialize_result_type = std::string;
-#endif
-    }
-}
 
 namespace sqlite_orm {
     namespace internal {

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -17497,15 +17497,15 @@ namespace sqlite_orm {
     using carray_trule = pointer_trule<P, carray_pvt, D>;
 
     /**
-     *  SQL function that is a pass-through
-     *  for values (it returns a copy of its argument) but also saves the
+     *  SQL function that is a pass-through for values
+     *  (it returns its argument unchanged using move semantics) but also saves the
      *  value that is passed through into a C-language variable.
      */
     template<typename P>
     struct note_value_fn {
         using pointer_value_t = carray_value<P>;
 
-        P operator()(P value, pointer_value_t pv) const {
+        P operator()(P&& value, pointer_value_t pv) const {
             if(P* p = pv) {
                 *p = value;
             }

--- a/not_single_header_include/sqlite_orm/sqlite_orm.h
+++ b/not_single_header_include/sqlite_orm/sqlite_orm.h
@@ -35,6 +35,7 @@
 #include "../../dev/table_info.h"
 #include "../../dev/statement_finalizer.h"
 #include "../../dev/arithmetic_tag.h"
+#include "../../dev/pointer_value.h"
 #include "../../dev/statement_binder.h"
 #include "../../dev/row_extractor.h"
 #include "../../dev/util.h"
@@ -49,3 +50,4 @@
 #include "../../dev/finish_macros.h"
 #include "../../dev/node_tuple.h"
 #include "../../dev/get_prepared_statement.h"
+#include "../../dev/carray.h"

--- a/tests/tests2.cpp
+++ b/tests/tests2.cpp
@@ -591,10 +591,10 @@ TEST_CASE("Pointer") {
         int64 lastUpdatedId = -1;
         storage.update_all(
             set(c(&Object::id) = add(1ll, func<note_value_fn<int64>>(&Object::id, carray_trule_t{&lastUpdatedId}))));
-        REQUIRE(lastUpdatedId == 0);
+        REQUIRE(lastUpdatedId == 1);
         storage.update_all(
             set(c(&Object::id) = add(1ll, func<note_value_fn<int64>>(&Object::id, carray_trule_t{&lastUpdatedId}))));
-        REQUIRE(lastUpdatedId == 1);
+        REQUIRE(lastUpdatedId == 2);
     }
     storage.delete_scalar_function<note_value_fn<int64>>();
 

--- a/tests/tests2.cpp
+++ b/tests/tests2.cpp
@@ -570,10 +570,10 @@ TEST_CASE("Pointer") {
     struct test_pointer_passing_fn {
         carray_trule_t operator()(carray_value_t pv) const {
             int64 *p = pv;
-            return { p };
+            return {p};
         }
 
-        static const char* name() {
+        static const char *name() {
             return "test_pointer_passing";
         }
     };
@@ -583,7 +583,6 @@ TEST_CASE("Pointer") {
     storage.sync_schema();
 
     storage.insert(Object{});
-
 
     // test the note_value function
 
@@ -598,7 +597,6 @@ TEST_CASE("Pointer") {
         REQUIRE(lastUpdatedId == 1);
     }
     storage.delete_scalar_function<note_value_fn<int64>>();
-
 
     // test passing a pointer into another function
 

--- a/third_party/amalgamate/CHANGES.md
+++ b/third_party/amalgamate/CHANGES.md
@@ -8,3 +8,4 @@ The following changes have been made to the code with respect to <https://github
   - membership check
   - made function from `_is_within`
   - removed unused variable `actual_path`
+  - normalized paths

--- a/third_party/amalgamate/config.json
+++ b/third_party/amalgamate/config.json
@@ -26,6 +26,7 @@
 		"dev/table_info.h",
 		"dev/statement_finalizer.h",
 		"dev/arithmetic_tag.h",
+		"dev/pointer_value.h",
 		"dev/statement_binder.h",
 		"dev/row_extractor.h",
 		"dev/util.h",
@@ -39,7 +40,8 @@
 		"dev/storage.h",
 		"dev/finish_macros.h",
 		"dev/node_tuple.h",
-		"dev/get_prepared_statement.h"
+		"dev/get_prepared_statement.h",
+		"dev/carray.h"
 	],
 	"include_paths": ["dev"]
 }


### PR DESCRIPTION
sqlite offers a powerful feature called ['pointer-passing interface'](https://sqlite.org/bindptr.html). It allows for functions to work with native datatypes, i.e. accept them as arguments or return them to other functions.

One example is to extract a ASN1_TIME object from a certificate as a 'pointer value', then send it to a comparison function.

This makes it very simple to write a domain-specific set of functions instead of writing a complete sqlite extension.

Not sure why github displays a diff for commits that where already merged via other PRs - here's a pristine diff: https://github.com/fnc12/sqlite_orm/compare/dev...FireDaemon:feature/pointer-values