### PR TITLE
Making `make_error_code()` a customization point

### DIFF
--- a/dev/arg_values.h
+++ b/dev/arg_values.h
@@ -83,7 +83,7 @@ namespace sqlite_orm {
                 if(this->index < int(this->container.size()) && this->index >= 0) {
                     return this->currentValue;
                 } else {
-                    throw std::system_error(std::make_error_code(orm_error_code::index_is_out_of_bounds));
+                    throw std::system_error(orm_error_code::index_is_out_of_bounds);
                 }
             }
 
@@ -122,7 +122,7 @@ namespace sqlite_orm {
                 auto valuePointer = this->values[index];
                 return {valuePointer};
             } else {
-                throw std::system_error(std::make_error_code(orm_error_code::index_is_out_of_bounds));
+                throw std::system_error(orm_error_code::index_is_out_of_bounds);
             }
         }
 

--- a/dev/backup.h
+++ b/dev/backup.h
@@ -26,7 +26,7 @@ namespace sqlite_orm {
                 handle(sqlite3_backup_init(to_.get(), zDestName.c_str(), from_.get(), zSourceName.c_str())),
                 holder(move(holder_)), to(to_), from(from_) {
                 if(!this->handle) {
-                    throw std::system_error(std::make_error_code(orm_error_code::failed_to_init_a_backup));
+                    throw std::system_error(orm_error_code::failed_to_init_a_backup);
                 }
             }
 

--- a/dev/column_names_getter.h
+++ b/dev/column_names_getter.h
@@ -26,7 +26,7 @@ namespace sqlite_orm {
                 if(columnName.length()) {
                     return {move(columnName)};
                 } else {
-                    throw std::system_error(std::make_error_code(orm_error_code::column_not_found));
+                    throw std::system_error(orm_error_code::column_not_found);
                 }
             }
         };
@@ -86,7 +86,7 @@ namespace sqlite_orm {
                     if(columnName.length()) {
                         columnNames.push_back(columnName);
                     } else {
-                        throw std::system_error(std::make_error_code(orm_error_code::column_not_found));
+                        throw std::system_error(orm_error_code::column_not_found);
                     }
                 });
                 return columnNames;

--- a/dev/constraints.h
+++ b/dev/constraints.h
@@ -328,7 +328,7 @@ namespace sqlite_orm {
                     case decltype(argument)::rtrim:
                         return "RTRIM";
                 }
-                throw std::system_error(std::make_error_code(orm_error_code::invalid_collate_argument_enum));
+                throw std::system_error(orm_error_code::invalid_collate_argument_enum);
             }
         };
 

--- a/dev/error_code.h
+++ b/dev/error_code.h
@@ -127,9 +127,11 @@ namespace sqlite_orm {
 
 namespace std {
     template<>
-    struct is_error_code_enum<sqlite_orm::orm_error_code> : std::true_type {};
+    struct is_error_code_enum<sqlite_orm::orm_error_code> : true_type {};
+}
 
-    inline std::error_code make_error_code(sqlite_orm::orm_error_code errorCode) {
-        return std::error_code(static_cast<int>(errorCode), sqlite_orm::get_orm_error_category());
+namespace sqlite_orm {
+    inline std::error_code make_error_code(orm_error_code errorCode) noexcept {
+        return {static_cast<int>(errorCode), get_orm_error_category()};
     }
 }

--- a/dev/iterator.h
+++ b/dev/iterator.h
@@ -7,7 +7,6 @@
 #include <cstddef>  //  std::ptrdiff_t
 #include <iterator>  //  std::input_iterator_tag
 #include <system_error>  //  std::system_error
-#include <ios>  //  std::make_error_code
 
 #include "row_extractor.h"
 #include "statement_finalizer.h"
@@ -64,7 +63,7 @@ namespace sqlite_orm {
 
             const value_type& operator*() const {
                 if(!this->stmt || !this->current) {
-                    throw std::system_error(std::make_error_code(orm_error_code::trying_to_dereference_null_iterator));
+                    throw std::system_error(orm_error_code::trying_to_dereference_null_iterator);
                 }
                 return *this->current;
             }

--- a/dev/row_extractor.h
+++ b/dev/row_extractor.h
@@ -334,10 +334,10 @@ namespace sqlite_orm {
                 if(auto res = internal::journal_mode_from_string(row_value)) {
                     return std::move(*res);
                 } else {
-                    throw std::system_error(std::make_error_code(orm_error_code::incorrect_journal_mode_string));
+                    throw std::system_error(orm_error_code::incorrect_journal_mode_string);
                 }
             } else {
-                throw std::system_error(std::make_error_code(orm_error_code::incorrect_journal_mode_string));
+                throw std::system_error(orm_error_code::incorrect_journal_mode_string);
             }
         }
 

--- a/dev/statement_serializator.h
+++ b/dev/statement_serializator.h
@@ -150,7 +150,7 @@ namespace sqlite_orm {
                 if(auto columnNamePointer = context.impl.column_name(statement.expression)) {
                     ss << "\"" << *columnNamePointer << "\"";
                 } else {
-                    throw std::system_error(std::make_error_code(orm_error_code::column_not_found));
+                    throw std::system_error(orm_error_code::column_not_found);
                 }
                 return ss.str();
             }
@@ -321,7 +321,7 @@ namespace sqlite_orm {
                 if(auto columnnamePointer = context.column_name(m)) {
                     ss << "\"" << *columnnamePointer << "\"";
                 } else {
-                    throw std::system_error(std::make_error_code(orm_error_code::column_not_found));
+                    throw std::system_error(orm_error_code::column_not_found);
                 }
                 return ss.str();
             }
@@ -484,7 +484,7 @@ namespace sqlite_orm {
                 if(auto columnNamePointer = context.impl.column_name(c)) {
                     ss << "\"" << *columnNamePointer << "\"";
                 } else {
-                    throw std::system_error(std::make_error_code(orm_error_code::column_not_found));
+                    throw std::system_error(orm_error_code::column_not_found);
                 }
                 return ss.str();
             }
@@ -793,7 +793,7 @@ namespace sqlite_orm {
                             }
                             ++columnIndex;
                         } else {
-                            throw std::system_error(std::make_error_code(orm_error_code::column_not_found));
+                            throw std::system_error(orm_error_code::column_not_found);
                         }
                     });
                     res += ")";
@@ -822,7 +822,7 @@ namespace sqlite_orm {
                             }
                             ++columnIndex;
                         } else {
-                            throw std::system_error(std::make_error_code(orm_error_code::column_not_found));
+                            throw std::system_error(orm_error_code::column_not_found);
                         }
                     });
                     res += ")";
@@ -1091,7 +1091,7 @@ namespace sqlite_orm {
                             ss << " ";
                             ++index;
                         } else {
-                            throw std::system_error(std::make_error_code(orm_error_code::column_not_found));
+                            throw std::system_error(orm_error_code::column_not_found);
                         }
                     });
                 }
@@ -1241,10 +1241,10 @@ namespace sqlite_orm {
                         });
                         return ss.str();
                     } else {
-                        throw std::system_error(std::make_error_code(orm_error_code::no_tables_specified));
+                        throw std::system_error(orm_error_code::no_tables_specified);
                     }
                 } else {
-                    throw std::system_error(std::make_error_code(orm_error_code::incorrect_set_fields_specified));
+                    throw std::system_error(orm_error_code::incorrect_set_fields_specified);
                 }
             }
         };
@@ -1407,7 +1407,7 @@ namespace sqlite_orm {
                         ss << " \"" << *columnNamePointer << "\""
                            << " = " << idsStrings[index];
                     } else {
-                        throw std::system_error(std::make_error_code(sqlite_orm::orm_error_code::column_not_found));
+                        throw std::system_error(sqlite_orm::orm_error_code::column_not_found);
                     }
                     ++index;
                 });
@@ -1528,7 +1528,7 @@ namespace sqlite_orm {
                         ss << " ";
                     }
                 } else if(valuesCount != 1) {
-                    throw std::system_error(std::make_error_code(orm_error_code::cannot_use_default_value));
+                    throw std::system_error(orm_error_code::cannot_use_default_value);
                 }
                 return ss.str();
             }
@@ -1634,7 +1634,7 @@ namespace sqlite_orm {
                 }
                 return ss.str();
             } else {
-                throw std::system_error(std::make_error_code(orm_error_code::table_has_no_primary_key_column));
+                throw std::system_error(orm_error_code::table_has_no_primary_key_column);
             }
         }
 
@@ -1788,7 +1788,7 @@ namespace sqlite_orm {
                             ss << " ASC";
                             break;
                         default:
-                            throw std::system_error(std::make_error_code(orm_error_code::incorrect_order));
+                            throw std::system_error(orm_error_code::incorrect_order);
                     }
                 }
                 return ss.str();
@@ -1986,7 +1986,7 @@ namespace sqlite_orm {
                     auto name = context.column_name(v);
 
                     if(name == nullptr)
-                        throw std::system_error(std::make_error_code(orm_error_code::column_not_found));
+                        throw std::system_error(orm_error_code::column_not_found);
                     ss << sep << "'" << *name << "'";
                     sep = ", ";
                 });

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -1151,21 +1151,21 @@ namespace sqlite_orm {
                 auto& tImpl = this->get_impl<object_type>();
                 auto& object = statement.expression.obj;
                 sqlite3_reset(stmt);
-                iterate_tuple(
-                    statement.expression.columns.columns,
-                    [&object, &index, &stmt, &tImpl, db](auto& memberPointer) {
-                        using column_type = typename std::decay<decltype(memberPointer)>::type;
-                        using field_type = typename column_result_t<self, column_type>::type;
-                        const auto* value =
-                            tImpl.table.template get_object_field_pointer<field_type>(object, memberPointer);
-                        if(!value) {
-                            throw std::system_error(std::make_error_code(sqlite_orm::orm_error_code::value_is_null));
-                        }
-                        if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, *value)) {
-                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                    sqlite3_errmsg(db));
-                        }
-                    });
+                iterate_tuple(statement.expression.columns.columns,
+                              [&object, &index, &stmt, &tImpl, db](auto& memberPointer) {
+                                  using column_type = typename std::decay<decltype(memberPointer)>::type;
+                                  using field_type = typename column_result_t<self, column_type>::type;
+                                  const auto* value =
+                                      tImpl.table.template get_object_field_pointer<field_type>(object, memberPointer);
+                                  if(!value) {
+                                      throw std::system_error(orm_error_code::value_is_null);
+                                  }
+                                  if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, *value)) {
+                                      throw std::system_error(
+                                          std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                          sqlite3_errmsg(db));
+                                  }
+                              });
                 perform_step(db, stmt);
                 return sqlite3_last_insert_rowid(db);
             }
@@ -1457,7 +1457,7 @@ namespace sqlite_orm {
                         return res;
                     } break;
                     case SQLITE_DONE: {
-                        throw std::system_error(std::make_error_code(sqlite_orm::orm_error_code::not_found));
+                        throw std::system_error(orm_error_code::not_found);
                     } break;
                     default: {
                         throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
@@ -1692,8 +1692,7 @@ namespace sqlite_orm {
                                 if(auto columnName = storageImpl.table.find_column_name(column)) {
                                     ss << ' ' << *columnName << " = ?";
                                 } else {
-                                    throw std::system_error(
-                                        std::make_error_code(sqlite_orm::orm_error_code::column_not_found));
+                                    throw std::system_error(orm_error_code::column_not_found);
                                 }
                                 ++columnIndex;
                             });
@@ -1716,8 +1715,7 @@ namespace sqlite_orm {
                                             tImpl.table.template get_object_field_pointer<field_type>(object,
                                                                                                       memberPointer);
                                         if(!value) {
-                                            throw std::system_error(
-                                                std::make_error_code(sqlite_orm::orm_error_code::value_is_null));
+                                            throw std::system_error(orm_error_code::value_is_null);
                                         }
                                         if(SQLITE_OK !=
                                            statement_binder<field_type>().bind(stmt, columnIndex++, *value)) {

--- a/dev/storage_base.h
+++ b/dev/storage_base.h
@@ -5,7 +5,7 @@
 #include <string>  //  std::string
 #include <sstream>  //  std::stringstream
 #include <utility>  //  std::move
-#include <system_error>  //  std::system_error, std::error_code, std::make_error_code
+#include <system_error>  //  std::system_error, std::error_code
 #include <vector>  //  std::vector
 #include <memory>  //  std::make_shared, std::shared_ptr
 #include <map>  //  std::map
@@ -380,7 +380,7 @@ namespace sqlite_orm {
                 perform_void_exec(db, "COMMIT");
                 this->connection->release();
                 if(this->connection->retain_count() < 0) {
-                    throw std::system_error(std::make_error_code(orm_error_code::no_active_transaction));
+                    throw std::system_error(orm_error_code::no_active_transaction);
                 }
             }
 
@@ -389,7 +389,7 @@ namespace sqlite_orm {
                 perform_void_exec(db, "ROLLBACK");
                 this->connection->release();
                 if(this->connection->retain_count() < 0) {
-                    throw std::system_error(std::make_error_code(orm_error_code::no_active_transaction));
+                    throw std::system_error(orm_error_code::no_active_transaction);
                 }
             }
 
@@ -600,7 +600,7 @@ namespace sqlite_orm {
                         }
                     }
                 } else {
-                    throw std::system_error(std::make_error_code(orm_error_code::function_not_found));
+                    throw std::system_error(orm_error_code::function_not_found);
                 }
             }
 
@@ -662,7 +662,7 @@ namespace sqlite_orm {
                 std::unique_ptr<int, void (*)(int*)> callablePointer(functionPointer->create(),
                                                                      functionPointer->destroy);
                 if(functionPointer->argumentsCount != -1 && functionPointer->argumentsCount != argsCount) {
-                    throw std::system_error(std::make_error_code(orm_error_code::arguments_count_does_not_match));
+                    throw std::system_error(orm_error_code::arguments_count_does_not_match);
                 }
                 functionPointer->run(context, functionPointer, argsCount, values);
             }

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -259,10 +259,12 @@ namespace sqlite_orm {
 
 namespace std {
     template<>
-    struct is_error_code_enum<sqlite_orm::orm_error_code> : std::true_type {};
+    struct is_error_code_enum<sqlite_orm::orm_error_code> : true_type {};
+}
 
-    inline std::error_code make_error_code(sqlite_orm::orm_error_code errorCode) {
-        return std::error_code(static_cast<int>(errorCode), sqlite_orm::get_orm_error_category());
+namespace sqlite_orm {
+    inline std::error_code make_error_code(orm_error_code errorCode) noexcept {
+        return {static_cast<int>(errorCode), get_orm_error_category()};
     }
 }
 #pragma once
@@ -1403,7 +1405,7 @@ namespace sqlite_orm {
                     case decltype(argument)::rtrim:
                         return "RTRIM";
                 }
-                throw std::system_error(std::make_error_code(orm_error_code::invalid_collate_argument_enum));
+                throw std::system_error(orm_error_code::invalid_collate_argument_enum);
             }
         };
 
@@ -8387,10 +8389,10 @@ namespace sqlite_orm {
                 if(auto res = internal::journal_mode_from_string(row_value)) {
                     return std::move(*res);
                 } else {
-                    throw std::system_error(std::make_error_code(orm_error_code::incorrect_journal_mode_string));
+                    throw std::system_error(orm_error_code::incorrect_journal_mode_string);
                 }
             } else {
-                throw std::system_error(std::make_error_code(orm_error_code::incorrect_journal_mode_string));
+                throw std::system_error(orm_error_code::incorrect_journal_mode_string);
             }
         }
 
@@ -10689,7 +10691,6 @@ namespace sqlite_orm {
 #include <cstddef>  //  std::ptrdiff_t
 #include <iterator>  //  std::input_iterator_tag
 #include <system_error>  //  std::system_error
-#include <ios>  //  std::make_error_code
 
 // #include "row_extractor.h"
 
@@ -10749,7 +10750,7 @@ namespace sqlite_orm {
 
             const value_type& operator*() const {
                 if(!this->stmt || !this->current) {
-                    throw std::system_error(std::make_error_code(orm_error_code::trying_to_dereference_null_iterator));
+                    throw std::system_error(orm_error_code::trying_to_dereference_null_iterator);
                 }
                 return *this->current;
             }
@@ -12571,7 +12572,7 @@ namespace sqlite_orm {
 #include <string>  //  std::string
 #include <sstream>  //  std::stringstream
 #include <utility>  //  std::move
-#include <system_error>  //  std::system_error, std::error_code, std::make_error_code
+#include <system_error>  //  std::system_error, std::error_code
 #include <vector>  //  std::vector
 #include <memory>  //  std::make_shared, std::shared_ptr
 #include <map>  //  std::map
@@ -13009,7 +13010,7 @@ namespace sqlite_orm {
                 handle(sqlite3_backup_init(to_.get(), zDestName.c_str(), from_.get(), zSourceName.c_str())),
                 holder(move(holder_)), to(to_), from(from_) {
                 if(!this->handle) {
-                    throw std::system_error(std::make_error_code(orm_error_code::failed_to_init_a_backup));
+                    throw std::system_error(orm_error_code::failed_to_init_a_backup);
                 }
             }
 
@@ -13149,7 +13150,7 @@ namespace sqlite_orm {
                 if(this->index < int(this->container.size()) && this->index >= 0) {
                     return this->currentValue;
                 } else {
-                    throw std::system_error(std::make_error_code(orm_error_code::index_is_out_of_bounds));
+                    throw std::system_error(orm_error_code::index_is_out_of_bounds);
                 }
             }
 
@@ -13188,7 +13189,7 @@ namespace sqlite_orm {
                 auto valuePointer = this->values[index];
                 return {valuePointer};
             } else {
-                throw std::system_error(std::make_error_code(orm_error_code::index_is_out_of_bounds));
+                throw std::system_error(orm_error_code::index_is_out_of_bounds);
             }
         }
 
@@ -13601,7 +13602,7 @@ namespace sqlite_orm {
                 perform_void_exec(db, "COMMIT");
                 this->connection->release();
                 if(this->connection->retain_count() < 0) {
-                    throw std::system_error(std::make_error_code(orm_error_code::no_active_transaction));
+                    throw std::system_error(orm_error_code::no_active_transaction);
                 }
             }
 
@@ -13610,7 +13611,7 @@ namespace sqlite_orm {
                 perform_void_exec(db, "ROLLBACK");
                 this->connection->release();
                 if(this->connection->retain_count() < 0) {
-                    throw std::system_error(std::make_error_code(orm_error_code::no_active_transaction));
+                    throw std::system_error(orm_error_code::no_active_transaction);
                 }
             }
 
@@ -13821,7 +13822,7 @@ namespace sqlite_orm {
                         }
                     }
                 } else {
-                    throw std::system_error(std::make_error_code(orm_error_code::function_not_found));
+                    throw std::system_error(orm_error_code::function_not_found);
                 }
             }
 
@@ -13883,7 +13884,7 @@ namespace sqlite_orm {
                 std::unique_ptr<int, void (*)(int*)> callablePointer(functionPointer->create(),
                                                                      functionPointer->destroy);
                 if(functionPointer->argumentsCount != -1 && functionPointer->argumentsCount != argsCount) {
-                    throw std::system_error(std::make_error_code(orm_error_code::arguments_count_does_not_match));
+                    throw std::system_error(orm_error_code::arguments_count_does_not_match);
                 }
                 functionPointer->run(context, functionPointer, argsCount, values);
             }
@@ -14305,7 +14306,7 @@ namespace sqlite_orm {
                 if(columnName.length()) {
                     return {move(columnName)};
                 } else {
-                    throw std::system_error(std::make_error_code(orm_error_code::column_not_found));
+                    throw std::system_error(orm_error_code::column_not_found);
                 }
             }
         };
@@ -14365,7 +14366,7 @@ namespace sqlite_orm {
                     if(columnName.length()) {
                         columnNames.push_back(columnName);
                     } else {
-                        throw std::system_error(std::make_error_code(orm_error_code::column_not_found));
+                        throw std::system_error(orm_error_code::column_not_found);
                     }
                 });
                 return columnNames;
@@ -14585,7 +14586,7 @@ namespace sqlite_orm {
                 if(auto columnNamePointer = context.impl.column_name(statement.expression)) {
                     ss << "\"" << *columnNamePointer << "\"";
                 } else {
-                    throw std::system_error(std::make_error_code(orm_error_code::column_not_found));
+                    throw std::system_error(orm_error_code::column_not_found);
                 }
                 return ss.str();
             }
@@ -14756,7 +14757,7 @@ namespace sqlite_orm {
                 if(auto columnnamePointer = context.column_name(m)) {
                     ss << "\"" << *columnnamePointer << "\"";
                 } else {
-                    throw std::system_error(std::make_error_code(orm_error_code::column_not_found));
+                    throw std::system_error(orm_error_code::column_not_found);
                 }
                 return ss.str();
             }
@@ -14919,7 +14920,7 @@ namespace sqlite_orm {
                 if(auto columnNamePointer = context.impl.column_name(c)) {
                     ss << "\"" << *columnNamePointer << "\"";
                 } else {
-                    throw std::system_error(std::make_error_code(orm_error_code::column_not_found));
+                    throw std::system_error(orm_error_code::column_not_found);
                 }
                 return ss.str();
             }
@@ -15228,7 +15229,7 @@ namespace sqlite_orm {
                             }
                             ++columnIndex;
                         } else {
-                            throw std::system_error(std::make_error_code(orm_error_code::column_not_found));
+                            throw std::system_error(orm_error_code::column_not_found);
                         }
                     });
                     res += ")";
@@ -15257,7 +15258,7 @@ namespace sqlite_orm {
                             }
                             ++columnIndex;
                         } else {
-                            throw std::system_error(std::make_error_code(orm_error_code::column_not_found));
+                            throw std::system_error(orm_error_code::column_not_found);
                         }
                     });
                     res += ")";
@@ -15526,7 +15527,7 @@ namespace sqlite_orm {
                             ss << " ";
                             ++index;
                         } else {
-                            throw std::system_error(std::make_error_code(orm_error_code::column_not_found));
+                            throw std::system_error(orm_error_code::column_not_found);
                         }
                     });
                 }
@@ -15676,10 +15677,10 @@ namespace sqlite_orm {
                         });
                         return ss.str();
                     } else {
-                        throw std::system_error(std::make_error_code(orm_error_code::no_tables_specified));
+                        throw std::system_error(orm_error_code::no_tables_specified);
                     }
                 } else {
-                    throw std::system_error(std::make_error_code(orm_error_code::incorrect_set_fields_specified));
+                    throw std::system_error(orm_error_code::incorrect_set_fields_specified);
                 }
             }
         };
@@ -15842,7 +15843,7 @@ namespace sqlite_orm {
                         ss << " \"" << *columnNamePointer << "\""
                            << " = " << idsStrings[index];
                     } else {
-                        throw std::system_error(std::make_error_code(sqlite_orm::orm_error_code::column_not_found));
+                        throw std::system_error(sqlite_orm::orm_error_code::column_not_found);
                     }
                     ++index;
                 });
@@ -15963,7 +15964,7 @@ namespace sqlite_orm {
                         ss << " ";
                     }
                 } else if(valuesCount != 1) {
-                    throw std::system_error(std::make_error_code(orm_error_code::cannot_use_default_value));
+                    throw std::system_error(orm_error_code::cannot_use_default_value);
                 }
                 return ss.str();
             }
@@ -16069,7 +16070,7 @@ namespace sqlite_orm {
                 }
                 return ss.str();
             } else {
-                throw std::system_error(std::make_error_code(orm_error_code::table_has_no_primary_key_column));
+                throw std::system_error(orm_error_code::table_has_no_primary_key_column);
             }
         }
 
@@ -16223,7 +16224,7 @@ namespace sqlite_orm {
                             ss << " ASC";
                             break;
                         default:
-                            throw std::system_error(std::make_error_code(orm_error_code::incorrect_order));
+                            throw std::system_error(orm_error_code::incorrect_order);
                     }
                 }
                 return ss.str();
@@ -16421,7 +16422,7 @@ namespace sqlite_orm {
                     auto name = context.column_name(v);
 
                     if(name == nullptr)
-                        throw std::system_error(std::make_error_code(orm_error_code::column_not_found));
+                        throw std::system_error(orm_error_code::column_not_found);
                     ss << sep << "'" << *name << "'";
                     sep = ", ";
                 });
@@ -17968,21 +17969,21 @@ namespace sqlite_orm {
                 auto& tImpl = this->get_impl<object_type>();
                 auto& object = statement.expression.obj;
                 sqlite3_reset(stmt);
-                iterate_tuple(
-                    statement.expression.columns.columns,
-                    [&object, &index, &stmt, &tImpl, db](auto& memberPointer) {
-                        using column_type = typename std::decay<decltype(memberPointer)>::type;
-                        using field_type = typename column_result_t<self, column_type>::type;
-                        const auto* value =
-                            tImpl.table.template get_object_field_pointer<field_type>(object, memberPointer);
-                        if(!value) {
-                            throw std::system_error(std::make_error_code(sqlite_orm::orm_error_code::value_is_null));
-                        }
-                        if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, *value)) {
-                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                    sqlite3_errmsg(db));
-                        }
-                    });
+                iterate_tuple(statement.expression.columns.columns,
+                              [&object, &index, &stmt, &tImpl, db](auto& memberPointer) {
+                                  using column_type = typename std::decay<decltype(memberPointer)>::type;
+                                  using field_type = typename column_result_t<self, column_type>::type;
+                                  const auto* value =
+                                      tImpl.table.template get_object_field_pointer<field_type>(object, memberPointer);
+                                  if(!value) {
+                                      throw std::system_error(orm_error_code::value_is_null);
+                                  }
+                                  if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, *value)) {
+                                      throw std::system_error(
+                                          std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
+                                          sqlite3_errmsg(db));
+                                  }
+                              });
                 perform_step(db, stmt);
                 return sqlite3_last_insert_rowid(db);
             }
@@ -18274,7 +18275,7 @@ namespace sqlite_orm {
                         return res;
                     } break;
                     case SQLITE_DONE: {
-                        throw std::system_error(std::make_error_code(sqlite_orm::orm_error_code::not_found));
+                        throw std::system_error(orm_error_code::not_found);
                     } break;
                     default: {
                         throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
@@ -18509,8 +18510,7 @@ namespace sqlite_orm {
                                 if(auto columnName = storageImpl.table.find_column_name(column)) {
                                     ss << ' ' << *columnName << " = ?";
                                 } else {
-                                    throw std::system_error(
-                                        std::make_error_code(sqlite_orm::orm_error_code::column_not_found));
+                                    throw std::system_error(orm_error_code::column_not_found);
                                 }
                                 ++columnIndex;
                             });
@@ -18533,8 +18533,7 @@ namespace sqlite_orm {
                                             tImpl.table.template get_object_field_pointer<field_type>(object,
                                                                                                       memberPointer);
                                         if(!value) {
-                                            throw std::system_error(
-                                                std::make_error_code(sqlite_orm::orm_error_code::value_is_null));
+                                            throw std::system_error(orm_error_code::value_is_null);
                                         }
                                         if(SQLITE_OK !=
                                            statement_binder<field_type>().bind(stmt, columnIndex++, *value)) {

--- a/tests/built_in_functions_tests/math_functions.cpp
+++ b/tests/built_in_functions_tests/math_functions.cpp
@@ -14,6 +14,7 @@ TEST_CASE("math functions") {
     using namespace std::placeholders;
     auto storage = make_storage("");
     auto doubleComparator = std::bind(is_double_eq, _1, _2, Epsilon);
+#ifdef SQLITE_ORM_OPTIONAL_SUPPORTED
     auto optionalComparator = [](const std::optional<double> &lhs, const std::optional<double> &rhs) {
         if(lhs.has_value() && rhs.has_value()) {
             return is_double_eq(*lhs, *rhs, Epsilon);
@@ -23,6 +24,7 @@ TEST_CASE("math functions") {
             return false;
         }
     };
+#endif
     SECTION("acos"){SECTION("simple"){auto rows = storage.select(sqlite_orm::acos(1));
     decltype(rows) expected;
     expected.push_back(0);

--- a/tests/unique_cases/issue663.cpp
+++ b/tests/unique_cases/issue663.cpp
@@ -191,7 +191,7 @@ TEST_CASE("Issue 663 - fail test") {
         storage.insert_range(inputUsers.begin(), inputUsers.end());
         REQUIRE(false);
     } catch(const std::system_error& e) {
-        REQUIRE(e.code() == std::make_error_code(orm_error_code::cannot_use_default_value));
+        REQUIRE(e.code() == make_error_code(orm_error_code::cannot_use_default_value));
         REQUIRE(storage.count<User>() == 0);
     }
 }

--- a/third_party/amalgamate/amalgamate.py
+++ b/third_party/amalgamate/amalgamate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding=utf-8
 
 # amalgamate.py - Amalgamate C source and header files.
@@ -97,7 +97,7 @@ class Amalgamation(object):
             t = TranslationUnit(file_path, self, True)
             amalgamation += t.content
 
-        with open(self.target, 'w') as f:
+        with open(self.target, mode='w', newline='\n') as f:
             f.write(amalgamation)
 
         print("...done!\n")


### PR DESCRIPTION
Addresses #935.

Additionally:
* Fix unguarded usage of std::optional in math functions unit test
* Require python3 in amalgamation script
* Produce amalgamated sqlite_orm.h using LF newlines explicitly