### PR TITLE
Amended using clause

### DIFF
--- a/dev/conditions.h
+++ b/dev/conditions.h
@@ -752,9 +752,9 @@ namespace sqlite_orm {
         /**
          *  USING argument holder.
          */
-        template<class F, class O>
+        template<class T, class M>
         struct using_t {
-            F O::*column = nullptr;
+            column_pointer<T, M> column;
 
             operator std::string() const {
                 return "USING";
@@ -985,8 +985,12 @@ namespace sqlite_orm {
     }
 
     template<class F, class O>
-    internal::using_t<F, O> using_(F O::*p) {
-        return {std::move(p)};
+    internal::using_t<O, F O::*> using_(F O::*p) {
+        return {p};
+    }
+    template<class T, class M>
+    internal::using_t<T, M> using_(internal::column_pointer<T, M> cp) {
+        return {std::move(cp)};
     }
 
     template<class T>

--- a/dev/cxx_polyfill.h
+++ b/dev/cxx_polyfill.h
@@ -8,13 +8,17 @@ namespace sqlite_orm {
     namespace internal {
         namespace polyfill {
 #if __cplusplus < 201703L  // before C++17
-            template<class...>
-            using void_t = void;
-
             template<bool v>
             using bool_constant = std::integral_constant<bool, v>;
+
+            template<class B>
+            struct negation : bool_constant<!bool(B::value)> {};
+
+            template<class...>
+            using void_t = void;
 #else
             using std::bool_constant;
+            using std::negation;
             using std::void_t;
 #endif
 

--- a/dev/node_tuple.h
+++ b/dev/node_tuple.h
@@ -319,6 +319,12 @@ namespace sqlite_orm {
             using type = typename node_tuple<T>::type;
         };
 
+        template<class T, class M>
+        struct node_tuple<using_t<T, M>, void> {
+            using node_type = using_t<T, M>;
+            using type = typename node_tuple<M>::type;
+        };
+
         template<class T, class O>
         struct node_tuple<join_t<T, O>, void> {
             using node_type = join_t<T, O>;

--- a/dev/node_tuple.h
+++ b/dev/node_tuple.h
@@ -319,6 +319,8 @@ namespace sqlite_orm {
             using type = typename node_tuple<T>::type;
         };
 
+        // note: not strictly necessary as there's no binding support for USING;
+        // we provide it nevertheless, in line with on_t.
         template<class T, class M>
         struct node_tuple<using_t<T, M>, void> {
             using node_type = using_t<T, M>;

--- a/dev/statement_serializator.h
+++ b/dev/statement_serializator.h
@@ -2327,15 +2327,15 @@ namespace sqlite_orm {
             }
         };
 
-        template<class F, class O>
-        struct statement_serializator<using_t<F, O>, void> {
-            using statement_type = using_t<F, O>;
+        template<class T, class M>
+        struct statement_serializator<using_t<T, M>, void> {
+            using statement_type = using_t<T, M>;
 
             template<class C>
             std::string operator()(const statement_type& statement, const C& context) const {
                 auto newContext = context;
                 newContext.skip_table_name = true;
-                return static_cast<std::string>(statement) + " (" + serialize(statement.column, newContext) + " )";
+                return static_cast<std::string>(statement) + " (" + serialize(statement.column, newContext) + ")";
             }
         };
 

--- a/dev/type_traits.h
+++ b/dev/type_traits.h
@@ -13,7 +13,7 @@ namespace sqlite_orm {
 
         // enable_if for types
         template<template<typename...> class Op, class... Args>
-        using match_if_not = std::enable_if_t<std::negation<Op<Args...>>::value>;
+        using match_if_not = std::enable_if_t<polyfill::negation<Op<Args...>>::value>;
 
         // enable_if for types
         template<class T, template<typename...> class Primary>
@@ -25,7 +25,7 @@ namespace sqlite_orm {
 
         // enable_if for functions
         template<template<typename...> class Op, class... Args>
-        using satisfies_not = std::enable_if_t<std::negation<Op<Args...>>::value, bool>;
+        using satisfies_not = std::enable_if_t<polyfill::negation<Op<Args...>>::value, bool>;
 
         // enable_if for functions
         template<class T, template<typename...> class Primary>

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -3454,9 +3454,9 @@ namespace sqlite_orm {
         /**
          *  USING argument holder.
          */
-        template<class F, class O>
+        template<class T, class M>
         struct using_t {
-            F O::*column = nullptr;
+            column_pointer<T, M> column;
 
             operator std::string() const {
                 return "USING";
@@ -3687,8 +3687,12 @@ namespace sqlite_orm {
     }
 
     template<class F, class O>
-    internal::using_t<F, O> using_(F O::*p) {
-        return {std::move(p)};
+    internal::using_t<O, F O::*> using_(F O::*p) {
+        return {p};
+    }
+    template<class T, class M>
+    internal::using_t<T, M> using_(internal::column_pointer<T, M> cp) {
+        return {std::move(cp)};
     }
 
     template<class T>
@@ -16760,15 +16764,15 @@ namespace sqlite_orm {
             }
         };
 
-        template<class F, class O>
-        struct statement_serializator<using_t<F, O>, void> {
-            using statement_type = using_t<F, O>;
+        template<class T, class M>
+        struct statement_serializator<using_t<T, M>, void> {
+            using statement_type = using_t<T, M>;
 
             template<class C>
             std::string operator()(const statement_type& statement, const C& context) const {
                 auto newContext = context;
                 newContext.skip_table_name = true;
-                return static_cast<std::string>(statement) + " (" + serialize(statement.column, newContext) + " )";
+                return static_cast<std::string>(statement) + " (" + serialize(statement.column, newContext) + ")";
             }
         };
 
@@ -18924,6 +18928,12 @@ __pragma(pop_macro("min"))
         struct node_tuple<on_t<T>, void> {
             using node_type = on_t<T>;
             using type = typename node_tuple<T>::type;
+        };
+
+        template<class T, class M>
+        struct node_tuple<using_t<T, M>, void> {
+            using node_type = using_t<T, M>;
+            using type = typename node_tuple<M>::type;
         };
 
         template<class T, class O>

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -18934,6 +18934,8 @@ __pragma(pop_macro("min"))
             using type = typename node_tuple<T>::type;
         };
 
+        // note: not strictly necessary as there's no binding support for USING;
+        // we provide it nevertheless, in line with on_t.
         template<class T, class M>
         struct node_tuple<using_t<T, M>, void> {
             using node_type = using_t<T, M>;

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -47,13 +47,17 @@ __pragma(push_macro("min"))
     namespace internal {
         namespace polyfill {
 #if __cplusplus < 201703L  // before C++17
-            template<class...>
-            using void_t = void;
-
             template<bool v>
             using bool_constant = std::integral_constant<bool, v>;
+
+            template<class B>
+            struct negation : bool_constant<!bool(B::value)> {};
+
+            template<class...>
+            using void_t = void;
 #else
             using std::bool_constant;
+            using std::negation;
             using std::void_t;
 #endif
 
@@ -102,7 +106,7 @@ namespace sqlite_orm {
 
         // enable_if for types
         template<template<typename...> class Op, class... Args>
-        using match_if_not = std::enable_if_t<std::negation<Op<Args...>>::value>;
+        using match_if_not = std::enable_if_t<polyfill::negation<Op<Args...>>::value>;
 
         // enable_if for types
         template<class T, template<typename...> class Primary>
@@ -114,7 +118,7 @@ namespace sqlite_orm {
 
         // enable_if for functions
         template<template<typename...> class Op, class... Args>
-        using satisfies_not = std::enable_if_t<std::negation<Op<Args...>>::value, bool>;
+        using satisfies_not = std::enable_if_t<polyfill::negation<Op<Args...>>::value, bool>;
 
         // enable_if for functions
         template<class T, template<typename...> class Primary>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -93,6 +93,7 @@ add_executable(unit_tests
     statement_serializator_tests/logical_operators.cpp
     statement_serializator_tests/statements/select.cpp
     statement_serializator_tests/select_constraints.cpp
+    statement_serializator_tests/conditions.cpp
     statement_serializator_tests/statements/insert_replace.cpp
     statement_serializator_tests/statements/update.cpp
     statement_serializator_tests/statements/remove.cpp

--- a/tests/statement_serializator_tests/conditions.cpp
+++ b/tests/statement_serializator_tests/conditions.cpp
@@ -1,0 +1,29 @@
+#include <sqlite_orm/sqlite_orm.h>
+#include <catch2/catch.hpp>
+
+using namespace sqlite_orm;
+
+TEST_CASE("statement_serializator conditions") {
+    SECTION("using") {
+        struct User {
+            int64 id;
+        };
+
+        auto t1 = make_table("user", make_column("id", &User::id));
+        auto storage = internal::storage_impl<decltype(t1)>{t1};
+        using storage_impl = decltype(storage);
+
+        internal::serializator_context<storage_impl> ctx{storage};
+
+        SECTION("using column") {
+            auto ast = using_(&User::id);
+            auto value = serialize(ast, ctx);
+            REQUIRE(value == R"(USING ("id"))");
+        }
+        SECTION("using explicit column") {
+            auto ast = using_(column<User>(&User::id));
+            auto value = serialize(ast, ctx);
+            REQUIRE(value == R"(USING ("id"))");
+        }
+    }
+}

--- a/tests/static_tests/node_tuple.cpp
+++ b/tests/static_tests/node_tuple.cpp
@@ -788,12 +788,27 @@ TEST_CASE("Node tuple") {
             using Expected = std::tuple<decltype(&User::id), int>;
             static_assert(is_same<Tuple, Expected>::value, "left_join");
         }
-        SECTION("join") {
+        SECTION("join on") {
             auto j = join<User>(on(is_equal(&User::id, 2)));
             using Join = decltype(j);
             using Tuple = node_tuple<Join>::type;
             using Expected = std::tuple<decltype(&User::id), int>;
-            static_assert(is_same<Tuple, Expected>::value, "join");
+            static_assert(is_same<Tuple, Expected>::value, "join on");
+        }
+        SECTION("join using column") {
+            auto j = join<User>(using_(&User::id));
+            using Join = decltype(j);
+            using Tuple = node_tuple<Join>::type;
+            using Expected = std::tuple<decltype(&User::id)>;
+            static_assert(is_same<Tuple, Expected>::value, "join using");
+        }
+        SECTION("join using explicit column") {
+            struct Derived : User {};
+            auto j = join<User>(using_(column<Derived>(&User::id)));
+            using Join = decltype(j);
+            using Tuple = node_tuple<Join>::type;
+            using Expected = std::tuple<decltype(&User::id)>;
+            static_assert(is_same<Tuple, Expected>::value, "join using explicit column");
         }
         SECTION("left_outer_join") {
             auto j = left_outer_join<User>(on(is_equal(&User::id, 2)));


### PR DESCRIPTION
Addresses #955.

- Allowed explicit columns
- using_t holder internally always utilizing column_pointer
- node_tuple<using_t <>>
- Serialization unit tests for USING
- Node tuple unit tests for USING

Please verify whether `typename node_tuple<using_t<column_pointer<Derived, decltype(&Base::member)>>::type -> decltype(&Base::member)` is correct.

Note that `using_t` is implemented such that it always carries a `column_pointer`.