### PR TITLE
Amending pointer argument validation

### DIFF
--- a/dev/cxx_polyfill.h
+++ b/dev/cxx_polyfill.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <type_traits>
+
+#include "start_macros.h"
+
+namespace sqlite_orm {
+    namespace internal {
+        namespace polyfill {
+#if __cplusplus < 201703L  // before C++17
+            template<class...>
+            using void_t = void;
+
+            template<bool v>
+            using bool_constant = std::integral_constant<bool, v>;
+#else
+            using std::bool_constant;
+            using std::void_t;
+#endif
+
+#if __cplusplus < 202312L  // before C++23
+            template<typename Type, template<typename...> class Primary>
+            SQLITE_ORM_INLINE_VAR constexpr bool is_specialization_of_v = false;
+
+            template<template<typename...> class Primary, class... Types>
+            SQLITE_ORM_INLINE_VAR constexpr bool is_specialization_of_v<Primary<Types...>, Primary> = true;
+
+            template<typename Type, template<typename...> class Primary>
+            struct is_specialization_of : bool_constant<is_specialization_of_v<Type, Primary>> {};
+
+            template<typename... T>
+            using is_specialization_of_t = typename is_specialization_of<T...>::type;
+#else
+            using std::is_specialization_of, std::is_specialization_of_t, std::is_specialization_of_v;
+#endif
+
+            template<typename...>
+            SQLITE_ORM_INLINE_VAR constexpr bool always_false_v = false;
+
+            template<size_t I>
+            using index_constant = std::integral_constant<size_t, I>;
+        }
+    }
+}

--- a/dev/function.h
+++ b/dev/function.h
@@ -169,13 +169,13 @@ namespace sqlite_orm {
             args_tuple args;
         };
 
-        template<typename Type, template<typename...> typename Primary>
+        template<typename Type, template<typename...> class Primary>
         SQLITE_ORM_INLINE_VAR constexpr bool is_specialization_v = false;
 
-        template<template<typename...> typename Primary, typename... Types>
+        template<template<typename...> class Primary, class... Types>
         SQLITE_ORM_INLINE_VAR constexpr bool is_specialization_v<Primary<Types...>, Primary> = true;
 
-        template<typename Type, template<typename...> typename Primary>
+        template<typename Type, template<typename...> class Primary>
         struct is_specialization : std::bool_constant<is_specialization_v<Type, Primary>> {};
 
         template<typename... T>

--- a/dev/function.h
+++ b/dev/function.h
@@ -219,7 +219,12 @@ namespace sqlite_orm {
                 assert_same_pointer_type<I, PointerArg::tag::value, Binding::tag::value>();
 
         template<size_t I, class FnArg, class CallArg>
-        SQLITE_ORM_CONSTEVAL bool validate_pointer_value_type() {
+        SQLITE_ORM_CONSTEVAL bool validate_pointer_value_type(std::false_type) {
+            return true;
+        }
+
+        template<size_t I, class FnArg, class CallArg>
+        SQLITE_ORM_CONSTEVAL bool validate_pointer_value_type(std::true_type) {
             return is_same_pvt_v<I, FnArg, CallArg>;
         }
 
@@ -232,11 +237,12 @@ namespace sqlite_orm {
             using func_arg_t = std::tuple_element_t<I, FnArgs>;
             using passed_arg_t = unpacked_arg_t<std::tuple_element_t<I, CallArgs>>;
 
-            constexpr bool valid = (!is_specialization_v<func_arg_t, pointer_arg> &&
-                                    !is_specialization_v<passed_arg_t, pointer_binding>) ||
-                                   validate_pointer_value_type<I,
+            constexpr bool valid = validate_pointer_value_type<I,
                                                                std::tuple_element_t<I, FnArgs>,
-                                                               unpacked_arg_t<std::tuple_element_t<I, CallArgs>>>();
+                                                               unpacked_arg_t<std::tuple_element_t<I, CallArgs>>>(
+                std::integral_constant < bool,
+                is_specialization_v<func_arg_t, pointer_arg> || is_specialization_v < passed_arg_t,
+                pointer_binding >> {});
 
             return validate_pointer_value_types<FnArgs, CallArgs>(index_constant<I - 1>{}) && valid;
         }

--- a/dev/pointer_value.h
+++ b/dev/pointer_value.h
@@ -69,8 +69,8 @@ namespace sqlite_orm {
 
       protected:
         // Constructing pointer bindings must go through bindable_pointer()
-        template<class T, class P, class D>
-        friend auto bindable_pointer(P*, D) noexcept -> pointer_binding<P, T, D>;
+        template<class T2, class P2, class D2>
+        friend auto bindable_pointer(P2*, D2) noexcept -> pointer_binding<P2, T2, D2>;
         template<class B>
         friend B bindable_pointer(typename B::qualified_type*, typename B::deleter_type) noexcept;
 

--- a/dev/start_macros.h
+++ b/dev/start_macros.h
@@ -25,7 +25,6 @@ __pragma(push_macro("min"))
 #define SQLITE_ORM_CONSTEVAL consteval
 #define SQLITE_ORM_NOUNIQUEADDRESS [[no_unique_address]]
 #else
-#define SQLITE_ORM_CONSTEVAL
 #define SQLITE_ORM_CONSTEVAL constexpr
 #define SQLITE_ORM_NOUNIQUEADDRESS
 #endif

--- a/dev/xdestroy_handling.h
+++ b/dev/xdestroy_handling.h
@@ -6,6 +6,7 @@
 #endif
 
 #include "start_macros.h"
+#include "cxx_polyfill.h"
 
 namespace sqlite_orm {
 
@@ -63,9 +64,9 @@ namespace sqlite_orm {
         template<typename D>
         struct is_integral_fp_c<
             D,
-            std::void_t<typename D::value_type,
-                        decltype(D::value),
-                        std::enable_if_t<std::is_function<std::remove_pointer_t<typename D::value_type>>::value>>>
+            polyfill::void_t<typename D::value_type,
+                             decltype(D::value),
+                             std::enable_if_t<std::is_function<std::remove_pointer_t<typename D::value_type>>::value>>>
             : std::true_type {};
         template<typename D>
         SQLITE_ORM_INLINE_VAR constexpr bool is_integral_fp_c_v = is_integral_fp_c<D>::value;
@@ -75,15 +76,16 @@ namespace sqlite_orm {
         template<typename D>
         struct can_yield_fp<
             D,
-            std::void_t<decltype(+std::declval<D>()),
-                        std::enable_if_t<std::is_function<std::remove_pointer_t<decltype(+std::declval<D>())>>::value>>>
+            polyfill::void_t<
+                decltype(+std::declval<D>()),
+                std::enable_if_t<std::is_function<std::remove_pointer_t<decltype(+std::declval<D>())>>::value>>>
             : std::true_type {};
         template<typename D>
         SQLITE_ORM_INLINE_VAR constexpr bool can_yield_fp_v = can_yield_fp<D>::value;
 
         template<typename D, bool = can_yield_fp_v<D>>
         struct yield_fp_of {
-            using type = std::void_t<>;
+            using type = polyfill::void_t<>;
         };
         template<typename D>
         struct yield_fp_of<D, true> {

--- a/examples/pointer_passing_interface.cpp
+++ b/examples/pointer_passing_interface.cpp
@@ -85,9 +85,9 @@ int main() {
     // function returning a pointer to a std::error_category,
     // which is only visible to functions accepting pointer values of type "ecat"
     struct get_error_category_fn {
-        using ecat_binding_t = static_pointer_binding<const std::error_category, ecat_pvt>;
+        using ecat_binding = static_pointer_binding<const std::error_category, ecat_pvt>;
 
-        ecat_binding_t operator()(unsigned int errorCategory) const {
+        ecat_binding operator()(unsigned int errorCategory) const {
             size_t idx = min<size_t>(errorCategory, ecat_map.size());
             const error_category* ecat = idx != ecat_map.size() ? &get<const error_category&>(ecat_map[idx]) : nullptr;
             return statically_bindable_pointer<ecat_pvt>(ecat);
@@ -130,14 +130,14 @@ int main() {
 
     // function returning an error_code object from an error value
     struct make_error_code_fn {
-        using ecode_binding_t = pointer_binding<std::error_code, ecode_pvt, std::default_delete<std::error_code>>;
+        using ecode_binding = pointer_binding<std::error_code, ecode_pvt, std::default_delete<std::error_code>>;
 
-        ecode_binding_t operator()(int errorValue, unsigned int errorCategory) const {
+        ecode_binding operator()(int errorValue, unsigned int errorCategory) const {
             size_t idx = min<size_t>(errorCategory, ecat_map.size());
             error_code* ec = idx != ecat_map.size()
                                  ? new error_code{errorValue, get<const error_category&>(ecat_map[idx])}
                                  : nullptr;
-            return bindable_pointer<ecode_pvt>(ec, default_delete<error_code>{});
+            return bindable_pointer<ecode_binding>(ec, default_delete<error_code>{});
         }
 
         static constexpr const char* name() {

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -494,6 +494,51 @@ namespace sqlite_orm {
 
 // #include "start_macros.h"
 
+// #include "cxx_polyfill.h"
+
+#include <type_traits>
+
+// #include "start_macros.h"
+
+namespace sqlite_orm {
+    namespace internal {
+        namespace polyfill {
+#if __cplusplus < 201703L  // before C++17
+            template<class...>
+            using void_t = void;
+
+            template<bool v>
+            using bool_constant = std::integral_constant<bool, v>;
+#else
+            using std::bool_constant;
+            using std::void_t;
+#endif
+
+#if __cplusplus < 202312L  // before C++23
+            template<typename Type, template<typename...> class Primary>
+            SQLITE_ORM_INLINE_VAR constexpr bool is_specialization_of_v = false;
+
+            template<template<typename...> class Primary, class... Types>
+            SQLITE_ORM_INLINE_VAR constexpr bool is_specialization_of_v<Primary<Types...>, Primary> = true;
+
+            template<typename Type, template<typename...> class Primary>
+            struct is_specialization_of : bool_constant<is_specialization_of_v<Type, Primary>> {};
+
+            template<typename... T>
+            using is_specialization_of_t = typename is_specialization_of<T...>::type;
+#else
+            using std::is_specialization_of, std::is_specialization_of_t, std::is_specialization_of_v;
+#endif
+
+            template<typename...>
+            SQLITE_ORM_INLINE_VAR constexpr bool always_false_v = false;
+
+            template<size_t I>
+            using index_constant = std::integral_constant<size_t, I>;
+        }
+    }
+}
+
 namespace sqlite_orm {
 
     using xdestroy_fn_t = void (*)(void*);
@@ -550,9 +595,9 @@ namespace sqlite_orm {
         template<typename D>
         struct is_integral_fp_c<
             D,
-            std::void_t<typename D::value_type,
-                        decltype(D::value),
-                        std::enable_if_t<std::is_function<std::remove_pointer_t<typename D::value_type>>::value>>>
+            polyfill::void_t<typename D::value_type,
+                             decltype(D::value),
+                             std::enable_if_t<std::is_function<std::remove_pointer_t<typename D::value_type>>::value>>>
             : std::true_type {};
         template<typename D>
         SQLITE_ORM_INLINE_VAR constexpr bool is_integral_fp_c_v = is_integral_fp_c<D>::value;
@@ -562,15 +607,16 @@ namespace sqlite_orm {
         template<typename D>
         struct can_yield_fp<
             D,
-            std::void_t<decltype(+std::declval<D>()),
-                        std::enable_if_t<std::is_function<std::remove_pointer_t<decltype(+std::declval<D>())>>::value>>>
+            polyfill::void_t<
+                decltype(+std::declval<D>()),
+                std::enable_if_t<std::is_function<std::remove_pointer_t<decltype(+std::declval<D>())>>::value>>>
             : std::true_type {};
         template<typename D>
         SQLITE_ORM_INLINE_VAR constexpr bool can_yield_fp_v = can_yield_fp<D>::value;
 
         template<typename D, bool = can_yield_fp_v<D>>
         struct yield_fp_of {
-            using type = std::void_t<>;
+            using type = polyfill::void_t<>;
         };
         template<typename D>
         struct yield_fp_of<D, true> {
@@ -8629,6 +8675,8 @@ namespace sqlite_orm {
 #include <functional>  //  std::function
 #include <algorithm>  //  std::min
 
+// #include "cxx_polyfill.h"
+
 namespace sqlite_orm {
 
     struct arg_values;
@@ -8792,24 +8840,6 @@ namespace sqlite_orm {
             args_tuple args;
         };
 
-        template<typename Type, template<typename...> class Primary>
-        SQLITE_ORM_INLINE_VAR constexpr bool is_specialization_v = false;
-
-        template<template<typename...> class Primary, class... Types>
-        SQLITE_ORM_INLINE_VAR constexpr bool is_specialization_v<Primary<Types...>, Primary> = true;
-
-        template<typename Type, template<typename...> class Primary>
-        struct is_specialization : std::bool_constant<is_specialization_v<Type, Primary>> {};
-
-        template<typename... T>
-        using is_specialization_t = typename is_specialization<T...>::type;
-
-        template<typename...>
-        SQLITE_ORM_INLINE_VAR constexpr bool always_false_v = false;
-
-        template<size_t I>
-        using index_constant = std::integral_constant<size_t, I>;
-
         template<class T>
         struct unpacked_arg {
             using type = T;
@@ -8821,25 +8851,40 @@ namespace sqlite_orm {
         template<class T>
         using unpacked_arg_t = typename unpacked_arg<T>::type;
 
-        template<size_t I, const char* PointerArg, const char* Binding>
-        SQLITE_ORM_CONSTEVAL bool assert_same_pointer_type() {
-            constexpr bool valid = Binding == PointerArg;
-            static_assert(valid, "Pointer value types of I-th argument do not match");
-            return valid;
-        }
         template<size_t I, class FnArg, class CallArg>
         SQLITE_ORM_CONSTEVAL bool expected_pointer_value() {
-            static_assert(always_false_v<FnArg, CallArg>, "Expected a pointer value for I-th argument");
+            static_assert(polyfill::always_false_v<FnArg, CallArg>, "Expected a pointer value for I-th argument");
             return false;
         }
 
         template<size_t I, class FnArg, class CallArg, class EnableIfTag = void>
         SQLITE_ORM_INLINE_VAR constexpr bool is_same_pvt_v = expected_pointer_value<I, FnArg, CallArg>();
 
+#if __cplusplus >= 201703L  // using C++17 or higher
+        template<size_t I, const char* PointerArg, const char* Binding>
+        SQLITE_ORM_CONSTEVAL bool assert_same_pointer_type() {
+            constexpr bool valid = Binding == PointerArg;
+            static_assert(valid, "Pointer value types of I-th argument do not match");
+            return valid;
+        }
+
         template<size_t I, class PointerArg, class Binding>
         SQLITE_ORM_INLINE_VAR constexpr bool
-            is_same_pvt_v<I, PointerArg, Binding, std::void_t<typename PointerArg::tag, typename Binding::tag>> =
+            is_same_pvt_v<I, PointerArg, Binding, polyfill::void_t<typename PointerArg::tag, typename Binding::tag>> =
                 assert_same_pointer_type<I, PointerArg::tag::value, Binding::tag::value>();
+#else
+        template<size_t I, class PointerArg, class Binding>
+        SQLITE_ORM_CONSTEVAL bool assert_same_pointer_type() {
+            constexpr bool valid = Binding::value == PointerArg::value;
+            static_assert(valid, "Pointer value types of I-th argument do not match");
+            return valid;
+        }
+
+        template<size_t I, class PointerArg, class Binding>
+        SQLITE_ORM_INLINE_VAR constexpr bool
+            is_same_pvt_v<I, PointerArg, Binding, polyfill::void_t<typename PointerArg::tag, typename Binding::tag>> =
+                assert_same_pointer_type<I, typename PointerArg::tag, typename Binding::tag>();
+#endif
 
         template<size_t I, class FnArg, class CallArg>
         SQLITE_ORM_CONSTEVAL bool validate_pointer_value_type(std::false_type) {
@@ -8852,22 +8897,21 @@ namespace sqlite_orm {
         }
 
         template<class FnArgs, class CallArgs>
-        SQLITE_ORM_CONSTEVAL bool validate_pointer_value_types(index_constant<size_t(-1)>) {
+        SQLITE_ORM_CONSTEVAL bool validate_pointer_value_types(polyfill::index_constant<size_t(-1)>) {
             return true;
         }
         template<class FnArgs, class CallArgs, size_t I>
-        SQLITE_ORM_CONSTEVAL bool validate_pointer_value_types(index_constant<I>) {
+        SQLITE_ORM_CONSTEVAL bool validate_pointer_value_types(polyfill::index_constant<I>) {
             using func_arg_t = std::tuple_element_t<I, FnArgs>;
             using passed_arg_t = unpacked_arg_t<std::tuple_element_t<I, CallArgs>>;
 
             constexpr bool valid = validate_pointer_value_type<I,
                                                                std::tuple_element_t<I, FnArgs>,
                                                                unpacked_arg_t<std::tuple_element_t<I, CallArgs>>>(
-                std::integral_constant < bool,
-                is_specialization_v<func_arg_t, pointer_arg> || is_specialization_v < passed_arg_t,
-                pointer_binding >> {});
+                polyfill::bool_constant < (polyfill::is_specialization_of_v<func_arg_t, pointer_arg>) ||
+                (polyfill::is_specialization_of_v<passed_arg_t, pointer_binding>) > {});
 
-            return validate_pointer_value_types<FnArgs, CallArgs>(index_constant<I - 1>{}) && valid;
+            return validate_pointer_value_types<FnArgs, CallArgs>(polyfill::index_constant<I - 1>{}) && valid;
         }
     }
 
@@ -8883,7 +8927,7 @@ namespace sqlite_orm {
         static_assert((argsCount == functionArgsCount &&
                        !std::is_same<function_args_tuple, std::tuple<arg_values>>::value &&
                        internal::validate_pointer_value_types<function_args_tuple, args_tuple>(
-                           internal::index_constant<std::min<>(functionArgsCount, argsCount) - 1>{})) ||
+                           internal::polyfill::index_constant<std::min<>(functionArgsCount, argsCount) - 1>{})) ||
                           std::is_same<function_args_tuple, std::tuple<arg_values>>::value,
                       "Number of arguments does not match");
         return {std::make_tuple(std::forward<Args>(args)...)};

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -25,7 +25,6 @@ __pragma(push_macro("min"))
 #define SQLITE_ORM_CONSTEVAL consteval
 #define SQLITE_ORM_NOUNIQUEADDRESS [[no_unique_address]]
 #else
-#define SQLITE_ORM_CONSTEVAL
 #define SQLITE_ORM_CONSTEVAL constexpr
 #define SQLITE_ORM_NOUNIQUEADDRESS
 #endif
@@ -7054,8 +7053,8 @@ namespace sqlite_orm {
 
       protected:
         // Constructing pointer bindings must go through bindable_pointer()
-        template<class T, class P, class D>
-        friend auto bindable_pointer(P*, D) noexcept -> pointer_binding<P, T, D>;
+        template<class T2, class P2, class D2>
+        friend auto bindable_pointer(P2*, D2) noexcept -> pointer_binding<P2, T2, D2>;
         template<class B>
         friend B bindable_pointer(typename B::qualified_type*, typename B::deleter_type) noexcept;
 
@@ -8793,13 +8792,13 @@ namespace sqlite_orm {
             args_tuple args;
         };
 
-        template<typename Type, template<typename...> typename Primary>
+        template<typename Type, template<typename...> class Primary>
         SQLITE_ORM_INLINE_VAR constexpr bool is_specialization_v = false;
 
-        template<template<typename...> typename Primary, typename... Types>
+        template<template<typename...> class Primary, class... Types>
         SQLITE_ORM_INLINE_VAR constexpr bool is_specialization_v<Primary<Types...>, Primary> = true;
 
-        template<typename Type, template<typename...> typename Primary>
+        template<typename Type, template<typename...> class Primary>
         struct is_specialization : std::bool_constant<is_specialization_v<Type, Primary>> {};
 
         template<typename... T>

--- a/tests/tests2.cpp
+++ b/tests/tests2.cpp
@@ -4,7 +4,7 @@
 #include <optional>  // std::optional
 #endif  // SQLITE_ORM_OPTIONAL_SUPPORTED
 #include <memory>  // std::default_delete
-#include <malloc.h>  // free()
+#include <stdlib.h>  // free()
 
 using namespace sqlite_orm;
 using std::default_delete;


### PR DESCRIPTION
Addresses discussions/#857.

* Addresses warnings found with clang.
* Compilers seem to disagree about short-circuiting invocation of constexpr/consteval functions.

Additionally, I introduced 'polyfilling' useful generic type traits missing in previous C++ standards, currently in namespace `sqlite_orm::internal::polyfill`. @fnc12 Please review whether you are happy with this approach.