### PR TITLE
Encapsulate throwing sqlite errors as system errors

### DIFF
--- a/dev/arg_values.h
+++ b/dev/arg_values.h
@@ -83,7 +83,7 @@ namespace sqlite_orm {
                 if(this->index < int(this->container.size()) && this->index >= 0) {
                     return this->currentValue;
                 } else {
-                    throw std::system_error(orm_error_code::index_is_out_of_bounds);
+                    throw std::system_error{orm_error_code::index_is_out_of_bounds};
                 }
             }
 
@@ -122,7 +122,7 @@ namespace sqlite_orm {
                 auto valuePointer = this->values[index];
                 return {valuePointer};
             } else {
-                throw std::system_error(orm_error_code::index_is_out_of_bounds);
+                throw std::system_error{orm_error_code::index_is_out_of_bounds};
             }
         }
 

--- a/dev/backup.h
+++ b/dev/backup.h
@@ -26,7 +26,7 @@ namespace sqlite_orm {
                 handle(sqlite3_backup_init(to_.get(), zDestName.c_str(), from_.get(), zSourceName.c_str())),
                 holder(move(holder_)), to(to_), from(from_) {
                 if(!this->handle) {
-                    throw std::system_error(orm_error_code::failed_to_init_a_backup);
+                    throw std::system_error{orm_error_code::failed_to_init_a_backup};
                 }
             }
 

--- a/dev/backup.h
+++ b/dev/backup.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <sqlite3.h>
+#include <system_error>  //  std::system_error
 #include <string>  //  std::string
 #include <memory>
 

--- a/dev/column_names_getter.h
+++ b/dev/column_names_getter.h
@@ -26,7 +26,7 @@ namespace sqlite_orm {
                 if(columnName.length()) {
                     return {move(columnName)};
                 } else {
-                    throw std::system_error(orm_error_code::column_not_found);
+                    throw std::system_error{orm_error_code::column_not_found};
                 }
             }
         };
@@ -86,7 +86,7 @@ namespace sqlite_orm {
                     if(columnName.length()) {
                         columnNames.push_back(columnName);
                     } else {
-                        throw std::system_error(orm_error_code::column_not_found);
+                        throw std::system_error{orm_error_code::column_not_found};
                     }
                 });
                 return columnNames;

--- a/dev/column_names_getter.h
+++ b/dev/column_names_getter.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <system_error>  //  std::system_error
 #include <string>  //  std::string
 #include <vector>  //  std::vector
 #include <functional>  //  std::reference_wrapper

--- a/dev/connection_holder.h
+++ b/dev/connection_holder.h
@@ -19,8 +19,9 @@ namespace sqlite_orm {
                 if(1 == this->_retain_count) {
                     auto rc = sqlite3_open(this->filename.c_str(), &this->db);
                     if(rc != SQLITE_OK) {
-                        throw std::system_error(std::error_code(sqlite3_errcode(this->db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(this->db));
+                        throw std::system_error{sqlite3_errcode(this->db),
+                                                get_sqlite_error_category(),
+                                                sqlite3_errmsg(this->db)};
                     }
                 }
             }
@@ -30,8 +31,9 @@ namespace sqlite_orm {
                 if(0 == this->_retain_count) {
                     auto rc = sqlite3_close(this->db);
                     if(rc != SQLITE_OK) {
-                        throw std::system_error(std::error_code(sqlite3_errcode(this->db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(this->db));
+                        throw std::system_error{sqlite3_errcode(this->db),
+                                                get_sqlite_error_category(),
+                                                sqlite3_errmsg(this->db)};
                     }
                 }
             }

--- a/dev/connection_holder.h
+++ b/dev/connection_holder.h
@@ -2,7 +2,6 @@
 
 #include <sqlite3.h>
 #include <string>  //  std::string
-#include <system_error>  //  std::system_error
 
 #include "error_code.h"
 

--- a/dev/connection_holder.h
+++ b/dev/connection_holder.h
@@ -19,9 +19,7 @@ namespace sqlite_orm {
                 if(1 == this->_retain_count) {
                     auto rc = sqlite3_open(this->filename.c_str(), &this->db);
                     if(rc != SQLITE_OK) {
-                        throw std::system_error{sqlite3_errcode(this->db),
-                                                get_sqlite_error_category(),
-                                                sqlite3_errmsg(this->db)};
+                        throw_translated_sqlite_error(db);
                     }
                 }
             }
@@ -31,9 +29,7 @@ namespace sqlite_orm {
                 if(0 == this->_retain_count) {
                     auto rc = sqlite3_close(this->db);
                     if(rc != SQLITE_OK) {
-                        throw std::system_error{sqlite3_errcode(this->db),
-                                                get_sqlite_error_category(),
-                                                sqlite3_errmsg(this->db)};
+                        throw_translated_sqlite_error(db);
                     }
                 }
             }

--- a/dev/constraints.h
+++ b/dev/constraints.h
@@ -328,7 +328,7 @@ namespace sqlite_orm {
                     case decltype(argument)::rtrim:
                         return "RTRIM";
                 }
-                throw std::system_error(orm_error_code::invalid_collate_argument_enum);
+                throw std::system_error{orm_error_code::invalid_collate_argument_enum};
             }
         };
 

--- a/dev/constraints.h
+++ b/dev/constraints.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <system_error>  //  std::system_error
 #include <ostream>  //  std::ostream
 #include <sstream>  //  std::stringstream
 #include <string>  //  std::string

--- a/dev/error_code.h
+++ b/dev/error_code.h
@@ -148,7 +148,7 @@ namespace sqlite_orm {
     }
 
     inline std::system_error sqlite_to_system_error(int ev) {
-        return {sqlite_errc(ev), sqlite3_errstr(ev)};
+        return {sqlite_errc(ev)};
     }
 
     inline std::system_error sqlite_to_system_error(sqlite3* db) {

--- a/dev/error_code.h
+++ b/dev/error_code.h
@@ -120,8 +120,9 @@ namespace sqlite_orm {
 
     template<typename... T>
     [[noreturn]] void throw_error(sqlite3* db, T&&... args) {
-        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                get_error_message(db, std::forward<T>(args)...));
+        throw std::system_error{sqlite3_errcode(db),
+                                get_sqlite_error_category(),
+                                get_error_message(db, std::forward<T>(args)...)};
     }
 }
 

--- a/dev/error_code.h
+++ b/dev/error_code.h
@@ -9,6 +9,14 @@
 
 namespace sqlite_orm {
 
+    /** @short Enables classifying sqlite error codes.
+
+        @note We don't bother listing all possible values;
+        this also allows for compatibility with
+        'Construction rules for enum class values (P0138R2)'
+     */
+    enum class sqlite_errc {};
+
     enum class orm_error_code {
         not_found = 1,
         type_is_not_mapped_to_storage,
@@ -32,6 +40,14 @@ namespace sqlite_orm {
         no_tables_specified,
     };
 
+}
+
+namespace std {
+    template<>
+    struct is_error_code_enum<::sqlite_orm::sqlite_errc> : true_type {};
+
+    template<>
+    struct is_error_code_enum<::sqlite_orm::orm_error_code> : true_type {};
 }
 
 namespace sqlite_orm {
@@ -109,6 +125,14 @@ namespace sqlite_orm {
         return res;
     }
 
+    inline std::error_code make_error_code(sqlite_errc ev) noexcept {
+        return {static_cast<int>(ev), get_sqlite_error_category()};
+    }
+
+    inline std::error_code make_error_code(orm_error_code ev) noexcept {
+        return {static_cast<int>(ev), get_orm_error_category()};
+    }
+
     template<typename... T>
     std::string get_error_message(sqlite3* db, T&&... args) {
         std::ostringstream stream;
@@ -120,19 +144,22 @@ namespace sqlite_orm {
 
     template<typename... T>
     [[noreturn]] void throw_error(sqlite3* db, T&&... args) {
-        throw std::system_error{sqlite3_errcode(db),
-                                get_sqlite_error_category(),
-                                get_error_message(db, std::forward<T>(args)...)};
+        throw std::system_error{sqlite_errc(sqlite3_errcode(db)), get_error_message(db, std::forward<T>(args)...)};
     }
-}
 
-namespace std {
-    template<>
-    struct is_error_code_enum<sqlite_orm::orm_error_code> : true_type {};
-}
+    inline std::system_error sqlite_to_system_error(int ev) {
+        return {sqlite_errc(ev), sqlite3_errstr(ev)};
+    }
 
-namespace sqlite_orm {
-    inline std::error_code make_error_code(orm_error_code errorCode) noexcept {
-        return {static_cast<int>(errorCode), get_orm_error_category()};
+    inline std::system_error sqlite_to_system_error(sqlite3* db) {
+        return {sqlite_errc(sqlite3_errcode(db)), sqlite3_errmsg(db)};
+    }
+
+    [[noreturn]] inline void throw_translated_sqlite_error(int ev) {
+        throw sqlite_to_system_error(ev);
+    }
+
+    [[noreturn]] inline void throw_translated_sqlite_error(sqlite3* db) {
+        throw sqlite_to_system_error(db);
     }
 }

--- a/dev/iterator.h
+++ b/dev/iterator.h
@@ -87,8 +87,9 @@ namespace sqlite_orm {
                             break;
                         default: {
                             auto db = this->view->connection.get();
-                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                    sqlite3_errmsg(db));
+                            throw std::system_error{sqlite3_errcode(db),
+                                                    get_sqlite_error_category(),
+                                                    sqlite3_errmsg(db)};
                         }
                     }
                 }

--- a/dev/iterator.h
+++ b/dev/iterator.h
@@ -63,7 +63,7 @@ namespace sqlite_orm {
 
             const value_type& operator*() const {
                 if(!this->stmt || !this->current) {
-                    throw std::system_error(orm_error_code::trying_to_dereference_null_iterator);
+                    throw std::system_error{orm_error_code::trying_to_dereference_null_iterator};
                 }
                 return *this->current;
             }
@@ -87,9 +87,7 @@ namespace sqlite_orm {
                             break;
                         default: {
                             auto db = this->view->connection.get();
-                            throw std::system_error{sqlite3_errcode(db),
-                                                    get_sqlite_error_category(),
-                                                    sqlite3_errmsg(db)};
+                            throw_translated_sqlite_error(db);
                         }
                     }
                 }

--- a/dev/pragma.h
+++ b/dev/pragma.h
@@ -134,8 +134,7 @@ namespace sqlite_orm {
                 if(rc == SQLITE_OK) {
                     return result;
                 } else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                            sqlite3_errmsg(db));
+                    throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
                 }
             }
 

--- a/dev/pragma.h
+++ b/dev/pragma.h
@@ -134,7 +134,7 @@ namespace sqlite_orm {
                 if(rc == SQLITE_OK) {
                     return result;
                 } else {
-                    throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
+                    throw_translated_sqlite_error(db);
                 }
             }
 

--- a/dev/row_extractor.h
+++ b/dev/row_extractor.h
@@ -3,6 +3,7 @@
 #include <sqlite3.h>
 #include <type_traits>  //  std::enable_if_t, std::is_arithmetic, std::is_same, std::enable_if
 #include <stdlib.h>  //  atof, atoi, atoll
+#include <system_error>  //  std::system_error
 #include <string>  //  std::string, std::wstring
 #ifndef SQLITE_ORM_OMITS_CODECVT
 #include <codecvt>  //  std::wstring_convert, std::codecvt_utf8_utf16

--- a/dev/row_extractor.h
+++ b/dev/row_extractor.h
@@ -349,10 +349,10 @@ namespace sqlite_orm {
                 if(auto res = internal::journal_mode_from_string(row_value)) {
                     return std::move(*res);
                 } else {
-                    throw std::system_error(orm_error_code::incorrect_journal_mode_string);
+                    throw std::system_error{orm_error_code::incorrect_journal_mode_string};
                 }
             } else {
-                throw std::system_error(orm_error_code::incorrect_journal_mode_string);
+                throw std::system_error{orm_error_code::incorrect_journal_mode_string};
             }
         }
 

--- a/dev/statement_serializator.h
+++ b/dev/statement_serializator.h
@@ -150,7 +150,7 @@ namespace sqlite_orm {
                 if(auto columnNamePointer = context.impl.column_name(statement.expression)) {
                     ss << "\"" << *columnNamePointer << "\"";
                 } else {
-                    throw std::system_error(orm_error_code::column_not_found);
+                    throw std::system_error{orm_error_code::column_not_found};
                 }
                 return ss.str();
             }
@@ -321,7 +321,7 @@ namespace sqlite_orm {
                 if(auto columnnamePointer = context.column_name(m)) {
                     ss << "\"" << *columnnamePointer << "\"";
                 } else {
-                    throw std::system_error(orm_error_code::column_not_found);
+                    throw std::system_error{orm_error_code::column_not_found};
                 }
                 return ss.str();
             }
@@ -484,7 +484,7 @@ namespace sqlite_orm {
                 if(auto columnNamePointer = context.impl.column_name(c)) {
                     ss << "\"" << *columnNamePointer << "\"";
                 } else {
-                    throw std::system_error(orm_error_code::column_not_found);
+                    throw std::system_error{orm_error_code::column_not_found};
                 }
                 return ss.str();
             }
@@ -793,7 +793,7 @@ namespace sqlite_orm {
                             }
                             ++columnIndex;
                         } else {
-                            throw std::system_error(orm_error_code::column_not_found);
+                            throw std::system_error{orm_error_code::column_not_found};
                         }
                     });
                     res += ")";
@@ -822,7 +822,7 @@ namespace sqlite_orm {
                             }
                             ++columnIndex;
                         } else {
-                            throw std::system_error(orm_error_code::column_not_found);
+                            throw std::system_error{orm_error_code::column_not_found};
                         }
                     });
                     res += ")";
@@ -1091,7 +1091,7 @@ namespace sqlite_orm {
                             ss << " ";
                             ++index;
                         } else {
-                            throw std::system_error(orm_error_code::column_not_found);
+                            throw std::system_error{orm_error_code::column_not_found};
                         }
                     });
                 }
@@ -1241,10 +1241,10 @@ namespace sqlite_orm {
                         });
                         return ss.str();
                     } else {
-                        throw std::system_error(orm_error_code::no_tables_specified);
+                        throw std::system_error{orm_error_code::no_tables_specified};
                     }
                 } else {
-                    throw std::system_error(orm_error_code::incorrect_set_fields_specified);
+                    throw std::system_error{orm_error_code::incorrect_set_fields_specified};
                 }
             }
         };
@@ -1407,7 +1407,7 @@ namespace sqlite_orm {
                         ss << " \"" << *columnNamePointer << "\""
                            << " = " << idsStrings[index];
                     } else {
-                        throw std::system_error(sqlite_orm::orm_error_code::column_not_found);
+                        throw std::system_error{orm_error_code::column_not_found};
                     }
                     ++index;
                 });
@@ -1528,7 +1528,7 @@ namespace sqlite_orm {
                         ss << " ";
                     }
                 } else if(valuesCount != 1) {
-                    throw std::system_error(orm_error_code::cannot_use_default_value);
+                    throw std::system_error{orm_error_code::cannot_use_default_value};
                 }
                 return ss.str();
             }
@@ -1634,7 +1634,7 @@ namespace sqlite_orm {
                 }
                 return ss.str();
             } else {
-                throw std::system_error(orm_error_code::table_has_no_primary_key_column);
+                throw std::system_error{orm_error_code::table_has_no_primary_key_column};
             }
         }
 
@@ -1788,7 +1788,7 @@ namespace sqlite_orm {
                             ss << " ASC";
                             break;
                         default:
-                            throw std::system_error(orm_error_code::incorrect_order);
+                            throw std::system_error{orm_error_code::incorrect_order};
                     }
                 }
                 return ss.str();
@@ -1986,7 +1986,7 @@ namespace sqlite_orm {
                     auto name = context.column_name(v);
 
                     if(name == nullptr)
-                        throw std::system_error(orm_error_code::column_not_found);
+                        throw std::system_error{orm_error_code::column_not_found};
                     ss << sep << "'" << *name << "'";
                     sep = ", ";
                 });

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>  //  std::unique/shared_ptr, std::make_unique/shared
+#include <system_error>  //  std::system_error
 #include <string>  //  std::string
 #include <sqlite3.h>
 #include <type_traits>  //  std::remove_reference, std::is_base_of, std::decay, std::false_type, std::true_type

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -821,8 +821,7 @@ namespace sqlite_orm {
                 auto query = serialize(tableImpl.table, context);
                 auto rc = sqlite3_exec(db, query.c_str(), nullptr, nullptr, nullptr);
                 if(rc != SQLITE_OK) {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                            sqlite3_errmsg(db));
+                    throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
                 }
                 return res;
             }
@@ -923,8 +922,7 @@ namespace sqlite_orm {
                 if(sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
                     return prepared_statement_t<S>{std::forward<S>(statement), stmt, con};
                 } else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                            sqlite3_errmsg(db));
+                    throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
                 }
             }
 
@@ -1114,8 +1112,7 @@ namespace sqlite_orm {
                     using node_type = typename std::decay<decltype(node)>::type;
                     conditional_binder<node_type, is_bindable<node_type>> binder{stmt, index};
                     if(SQLITE_OK != binder(node)) {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
+                        throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
                     }
                 });
                 perform_step(db, stmt);
@@ -1132,8 +1129,7 @@ namespace sqlite_orm {
                     using node_type = typename std::decay<decltype(node)>::type;
                     conditional_binder<node_type, is_bindable<node_type>> binder{stmt, index};
                     if(SQLITE_OK != binder(node)) {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
+                        throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
                     }
                 });
                 perform_step(db, stmt);
@@ -1161,9 +1157,9 @@ namespace sqlite_orm {
                                       throw std::system_error(orm_error_code::value_is_null);
                                   }
                                   if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, *value)) {
-                                      throw std::system_error(
-                                          std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                          sqlite3_errmsg(db));
+                                      throw std::system_error{sqlite3_errcode(db),
+                                                              get_sqlite_error_category(),
+                                                              sqlite3_errmsg(db)};
                                   }
                               });
                 perform_step(db, stmt);
@@ -1193,17 +1189,17 @@ namespace sqlite_orm {
                         if(column.member_pointer) {
                             if(SQLITE_OK !=
                                statement_binder<field_type>().bind(stmt, index++, object.*column.member_pointer)) {
-                                throw std::system_error(
-                                    std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                    sqlite3_errmsg(db));
+                                throw std::system_error{sqlite3_errcode(db),
+                                                        get_sqlite_error_category(),
+                                                        sqlite3_errmsg(db)};
                             }
                         } else {
                             using getter_type = typename column_type::getter_type;
                             field_value_holder<getter_type> valueHolder{((object).*(column.getter))()};
                             if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, valueHolder.value)) {
-                                throw std::system_error(
-                                    std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                    sqlite3_errmsg(db));
+                                throw std::system_error{sqlite3_errcode(db),
+                                                        get_sqlite_error_category(),
+                                                        sqlite3_errmsg(db)};
                             }
                         }
                     });
@@ -1250,17 +1246,17 @@ namespace sqlite_orm {
                             if(column.member_pointer) {
                                 if(SQLITE_OK !=
                                    statement_binder<field_type>().bind(stmt, index++, object.*column.member_pointer)) {
-                                    throw std::system_error(
-                                        std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                        sqlite3_errmsg(db));
+                                    throw std::system_error{sqlite3_errcode(db),
+                                                            get_sqlite_error_category(),
+                                                            sqlite3_errmsg(db)};
                                 }
                             } else {
                                 using getter_type = typename column_type::getter_type;
                                 field_value_holder<getter_type> valueHolder{((object).*(column.getter))()};
                                 if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, valueHolder.value)) {
-                                    throw std::system_error(
-                                        std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                        sqlite3_errmsg(db));
+                                    throw std::system_error{sqlite3_errcode(db),
+                                                            get_sqlite_error_category(),
+                                                            sqlite3_errmsg(db)};
                                 }
                             }
                         }
@@ -1297,8 +1293,7 @@ namespace sqlite_orm {
                 iterate_ast(statement.expression.ids, [stmt, &index, db](auto& v) {
                     using field_type = typename std::decay<decltype(v)>::type;
                     if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, v)) {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
+                        throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
                     }
                 });
                 perform_step(db, stmt);
@@ -1325,17 +1320,17 @@ namespace sqlite_orm {
                             auto bind_res =
                                 statement_binder<field_type>().bind(stmt, index++, o.*column.member_pointer);
                             if(SQLITE_OK != bind_res) {
-                                throw std::system_error(
-                                    std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                    sqlite3_errmsg(db));
+                                throw std::system_error{sqlite3_errcode(db),
+                                                        get_sqlite_error_category(),
+                                                        sqlite3_errmsg(db)};
                             }
                         } else {
                             using getter_type = typename column_type::getter_type;
                             field_value_holder<getter_type> valueHolder{((o).*(column.getter))()};
                             if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, valueHolder.value)) {
-                                throw std::system_error(
-                                    std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                    sqlite3_errmsg(db));
+                                throw std::system_error{sqlite3_errcode(db),
+                                                        get_sqlite_error_category(),
+                                                        sqlite3_errmsg(db)};
                             }
                         }
                     }
@@ -1347,17 +1342,17 @@ namespace sqlite_orm {
                         if(column.member_pointer) {
                             if(SQLITE_OK !=
                                statement_binder<field_type>().bind(stmt, index++, o.*column.member_pointer)) {
-                                throw std::system_error(
-                                    std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                    sqlite3_errmsg(db));
+                                throw std::system_error{sqlite3_errcode(db),
+                                                        get_sqlite_error_category(),
+                                                        sqlite3_errmsg(db)};
                             }
                         } else {
                             using getter_type = typename column_type::getter_type;
                             field_value_holder<getter_type> valueHolder{((o).*(column.getter))()};
                             if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, valueHolder.value)) {
-                                throw std::system_error(
-                                    std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                    sqlite3_errmsg(db));
+                                throw std::system_error{sqlite3_errcode(db),
+                                                        get_sqlite_error_category(),
+                                                        sqlite3_errmsg(db)};
                             }
                         }
                     }
@@ -1376,8 +1371,7 @@ namespace sqlite_orm {
                 iterate_ast(statement.expression.ids, [stmt, &index, db](auto& v) {
                     using field_type = typename std::decay<decltype(v)>::type;
                     if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, v)) {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
+                        throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
                     }
                 });
                 auto stepRes = sqlite3_step(stmt);
@@ -1392,8 +1386,7 @@ namespace sqlite_orm {
                         return {};
                     } break;
                     default: {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
+                        throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
                     }
                 }
             }
@@ -1410,8 +1403,7 @@ namespace sqlite_orm {
                 iterate_ast(statement.expression.ids, [stmt, &index, db](auto& v) {
                     using field_type = typename std::decay<decltype(v)>::type;
                     if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, v)) {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
+                        throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
                     }
                 });
                 auto stepRes = sqlite3_step(stmt);
@@ -1426,8 +1418,7 @@ namespace sqlite_orm {
                         return {};
                     } break;
                     default: {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
+                        throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
                     }
                 }
             }
@@ -1444,8 +1435,7 @@ namespace sqlite_orm {
                 iterate_ast(statement.expression.ids, [stmt, &index, db](auto& v) {
                     using field_type = typename std::decay<decltype(v)>::type;
                     if(SQLITE_OK != statement_binder<field_type>().bind(stmt, index++, v)) {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
+                        throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
                     }
                 });
                 auto stepRes = sqlite3_step(stmt);
@@ -1460,8 +1450,7 @@ namespace sqlite_orm {
                         throw std::system_error(orm_error_code::not_found);
                     } break;
                     default: {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
+                        throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
                     }
                 }
             }
@@ -1477,8 +1466,7 @@ namespace sqlite_orm {
                     using node_type = typename std::decay<decltype(node)>::type;
                     conditional_binder<node_type, is_bindable<node_type>> binder{stmt, index};
                     if(SQLITE_OK != binder(node)) {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
+                        throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
                     }
                 });
                 perform_step(db, stmt);
@@ -1496,8 +1484,9 @@ namespace sqlite_orm {
                         using node_type = typename std::decay<decltype(node)>::type;
                         conditional_binder<node_type, is_bindable<node_type>> binder{stmt, index};
                         if(SQLITE_OK != binder(node)) {
-                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                    sqlite3_errmsg(db));
+                            throw std::system_error{sqlite3_errcode(db),
+                                                    get_sqlite_error_category(),
+                                                    sqlite3_errmsg(db)};
                         }
                     });
                 });
@@ -1505,8 +1494,7 @@ namespace sqlite_orm {
                     using node_type = typename std::decay<decltype(node)>::type;
                     conditional_binder<node_type, is_bindable<node_type>> binder{stmt, index};
                     if(SQLITE_OK != binder(node)) {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
+                        throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
                     }
                 });
                 perform_step(db, stmt);
@@ -1523,8 +1511,7 @@ namespace sqlite_orm {
                     using node_type = typename std::decay<decltype(node)>::type;
                     conditional_binder<node_type, is_bindable<node_type>> binder{stmt, index};
                     if(SQLITE_OK != binder(node)) {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
+                        throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
                     }
                 });
                 std::vector<R> res;
@@ -1544,8 +1531,9 @@ namespace sqlite_orm {
                         case SQLITE_DONE:
                             break;
                         default: {
-                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                    sqlite3_errmsg(db));
+                            throw std::system_error{sqlite3_errcode(db),
+                                                    get_sqlite_error_category(),
+                                                    sqlite3_errmsg(db)};
                         }
                     }
                 } while(stepRes != SQLITE_DONE);
@@ -1564,8 +1552,7 @@ namespace sqlite_orm {
                     using node_type = typename std::decay<decltype(node)>::type;
                     conditional_binder<node_type, is_bindable<node_type>> binder{stmt, index};
                     if(SQLITE_OK != binder(node)) {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
+                        throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
                     }
                 });
                 R res;
@@ -1582,8 +1569,9 @@ namespace sqlite_orm {
                         case SQLITE_DONE:
                             break;
                         default: {
-                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                    sqlite3_errmsg(db));
+                            throw std::system_error{sqlite3_errcode(db),
+                                                    get_sqlite_error_category(),
+                                                    sqlite3_errmsg(db)};
                         }
                     }
                 } while(stepRes != SQLITE_DONE);
@@ -1602,8 +1590,7 @@ namespace sqlite_orm {
                     using node_type = typename std::decay<decltype(node)>::type;
                     conditional_binder<node_type, is_bindable<node_type>> binder{stmt, index};
                     if(SQLITE_OK != binder(node)) {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
+                        throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
                     }
                 });
                 R res;
@@ -1620,8 +1607,9 @@ namespace sqlite_orm {
                         case SQLITE_DONE:
                             break;
                         default: {
-                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                    sqlite3_errmsg(db));
+                            throw std::system_error{sqlite3_errcode(db),
+                                                    get_sqlite_error_category(),
+                                                    sqlite3_errmsg(db)};
                         }
                     }
                 } while(stepRes != SQLITE_DONE);
@@ -1641,8 +1629,7 @@ namespace sqlite_orm {
                     using node_type = typename std::decay<decltype(node)>::type;
                     conditional_binder<node_type, is_bindable<node_type>> binder{stmt, index};
                     if(SQLITE_OK != binder(node)) {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
+                        throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
                     }
                 });
                 R res;
@@ -1659,8 +1646,9 @@ namespace sqlite_orm {
                         case SQLITE_DONE:
                             break;
                         default: {
-                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                    sqlite3_errmsg(db));
+                            throw std::system_error{sqlite3_errcode(db),
+                                                    get_sqlite_error_category(),
+                                                    sqlite3_errmsg(db)};
                         }
                     }
                 } while(stepRes != SQLITE_DONE);
@@ -1719,27 +1707,27 @@ namespace sqlite_orm {
                                         }
                                         if(SQLITE_OK !=
                                            statement_binder<field_type>().bind(stmt, columnIndex++, *value)) {
-                                            throw std::system_error(
-                                                std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
+                                            throw std::system_error{sqlite3_errcode(db),
+                                                                    get_sqlite_error_category(),
+                                                                    sqlite3_errmsg(db)};
                                         }
                                     });
                                 if(SQLITE_ROW != sqlite3_step(stmt)) {
-                                    throw std::system_error(
-                                        std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                        sqlite3_errmsg(db));
+                                    throw std::system_error{sqlite3_errcode(db),
+                                                            get_sqlite_error_category(),
+                                                            sqlite3_errmsg(db)};
                                 }
                                 auto countResult = sqlite3_column_int(stmt, 0);
                                 res = countResult > 0;
                                 if(SQLITE_DONE != sqlite3_step(stmt)) {
-                                    throw std::system_error(
-                                        std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                        sqlite3_errmsg(db));
+                                    throw std::system_error{sqlite3_errcode(db),
+                                                            get_sqlite_error_category(),
+                                                            sqlite3_errmsg(db)};
                                 }
                             } else {
-                                throw std::system_error(
-                                    std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                    sqlite3_errmsg(db));
+                                throw std::system_error{sqlite3_errcode(db),
+                                                        get_sqlite_error_category(),
+                                                        sqlite3_errmsg(db)};
                             }
                         })();
                     });

--- a/dev/storage_base.h
+++ b/dev/storage_base.h
@@ -160,7 +160,7 @@ namespace sqlite_orm {
                     nullptr);
 
                 if(res != SQLITE_OK) {
-                    throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
+                    throw_translated_sqlite_error(db);
                 }
                 return tableNames;
             }
@@ -350,7 +350,7 @@ namespace sqlite_orm {
                                                                functionPointer,
                                                                functionExists ? collate_callback : nullptr);
                     if(resultCode != SQLITE_OK) {
-                        throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
+                        throw_translated_sqlite_error(db);
                     }
                 }
             }
@@ -378,7 +378,7 @@ namespace sqlite_orm {
                 perform_void_exec(db, "COMMIT");
                 this->connection->release();
                 if(this->connection->retain_count() < 0) {
-                    throw std::system_error(orm_error_code::no_active_transaction);
+                    throw std::system_error{orm_error_code::no_active_transaction};
                 }
             }
 
@@ -387,7 +387,7 @@ namespace sqlite_orm {
                 perform_void_exec(db, "ROLLBACK");
                 this->connection->release();
                 if(this->connection->retain_count() < 0) {
-                    throw std::system_error(orm_error_code::no_active_transaction);
+                    throw std::system_error{orm_error_code::no_active_transaction};
                 }
             }
 
@@ -520,7 +520,7 @@ namespace sqlite_orm {
                     &result,
                     nullptr);
                 if(rc != SQLITE_OK) {
-                    throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
+                    throw_translated_sqlite_error(db);
                 }
                 return result;
             }
@@ -545,7 +545,7 @@ namespace sqlite_orm {
                     auto resultCode =
                         sqlite3_create_collation(db, p.first.c_str(), SQLITE_UTF8, &p.second, collate_callback);
                     if(resultCode != SQLITE_OK) {
-                        throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
+                        throw_translated_sqlite_error(db);
                     }
                 }
 
@@ -591,13 +591,11 @@ namespace sqlite_orm {
                                                                      nullptr,
                                                                      nullptr);
                         if(resultCode != SQLITE_OK) {
-                            throw std::system_error{sqlite3_errcode(db),
-                                                    get_sqlite_error_category(),
-                                                    sqlite3_errmsg(db)};
+                            throw_translated_sqlite_error(db);
                         }
                     }
                 } else {
-                    throw std::system_error(orm_error_code::function_not_found);
+                    throw std::system_error{orm_error_code::function_not_found};
                 }
             }
 
@@ -612,7 +610,7 @@ namespace sqlite_orm {
                                                              nullptr,
                                                              nullptr);
                 if(resultCode != SQLITE_OK) {
-                    throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
+                    throw_translated_sqlite_error(db);
                 }
             }
 
@@ -626,7 +624,7 @@ namespace sqlite_orm {
                                                           aggregate_function_step_callback,
                                                           aggregate_function_final_callback);
                 if(resultCode != SQLITE_OK) {
-                    throw std::system_error{resultCode, get_sqlite_error_category(), sqlite3_errstr(resultCode)};
+                    throw_translated_sqlite_error(resultCode);
                 }
             }
 
@@ -657,7 +655,7 @@ namespace sqlite_orm {
                 std::unique_ptr<int, void (*)(int*)> callablePointer(functionPointer->create(),
                                                                      functionPointer->destroy);
                 if(functionPointer->argumentsCount != -1 && functionPointer->argumentsCount != argsCount) {
-                    throw std::system_error(orm_error_code::arguments_count_does_not_match);
+                    throw std::system_error{orm_error_code::arguments_count_does_not_match};
                 }
                 functionPointer->run(context, functionPointer, argsCount, values);
             }
@@ -689,7 +687,7 @@ namespace sqlite_orm {
                     &result,
                     nullptr);
                 if(rc != SQLITE_OK) {
-                    throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
+                    throw_translated_sqlite_error(db);
                 }
                 return result;
             }

--- a/dev/storage_base.h
+++ b/dev/storage_base.h
@@ -5,7 +5,7 @@
 #include <string>  //  std::string
 #include <sstream>  //  std::stringstream
 #include <utility>  //  std::move
-#include <system_error>  //  std::system_error, std::error_code
+#include <system_error>  //  std::system_error
 #include <vector>  //  std::vector
 #include <memory>  //  std::make_shared, std::shared_ptr
 #include <map>  //  std::map
@@ -160,8 +160,7 @@ namespace sqlite_orm {
                     nullptr);
 
                 if(res != SQLITE_OK) {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                            sqlite3_errmsg(db));
+                    throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
                 }
                 return tableNames;
             }
@@ -351,8 +350,7 @@ namespace sqlite_orm {
                                                                functionPointer,
                                                                functionExists ? collate_callback : nullptr);
                     if(resultCode != SQLITE_OK) {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
+                        throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
                     }
                 }
             }
@@ -522,8 +520,7 @@ namespace sqlite_orm {
                     &result,
                     nullptr);
                 if(rc != SQLITE_OK) {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                            sqlite3_errmsg(db));
+                    throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
                 }
                 return result;
             }
@@ -548,8 +545,7 @@ namespace sqlite_orm {
                     auto resultCode =
                         sqlite3_create_collation(db, p.first.c_str(), SQLITE_UTF8, &p.second, collate_callback);
                     if(resultCode != SQLITE_OK) {
-                        throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                sqlite3_errmsg(db));
+                        throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
                     }
                 }
 
@@ -595,8 +591,9 @@ namespace sqlite_orm {
                                                                      nullptr,
                                                                      nullptr);
                         if(resultCode != SQLITE_OK) {
-                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                    sqlite3_errmsg(db));
+                            throw std::system_error{sqlite3_errcode(db),
+                                                    get_sqlite_error_category(),
+                                                    sqlite3_errmsg(db)};
                         }
                     }
                 } else {
@@ -615,8 +612,7 @@ namespace sqlite_orm {
                                                              nullptr,
                                                              nullptr);
                 if(resultCode != SQLITE_OK) {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                            sqlite3_errmsg(db));
+                    throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
                 }
             }
 
@@ -630,8 +626,7 @@ namespace sqlite_orm {
                                                           aggregate_function_step_callback,
                                                           aggregate_function_final_callback);
                 if(resultCode != SQLITE_OK) {
-                    throw std::system_error(std::error_code(resultCode, get_sqlite_error_category()),
-                                            sqlite3_errstr(resultCode));
+                    throw std::system_error{resultCode, get_sqlite_error_category(), sqlite3_errstr(resultCode)};
                 }
             }
 
@@ -694,8 +689,7 @@ namespace sqlite_orm {
                     &result,
                     nullptr);
                 if(rc != SQLITE_OK) {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                            sqlite3_errmsg(db));
+                    throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
                 }
                 return result;
             }

--- a/dev/storage_impl.h
+++ b/dev/storage_impl.h
@@ -50,7 +50,7 @@ namespace sqlite_orm {
                     &result,
                     nullptr);
                 if(rc != SQLITE_OK) {
-                    throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
+                    throw_translated_sqlite_error(db);
                 }
                 return result;
             }
@@ -124,7 +124,7 @@ namespace sqlite_orm {
                     &result,
                     nullptr);
                 if(rc != SQLITE_OK) {
-                    throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
+                    throw_translated_sqlite_error(db);
                 }
                 return result;
             }

--- a/dev/storage_impl.h
+++ b/dev/storage_impl.h
@@ -3,7 +3,6 @@
 #include <string>  //  std::string
 #include <sqlite3.h>
 #include <cstddef>  //  std::nullptr_t
-#include <system_error>  //  std::system_error
 #include <sstream>  //  std::stringstream
 #include <stdlib.h>  //  std::atoi
 #include <type_traits>  //  std::forward, std::enable_if, std::is_same, std::remove_reference, std::false_type, std::true_type

--- a/dev/storage_impl.h
+++ b/dev/storage_impl.h
@@ -3,7 +3,7 @@
 #include <string>  //  std::string
 #include <sqlite3.h>
 #include <cstddef>  //  std::nullptr_t
-#include <system_error>  //  std::system_error, std::error_code
+#include <system_error>  //  std::system_error
 #include <sstream>  //  std::stringstream
 #include <stdlib.h>  //  std::atoi
 #include <type_traits>  //  std::forward, std::enable_if, std::is_same, std::remove_reference, std::false_type, std::true_type
@@ -50,8 +50,7 @@ namespace sqlite_orm {
                     &result,
                     nullptr);
                 if(rc != SQLITE_OK) {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                            sqlite3_errmsg(db));
+                    throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
                 }
                 return result;
             }
@@ -125,8 +124,7 @@ namespace sqlite_orm {
                     &result,
                     nullptr);
                 if(rc != SQLITE_OK) {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                            sqlite3_errmsg(db));
+                    throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
                 }
                 return result;
             }

--- a/dev/util.h
+++ b/dev/util.h
@@ -2,7 +2,6 @@
 
 #include <sqlite3.h>
 #include <string>  //  std::string
-#include <system_error>  //  std::system_error
 
 namespace sqlite_orm {
 

--- a/dev/util.h
+++ b/dev/util.h
@@ -2,7 +2,7 @@
 
 #include <sqlite3.h>
 #include <string>  //  std::string
-#include <system_error>  //  std::system_error, std::error_code
+#include <system_error>  //  std::system_error
 
 namespace sqlite_orm {
 
@@ -12,16 +12,14 @@ namespace sqlite_orm {
             if(rc == SQLITE_DONE) {
                 //  done..
             } else {
-                throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                        sqlite3_errmsg(db));
+                throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
             }
         }
 
         static void perform_void_exec(sqlite3* db, const std::string& query) {
             int rc = sqlite3_exec(db, query.c_str(), nullptr, nullptr, nullptr);
             if(rc != SQLITE_OK) {
-                throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                        sqlite3_errmsg(db));
+                throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
             }
         }
     }

--- a/dev/util.h
+++ b/dev/util.h
@@ -9,17 +9,15 @@ namespace sqlite_orm {
     namespace internal {
         inline void perform_step(sqlite3* db, sqlite3_stmt* stmt) {
             auto rc = sqlite3_step(stmt);
-            if(rc == SQLITE_DONE) {
-                //  done..
-            } else {
-                throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
+            if(rc != SQLITE_DONE) {
+                throw_translated_sqlite_error(db);
             }
         }
 
         static void perform_void_exec(sqlite3* db, const std::string& query) {
             int rc = sqlite3_exec(db, query.c_str(), nullptr, nullptr, nullptr);
             if(rc != SQLITE_OK) {
-                throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
+                throw_translated_sqlite_error(db);
             }
         }
     }

--- a/dev/view.h
+++ b/dev/view.h
@@ -64,14 +64,14 @@ namespace sqlite_orm {
                         using node_type = typename std::decay<decltype(node)>::type;
                         conditional_binder<node_type, is_bindable<node_type>> binder{stmt, index};
                         if(SQLITE_OK != binder(node)) {
-                            throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                                    sqlite3_errmsg(db));
+                            throw std::system_error{sqlite3_errcode(db),
+                                                    get_sqlite_error_category(),
+                                                    sqlite3_errmsg(db)};
                         }
                     });
                     return {stmt, *this};
                 } else {
-                    throw std::system_error(std::error_code(sqlite3_errcode(db), get_sqlite_error_category()),
-                                            sqlite3_errmsg(db));
+                    throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
                 }
             }
 

--- a/dev/view.h
+++ b/dev/view.h
@@ -64,14 +64,12 @@ namespace sqlite_orm {
                         using node_type = typename std::decay<decltype(node)>::type;
                         conditional_binder<node_type, is_bindable<node_type>> binder{stmt, index};
                         if(SQLITE_OK != binder(node)) {
-                            throw std::system_error{sqlite3_errcode(db),
-                                                    get_sqlite_error_category(),
-                                                    sqlite3_errmsg(db)};
+                            throw_translated_sqlite_error(db);
                         }
                     });
                     return {stmt, *this};
                 } else {
-                    throw std::system_error{sqlite3_errcode(db), get_sqlite_error_category(), sqlite3_errmsg(db)};
+                    throw_translated_sqlite_error(db);
                 }
             }
 

--- a/dev/view.h
+++ b/dev/view.h
@@ -4,7 +4,6 @@
 #include <string>  //  std::string
 #include <utility>  //  std::forward, std::move
 #include <sqlite3.h>
-#include <system_error>  //  std::system_error
 #include <tuple>  //  std::tuple, std::make_tuple
 
 #include "row_extractor.h"

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -281,7 +281,7 @@ namespace sqlite_orm {
     }
 
     inline std::system_error sqlite_to_system_error(int ev) {
-        return {sqlite_errc(ev), sqlite3_errstr(ev)};
+        return {sqlite_errc(ev)};
     }
 
     inline std::system_error sqlite_to_system_error(sqlite3* db) {


### PR DESCRIPTION
* Dedicated `enum class sqlite_errc`
* High-level functions `sqlite_error_to_system_error()`
* High-level functions `throw_translated_sqlite_error()` for decluttering code