### PR TITLE
Explicitly handle AST iteration of USING-clause

### DIFF
--- a/dev/ast_iterator.h
+++ b/dev/ast_iterator.h
@@ -497,6 +497,8 @@ namespace sqlite_orm {
             }
         };
 
+        // note: not strictly necessary as there's no binding support for USING;
+        // we provide it nevertheless, in line with on_t.
         template<class T>
         struct ast_iterator<T, std::enable_if_t<polyfill::is_specialization_of_v<T, using_t>>> {
             using node_type = T;

--- a/dev/ast_iterator.h
+++ b/dev/ast_iterator.h
@@ -492,8 +492,18 @@ namespace sqlite_orm {
             using node_type = on_t<T>;
 
             template<class L>
-            void operator()(const node_type& o, const L& l) const {
-                iterate_ast(o.arg, l);
+            void operator()(const node_type& o, const L& lambda) const {
+                iterate_ast(o.arg, lambda);
+            }
+        };
+
+        template<class T>
+        struct ast_iterator<T, std::enable_if_t<polyfill::is_specialization_of_v<T, using_t>>> {
+            using node_type = T;
+
+            template<class L>
+            void operator()(const node_type& o, const L& lambda) const {
+                iterate_ast(o.column, lambda);
             }
         };
 

--- a/dev/node_tuple.h
+++ b/dev/node_tuple.h
@@ -324,7 +324,7 @@ namespace sqlite_orm {
         template<class T, class M>
         struct node_tuple<using_t<T, M>, void> {
             using node_type = using_t<T, M>;
-            using type = typename node_tuple<M>::type;
+            using type = typename node_tuple<column_pointer<T, M>>::type;
         };
 
         template<class T, class O>

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -12324,8 +12324,20 @@ namespace sqlite_orm {
             using node_type = on_t<T>;
 
             template<class L>
-            void operator()(const node_type& o, const L& l) const {
-                iterate_ast(o.arg, l);
+            void operator()(const node_type& o, const L& lambda) const {
+                iterate_ast(o.arg, lambda);
+            }
+        };
+
+        // note: not strictly necessary as there's no binding support for USING;
+        // we provide it nevertheless, in line with on_t.
+        template<class T>
+        struct ast_iterator<T, std::enable_if_t<polyfill::is_specialization_of_v<T, using_t>>> {
+            using node_type = T;
+
+            template<class L>
+            void operator()(const node_type& o, const L& lambda) const {
+                iterate_ast(o.column, lambda);
             }
         };
 
@@ -18939,7 +18951,7 @@ __pragma(pop_macro("min"))
         template<class T, class M>
         struct node_tuple<using_t<T, M>, void> {
             using node_type = using_t<T, M>;
-            using type = typename node_tuple<M>::type;
+            using type = typename node_tuple<column_pointer<T, M>>::type;
         };
 
         template<class T, class O>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -129,6 +129,10 @@ if(SQLITE_ORM_OMITS_CODECVT)
 	target_compile_definitions(unit_tests PRIVATE SQLITE_ORM_OMITS_CODECVT=1)
 endif()
 
+if (MSVC)
+	add_compile_options(/MP) # Enable multi parrallel build
+endif()
+
 target_precompile_headers(unit_tests PRIVATE
     <sqlite_orm/sqlite_orm.h>
     <catch2/catch.hpp>)

--- a/tests/ast_iterator_tests.cpp
+++ b/tests/ast_iterator_tests.cpp
@@ -125,6 +125,17 @@ TEST_CASE("ast_iterator") {
             internal::iterate_ast(node, lambda);
         }
     }
+    SECTION("on") {
+        auto node = on(&User::id == c(0));
+        expected.push_back(typeid(&User::id));
+        expected.push_back(typeid(int));
+        internal::iterate_ast(node, lambda);
+    }
+    SECTION("using") {
+        auto node = using_(&User::id);
+        expected.push_back(typeid(internal::column_pointer<User, decltype(&User::id)>{&User::id}));
+        internal::iterate_ast(node, lambda);
+    }
     SECTION("exists") {
         auto node = exists(select(5));
         expected.push_back(typeid(int));

--- a/tests/static_tests/node_tuple.cpp
+++ b/tests/static_tests/node_tuple.cpp
@@ -799,7 +799,7 @@ TEST_CASE("Node tuple") {
             auto j = join<User>(using_(&User::id));
             using Join = decltype(j);
             using Tuple = node_tuple<Join>::type;
-            using Expected = std::tuple<decltype(&User::id)>;
+            using Expected = std::tuple<internal::column_pointer<User, decltype(&User::id)>>;
             static_assert(is_same<Tuple, Expected>::value, "join using");
         }
         SECTION("join using explicit column") {
@@ -807,7 +807,7 @@ TEST_CASE("Node tuple") {
             auto j = join<User>(using_(column<Derived>(&User::id)));
             using Join = decltype(j);
             using Tuple = node_tuple<Join>::type;
-            using Expected = std::tuple<decltype(&User::id)>;
+            using Expected = std::tuple<internal::column_pointer<Derived, decltype(&User::id)>>;
             static_assert(is_same<Tuple, Expected>::value, "join using explicit column");
         }
         SECTION("left_outer_join") {


### PR DESCRIPTION
Amends PR #956, issue #955.

- unit test for AST iteration of ON-clause
- unit test for AST iteration of USING-clause

Additionally trying multi-processor compilation of unit tests.