### PR TITLE
Count static assertions in unit tests towards the total

### DIFF
--- a/tests/constraints/foreign_key.cpp
+++ b/tests/constraints/foreign_key.cpp
@@ -42,14 +42,14 @@ TEST_CASE("Foreign key") {
         using namespace internal::storage_traits;
 
         using Storage = decltype(storage);
-        static_assert(storage_foreign_keys_count<Storage, Location>::value == 1, "");
-        static_assert(storage_foreign_keys_count<Storage, Visit>::value == 0, "");
+        STATIC_REQUIRE(storage_foreign_keys_count<Storage, Location>::value == 1);
+        STATIC_REQUIRE(storage_foreign_keys_count<Storage, Visit>::value == 0);
 
         using LocationFks = storage_fk_references<Storage, Location>::type;
-        static_assert(std::is_same<LocationFks, std::tuple<Visit>>::value, "");
+        STATIC_REQUIRE(std::is_same<LocationFks, std::tuple<Visit>>::value);
 
         using VisitFks = storage_fk_references<Storage, Visit>::type;
-        static_assert(std::is_same<VisitFks, std::tuple<>>::value, "");
+        STATIC_REQUIRE(std::is_same<VisitFks, std::tuple<>>::value);
     }
     storage.sync_schema();
 

--- a/tests/get_all_custom_containers.cpp
+++ b/tests/get_all_custom_containers.cpp
@@ -41,7 +41,7 @@ struct Tester {
     template<class E, class T>
     void testContainer(const T& users) const {
         REQUIRE(std::equal(users.begin(), users.end(), this->expected.begin(), this->expected.end(), Comparator{}));
-        static_assert(std::is_same<T, E>::value, "");
+        STATIC_REQUIRE(std::is_same<T, E>::value);
     }
 
     template<class E, class S, class T>

--- a/tests/prepared_statement_tests/get_all.cpp
+++ b/tests/prepared_statement_tests/get_all.cpp
@@ -60,14 +60,14 @@ TEST_CASE("Prepared get all") {
             using Statement = decltype(statement);
             using ExpressionType = Statement::expression_type;
             using NodeTuple = internal::node_tuple<ExpressionType>::type;
-            static_assert(std::tuple_size<NodeTuple>::value == 2, "");
+            STATIC_REQUIRE(std::tuple_size<NodeTuple>::value == 2);
             {
                 using Arg0 = std::tuple_element<0, NodeTuple>::type;
-                static_assert(std::is_same<Arg0, decltype(&User::id)>::value, "");
+                STATIC_REQUIRE(std::is_same<Arg0, decltype(&User::id)>::value);
             }
             {
                 using Arg1 = std::tuple_element<1, NodeTuple>::type;
-                static_assert(std::is_same<Arg1, int>::value, "");
+                STATIC_REQUIRE(std::is_same<Arg1, int>::value);
             }
         }
         REQUIRE(get<0>(statement) == 3);
@@ -91,14 +91,14 @@ TEST_CASE("Prepared get all") {
             using Statement = decltype(statement);
             using ExpressionType = Statement::expression_type;
             using NodeTuple = internal::node_tuple<ExpressionType>::type;
-            static_assert(std::tuple_size<NodeTuple>::value == 2, "");
+            STATIC_REQUIRE(std::tuple_size<NodeTuple>::value == 2);
             {
                 using Arg0 = std::tuple_element<0, NodeTuple>::type;
-                static_assert(std::is_same<Arg0, decltype(&User::id)>::value, "");
+                STATIC_REQUIRE(std::is_same<Arg0, decltype(&User::id)>::value);
             }
             {
                 using Arg1 = std::tuple_element<1, NodeTuple>::type;
-                static_assert(std::is_same<Arg1, int>::value, "");
+                STATIC_REQUIRE(std::is_same<Arg1, int>::value);
             }
         }
         REQUIRE(get<0>(statement) == id);

--- a/tests/prepared_statement_tests/get_all_optional.cpp
+++ b/tests/prepared_statement_tests/get_all_optional.cpp
@@ -60,10 +60,10 @@ TEST_CASE("Prepared get all optional") {
         using NodeTuple = internal::node_tuple<Expression>::type;
         using BindTuple = typename internal::bindable_filter<NodeTuple>::type;
         {
-            static_assert(std::tuple_size<BindTuple>::value == 1, "");
+            STATIC_REQUIRE(std::tuple_size<BindTuple>::value == 1);
             {
                 using Arg0 = std::tuple_element<0, BindTuple>::type;
-                static_assert(std::is_same<Arg0, int>::value, "");
+                STATIC_REQUIRE(std::is_same<Arg0, int>::value);
             }
         }
         REQUIRE(get<0>(statement) == 3);
@@ -100,10 +100,10 @@ TEST_CASE("Prepared get all optional") {
         using NodeTuple = internal::node_tuple<Expression>::type;
         using BindTuple = typename internal::bindable_filter<NodeTuple>::type;
         {
-            static_assert(std::tuple_size<BindTuple>::value == 1, "");
+            STATIC_REQUIRE(std::tuple_size<BindTuple>::value == 1);
             {
                 using Arg0 = std::tuple_element<0, BindTuple>::type;
-                static_assert(std::is_same<Arg0, int>::value, "");
+                STATIC_REQUIRE(std::is_same<Arg0, int>::value);
             }
         }
         REQUIRE(get<0>(statement) == 3);

--- a/tests/prepared_statement_tests/get_all_pointer.cpp
+++ b/tests/prepared_statement_tests/get_all_pointer.cpp
@@ -62,10 +62,10 @@ TEST_CASE("Prepared get all pointer") {
         using NodeTuple = internal::node_tuple<Expression>::type;
         using BindTuple = typename internal::bindable_filter<NodeTuple>::type;
         {
-            static_assert(std::tuple_size<BindTuple>::value == 1, "");
+            STATIC_REQUIRE(std::tuple_size<BindTuple>::value == 1);
             {
                 using Arg0 = std::tuple_element<0, BindTuple>::type;
-                static_assert(std::is_same<Arg0, int>::value, "");
+                STATIC_REQUIRE(std::is_same<Arg0, int>::value);
             }
         }
         REQUIRE(get<0>(statement) == 3);
@@ -103,10 +103,10 @@ TEST_CASE("Prepared get all pointer") {
         using NodeTuple = internal::node_tuple<Expression>::type;
         using BindTuple = typename internal::bindable_filter<NodeTuple>::type;
         {
-            static_assert(std::tuple_size<BindTuple>::value == 1, "");
+            STATIC_REQUIRE(std::tuple_size<BindTuple>::value == 1);
             {
                 using Arg0 = std::tuple_element<0, BindTuple>::type;
-                static_assert(std::is_same<Arg0, int>::value, "");
+                STATIC_REQUIRE(std::is_same<Arg0, int>::value);
             }
         }
         REQUIRE(get<0>(statement) == 3);

--- a/tests/prepared_statement_tests/update_all.cpp
+++ b/tests/prepared_statement_tests/update_all.cpp
@@ -43,10 +43,10 @@ TEST_CASE("Prepared update all") {
         using Expression = Statement::expression_type;
         using SetTuple = internal::node_tuple<Expression>::set_tuple;
         using SetBind = internal::bindable_filter<SetTuple>::type;
-        static_assert(std::tuple_size<SetBind>::value == 1, "");
+        STATIC_REQUIRE(std::tuple_size<SetBind>::value == 1);
         {
             using Arg0 = std::tuple_element<0, SetBind>::type;
-            static_assert(std::is_same<Arg0, const char*>::value, "");
+            STATIC_REQUIRE(std::is_same<Arg0, const char*>::value);
         }
         REQUIRE(strcmp(get<0>(statement), "_") == 0);
         testSerializing(statement);
@@ -109,10 +109,10 @@ TEST_CASE("Prepared update all") {
         using Expression = Statement::expression_type;
         using SetTuple = internal::node_tuple<Expression>::set_tuple;
         using SetBind = internal::bindable_filter<SetTuple>::type;
-        static_assert(std::tuple_size<SetBind>::value == 1, "");
+        STATIC_REQUIRE(std::tuple_size<SetBind>::value == 1);
         {
             using Arg0 = std::tuple_element<0, SetBind>::type;
-            static_assert(std::is_same<Arg0, std::string>::value, "");
+            STATIC_REQUIRE(std::is_same<Arg0, std::string>::value);
         }
         REQUIRE(get<0>(statement) == "_");
         REQUIRE(&get<0>(statement) == &str);

--- a/tests/statement_serializator_tests/foreign_key.cpp
+++ b/tests/statement_serializator_tests/foreign_key.cpp
@@ -28,8 +28,8 @@ TEST_CASE("statement_serializator foreign key") {
             auto fk = foreign_key(&Visit::userId).references(&User::id);
 
             using ForeignKey = decltype(fk);
-            static_assert(std::is_same<ForeignKey::target_type, User>::value, "");
-            static_assert(std::is_same<ForeignKey::source_type, Visit>::value, "");
+            STATIC_REQUIRE(std::is_same<ForeignKey::target_type, User>::value);
+            STATIC_REQUIRE(std::is_same<ForeignKey::source_type, Visit>::value);
 
             auto visitsTable = make_table("visits",
                                           make_column("id", &Visit::id, primary_key(), autoincrement()),
@@ -52,8 +52,8 @@ TEST_CASE("statement_serializator foreign key") {
                 auto fk = foreign_key(&Visit::userId).references(&User::id).on_update.no_action();
 
                 using ForeignKey = decltype(fk);
-                static_assert(std::is_same<ForeignKey::target_type, User>::value, "");
-                static_assert(std::is_same<ForeignKey::source_type, Visit>::value, "");
+                STATIC_REQUIRE(std::is_same<ForeignKey::target_type, User>::value);
+                STATIC_REQUIRE(std::is_same<ForeignKey::source_type, Visit>::value);
 
                 auto visitsTable = make_table("visits",
                                               make_column("id", &Visit::id, primary_key(), autoincrement()),
@@ -75,8 +75,8 @@ TEST_CASE("statement_serializator foreign key") {
                 auto fk = foreign_key(&Visit::userId).references(&User::id).on_update.restrict_();
 
                 using ForeignKey = decltype(fk);
-                static_assert(std::is_same<ForeignKey::target_type, User>::value, "");
-                static_assert(std::is_same<ForeignKey::source_type, Visit>::value, "");
+                STATIC_REQUIRE(std::is_same<ForeignKey::target_type, User>::value);
+                STATIC_REQUIRE(std::is_same<ForeignKey::source_type, Visit>::value);
 
                 auto visitsTable = make_table("visits",
                                               make_column("id", &Visit::id, primary_key(), autoincrement()),
@@ -98,8 +98,8 @@ TEST_CASE("statement_serializator foreign key") {
                 auto fk = foreign_key(&Visit::userId).references(&User::id).on_update.set_null();
 
                 using ForeignKey = decltype(fk);
-                static_assert(std::is_same<ForeignKey::target_type, User>::value, "");
-                static_assert(std::is_same<ForeignKey::source_type, Visit>::value, "");
+                STATIC_REQUIRE(std::is_same<ForeignKey::target_type, User>::value);
+                STATIC_REQUIRE(std::is_same<ForeignKey::source_type, Visit>::value);
 
                 auto visitsTable = make_table("visits",
                                               make_column("id", &Visit::id, primary_key(), autoincrement()),
@@ -121,8 +121,8 @@ TEST_CASE("statement_serializator foreign key") {
                 auto fk = foreign_key(&Visit::userId).references(&User::id).on_update.set_default();
 
                 using ForeignKey = decltype(fk);
-                static_assert(std::is_same<ForeignKey::target_type, User>::value, "");
-                static_assert(std::is_same<ForeignKey::source_type, Visit>::value, "");
+                STATIC_REQUIRE(std::is_same<ForeignKey::target_type, User>::value);
+                STATIC_REQUIRE(std::is_same<ForeignKey::source_type, Visit>::value);
 
                 auto visitsTable = make_table("visits",
                                               make_column("id", &Visit::id, primary_key(), autoincrement()),
@@ -144,8 +144,8 @@ TEST_CASE("statement_serializator foreign key") {
                 auto fk = foreign_key(&Visit::userId).references(&User::id).on_update.cascade();
 
                 using ForeignKey = decltype(fk);
-                static_assert(std::is_same<ForeignKey::target_type, User>::value, "");
-                static_assert(std::is_same<ForeignKey::source_type, Visit>::value, "");
+                STATIC_REQUIRE(std::is_same<ForeignKey::target_type, User>::value);
+                STATIC_REQUIRE(std::is_same<ForeignKey::source_type, Visit>::value);
 
                 auto visitsTable = make_table("visits",
                                               make_column("id", &Visit::id, primary_key(), autoincrement()),
@@ -169,8 +169,8 @@ TEST_CASE("statement_serializator foreign key") {
                 auto fk = foreign_key(&Visit::userId).references(&User::id).on_delete.no_action();
 
                 using ForeignKey = decltype(fk);
-                static_assert(std::is_same<ForeignKey::target_type, User>::value, "");
-                static_assert(std::is_same<ForeignKey::source_type, Visit>::value, "");
+                STATIC_REQUIRE(std::is_same<ForeignKey::target_type, User>::value);
+                STATIC_REQUIRE(std::is_same<ForeignKey::source_type, Visit>::value);
 
                 auto visitsTable = make_table("visits",
                                               make_column("id", &Visit::id, primary_key(), autoincrement()),
@@ -192,8 +192,8 @@ TEST_CASE("statement_serializator foreign key") {
                 auto fk = foreign_key(&Visit::userId).references(&User::id).on_delete.restrict_();
 
                 using ForeignKey = decltype(fk);
-                static_assert(std::is_same<ForeignKey::target_type, User>::value, "");
-                static_assert(std::is_same<ForeignKey::source_type, Visit>::value, "");
+                STATIC_REQUIRE(std::is_same<ForeignKey::target_type, User>::value);
+                STATIC_REQUIRE(std::is_same<ForeignKey::source_type, Visit>::value);
 
                 auto visitsTable = make_table("visits",
                                               make_column("id", &Visit::id, primary_key(), autoincrement()),
@@ -215,8 +215,8 @@ TEST_CASE("statement_serializator foreign key") {
                 auto fk = foreign_key(&Visit::userId).references(&User::id).on_delete.set_null();
 
                 using ForeignKey = decltype(fk);
-                static_assert(std::is_same<ForeignKey::target_type, User>::value, "");
-                static_assert(std::is_same<ForeignKey::source_type, Visit>::value, "");
+                STATIC_REQUIRE(std::is_same<ForeignKey::target_type, User>::value);
+                STATIC_REQUIRE(std::is_same<ForeignKey::source_type, Visit>::value);
 
                 auto visitsTable = make_table("visits",
                                               make_column("id", &Visit::id, primary_key(), autoincrement()),
@@ -238,8 +238,8 @@ TEST_CASE("statement_serializator foreign key") {
                 auto fk = foreign_key(&Visit::userId).references(&User::id).on_delete.set_default();
 
                 using ForeignKey = decltype(fk);
-                static_assert(std::is_same<ForeignKey::target_type, User>::value, "");
-                static_assert(std::is_same<ForeignKey::source_type, Visit>::value, "");
+                STATIC_REQUIRE(std::is_same<ForeignKey::target_type, User>::value);
+                STATIC_REQUIRE(std::is_same<ForeignKey::source_type, Visit>::value);
 
                 auto visitsTable = make_table("visits",
                                               make_column("id", &Visit::id, primary_key(), autoincrement()),
@@ -261,8 +261,8 @@ TEST_CASE("statement_serializator foreign key") {
                 auto fk = foreign_key(&Visit::userId).references(&User::id).on_delete.cascade();
 
                 using ForeignKey = decltype(fk);
-                static_assert(std::is_same<ForeignKey::target_type, User>::value, "");
-                static_assert(std::is_same<ForeignKey::source_type, Visit>::value, "");
+                STATIC_REQUIRE(std::is_same<ForeignKey::target_type, User>::value);
+                STATIC_REQUIRE(std::is_same<ForeignKey::source_type, Visit>::value);
 
                 auto visitsTable = make_table("visits",
                                               make_column("id", &Visit::id, primary_key(), autoincrement()),
@@ -303,8 +303,8 @@ TEST_CASE("statement_serializator foreign key") {
         auto fk = foreign_key(&Token::usedId).references(column<User>(&User::id));
 
         using ForeignKey = decltype(fk);
-        static_assert(std::is_same<ForeignKey::target_type, User>::value, "");
-        static_assert(std::is_same<ForeignKey::source_type, Token>::value, "");
+        STATIC_REQUIRE(std::is_same<ForeignKey::target_type, User>::value);
+        STATIC_REQUIRE(std::is_same<ForeignKey::source_type, Token>::value);
 
         auto usersTable =
             make_table<User>("users", make_column("id", &User::id, primary_key()), make_column("name", &User::name));
@@ -340,8 +340,8 @@ TEST_CASE("statement_serializator foreign key") {
         auto fk = foreign_key(&UserVisit::userId, &UserVisit::userFirstName).references(&User::id, &User::firstName);
 
         using ForeignKey = decltype(fk);
-        static_assert(std::is_same<ForeignKey::target_type, User>::value, "");
-        static_assert(std::is_same<ForeignKey::source_type, UserVisit>::value, "");
+        STATIC_REQUIRE(std::is_same<ForeignKey::target_type, User>::value);
+        STATIC_REQUIRE(std::is_same<ForeignKey::source_type, UserVisit>::value);
 
         auto usersTable = make_table("users",
                                      make_column("id", &User::id),
@@ -349,7 +349,7 @@ TEST_CASE("statement_serializator foreign key") {
                                      make_column("last_name", &User::lastName),
                                      primary_key(&User::id, &User::firstName));
 
-        static_assert(internal::storage_traits::table_foreign_keys_count<decltype(usersTable), User>::value == 0, "");
+        STATIC_REQUIRE(internal::storage_traits::table_foreign_keys_count<decltype(usersTable), User>::value == 0);
         static_assert(internal::storage_traits::table_foreign_keys_count<decltype(usersTable), UserVisit>::value == 0,
                       "");
 
@@ -358,7 +358,7 @@ TEST_CASE("statement_serializator foreign key") {
                                       make_column("user_first_name", &UserVisit::userFirstName),
                                       make_column("time", &UserVisit::time),
                                       fk);
-        static_assert(internal::storage_traits::table_foreign_keys_count<decltype(visitsTable), User>::value == 1, "");
+        STATIC_REQUIRE(internal::storage_traits::table_foreign_keys_count<decltype(visitsTable), User>::value == 1);
         static_assert(internal::storage_traits::table_foreign_keys_count<decltype(visitsTable), UserVisit>::value == 0,
                       "");
 

--- a/tests/static_if_tests.cpp
+++ b/tests/static_if_tests.cpp
@@ -53,7 +53,7 @@ TEST_CASE("static_if") {
             std::string name;
         };
         auto ch = check(length(&User::name) > 5);
-        static_assert(!internal::is_column<decltype(ch)>::value, "");
+        STATIC_REQUIRE(!internal::is_column<decltype(ch)>::value);
         int called = 0;
         internal::static_if<internal::is_column<decltype(ch)>{}>(
             [&called] {

--- a/tests/static_tests/bindable_filter.cpp
+++ b/tests/static_tests/bindable_filter.cpp
@@ -67,18 +67,18 @@ TEST_CASE("bindable_filter") {
                                  Custom,
                                  std::unique_ptr<Custom>>;
         using Res = bindable_filter<Tuple>::type;
-        static_assert(is_same<Res, Tuple>::value, "");
+        STATIC_REQUIRE(is_same<Res, Tuple>::value);
     }
     {
         using Tuple = std::tuple<decltype(&User::id), decltype(&User::name), int>;
         using Res = bindable_filter<Tuple>::type;
         using Expected = std::tuple<int>;
-        static_assert(is_same<Res, Expected>::value, "");
+        STATIC_REQUIRE(is_same<Res, Expected>::value);
     }
     {
         using Tuple = std::tuple<std::string, decltype(&User::name), float, decltype(&User::id), short>;
         using Res = bindable_filter<Tuple>::type;
         using Expected = std::tuple<std::string, float, short>;
-        static_assert(is_same<Res, Expected>::value, "");
+        STATIC_REQUIRE(is_same<Res, Expected>::value);
     }
 }

--- a/tests/static_tests/column_result_t.cpp
+++ b/tests/static_tests/column_result_t.cpp
@@ -7,7 +7,7 @@ using namespace sqlite_orm;
 template<class St, class E, class V>
 void runTest(V value) {
     using Type = typename internal::column_result_t<St, V>::type;
-    static_assert(std::is_same<Type, E>::value, "");
+    STATIC_REQUIRE(std::is_same<Type, E>::value);
 }
 
 TEST_CASE("column_result_t") {

--- a/tests/static_tests/count_tuple.cpp
+++ b/tests/static_tests/count_tuple.cpp
@@ -13,44 +13,44 @@ TEST_CASE("count_tuple") {
     {
         auto t = std::make_tuple(where(is_equal(&User::id, 5)), limit(5), order_by(&User::name));
         using T = decltype(t);
-        static_assert(count_tuple<T, internal::is_where>::value == 1, "");
-        static_assert(count_tuple<T, internal::is_group_by>::value == 0, "");
-        static_assert(count_tuple<T, internal::is_order_by>::value == 1, "");
-        static_assert(count_tuple<T, internal::is_limit>::value == 1, "");
+        STATIC_REQUIRE(count_tuple<T, internal::is_where>::value == 1);
+        STATIC_REQUIRE(count_tuple<T, internal::is_group_by>::value == 0);
+        STATIC_REQUIRE(count_tuple<T, internal::is_order_by>::value == 1);
+        STATIC_REQUIRE(count_tuple<T, internal::is_limit>::value == 1);
     }
     {
         auto t = std::make_tuple(where(lesser_than(&User::id, 10)),
                                  where(greater_than(&User::id, 5)),
                                  group_by(&User::name));
         using T = decltype(t);
-        static_assert(count_tuple<T, internal::is_where>::value == 2, "");
-        static_assert(count_tuple<T, internal::is_group_by>::value == 1, "");
-        static_assert(count_tuple<T, internal::is_order_by>::value == 0, "");
-        static_assert(count_tuple<T, internal::is_limit>::value == 0, "");
+        STATIC_REQUIRE(count_tuple<T, internal::is_where>::value == 2);
+        STATIC_REQUIRE(count_tuple<T, internal::is_group_by>::value == 1);
+        STATIC_REQUIRE(count_tuple<T, internal::is_order_by>::value == 0);
+        STATIC_REQUIRE(count_tuple<T, internal::is_limit>::value == 0);
     }
     {
         auto t = std::make_tuple(group_by(&User::name), limit(10, offset(5)));
         using T = decltype(t);
-        static_assert(count_tuple<T, internal::is_where>::value == 0, "");
-        static_assert(count_tuple<T, internal::is_group_by>::value == 1, "");
-        static_assert(count_tuple<T, internal::is_order_by>::value == 0, "");
-        static_assert(count_tuple<T, internal::is_limit>::value == 1, "");
+        STATIC_REQUIRE(count_tuple<T, internal::is_where>::value == 0);
+        STATIC_REQUIRE(count_tuple<T, internal::is_group_by>::value == 1);
+        STATIC_REQUIRE(count_tuple<T, internal::is_order_by>::value == 0);
+        STATIC_REQUIRE(count_tuple<T, internal::is_limit>::value == 1);
     }
     {
         auto t =
             std::make_tuple(where(is_null(&User::name)), order_by(&User::id), multi_order_by(order_by(&User::name)));
         using T = decltype(t);
-        static_assert(count_tuple<T, internal::is_where>::value == 1, "");
-        static_assert(count_tuple<T, internal::is_group_by>::value == 0, "");
-        static_assert(count_tuple<T, internal::is_order_by>::value == 2, "");
-        static_assert(count_tuple<T, internal::is_limit>::value == 0, "");
+        STATIC_REQUIRE(count_tuple<T, internal::is_where>::value == 1);
+        STATIC_REQUIRE(count_tuple<T, internal::is_group_by>::value == 0);
+        STATIC_REQUIRE(count_tuple<T, internal::is_order_by>::value == 2);
+        STATIC_REQUIRE(count_tuple<T, internal::is_limit>::value == 0);
     }
     {
         auto t = std::make_tuple(dynamic_order_by(make_storage("")));
         using T = decltype(t);
-        static_assert(count_tuple<T, internal::is_where>::value == 0, "");
-        static_assert(count_tuple<T, internal::is_group_by>::value == 0, "");
-        static_assert(count_tuple<T, internal::is_order_by>::value == 1, "");
-        static_assert(count_tuple<T, internal::is_limit>::value == 0, "");
+        STATIC_REQUIRE(count_tuple<T, internal::is_where>::value == 0);
+        STATIC_REQUIRE(count_tuple<T, internal::is_group_by>::value == 0);
+        STATIC_REQUIRE(count_tuple<T, internal::is_order_by>::value == 1);
+        STATIC_REQUIRE(count_tuple<T, internal::is_limit>::value == 0);
     }
 }

--- a/tests/static_tests/find_in_tuple.cpp
+++ b/tests/static_tests/find_in_tuple.cpp
@@ -11,18 +11,18 @@ TEST_CASE("find_in_tuple") {
     using tuple = std::tuple<into_t<User>, columns_t<decltype(&User::id)>>;
     {
         using found = find_in_tuple<tuple, is_into>::type;
-        static_assert(std::is_same<found, into_t<User>>::value, "");
+        STATIC_REQUIRE(std::is_same<found, into_t<User>>::value);
     }
     {
         using found = find_in_tuple<tuple, is_columns>::type;
-        static_assert(std::is_same<found, columns_t<decltype(&User::id)>>::value, "");
+        STATIC_REQUIRE(std::is_same<found, columns_t<decltype(&User::id)>>::value);
     }
     {
         using found = find_in_tuple<tuple, is_column>::type;
-        static_assert(std::is_same<found, void>::value, "");
+        STATIC_REQUIRE(std::is_same<found, void>::value);
     }
     {
         using found = find_in_tuple<tuple, is_primary_key>::type;
-        static_assert(std::is_same<found, void>::value, "");
+        STATIC_REQUIRE(std::is_same<found, void>::value);
     }
 }

--- a/tests/static_tests/foreign_key.cpp
+++ b/tests/static_tests/foreign_key.cpp
@@ -38,29 +38,29 @@ TEST_CASE("foreign key static") {
         std::string file_path;
     };
     auto cppInclusionIncluderPathFk = foreign_key(&CppInclusion::includer_path).references(&File::path);
-    static_assert(std::is_same<decltype(cppInclusionIncluderPathFk)::target_type, File>::value, "");
-    static_assert(std::is_same<decltype(cppInclusionIncluderPathFk)::source_type, CppInclusion>::value, "");
+    STATIC_REQUIRE(std::is_same<decltype(cppInclusionIncluderPathFk)::target_type, File>::value);
+    STATIC_REQUIRE(std::is_same<decltype(cppInclusionIncluderPathFk)::source_type, CppInclusion>::value);
 
     auto cppInclusionIncludeePathFk = foreign_key(&CppInclusion::includee_path).references(&File::path);
-    static_assert(std::is_same<decltype(cppInclusionIncludeePathFk)::target_type, File>::value, "");
-    static_assert(std::is_same<decltype(cppInclusionIncludeePathFk)::source_type, CppInclusion>::value, "");
+    STATIC_REQUIRE(std::is_same<decltype(cppInclusionIncludeePathFk)::target_type, File>::value);
+    STATIC_REQUIRE(std::is_same<decltype(cppInclusionIncludeePathFk)::source_type, CppInclusion>::value);
 
     auto functionDeclFilePathFk = foreign_key(&FunctionDecl::file_path).references(&File::path);
-    static_assert(std::is_same<decltype(functionDeclFilePathFk)::target_type, File>::value, "");
-    static_assert(std::is_same<decltype(functionDeclFilePathFk)::source_type, FunctionDecl>::value, "");
+    STATIC_REQUIRE(std::is_same<decltype(functionDeclFilePathFk)::target_type, File>::value);
+    STATIC_REQUIRE(std::is_same<decltype(functionDeclFilePathFk)::source_type, FunctionDecl>::value);
 
     auto varDeclFilePathFk = foreign_key(&VarDecl::file_path).references(&File::path);
-    static_assert(std::is_same<decltype(varDeclFilePathFk)::target_type, File>::value, "");
-    static_assert(std::is_same<decltype(varDeclFilePathFk)::source_type, VarDecl>::value, "");
+    STATIC_REQUIRE(std::is_same<decltype(varDeclFilePathFk)::target_type, File>::value);
+    STATIC_REQUIRE(std::is_same<decltype(varDeclFilePathFk)::source_type, VarDecl>::value);
 
     auto functionDefFilePathFk = foreign_key(&FunctionDef::file_path).references(&File::path);
-    static_assert(std::is_same<decltype(functionDefFilePathFk)::target_type, File>::value, "");
-    static_assert(std::is_same<decltype(functionDefFilePathFk)::source_type, FunctionDef>::value, "");
+    STATIC_REQUIRE(std::is_same<decltype(functionDefFilePathFk)::target_type, File>::value);
+    STATIC_REQUIRE(std::is_same<decltype(functionDefFilePathFk)::source_type, FunctionDef>::value);
 
     auto functionCallParentFunctionName =
         foreign_key(&FunctionCall::parent_function_name).references(&FunctionDef::function_name);
-    static_assert(std::is_same<decltype(functionCallParentFunctionName)::target_type, FunctionDef>::value, "");
-    static_assert(std::is_same<decltype(functionCallParentFunctionName)::source_type, FunctionCall>::value, "");
+    STATIC_REQUIRE(std::is_same<decltype(functionCallParentFunctionName)::target_type, FunctionDef>::value);
+    STATIC_REQUIRE(std::is_same<decltype(functionCallParentFunctionName)::source_type, FunctionCall>::value);
 
     auto storage = make_storage({},
                                 make_table("files", make_column("path", &File::path, primary_key())),
@@ -105,31 +105,31 @@ TEST_CASE("foreign key static") {
     {
         using FkTuple = storage_fk_references<Storage, FunctionCall>::type;
         using Expected = std::tuple<>;
-        static_assert(std::is_same<FkTuple, Expected>::value, "");
+        STATIC_REQUIRE(std::is_same<FkTuple, Expected>::value);
     }
     {
         using FkTuple = storage_fk_references<Storage, FunctionDef>::type;
         using Expected = std::tuple<FunctionCall>;
-        static_assert(std::is_same<FkTuple, Expected>::value, "");
+        STATIC_REQUIRE(std::is_same<FkTuple, Expected>::value);
     }
     {
         using FkTuple = storage_fk_references<Storage, VarDecl>::type;
         using Expected = std::tuple<>;
-        static_assert(std::is_same<FkTuple, Expected>::value, "");
+        STATIC_REQUIRE(std::is_same<FkTuple, Expected>::value);
     }
     {
         using FkTuple = storage_fk_references<Storage, FunctionDecl>::type;
         using Expected = std::tuple<>;
-        static_assert(std::is_same<FkTuple, Expected>::value, "");
+        STATIC_REQUIRE(std::is_same<FkTuple, Expected>::value);
     }
     {
         using FkTuple = storage_fk_references<Storage, CppInclusion>::type;
         using Expected = std::tuple<>;
-        static_assert(std::is_same<FkTuple, Expected>::value, "");
+        STATIC_REQUIRE(std::is_same<FkTuple, Expected>::value);
     }
     {
         using FkTuple = storage_fk_references<Storage, File>::type;
         using Expected = std::tuple<CppInclusion, CppInclusion, FunctionDecl, VarDecl, FunctionDef>;
-        static_assert(std::is_same<FkTuple, Expected>::value, "");
+        STATIC_REQUIRE(std::is_same<FkTuple, Expected>::value);
     }
 }

--- a/tests/static_tests/function_static_tests.cpp
+++ b/tests/static_tests/function_static_tests.cpp
@@ -33,18 +33,18 @@ TEST_CASE("function static") {
                     }
                 };
 
-                static_assert(internal::is_scalar_function<Function>::value, "");
-                static_assert(!internal::is_aggregate_function<Function>::value, "");
+                STATIC_REQUIRE(internal::is_scalar_function<Function>::value);
+                STATIC_REQUIRE(!internal::is_aggregate_function<Function>::value);
 
                 using RunMemberFunctionPointer = internal::scalar_run_member_pointer<Function>::type;
                 using ExpectedType = double (Function::*)(double) const;
-                static_assert(std::is_same<RunMemberFunctionPointer, ExpectedType>::value, "");
+                STATIC_REQUIRE(std::is_same<RunMemberFunctionPointer, ExpectedType>::value);
 
                 using ArgumentsTuple = internal::member_function_arguments<RunMemberFunctionPointer>::tuple_type;
                 using ExpectedArgumentsTuple = std::tuple<double>;
-                static_assert(std::is_same<ArgumentsTuple, ExpectedArgumentsTuple>::value, "");
+                STATIC_REQUIRE(std::is_same<ArgumentsTuple, ExpectedArgumentsTuple>::value);
 
-                static_assert(std::is_same<internal::callable_arguments<Function>::return_type, double>::value, "");
+                STATIC_REQUIRE(std::is_same<internal::callable_arguments<Function>::return_type, double>::value);
                 static_assert(
                     std::is_same<internal::callable_arguments<Function>::args_tuple, std::tuple<double>>::value,
                     "");
@@ -56,18 +56,18 @@ TEST_CASE("function static") {
                     }
                 };
 
-                static_assert(internal::is_scalar_function<Function>::value, "");
-                static_assert(!internal::is_aggregate_function<Function>::value, "");
+                STATIC_REQUIRE(internal::is_scalar_function<Function>::value);
+                STATIC_REQUIRE(!internal::is_aggregate_function<Function>::value);
 
                 using RunMemberFunctionPointer = internal::scalar_run_member_pointer<Function>::type;
                 using ExpectedType = double (Function::*)(double);
-                static_assert(std::is_same<RunMemberFunctionPointer, ExpectedType>::value, "");
+                STATIC_REQUIRE(std::is_same<RunMemberFunctionPointer, ExpectedType>::value);
 
                 using ArgumentsTuple = internal::member_function_arguments<RunMemberFunctionPointer>::tuple_type;
                 using ExpectedArgumentsTuple = std::tuple<double>;
-                static_assert(std::is_same<ArgumentsTuple, ExpectedArgumentsTuple>::value, "");
+                STATIC_REQUIRE(std::is_same<ArgumentsTuple, ExpectedArgumentsTuple>::value);
 
-                static_assert(std::is_same<internal::callable_arguments<Function>::return_type, double>::value, "");
+                STATIC_REQUIRE(std::is_same<internal::callable_arguments<Function>::return_type, double>::value);
                 static_assert(
                     std::is_same<internal::callable_arguments<Function>::args_tuple, std::tuple<double>>::value,
                     "");
@@ -79,18 +79,18 @@ TEST_CASE("function static") {
                     }
                 };
 
-                static_assert(internal::is_scalar_function<Function>::value, "");
-                static_assert(!internal::is_aggregate_function<Function>::value, "");
+                STATIC_REQUIRE(internal::is_scalar_function<Function>::value);
+                STATIC_REQUIRE(!internal::is_aggregate_function<Function>::value);
 
                 using RunMemberFunctionPointer = internal::scalar_run_member_pointer<Function>::type;
                 using ExpectedType = int (Function::*)(std::string) const;
-                static_assert(std::is_same<RunMemberFunctionPointer, ExpectedType>::value, "");
+                STATIC_REQUIRE(std::is_same<RunMemberFunctionPointer, ExpectedType>::value);
 
                 using ArgumentsTuple = internal::member_function_arguments<RunMemberFunctionPointer>::tuple_type;
                 using ExpectedArgumentsTuple = std::tuple<std::string>;
-                static_assert(std::is_same<ArgumentsTuple, ExpectedArgumentsTuple>::value, "");
+                STATIC_REQUIRE(std::is_same<ArgumentsTuple, ExpectedArgumentsTuple>::value);
 
-                static_assert(std::is_same<internal::callable_arguments<Function>::return_type, int>::value, "");
+                STATIC_REQUIRE(std::is_same<internal::callable_arguments<Function>::return_type, int>::value);
                 static_assert(
                     std::is_same<internal::callable_arguments<Function>::args_tuple, std::tuple<std::string>>::value,
                     "");
@@ -102,18 +102,18 @@ TEST_CASE("function static") {
                     }
                 };
 
-                static_assert(internal::is_scalar_function<Function>::value, "");
-                static_assert(!internal::is_aggregate_function<Function>::value, "");
+                STATIC_REQUIRE(internal::is_scalar_function<Function>::value);
+                STATIC_REQUIRE(!internal::is_aggregate_function<Function>::value);
 
                 using RunMemberFunctionPointer = internal::scalar_run_member_pointer<Function>::type;
                 using ExpectedType = int (Function::*)(std::string);
-                static_assert(std::is_same<RunMemberFunctionPointer, ExpectedType>::value, "");
+                STATIC_REQUIRE(std::is_same<RunMemberFunctionPointer, ExpectedType>::value);
 
                 using ArgumentsTuple = internal::member_function_arguments<RunMemberFunctionPointer>::tuple_type;
                 using ExpectedArgumentsTuple = std::tuple<std::string>;
-                static_assert(std::is_same<ArgumentsTuple, ExpectedArgumentsTuple>::value, "");
+                STATIC_REQUIRE(std::is_same<ArgumentsTuple, ExpectedArgumentsTuple>::value);
 
-                static_assert(std::is_same<internal::callable_arguments<Function>::return_type, int>::value, "");
+                STATIC_REQUIRE(std::is_same<internal::callable_arguments<Function>::return_type, int>::value);
                 static_assert(
                     std::is_same<internal::callable_arguments<Function>::args_tuple, std::tuple<std::string>>::value,
                     "");
@@ -125,16 +125,16 @@ TEST_CASE("function static") {
                     }
                 };
 
-                static_assert(internal::is_scalar_function<Function>::value, "");
-                static_assert(!internal::is_aggregate_function<Function>::value, "");
+                STATIC_REQUIRE(internal::is_scalar_function<Function>::value);
+                STATIC_REQUIRE(!internal::is_aggregate_function<Function>::value);
 
                 using RunMemberFunctionPointer = internal::scalar_run_member_pointer<Function>::type;
                 using ExpectedType = std::string (Function::*)(const std::string &, const std::string &) const;
-                static_assert(std::is_same<RunMemberFunctionPointer, ExpectedType>::value, "");
+                STATIC_REQUIRE(std::is_same<RunMemberFunctionPointer, ExpectedType>::value);
 
                 using ArgumentsTuple = internal::member_function_arguments<RunMemberFunctionPointer>::tuple_type;
                 using ExpectedArgumentsTuple = std::tuple<std::string, std::string>;
-                static_assert(std::is_same<ArgumentsTuple, ExpectedArgumentsTuple>::value, "");
+                STATIC_REQUIRE(std::is_same<ArgumentsTuple, ExpectedArgumentsTuple>::value);
 
                 static_assert(std::is_same<internal::callable_arguments<Function>::return_type, std::string>::value,
                               "");
@@ -149,16 +149,16 @@ TEST_CASE("function static") {
                     }
                 };
 
-                static_assert(internal::is_scalar_function<Function>::value, "");
-                static_assert(!internal::is_aggregate_function<Function>::value, "");
+                STATIC_REQUIRE(internal::is_scalar_function<Function>::value);
+                STATIC_REQUIRE(!internal::is_aggregate_function<Function>::value);
 
                 using RunMemberFunctionPointer = internal::scalar_run_member_pointer<Function>::type;
                 using ExpectedType = std::string (Function::*)(const std::string &, const std::string &);
-                static_assert(std::is_same<RunMemberFunctionPointer, ExpectedType>::value, "");
+                STATIC_REQUIRE(std::is_same<RunMemberFunctionPointer, ExpectedType>::value);
 
                 using ArgumentsTuple = internal::member_function_arguments<RunMemberFunctionPointer>::tuple_type;
                 using ExpectedArgumentsTuple = std::tuple<std::string, std::string>;
-                static_assert(std::is_same<ArgumentsTuple, ExpectedArgumentsTuple>::value, "");
+                STATIC_REQUIRE(std::is_same<ArgumentsTuple, ExpectedArgumentsTuple>::value);
 
                 static_assert(std::is_same<internal::callable_arguments<Function>::return_type, std::string>::value,
                               "");
@@ -184,19 +184,19 @@ TEST_CASE("function static") {
                 }
             };
 
-            static_assert(internal::is_aggregate_function<Function>::value, "");
-            static_assert(!internal::is_scalar_function<Function>::value, "");
+            STATIC_REQUIRE(internal::is_aggregate_function<Function>::value);
+            STATIC_REQUIRE(!internal::is_scalar_function<Function>::value);
 
             using StepMemberFunctionPointer = internal::aggregate_run_member_pointer<Function>::step_type;
             using ExpectedStepType = void (Function::*)(int);
-            static_assert(std::is_same<StepMemberFunctionPointer, ExpectedStepType>::value, "");
+            STATIC_REQUIRE(std::is_same<StepMemberFunctionPointer, ExpectedStepType>::value);
 
             using FinMemberFunctionPointer = internal::aggregate_run_member_pointer<Function>::fin_type;
             using ExpectedFinType = int (Function::*)() const;
-            static_assert(std::is_same<FinMemberFunctionPointer, ExpectedFinType>::value, "");
+            STATIC_REQUIRE(std::is_same<FinMemberFunctionPointer, ExpectedFinType>::value);
 
-            static_assert(std::is_same<internal::callable_arguments<Function>::return_type, int>::value, "");
-            static_assert(std::is_same<internal::callable_arguments<Function>::args_tuple, std::tuple<int>>::value, "");
+            STATIC_REQUIRE(std::is_same<internal::callable_arguments<Function>::return_type, int>::value);
+            STATIC_REQUIRE(std::is_same<internal::callable_arguments<Function>::args_tuple, std::tuple<int>>::value);
         }
         SECTION("void(std::string) const & std::string()") {
             struct Function {
@@ -211,18 +211,18 @@ TEST_CASE("function static") {
                 }
             };
 
-            static_assert(internal::is_aggregate_function<Function>::value, "");
-            static_assert(!internal::is_scalar_function<Function>::value, "");
+            STATIC_REQUIRE(internal::is_aggregate_function<Function>::value);
+            STATIC_REQUIRE(!internal::is_scalar_function<Function>::value);
 
             using StepMemberFunctionPointer = internal::aggregate_run_member_pointer<Function>::step_type;
             using ExpectedStepType = void (Function::*)(std::string) const;
-            static_assert(std::is_same<StepMemberFunctionPointer, ExpectedStepType>::value, "");
+            STATIC_REQUIRE(std::is_same<StepMemberFunctionPointer, ExpectedStepType>::value);
 
             using FinMemberFunctionPointer = internal::aggregate_run_member_pointer<Function>::fin_type;
             using ExpectedFinType = std::string (Function::*)();
-            static_assert(std::is_same<FinMemberFunctionPointer, ExpectedFinType>::value, "");
+            STATIC_REQUIRE(std::is_same<FinMemberFunctionPointer, ExpectedFinType>::value);
 
-            static_assert(std::is_same<internal::callable_arguments<Function>::return_type, std::string>::value, "");
+            STATIC_REQUIRE(std::is_same<internal::callable_arguments<Function>::return_type, std::string>::value);
             static_assert(
                 std::is_same<internal::callable_arguments<Function>::args_tuple, std::tuple<std::string>>::value,
                 "");

--- a/tests/static_tests/has_some_type.cpp
+++ b/tests/static_tests/has_some_type.cpp
@@ -17,7 +17,7 @@ TEST_CASE("has_some_type") {
     using empty_tuple_type = std::tuple<>;
     using tuple_type = std::tuple<int, char, my_vector<char>, std::string>;
 
-    static_assert(tuple_helper::has_some_type<my_vector, tuple_type>::value, "");
-    static_assert(!tuple_helper::has_some_type<std::shared_ptr, tuple_type>::value, "");
-    static_assert(!tuple_helper::has_some_type<my_vector, empty_tuple_type>::value, "");
+    STATIC_REQUIRE(tuple_helper::has_some_type<my_vector, tuple_type>::value);
+    STATIC_REQUIRE(!tuple_helper::has_some_type<std::shared_ptr, tuple_type>::value);
+    STATIC_REQUIRE(!tuple_helper::has_some_type<my_vector, empty_tuple_type>::value);
 }

--- a/tests/static_tests/is_primary_key_insertable.cpp
+++ b/tests/static_tests/is_primary_key_insertable.cpp
@@ -22,10 +22,10 @@ TEST_CASE("is_primary_key_insertable") {
         make_column("", &User::password, primary_key()));
 
     iterate_tuple(insertable, [](auto& v) {
-        static_assert(internal::is_primary_key_insertable<typename std::decay<decltype(v)>::type>::value, "");
+        STATIC_REQUIRE(internal::is_primary_key_insertable<typename std::decay<decltype(v)>::type>::value);
     });
 
     iterate_tuple(noninsertable, [](auto& v) {
-        static_assert(!internal::is_primary_key_insertable<typename std::decay<decltype(v)>::type>::value, "");
+        STATIC_REQUIRE(!internal::is_primary_key_insertable<typename std::decay<decltype(v)>::type>::value);
     });
 }

--- a/tests/static_tests/member_traits_tests.cpp
+++ b/tests/static_tests/member_traits_tests.cpp
@@ -102,97 +102,97 @@ TEST_CASE("member_traits_tests") {
         }
     };
 
-    static_assert(is_field_member_pointer<decltype(&User::id)>::value, "");
-    static_assert(!is_field_member_pointer<decltype(&User::getIdByValConst)>::value, "");
-    static_assert(!is_field_member_pointer<decltype(&User::getIdByRefConst)>::value, "");
-    static_assert(!is_field_member_pointer<decltype(&User::getIdByRef)>::value, "");
-    static_assert(!is_field_member_pointer<decltype(&User::getIdByConstRefConst)>::value, "");
-    static_assert(!is_field_member_pointer<decltype(&User::getIdByConstRef)>::value, "");
-    static_assert(!is_field_member_pointer<decltype(&User::getIdByValConstNoexcept)>::value, "");
-    static_assert(!is_field_member_pointer<decltype(&User::getIdByValNoexcept)>::value, "");
-    static_assert(!is_field_member_pointer<decltype(&User::getIdByRefConstNoexcept)>::value, "");
-    static_assert(!is_field_member_pointer<decltype(&User::getIdByRefNoexcept)>::value, "");
-    static_assert(!is_field_member_pointer<decltype(&User::getIdByConstRefConstNoexcept)>::value, "");
-    static_assert(!is_field_member_pointer<decltype(&User::getIdByConstRefNoExcept)>::value, "");
-    static_assert(!is_field_member_pointer<decltype(&User::setIdByVal)>::value, "");
-    static_assert(!is_field_member_pointer<decltype(&User::setIdByRef)>::value, "");
-    static_assert(!is_field_member_pointer<decltype(&User::setIdByConstRef)>::value, "");
-    static_assert(!is_field_member_pointer<decltype(&User::setIdByValueNoexcept)>::value, "");
-    static_assert(!is_field_member_pointer<decltype(&User::setIdByRefNoExcept)>::value, "");
-    static_assert(!is_field_member_pointer<decltype(&User::setIdByConstRefNoexcept)>::value, "");
+    STATIC_REQUIRE(is_field_member_pointer<decltype(&User::id)>::value);
+    STATIC_REQUIRE(!is_field_member_pointer<decltype(&User::getIdByValConst)>::value);
+    STATIC_REQUIRE(!is_field_member_pointer<decltype(&User::getIdByRefConst)>::value);
+    STATIC_REQUIRE(!is_field_member_pointer<decltype(&User::getIdByRef)>::value);
+    STATIC_REQUIRE(!is_field_member_pointer<decltype(&User::getIdByConstRefConst)>::value);
+    STATIC_REQUIRE(!is_field_member_pointer<decltype(&User::getIdByConstRef)>::value);
+    STATIC_REQUIRE(!is_field_member_pointer<decltype(&User::getIdByValConstNoexcept)>::value);
+    STATIC_REQUIRE(!is_field_member_pointer<decltype(&User::getIdByValNoexcept)>::value);
+    STATIC_REQUIRE(!is_field_member_pointer<decltype(&User::getIdByRefConstNoexcept)>::value);
+    STATIC_REQUIRE(!is_field_member_pointer<decltype(&User::getIdByRefNoexcept)>::value);
+    STATIC_REQUIRE(!is_field_member_pointer<decltype(&User::getIdByConstRefConstNoexcept)>::value);
+    STATIC_REQUIRE(!is_field_member_pointer<decltype(&User::getIdByConstRefNoExcept)>::value);
+    STATIC_REQUIRE(!is_field_member_pointer<decltype(&User::setIdByVal)>::value);
+    STATIC_REQUIRE(!is_field_member_pointer<decltype(&User::setIdByRef)>::value);
+    STATIC_REQUIRE(!is_field_member_pointer<decltype(&User::setIdByConstRef)>::value);
+    STATIC_REQUIRE(!is_field_member_pointer<decltype(&User::setIdByValueNoexcept)>::value);
+    STATIC_REQUIRE(!is_field_member_pointer<decltype(&User::setIdByRefNoExcept)>::value);
+    STATIC_REQUIRE(!is_field_member_pointer<decltype(&User::setIdByConstRefNoexcept)>::value);
 
-    static_assert(!is_getter<decltype(&User::id)>::value, "");
-    static_assert(is_getter<decltype(&User::getIdByValConst)>::value, "");
-    static_assert(is_getter<decltype(&User::getIdByRefConst)>::value, "");
-    static_assert(is_getter<decltype(&User::getIdByRef)>::value, "");
-    static_assert(is_getter<decltype(&User::getIdByConstRefConst)>::value, "");
-    static_assert(is_getter<decltype(&User::getIdByConstRef)>::value, "");
+    STATIC_REQUIRE(!is_getter<decltype(&User::id)>::value);
+    STATIC_REQUIRE(is_getter<decltype(&User::getIdByValConst)>::value);
+    STATIC_REQUIRE(is_getter<decltype(&User::getIdByRefConst)>::value);
+    STATIC_REQUIRE(is_getter<decltype(&User::getIdByRef)>::value);
+    STATIC_REQUIRE(is_getter<decltype(&User::getIdByConstRefConst)>::value);
+    STATIC_REQUIRE(is_getter<decltype(&User::getIdByConstRef)>::value);
 #ifdef SQLITE_ORM_NOTHROW_ALIASES_SUPPORTED
-    static_assert(is_getter<decltype(&User::getIdByValConstNoexcept)>::value, "");
-    static_assert(is_getter<decltype(&User::getIdByValNoexcept)>::value, "");
-    static_assert(is_getter<decltype(&User::getIdByRefConstNoexcept)>::value, "");
-    static_assert(is_getter<decltype(&User::getIdByRefNoexcept)>::value, "");
-    static_assert(is_getter<decltype(&User::getIdByConstRefConstNoexcept)>::value, "");
-    static_assert(is_getter<decltype(&User::getIdByConstRefNoExcept)>::value, "");
+    STATIC_REQUIRE(is_getter<decltype(&User::getIdByValConstNoexcept)>::value);
+    STATIC_REQUIRE(is_getter<decltype(&User::getIdByValNoexcept)>::value);
+    STATIC_REQUIRE(is_getter<decltype(&User::getIdByRefConstNoexcept)>::value);
+    STATIC_REQUIRE(is_getter<decltype(&User::getIdByRefNoexcept)>::value);
+    STATIC_REQUIRE(is_getter<decltype(&User::getIdByConstRefConstNoexcept)>::value);
+    STATIC_REQUIRE(is_getter<decltype(&User::getIdByConstRefNoExcept)>::value);
 #endif
-    static_assert(!is_getter<decltype(&User::setIdByVal)>::value, "");
-    static_assert(!is_getter<decltype(&User::setIdByRef)>::value, "");
-    static_assert(!is_getter<decltype(&User::setIdByConstRef)>::value, "");
-    static_assert(!is_getter<decltype(&User::setIdByValueNoexcept)>::value, "");
-    static_assert(!is_getter<decltype(&User::setIdByRefNoExcept)>::value, "");
-    static_assert(!is_getter<decltype(&User::setIdByConstRefNoexcept)>::value, "");
+    STATIC_REQUIRE(!is_getter<decltype(&User::setIdByVal)>::value);
+    STATIC_REQUIRE(!is_getter<decltype(&User::setIdByRef)>::value);
+    STATIC_REQUIRE(!is_getter<decltype(&User::setIdByConstRef)>::value);
+    STATIC_REQUIRE(!is_getter<decltype(&User::setIdByValueNoexcept)>::value);
+    STATIC_REQUIRE(!is_getter<decltype(&User::setIdByRefNoExcept)>::value);
+    STATIC_REQUIRE(!is_getter<decltype(&User::setIdByConstRefNoexcept)>::value);
 
-    static_assert(!is_setter<decltype(&User::id)>::value, "");
-    static_assert(!is_setter<decltype(&User::getIdByValConst)>::value, "");
-    static_assert(!is_setter<decltype(&User::getIdByRefConst)>::value, "");
-    static_assert(!is_setter<decltype(&User::getIdByRef)>::value, "");
-    static_assert(!is_setter<decltype(&User::getIdByConstRefConst)>::value, "");
-    static_assert(!is_setter<decltype(&User::getIdByConstRef)>::value, "");
-    static_assert(!is_setter<decltype(&User::getIdByValConstNoexcept)>::value, "");
-    static_assert(!is_setter<decltype(&User::getIdByValNoexcept)>::value, "");
-    static_assert(!is_setter<decltype(&User::getIdByRefConstNoexcept)>::value, "");
-    static_assert(!is_setter<decltype(&User::getIdByRefNoexcept)>::value, "");
-    static_assert(!is_setter<decltype(&User::getIdByConstRefConstNoexcept)>::value, "");
-    static_assert(!is_setter<decltype(&User::getIdByConstRefNoExcept)>::value, "");
-    static_assert(is_setter<decltype(&User::setIdByVal)>::value, "");
-    static_assert(is_setter<decltype(&User::setIdByRef)>::value, "");
-    static_assert(is_setter<decltype(&User::setIdByConstRef)>::value, "");
+    STATIC_REQUIRE(!is_setter<decltype(&User::id)>::value);
+    STATIC_REQUIRE(!is_setter<decltype(&User::getIdByValConst)>::value);
+    STATIC_REQUIRE(!is_setter<decltype(&User::getIdByRefConst)>::value);
+    STATIC_REQUIRE(!is_setter<decltype(&User::getIdByRef)>::value);
+    STATIC_REQUIRE(!is_setter<decltype(&User::getIdByConstRefConst)>::value);
+    STATIC_REQUIRE(!is_setter<decltype(&User::getIdByConstRef)>::value);
+    STATIC_REQUIRE(!is_setter<decltype(&User::getIdByValConstNoexcept)>::value);
+    STATIC_REQUIRE(!is_setter<decltype(&User::getIdByValNoexcept)>::value);
+    STATIC_REQUIRE(!is_setter<decltype(&User::getIdByRefConstNoexcept)>::value);
+    STATIC_REQUIRE(!is_setter<decltype(&User::getIdByRefNoexcept)>::value);
+    STATIC_REQUIRE(!is_setter<decltype(&User::getIdByConstRefConstNoexcept)>::value);
+    STATIC_REQUIRE(!is_setter<decltype(&User::getIdByConstRefNoExcept)>::value);
+    STATIC_REQUIRE(is_setter<decltype(&User::setIdByVal)>::value);
+    STATIC_REQUIRE(is_setter<decltype(&User::setIdByRef)>::value);
+    STATIC_REQUIRE(is_setter<decltype(&User::setIdByConstRef)>::value);
 #ifdef SQLITE_ORM_NOTHROW_ALIASES_SUPPORTED
-    static_assert(is_setter<decltype(&User::setIdByValueNoexcept)>::value, "");
-    static_assert(is_setter<decltype(&User::setIdByRefNoExcept)>::value, "");
-    static_assert(is_setter<decltype(&User::setIdByConstRefNoexcept)>::value, "");
+    STATIC_REQUIRE(is_setter<decltype(&User::setIdByValueNoexcept)>::value);
+    STATIC_REQUIRE(is_setter<decltype(&User::setIdByRefNoExcept)>::value);
+    STATIC_REQUIRE(is_setter<decltype(&User::setIdByConstRefNoexcept)>::value);
 #endif
 
-    static_assert(is_same<typename getter_traits<decltype(&User::getIdByValConst)>::object_type, User>::value, "");
-    static_assert(is_same<typename getter_traits<decltype(&User::getIdByValConst)>::field_type, int>::value, "");
+    STATIC_REQUIRE(is_same<typename getter_traits<decltype(&User::getIdByValConst)>::object_type, User>::value);
+    STATIC_REQUIRE(is_same<typename getter_traits<decltype(&User::getIdByValConst)>::field_type, int>::value);
 
-    static_assert(is_same<typename getter_traits<decltype(&User::getIdByRefConst)>::object_type, User>::value, "");
-    static_assert(is_same<typename getter_traits<decltype(&User::getIdByRefConst)>::field_type, int>::value, "");
+    STATIC_REQUIRE(is_same<typename getter_traits<decltype(&User::getIdByRefConst)>::object_type, User>::value);
+    STATIC_REQUIRE(is_same<typename getter_traits<decltype(&User::getIdByRefConst)>::field_type, int>::value);
 
-    static_assert(is_same<typename getter_traits<decltype(&User::getIdByRef)>::object_type, User>::value, "");
-    static_assert(is_same<typename getter_traits<decltype(&User::getIdByRef)>::field_type, int>::value, "");
+    STATIC_REQUIRE(is_same<typename getter_traits<decltype(&User::getIdByRef)>::object_type, User>::value);
+    STATIC_REQUIRE(is_same<typename getter_traits<decltype(&User::getIdByRef)>::field_type, int>::value);
 
-    static_assert(is_same<typename getter_traits<decltype(&User::getIdByConstRefConst)>::object_type, User>::value, "");
-    static_assert(is_same<typename getter_traits<decltype(&User::getIdByConstRefConst)>::field_type, int>::value, "");
+    STATIC_REQUIRE(is_same<typename getter_traits<decltype(&User::getIdByConstRefConst)>::object_type, User>::value);
+    STATIC_REQUIRE(is_same<typename getter_traits<decltype(&User::getIdByConstRefConst)>::field_type, int>::value);
 
-    static_assert(is_same<typename getter_traits<decltype(&User::getIdByConstRef)>::object_type, User>::value, "");
-    static_assert(is_same<typename getter_traits<decltype(&User::getIdByConstRef)>::field_type, int>::value, "");
+    STATIC_REQUIRE(is_same<typename getter_traits<decltype(&User::getIdByConstRef)>::object_type, User>::value);
+    STATIC_REQUIRE(is_same<typename getter_traits<decltype(&User::getIdByConstRef)>::field_type, int>::value);
 #ifdef SQLITE_ORM_NOTHROW_ALIASES_SUPPORTED
     static_assert(is_same<typename getter_traits<decltype(&User::getIdByValConstNoexcept)>::object_type, User>::value,
                   "");
     static_assert(is_same<typename getter_traits<decltype(&User::getIdByValConstNoexcept)>::field_type, int>::value,
                   "");
 
-    static_assert(is_same<typename getter_traits<decltype(&User::getIdByValNoexcept)>::object_type, User>::value, "");
-    static_assert(is_same<typename getter_traits<decltype(&User::getIdByValNoexcept)>::field_type, int>::value, "");
+    STATIC_REQUIRE(is_same<typename getter_traits<decltype(&User::getIdByValNoexcept)>::object_type, User>::value);
+    STATIC_REQUIRE(is_same<typename getter_traits<decltype(&User::getIdByValNoexcept)>::field_type, int>::value);
 
     static_assert(is_same<typename getter_traits<decltype(&User::getIdByRefConstNoexcept)>::object_type, User>::value,
                   "");
     static_assert(is_same<typename getter_traits<decltype(&User::getIdByRefConstNoexcept)>::field_type, int>::value,
                   "");
 
-    static_assert(is_same<typename getter_traits<decltype(&User::getIdByRefNoexcept)>::object_type, User>::value, "");
-    static_assert(is_same<typename getter_traits<decltype(&User::getIdByRefNoexcept)>::field_type, int>::value, "");
+    STATIC_REQUIRE(is_same<typename getter_traits<decltype(&User::getIdByRefNoexcept)>::object_type, User>::value);
+    STATIC_REQUIRE(is_same<typename getter_traits<decltype(&User::getIdByRefNoexcept)>::field_type, int>::value);
 
     static_assert(
         is_same<typename getter_traits<decltype(&User::getIdByConstRefConstNoexcept)>::object_type, User>::value,
@@ -206,62 +206,62 @@ TEST_CASE("member_traits_tests") {
     static_assert(is_same<typename getter_traits<decltype(&User::getIdByConstRefNoExcept)>::field_type, int>::value,
                   "");
 #endif
-    static_assert(is_same<typename setter_traits<decltype(&User::setIdByVal)>::object_type, User>::value, "");
-    static_assert(is_same<typename setter_traits<decltype(&User::setIdByVal)>::field_type, int>::value, "");
+    STATIC_REQUIRE(is_same<typename setter_traits<decltype(&User::setIdByVal)>::object_type, User>::value);
+    STATIC_REQUIRE(is_same<typename setter_traits<decltype(&User::setIdByVal)>::field_type, int>::value);
 
-    static_assert(is_same<typename setter_traits<decltype(&User::setIdByRef)>::object_type, User>::value, "");
-    static_assert(is_same<typename setter_traits<decltype(&User::setIdByRef)>::field_type, int>::value, "");
+    STATIC_REQUIRE(is_same<typename setter_traits<decltype(&User::setIdByRef)>::object_type, User>::value);
+    STATIC_REQUIRE(is_same<typename setter_traits<decltype(&User::setIdByRef)>::field_type, int>::value);
 
-    static_assert(is_same<typename setter_traits<decltype(&User::setIdByConstRef)>::object_type, User>::value, "");
-    static_assert(is_same<typename setter_traits<decltype(&User::setIdByConstRef)>::field_type, int>::value, "");
+    STATIC_REQUIRE(is_same<typename setter_traits<decltype(&User::setIdByConstRef)>::object_type, User>::value);
+    STATIC_REQUIRE(is_same<typename setter_traits<decltype(&User::setIdByConstRef)>::field_type, int>::value);
 #ifdef SQLITE_ORM_NOTHROW_ALIASES_SUPPORTED
-    static_assert(is_same<typename setter_traits<decltype(&User::setIdByValueNoexcept)>::object_type, User>::value, "");
-    static_assert(is_same<typename setter_traits<decltype(&User::setIdByValueNoexcept)>::field_type, int>::value, "");
+    STATIC_REQUIRE(is_same<typename setter_traits<decltype(&User::setIdByValueNoexcept)>::object_type, User>::value);
+    STATIC_REQUIRE(is_same<typename setter_traits<decltype(&User::setIdByValueNoexcept)>::field_type, int>::value);
 
-    static_assert(is_same<typename setter_traits<decltype(&User::setIdByRefNoExcept)>::object_type, User>::value, "");
-    static_assert(is_same<typename setter_traits<decltype(&User::setIdByRefNoExcept)>::field_type, int>::value, "");
+    STATIC_REQUIRE(is_same<typename setter_traits<decltype(&User::setIdByRefNoExcept)>::object_type, User>::value);
+    STATIC_REQUIRE(is_same<typename setter_traits<decltype(&User::setIdByRefNoExcept)>::field_type, int>::value);
 
     static_assert(is_same<typename setter_traits<decltype(&User::setIdByConstRefNoexcept)>::object_type, User>::value,
                   "");
     static_assert(is_same<typename setter_traits<decltype(&User::setIdByConstRefNoexcept)>::field_type, int>::value,
                   "");
 #endif
-    static_assert(is_same<typename field_member_traits<decltype(&User::id)>::object_type, User>::value, "");
-    static_assert(is_same<typename field_member_traits<decltype(&User::id)>::field_type, int>::value, "");
+    STATIC_REQUIRE(is_same<typename field_member_traits<decltype(&User::id)>::object_type, User>::value);
+    STATIC_REQUIRE(is_same<typename field_member_traits<decltype(&User::id)>::field_type, int>::value);
 
-    static_assert(is_same<typename member_traits<decltype(&User::id)>::object_type, User>::value, "");
-    static_assert(is_same<typename member_traits<decltype(&User::id)>::field_type, int>::value, "");
+    STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::id)>::object_type, User>::value);
+    STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::id)>::field_type, int>::value);
 
-    static_assert(is_same<typename member_traits<decltype(&User::getIdByValConst)>::object_type, User>::value, "");
-    static_assert(is_same<typename member_traits<decltype(&User::getIdByValConst)>::field_type, int>::value, "");
+    STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::getIdByValConst)>::object_type, User>::value);
+    STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::getIdByValConst)>::field_type, int>::value);
 
-    static_assert(is_same<typename member_traits<decltype(&User::getIdByRefConst)>::object_type, User>::value, "");
-    static_assert(is_same<typename member_traits<decltype(&User::getIdByRefConst)>::field_type, int>::value, "");
+    STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::getIdByRefConst)>::object_type, User>::value);
+    STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::getIdByRefConst)>::field_type, int>::value);
 
-    static_assert(is_same<typename member_traits<decltype(&User::getIdByRef)>::object_type, User>::value, "");
-    static_assert(is_same<typename member_traits<decltype(&User::getIdByRef)>::field_type, int>::value, "");
+    STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::getIdByRef)>::object_type, User>::value);
+    STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::getIdByRef)>::field_type, int>::value);
 
-    static_assert(is_same<typename member_traits<decltype(&User::getIdByConstRefConst)>::object_type, User>::value, "");
-    static_assert(is_same<typename member_traits<decltype(&User::getIdByConstRefConst)>::field_type, int>::value, "");
+    STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::getIdByConstRefConst)>::object_type, User>::value);
+    STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::getIdByConstRefConst)>::field_type, int>::value);
 
-    static_assert(is_same<typename member_traits<decltype(&User::getIdByConstRef)>::object_type, User>::value, "");
-    static_assert(is_same<typename member_traits<decltype(&User::getIdByConstRef)>::field_type, int>::value, "");
+    STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::getIdByConstRef)>::object_type, User>::value);
+    STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::getIdByConstRef)>::field_type, int>::value);
 #ifdef SQLITE_ORM_NOTHROW_ALIASES_SUPPORTED
     static_assert(is_same<typename member_traits<decltype(&User::getIdByValConstNoexcept)>::object_type, User>::value,
                   "");
     static_assert(is_same<typename member_traits<decltype(&User::getIdByValConstNoexcept)>::field_type, int>::value,
                   "");
 
-    static_assert(is_same<typename member_traits<decltype(&User::getIdByValNoexcept)>::object_type, User>::value, "");
-    static_assert(is_same<typename member_traits<decltype(&User::getIdByValNoexcept)>::field_type, int>::value, "");
+    STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::getIdByValNoexcept)>::object_type, User>::value);
+    STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::getIdByValNoexcept)>::field_type, int>::value);
 
     static_assert(is_same<typename member_traits<decltype(&User::getIdByRefConstNoexcept)>::object_type, User>::value,
                   "");
     static_assert(is_same<typename member_traits<decltype(&User::getIdByRefConstNoexcept)>::field_type, int>::value,
                   "");
 
-    static_assert(is_same<typename member_traits<decltype(&User::getIdByRefNoexcept)>::object_type, User>::value, "");
-    static_assert(is_same<typename member_traits<decltype(&User::getIdByRefNoexcept)>::field_type, int>::value, "");
+    STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::getIdByRefNoexcept)>::object_type, User>::value);
+    STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::getIdByRefNoexcept)>::field_type, int>::value);
 
     static_assert(
         is_same<typename member_traits<decltype(&User::getIdByConstRefConstNoexcept)>::object_type, User>::value,
@@ -275,20 +275,20 @@ TEST_CASE("member_traits_tests") {
     static_assert(is_same<typename member_traits<decltype(&User::getIdByConstRefNoExcept)>::field_type, int>::value,
                   "");
 #endif
-    static_assert(is_same<typename member_traits<decltype(&User::setIdByVal)>::object_type, User>::value, "");
-    static_assert(is_same<typename member_traits<decltype(&User::setIdByVal)>::field_type, int>::value, "");
+    STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::setIdByVal)>::object_type, User>::value);
+    STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::setIdByVal)>::field_type, int>::value);
 
-    static_assert(is_same<typename member_traits<decltype(&User::setIdByRef)>::object_type, User>::value, "");
-    static_assert(is_same<typename member_traits<decltype(&User::setIdByRef)>::field_type, int>::value, "");
+    STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::setIdByRef)>::object_type, User>::value);
+    STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::setIdByRef)>::field_type, int>::value);
 
-    static_assert(is_same<typename member_traits<decltype(&User::setIdByConstRef)>::object_type, User>::value, "");
-    static_assert(is_same<typename member_traits<decltype(&User::setIdByConstRef)>::field_type, int>::value, "");
+    STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::setIdByConstRef)>::object_type, User>::value);
+    STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::setIdByConstRef)>::field_type, int>::value);
 #ifdef SQLITE_ORM_NOTHROW_ALIASES_SUPPORTED
-    static_assert(is_same<typename member_traits<decltype(&User::setIdByValueNoexcept)>::object_type, User>::value, "");
-    static_assert(is_same<typename member_traits<decltype(&User::setIdByValueNoexcept)>::field_type, int>::value, "");
+    STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::setIdByValueNoexcept)>::object_type, User>::value);
+    STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::setIdByValueNoexcept)>::field_type, int>::value);
 
-    static_assert(is_same<typename member_traits<decltype(&User::setIdByRefNoExcept)>::object_type, User>::value, "");
-    static_assert(is_same<typename member_traits<decltype(&User::setIdByRefNoExcept)>::field_type, int>::value, "");
+    STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::setIdByRefNoExcept)>::object_type, User>::value);
+    STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::setIdByRefNoExcept)>::field_type, int>::value);
 
     static_assert(is_same<typename member_traits<decltype(&User::setIdByConstRefNoexcept)>::object_type, User>::value,
                   "");

--- a/tests/static_tests/node_tuple.cpp
+++ b/tests/static_tests/node_tuple.cpp
@@ -31,13 +31,13 @@ TEST_CASE("Node tuple") {
             using Tuple = node_tuple<int>::type;
             using Expected = std::tuple<int>;
             static_assert(is_same<Tuple, Expected>::value, "int");
-            static_assert(is_same<bindable_filter<Tuple>::type, std::tuple<int>>::value, "");
+            STATIC_REQUIRE(is_same<bindable_filter<Tuple>::type, std::tuple<int>>::value);
         }
         SECTION("float") {
             using Tuple = node_tuple<float>::type;
             using Expected = std::tuple<float>;
             static_assert(is_same<Tuple, Expected>::value, "float");
-            static_assert(is_same<bindable_filter<Tuple>::type, std::tuple<float>>::value, "");
+            STATIC_REQUIRE(is_same<bindable_filter<Tuple>::type, std::tuple<float>>::value);
         }
     }
     SECTION("binary_condition") {
@@ -48,7 +48,7 @@ TEST_CASE("Node tuple") {
             using Tuple = node_tuple<C>::type;
             using Expected = std::tuple<int, float>;
             static_assert(is_same<Tuple, Expected>::value, "lesser_than_t");
-            static_assert(is_same<bindable_filter<Tuple>::type, std::tuple<int, float>>::value, "");
+            STATIC_REQUIRE(is_same<bindable_filter<Tuple>::type, std::tuple<int, float>>::value);
         }
         SECTION("id < 10") {
             auto c = lesser_than(&User::id, 10);
@@ -56,7 +56,7 @@ TEST_CASE("Node tuple") {
             using Tuple = node_tuple<C>::type;
             using Expected = std::tuple<decltype(&User::id), int>;
             static_assert(is_same<Tuple, Expected>::value, "lesser_than_t");
-            static_assert(is_same<bindable_filter<Tuple>::type, std::tuple<int>>::value, "");
+            STATIC_REQUIRE(is_same<bindable_filter<Tuple>::type, std::tuple<int>>::value);
         }
         SECTION("5 <= 6.0f") {
             auto c = lesser_or_equal(5, 6.0f);
@@ -64,7 +64,7 @@ TEST_CASE("Node tuple") {
             using Tuple = node_tuple<C>::type;
             using Expected = std::tuple<int, float>;
             static_assert(is_same<Tuple, Expected>::value, "lesser_or_equal_t");
-            static_assert(is_same<bindable_filter<Tuple>::type, std::tuple<int, float>>::value, "");
+            STATIC_REQUIRE(is_same<bindable_filter<Tuple>::type, std::tuple<int, float>>::value);
         }
         SECTION("id <= 10.0") {
             auto c = lesser_or_equal(&User::id, 10.0);
@@ -72,7 +72,7 @@ TEST_CASE("Node tuple") {
             using Tuple = node_tuple<C>::type;
             using Expected = std::tuple<decltype(&User::id), double>;
             static_assert(is_same<Tuple, Expected>::value, "lesser_or_equal_t");
-            static_assert(is_same<bindable_filter<Tuple>::type, std::tuple<double>>::value, "");
+            STATIC_REQUIRE(is_same<bindable_filter<Tuple>::type, std::tuple<double>>::value);
         }
         SECTION("5 > 6.0f") {
             auto c = greater_than(5, 6.0f);
@@ -80,7 +80,7 @@ TEST_CASE("Node tuple") {
             using Tuple = node_tuple<C>::type;
             using Expected = std::tuple<int, float>;
             static_assert(is_same<Tuple, Expected>::value, "greater_than_t");
-            static_assert(is_same<bindable_filter<Tuple>::type, std::tuple<int, float>>::value, "");
+            STATIC_REQUIRE(is_same<bindable_filter<Tuple>::type, std::tuple<int, float>>::value);
         }
         SECTION("id > 20") {
             auto c = greater_than(&User::id, 20);
@@ -88,7 +88,7 @@ TEST_CASE("Node tuple") {
             using Tuple = node_tuple<C>::type;
             using Expected = std::tuple<decltype(&User::id), int>;
             static_assert(is_same<Tuple, Expected>::value, "greater_than_t");
-            static_assert(is_same<bindable_filter<Tuple>::type, std::tuple<int>>::value, "");
+            STATIC_REQUIRE(is_same<bindable_filter<Tuple>::type, std::tuple<int>>::value);
         }
         SECTION("5 >= 6.0f") {
             auto c = greater_or_equal(5, 6.0f);
@@ -96,7 +96,7 @@ TEST_CASE("Node tuple") {
             using Tuple = node_tuple<C>::type;
             using Expected = std::tuple<int, float>;
             static_assert(is_same<Tuple, Expected>::value, "greater_or_equal_t");
-            static_assert(is_same<bindable_filter<Tuple>::type, std::tuple<int, float>>::value, "");
+            STATIC_REQUIRE(is_same<bindable_filter<Tuple>::type, std::tuple<int, float>>::value);
         }
         SECTION("5 >= id") {
             auto c = greater_or_equal(5, &User::id);
@@ -104,7 +104,7 @@ TEST_CASE("Node tuple") {
             using Tuple = node_tuple<C>::type;
             using Expected = std::tuple<int, decltype(&User::id)>;
             static_assert(is_same<Tuple, Expected>::value, "greater_or_equal_t");
-            static_assert(is_same<bindable_filter<Tuple>::type, std::tuple<int>>::value, "");
+            STATIC_REQUIRE(is_same<bindable_filter<Tuple>::type, std::tuple<int>>::value);
         }
         SECTION("5 == 6.0f") {
             auto c = is_equal(5, 6.0f);
@@ -112,7 +112,7 @@ TEST_CASE("Node tuple") {
             using Tuple = node_tuple<C>::type;
             using Expected = std::tuple<int, float>;
             static_assert(is_same<Tuple, Expected>::value, "is_equal_t");
-            static_assert(is_same<bindable_filter<Tuple>::type, std::tuple<int, float>>::value, "");
+            STATIC_REQUIRE(is_same<bindable_filter<Tuple>::type, std::tuple<int, float>>::value);
         }
         SECTION("'ototo' == name") {
             auto c = is_equal("ototo", &User::name);
@@ -120,7 +120,7 @@ TEST_CASE("Node tuple") {
             using Tuple = node_tuple<C>::type;
             using Expected = std::tuple<const char*, decltype(&User::name)>;
             static_assert(is_same<Tuple, Expected>::value, "is_equal_t");
-            static_assert(is_same<bindable_filter<Tuple>::type, std::tuple<const char*>>::value, "");
+            STATIC_REQUIRE(is_same<bindable_filter<Tuple>::type, std::tuple<const char*>>::value);
         }
         SECTION("5 != 6.0f") {
             auto c = is_not_equal(5, 6.0f);
@@ -128,7 +128,7 @@ TEST_CASE("Node tuple") {
             using Tuple = node_tuple<C>::type;
             using Expected = std::tuple<int, float>;
             static_assert(is_same<Tuple, Expected>::value, "is_not_equal_t");
-            static_assert(is_same<bindable_filter<Tuple>::type, std::tuple<int, float>>::value, "");
+            STATIC_REQUIRE(is_same<bindable_filter<Tuple>::type, std::tuple<int, float>>::value);
         }
         SECTION("name != std::string('ototo')") {
             auto c = is_not_equal(&User::name, std::string("ototo"));
@@ -136,19 +136,19 @@ TEST_CASE("Node tuple") {
             using Tuple = node_tuple<C>::type;
             using Expected = std::tuple<decltype(&User::name), std::string>;
             static_assert(is_same<Tuple, Expected>::value, "is_not_equal_t");
-            static_assert(is_same<bindable_filter<Tuple>::type, std::tuple<std::string>>::value, "");
+            STATIC_REQUIRE(is_same<bindable_filter<Tuple>::type, std::tuple<std::string>>::value);
         }
         SECTION("bool and int") {
             using Tuple = node_tuple<and_condition_t<bool, int>>::type;
             using Expected = std::tuple<bool, int>;
             static_assert(is_same<Tuple, Expected>::value, "and_condition_t");
-            static_assert(is_same<bindable_filter<Tuple>::type, std::tuple<bool, int>>::value, "");
+            STATIC_REQUIRE(is_same<bindable_filter<Tuple>::type, std::tuple<bool, int>>::value);
         }
         SECTION("bool or int") {
             using Tuple = node_tuple<or_condition_t<bool, int>>::type;
             using Expected = std::tuple<bool, int>;
             static_assert(is_same<Tuple, Expected>::value, "or_condition_t");
-            static_assert(is_same<bindable_filter<Tuple>::type, std::tuple<bool, int>>::value, "");
+            STATIC_REQUIRE(is_same<bindable_filter<Tuple>::type, std::tuple<bool, int>>::value);
         }
     }
     SECTION("binary_operator") {
@@ -402,27 +402,27 @@ TEST_CASE("Node tuple") {
         auto expression = std::make_tuple(1, std::string("hi"));
         using Expression = decltype(expression);
         using Tuple = node_tuple<Expression>::type;
-        static_assert(is_same<Tuple, std::tuple<int, std::string>>::value, "");
+        STATIC_REQUIRE(is_same<Tuple, std::tuple<int, std::string>>::value);
     }
     SECTION("values") {
         SECTION("int + string") {
             auto expression = values(1, std::string("hi"));
             using Expression = decltype(expression);
             using Tuple = node_tuple<Expression>::type;
-            static_assert(is_same<Tuple, std::tuple<int, std::string>>::value, "");
+            STATIC_REQUIRE(is_same<Tuple, std::tuple<int, std::string>>::value);
         }
         SECTION("tuple") {
             auto expression = values(std::make_tuple(1, std::string("hi")));
             using Expression = decltype(expression);
             using Tuple = node_tuple<Expression>::type;
-            static_assert(is_same<Tuple, std::tuple<int, std::string>>::value, "");
+            STATIC_REQUIRE(is_same<Tuple, std::tuple<int, std::string>>::value);
         }
     }
     SECTION("into") {
         auto expression = into<User>();
         using Expression = decltype(expression);
         using Tuple = node_tuple<Expression>::type;
-        static_assert(is_same<Tuple, std::tuple<>>::value, "");
+        STATIC_REQUIRE(is_same<Tuple, std::tuple<>>::value);
     }
     SECTION("select") {
         SECTION("select(&User::id)") {
@@ -468,7 +468,7 @@ TEST_CASE("Node tuple") {
             using Statement = decltype(statement);
             using Tuple = node_tuple<Statement>::type;
             using ExpectedTuple = std::tuple<const char*, int>;
-            static_assert(std::is_same<Tuple, ExpectedTuple>::value, "");
+            STATIC_REQUIRE(std::is_same<Tuple, ExpectedTuple>::value);
         }
     }
     SECTION("get_all_t") {
@@ -845,28 +845,28 @@ TEST_CASE("Node tuple") {
         auto c = case_<std::string>(&User::name).when("USA", then("Dosmetic")).else_("Foreign").end();
         using Case = decltype(c);
         using CaseExpressionTuple = node_tuple<Case::case_expression_type>::type;
-        static_assert(is_same<CaseExpressionTuple, std::tuple<decltype(&User::name)>>::value, "");
+        STATIC_REQUIRE(is_same<CaseExpressionTuple, std::tuple<decltype(&User::name)>>::value);
 
-        static_assert(is_tuple<std::tuple<>>::value, "");
-        static_assert(is_tuple<std::tuple<int, std::string>>::value, "");
-        static_assert(!is_tuple<int>::value, "");
-        static_assert(is_pair<std::pair<int, std::string>>::value, "");
-        static_assert(!is_pair<int>::value, "");
+        STATIC_REQUIRE(is_tuple<std::tuple<>>::value);
+        STATIC_REQUIRE(is_tuple<std::tuple<int, std::string>>::value);
+        STATIC_REQUIRE(!is_tuple<int>::value);
+        STATIC_REQUIRE(is_pair<std::pair<int, std::string>>::value);
+        STATIC_REQUIRE(!is_pair<int>::value);
 
         using ArgsType = Case::args_type;
-        static_assert(is_tuple<ArgsType>::value, "");
-        static_assert(std::tuple_size<ArgsType>::value == 1, "");
+        STATIC_REQUIRE(is_tuple<ArgsType>::value);
+        STATIC_REQUIRE(std::tuple_size<ArgsType>::value == 1);
 
         using Arg0 = std::tuple_element<0, ArgsType>::type;
-        static_assert(is_pair<Arg0>::value, "");
+        STATIC_REQUIRE(is_pair<Arg0>::value);
         using Arg0First = Arg0::first_type;
-        static_assert(is_same<Arg0First, const char*>::value, "");
+        STATIC_REQUIRE(is_same<Arg0First, const char*>::value);
         using Arg0Second = Arg0::second_type;
-        static_assert(is_same<Arg0Second, const char*>::value, "");
-        static_assert(is_same<ArgsType, std::tuple<std::pair<const char*, const char*>>>::value, "");
+        STATIC_REQUIRE(is_same<Arg0Second, const char*>::value);
+        STATIC_REQUIRE(is_same<ArgsType, std::tuple<std::pair<const char*, const char*>>>::value);
 
         using ElseExpressionTuple = node_tuple<Case::else_expression_type>::type;
-        static_assert(is_same<ElseExpressionTuple, std::tuple<const char*>>::value, "");
+        STATIC_REQUIRE(is_same<ElseExpressionTuple, std::tuple<const char*>>::value);
     }
     SECTION("as") {
         struct GradeAlias : alias_tag {
@@ -879,7 +879,7 @@ TEST_CASE("Node tuple") {
         using A = decltype(a);
         using Tuple = node_tuple<A>::type;
         using ExpectedTuple = std::tuple<decltype(&User::name)>;
-        static_assert(is_same<Tuple, ExpectedTuple>::value, "");
+        STATIC_REQUIRE(is_same<Tuple, ExpectedTuple>::value);
     }
     SECTION("function_call") {
         struct Func {
@@ -891,27 +891,27 @@ TEST_CASE("Node tuple") {
         using Statement = decltype(statement);
         using Tuple = node_tuple<Statement>::type;
         using ExpectedTuple = std::tuple<int>;
-        static_assert(std::is_same<Tuple, ExpectedTuple>::value, "");
+        STATIC_REQUIRE(std::is_same<Tuple, ExpectedTuple>::value);
     }
     SECTION("excluded") {
         auto statement = excluded(&User::id);
         using Statement = decltype(statement);
         using Tuple = node_tuple<Statement>::type;
         using ExpectedTuple = std::tuple<decltype(&User::id)>;
-        static_assert(std::is_same<Tuple, ExpectedTuple>::value, "");
+        STATIC_REQUIRE(std::is_same<Tuple, ExpectedTuple>::value);
     }
     SECTION("upsert_clause") {
         auto statement = on_conflict(&User::id).do_update(set(c(&User::name) = excluded(&User::name)));
         using Statement = decltype(statement);
         using Tuple = node_tuple<Statement>::type;
         using ExpectedTuple = std::tuple<decltype(&User::name), decltype(&User::name)>;
-        static_assert(std::is_same<Tuple, ExpectedTuple>::value, "");
+        STATIC_REQUIRE(std::is_same<Tuple, ExpectedTuple>::value);
     }
     SECTION("group_by") {
         auto statement = group_by(&User::id);
         using Statement = decltype(statement);
         using Tuple = node_tuple<Statement>::type;
         using ExpectedTuple = std::tuple<decltype(&User::id)>;
-        static_assert(std::is_same<Tuple, ExpectedTuple>::value, "");
+        STATIC_REQUIRE(std::is_same<Tuple, ExpectedTuple>::value);
     }
 }

--- a/tests/static_tests/select_return_type.cpp
+++ b/tests/static_tests/select_return_type.cpp
@@ -15,7 +15,7 @@ TEST_CASE("Select return types") {
 
         using SelectVectorTuple = decltype(storage.select(columns(&User::id)));
         auto ids = storage.select(columns(&User::id));
-        static_assert(std::is_same<decltype(ids), SelectVectorTuple>::value, "");
+        STATIC_REQUIRE(std::is_same<decltype(ids), SelectVectorTuple>::value);
         static_assert(std::is_same<SelectVectorTuple, std::vector<std::tuple<int>>>::value,
                       "Incorrect select id vector type");
         using IdsTuple = SelectVectorTuple::value_type;

--- a/tests/static_tests/storage_traits.cpp
+++ b/tests/static_tests/storage_traits.cpp
@@ -30,14 +30,14 @@ TEST_CASE("storage traits") {
 
         using ArgsTuple = TableTypes::args_tuple;
         using ExpectedArgsTuple = std::tuple<Column1, Column2, Column3, Column4, UniqueC>;
-        static_assert(std::is_same<ArgsTuple, ExpectedArgsTuple>::value, "");
+        STATIC_REQUIRE(std::is_same<ArgsTuple, ExpectedArgsTuple>::value);
 
         using ColumnsTuple = TableTypes::columns_tuple;
         using ExpectedColumnsTuple = std::tuple<Column1, Column2, Column3, Column4>;
-        static_assert(std::is_same<ColumnsTuple, ExpectedColumnsTuple>::value, "");
+        STATIC_REQUIRE(std::is_same<ColumnsTuple, ExpectedColumnsTuple>::value);
 
         using ResultType = TableTypes::type;
         using ExpectedResultType = std::tuple<int64_t, std::string, std::string, std::string>;
-        static_assert(std::is_same<ResultType, ExpectedResultType>::value, "");
+        STATIC_REQUIRE(std::is_same<ResultType, ExpectedResultType>::value);
     }
 }

--- a/tests/static_tests/tuple_filter_single.cpp
+++ b/tests/static_tests/tuple_filter_single.cpp
@@ -14,25 +14,25 @@ TEST_CASE("tuple_filter") {
                 using Arg = int;
                 using Expected = std::tuple<int>;
                 using ResultType = internal::tuple_filter_single<Arg, internal::is_bindable>::type;
-                static_assert(std::is_same<ResultType, Expected>::value, "");
+                STATIC_REQUIRE(std::is_same<ResultType, Expected>::value);
             }
             SECTION("std::string") {
                 using Arg = std::string;
                 using Expected = std::tuple<std::string>;
                 using ResultType = internal::tuple_filter_single<Arg, internal::is_bindable>::type;
-                static_assert(std::is_same<ResultType, Expected>::value, "");
+                STATIC_REQUIRE(std::is_same<ResultType, Expected>::value);
             }
             SECTION("where_t") {
                 using Arg = internal::where_t<bool>;
                 using Expected = std::tuple<>;
                 using ResultType = internal::tuple_filter_single<Arg, internal::is_bindable>::type;
-                static_assert(std::is_same<ResultType, Expected>::value, "");
+                STATIC_REQUIRE(std::is_same<ResultType, Expected>::value);
             }
             SECTION("order_by_t") {
                 using Arg = internal::order_by_t<decltype(&User::id)>;
                 using Expected = std::tuple<>;
                 using ResultType = internal::tuple_filter_single<Arg, internal::is_bindable>::type;
-                static_assert(std::is_same<ResultType, Expected>::value, "");
+                STATIC_REQUIRE(std::is_same<ResultType, Expected>::value);
             }
         }
         SECTION("is_column") {
@@ -41,19 +41,19 @@ TEST_CASE("tuple_filter") {
                 using Arg = decltype(column);
                 using Expected = std::tuple<Arg>;
                 using ResultType = internal::tuple_filter_single<Arg, internal::is_column>::type;
-                static_assert(std::is_same<ResultType, Expected>::value, "");
+                STATIC_REQUIRE(std::is_same<ResultType, Expected>::value);
             }
             SECTION("order_by_t") {
                 using Arg = internal::order_by_t<decltype(&User::id)>;
                 using Expected = std::tuple<>;
                 using ResultType = internal::tuple_filter_single<Arg, internal::is_column>::type;
-                static_assert(std::is_same<ResultType, Expected>::value, "");
+                STATIC_REQUIRE(std::is_same<ResultType, Expected>::value);
             }
             SECTION("unique_t") {
                 using Arg = decltype(unique(&User::id));
                 using Expected = std::tuple<>;
                 using ResultType = internal::tuple_filter_single<Arg, internal::is_column>::type;
-                static_assert(std::is_same<ResultType, Expected>::value, "");
+                STATIC_REQUIRE(std::is_same<ResultType, Expected>::value);
             }
         }
     }
@@ -63,7 +63,7 @@ TEST_CASE("tuple_filter") {
                 std::tuple<int, std::string, internal::where_t<bool>, internal::order_by_t<decltype(&User::id)>>;
             using Expected = std::tuple<int, std::string>;
             using ResultType = internal::tuple_filter<Arg, internal::is_bindable>::type;
-            static_assert(std::is_same<ResultType, Expected>::value, "");
+            STATIC_REQUIRE(std::is_same<ResultType, Expected>::value);
         }
         SECTION("is_column") {
             auto column = make_column({}, &User::id);
@@ -73,7 +73,7 @@ TEST_CASE("tuple_filter") {
             using Arg = std::tuple<Column, OrderBy, Unique>;
             using Expected = std::tuple<Column>;
             using ResultType = internal::tuple_filter<Arg, internal::is_column>::type;
-            static_assert(std::is_same<ResultType, Expected>::value, "");
+            STATIC_REQUIRE(std::is_same<ResultType, Expected>::value);
         }
     }
 }

--- a/tests/static_tests/tuple_helper.cpp
+++ b/tests/static_tests/tuple_helper.cpp
@@ -24,6 +24,6 @@ TEST_CASE("tuple_helper static") {
         using ColumnsTuple = std::tuple<Column1, Column2, Column3, Column4>;
         using ColumnsMappedTypes = internal::tuple_transformer<ColumnsTuple, internal::column_field_type>::type;
         using Expected = std::tuple<int64_t, std::string, std::string, std::string>;
-        static_assert(std::is_same<ColumnsMappedTypes, Expected>::value, "");
+        STATIC_REQUIRE(std::is_same<ColumnsMappedTypes, Expected>::value);
     }
 }

--- a/tests/table_tests.cpp
+++ b/tests/table_tests.cpp
@@ -16,7 +16,7 @@ TEST_CASE("table::find_column_name") {
         auto contactIdColumn = make_column("contact_id", &Contact::id, primary_key(), autoincrement());
         {
             using column_type = decltype(contactIdColumn);
-            static_assert(internal::is_column<column_type>::value, "");
+            STATIC_REQUIRE(internal::is_column<column_type>::value);
         }
 
         auto table = make_table("contacts",

--- a/tests/tests2.cpp
+++ b/tests/tests2.cpp
@@ -692,24 +692,24 @@ TEST_CASE("obtain_xdestroy_for") {
 
         // null_xdestroy_f(int*)
         constexpr xdestroy_fn_t xDestroy1 = obtain_xdestroy_for(null_xdestroy_f, int_nullptr);
-        static_assert(xDestroy1 == nullptr, "");
+        STATIC_REQUIRE(xDestroy1 == nullptr);
         REQUIRE(xDestroy1 == nullptr);
 
         // free(int*)
         constexpr xdestroy_fn_t xDestroy2 = obtain_xdestroy_for(free, int_nullptr);
-        static_assert(xDestroy2 == free, "");
+        STATIC_REQUIRE(xDestroy2 == free);
         REQUIRE(xDestroy2 == free);
 
         // free_f(int*)
         constexpr xdestroy_fn_t xDestroy3 = obtain_xdestroy_for(free_f, int_nullptr);
-        static_assert(xDestroy3 == free, "");
+        STATIC_REQUIRE(xDestroy3 == free);
         REQUIRE(xDestroy3 == free);
 
 #if __cplusplus >= 201703L  // use of C++17 or higher
         // [](void* p){}
         constexpr auto lambda4_1 = [](void *p) {};
         constexpr xdestroy_fn_t xDestroy4_1 = obtain_xdestroy_for(lambda4_1, int_nullptr);
-        static_assert(xDestroy4_1 == lambda4_1, "");
+        STATIC_REQUIRE(xDestroy4_1 == lambda4_1);
         REQUIRE(xDestroy4_1 == lambda4_1);
 #else
         // [](void* p){}
@@ -732,32 +732,32 @@ TEST_CASE("obtain_xdestroy_for") {
 
         // default_delete<int>(int*)
         constexpr xdestroy_fn_t xDestroy5 = obtain_xdestroy_for(default_delete<int>{}, int_nullptr);
-        static_assert(xDestroy5 == xdestroy_proxy<default_delete<int>, int>, "");
+        STATIC_REQUIRE(xDestroy5 == xdestroy_proxy<default_delete<int>, int>);
         REQUIRE((xDestroy5 == xdestroy_proxy<default_delete<int>, int>));
 
         // delete_default_f<int>(int*)
         constexpr xdestroy_fn_t xDestroy6 = obtain_xdestroy_for(delete_default_f<int>, int_nullptr);
-        static_assert(xDestroy6 == xdestroy_proxy<delete_default_t<int>, int>, "");
+        STATIC_REQUIRE(xDestroy6 == xdestroy_proxy<delete_default_t<int>, int>);
         REQUIRE((xDestroy6 == xdestroy_proxy<delete_default_t<int>, int>));
 
         // delete_default_f<int>(const int*)
         constexpr xdestroy_fn_t xDestroy7 = obtain_xdestroy_for(delete_default_f<int>, const_int_nullptr);
-        static_assert(xDestroy7 == xdestroy_proxy<delete_default_t<int>, const int>, "");
+        STATIC_REQUIRE(xDestroy7 == xdestroy_proxy<delete_default_t<int>, const int>);
         REQUIRE((xDestroy7 == xdestroy_proxy<delete_default_t<int>, const int>));
 
         // xdestroy_holder{ free }(int*)
         constexpr xdestroy_fn_t xDestroy8 = obtain_xdestroy_for(xdestroy_holder{free}, int_nullptr);
-        static_assert(xDestroy8 == free, "");
+        STATIC_REQUIRE(xDestroy8 == free);
         REQUIRE(xDestroy8 == free);
 
         // xdestroy_holder{ free }(const int*)
         constexpr xdestroy_fn_t xDestroy9 = obtain_xdestroy_for(xdestroy_holder{free}, const_int_nullptr);
-        static_assert(xDestroy9 == free, "");
+        STATIC_REQUIRE(xDestroy9 == free);
         REQUIRE(xDestroy9 == free);
 
         // xdestroy_holder{ nullptr }(const int*)
         constexpr xdestroy_fn_t xDestroy10 = obtain_xdestroy_for(xdestroy_holder{nullptr}, const_int_nullptr);
-        static_assert(xDestroy10 == nullptr, "");
+        STATIC_REQUIRE(xDestroy10 == nullptr);
         REQUIRE(xDestroy10 == nullptr);
 
         // expressions that do not work

--- a/tests/tests5.cpp
+++ b/tests/tests5.cpp
@@ -282,7 +282,7 @@ TEST_CASE("issue730") {
     using Rows = decltype(rows);
     using ExpectedRows = std::vector<std::tuple<int64_t, std::string, std::string, std::string>>;
 
-    static_assert(std::is_same<Rows, ExpectedRows>::value, "");
+    STATIC_REQUIRE(std::is_same<Rows, ExpectedRows>::value);
 }
 
 TEST_CASE("issue822") {


### PR DESCRIPTION
This PR changes direct C++ static assertion in unit tests to using catch2's STATIC_REQUIRE macro (as described in [other macros](https://github.com/catchorg/Catch2/blob/devel/docs/other-macros.md#other-macros)).
The macro expands to a regular static assertion, however additionally registers it as a successful unit test.

An output on the test console might look like:

```
===============================================================================
All tests passed (2663 assertions in 206 test cases)
```

vs.
```
===============================================================================
All tests passed (3067 assertions in 206 test cases)
```

Commit c5fd3511eb43 changes it for some compile time assertions - for those w/o a specific assertion message.

If you @fnc12 like it, and think we should use them everywhere, we need to get rid of the assertion message.