### PR TITLE
Count some more static assertions in unit tests towards the total

### DIFF
--- a/dev/tuple_helper/same_or_void.h
+++ b/dev/tuple_helper/same_or_void.h
@@ -16,20 +16,13 @@ namespace sqlite_orm {
             using type = A;
         };
 
-        template<class A, class B>
-        struct same_or_void<A, B> {
-            using type = void;
-        };
-
         template<class A>
         struct same_or_void<A, A> {
             using type = A;
         };
 
         template<class A, class... Args>
-        struct same_or_void<A, A, Args...> {
-            using type = typename same_or_void<A, Args...>::type;
-        };
+        struct same_or_void<A, A, Args...> : same_or_void<A, Args...> {};
 
     }
 }

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -604,20 +604,13 @@ namespace sqlite_orm {
             using type = A;
         };
 
-        template<class A, class B>
-        struct same_or_void<A, B> {
-            using type = void;
-        };
-
         template<class A>
         struct same_or_void<A, A> {
             using type = A;
         };
 
         template<class A, class... Args>
-        struct same_or_void<A, A, Args...> {
-            using type = typename same_or_void<A, Args...>::type;
-        };
+        struct same_or_void<A, A, Args...> : same_or_void<A, Args...> {};
 
     }
 }

--- a/tests/statement_serializator_tests/foreign_key.cpp
+++ b/tests/statement_serializator_tests/foreign_key.cpp
@@ -350,8 +350,7 @@ TEST_CASE("statement_serializator foreign key") {
                                      primary_key(&User::id, &User::firstName));
 
         STATIC_REQUIRE(internal::storage_traits::table_foreign_keys_count<decltype(usersTable), User>::value == 0);
-        static_assert(internal::storage_traits::table_foreign_keys_count<decltype(usersTable), UserVisit>::value == 0,
-                      "");
+        STATIC_REQUIRE(internal::storage_traits::table_foreign_keys_count<decltype(usersTable), UserVisit>::value == 0);
 
         auto visitsTable = make_table("visits",
                                       make_column("user_id", &UserVisit::userId),
@@ -359,8 +358,8 @@ TEST_CASE("statement_serializator foreign key") {
                                       make_column("time", &UserVisit::time),
                                       fk);
         STATIC_REQUIRE(internal::storage_traits::table_foreign_keys_count<decltype(visitsTable), User>::value == 1);
-        static_assert(internal::storage_traits::table_foreign_keys_count<decltype(visitsTable), UserVisit>::value == 0,
-                      "");
+        STATIC_REQUIRE(internal::storage_traits::table_foreign_keys_count<decltype(visitsTable), UserVisit>::value ==
+                       0);
 
         using storage_impl_t = internal::storage_impl<decltype(usersTable), decltype(visitsTable)>;
 

--- a/tests/static_tests/aggregate_function_return_types.cpp
+++ b/tests/static_tests/aggregate_function_return_types.cpp
@@ -54,93 +54,66 @@ TEST_CASE("Aggregate function return types") {
                      make_table("users",
                                 make_column("id", &User::getConstIdByRefConst, &User::setIdByRef, primary_key()),
                                 make_column("name", &User::getConstNameByRefConst, &User::setNameByRef)));
-    static_assert(std::is_same<decltype(storage0.max(&User::id))::element_type, int>::value, "Incorrect max value");
-    static_assert(std::is_same<decltype(storage1.max(&User::getIdByValConst))::element_type, int>::value,
-                  "Incorrect max value");
-    static_assert(std::is_same<decltype(storage1.max(&User::setIdByVal))::element_type, int>::value,
-                  "Incorrect max value");
-    static_assert(std::is_same<decltype(storage2.max(&User::getConstIdByRefConst))::element_type, int>::value,
-                  "Incorrect max value");
-    static_assert(std::is_same<decltype(storage2.max(&User::setIdByRef))::element_type, int>::value,
-                  "Incorrect max value");
+    STATIC_REQUIRE(std::is_same<decltype(storage0.max(&User::id))::element_type, int>::value);
+    STATIC_REQUIRE(std::is_same<decltype(storage1.max(&User::getIdByValConst))::element_type, int>::value);
+    STATIC_REQUIRE(std::is_same<decltype(storage1.max(&User::setIdByVal))::element_type, int>::value);
+    STATIC_REQUIRE(std::is_same<decltype(storage2.max(&User::getConstIdByRefConst))::element_type, int>::value);
+    STATIC_REQUIRE(std::is_same<decltype(storage2.max(&User::setIdByRef))::element_type, int>::value);
 
-    static_assert(
-        std::is_same<decltype(storage0.max(&User::id, where(lesser_than(&User::id, 10))))::element_type, int>::value,
-        "Incorrect max value");
-    static_assert(
+    STATIC_REQUIRE(
+        std::is_same<decltype(storage0.max(&User::id, where(lesser_than(&User::id, 10))))::element_type, int>::value);
+    STATIC_REQUIRE(
         std::is_same<decltype(storage1.max(&User::getIdByValConst, where(lesser_than(&User::id, 10))))::element_type,
-                     int>::value,
-        "Incorrect max value");
-    static_assert(
+                     int>::value);
+    STATIC_REQUIRE(
         std::is_same<decltype(storage1.max(&User::setIdByVal, where(lesser_than(&User::id, 10))))::element_type,
-                     int>::value,
-        "Incorrect max value");
-    static_assert(std::is_same<decltype(storage2.max(&User::getConstIdByRefConst,
-                                                     where(lesser_than(&User::id, 10))))::element_type,
-                               int>::value,
-                  "Incorrect max value");
-    static_assert(
+                     int>::value);
+    STATIC_REQUIRE(std::is_same<decltype(storage2.max(&User::getConstIdByRefConst,
+                                                      where(lesser_than(&User::id, 10))))::element_type,
+                                int>::value);
+    STATIC_REQUIRE(
         std::is_same<decltype(storage2.max(&User::setIdByRef, where(lesser_than(&User::id, 10))))::element_type,
-                     int>::value,
-        "Incorrect max value");
+                     int>::value);
 
-    static_assert(std::is_same<decltype(storage0.min(&User::id))::element_type, int>::value, "Incorrect min value");
-    static_assert(std::is_same<decltype(storage1.min(&User::getIdByValConst))::element_type, int>::value,
-                  "Incorrect min value");
-    static_assert(std::is_same<decltype(storage1.min(&User::setIdByVal))::element_type, int>::value,
-                  "Incorrect min value");
-    static_assert(std::is_same<decltype(storage2.min(&User::getConstIdByRefConst))::element_type, int>::value,
-                  "Incorrect min value");
-    static_assert(std::is_same<decltype(storage2.min(&User::setIdByRef))::element_type, int>::value,
-                  "Incorrect min value");
+    STATIC_REQUIRE(std::is_same<decltype(storage0.min(&User::id))::element_type, int>::value);
+    STATIC_REQUIRE(std::is_same<decltype(storage1.min(&User::getIdByValConst))::element_type, int>::value);
+    STATIC_REQUIRE(std::is_same<decltype(storage1.min(&User::setIdByVal))::element_type, int>::value);
+    STATIC_REQUIRE(std::is_same<decltype(storage2.min(&User::getConstIdByRefConst))::element_type, int>::value);
+    STATIC_REQUIRE(std::is_same<decltype(storage2.min(&User::setIdByRef))::element_type, int>::value);
 
-    static_assert(
-        std::is_same<decltype(storage0.min(&User::id, where(lesser_than(&User::id, 10))))::element_type, int>::value,
-        "Incorrect min value");
-    static_assert(
+    STATIC_REQUIRE(
+        std::is_same<decltype(storage0.min(&User::id, where(lesser_than(&User::id, 10))))::element_type, int>::value);
+    STATIC_REQUIRE(
         std::is_same<decltype(storage1.min(&User::getIdByValConst, where(lesser_than(&User::id, 10))))::element_type,
-                     int>::value,
-        "Incorrect min value");
-    static_assert(
+                     int>::value);
+    STATIC_REQUIRE(
         std::is_same<decltype(storage1.min(&User::setIdByVal, where(lesser_than(&User::id, 10))))::element_type,
-                     int>::value,
-        "Incorrect min value");
-    static_assert(std::is_same<decltype(storage2.min(&User::getConstIdByRefConst,
-                                                     where(lesser_than(&User::id, 10))))::element_type,
-                               int>::value,
-                  "Incorrect min value");
-    static_assert(
+                     int>::value);
+    STATIC_REQUIRE(std::is_same<decltype(storage2.min(&User::getConstIdByRefConst,
+                                                      where(lesser_than(&User::id, 10))))::element_type,
+                                int>::value);
+    STATIC_REQUIRE(
         std::is_same<decltype(storage2.min(&User::setIdByRef, where(lesser_than(&User::id, 10))))::element_type,
-                     int>::value,
-        "Incorrect min value");
+                     int>::value);
 
-    static_assert(std::is_same<decltype(storage0.sum(&User::id))::element_type, int>::value, "Incorrect sum value");
-    static_assert(std::is_same<decltype(storage1.sum(&User::getIdByValConst))::element_type, int>::value,
-                  "Incorrect sum value");
-    static_assert(std::is_same<decltype(storage1.sum(&User::setIdByVal))::element_type, int>::value,
-                  "Incorrect sum value");
-    static_assert(std::is_same<decltype(storage2.sum(&User::getConstIdByRefConst))::element_type, int>::value,
-                  "Incorrect sum value");
-    static_assert(std::is_same<decltype(storage2.sum(&User::setIdByRef))::element_type, int>::value,
-                  "Incorrect sum value");
+    STATIC_REQUIRE(std::is_same<decltype(storage0.sum(&User::id))::element_type, int>::value);
+    STATIC_REQUIRE(std::is_same<decltype(storage1.sum(&User::getIdByValConst))::element_type, int>::value);
+    STATIC_REQUIRE(std::is_same<decltype(storage1.sum(&User::setIdByVal))::element_type, int>::value);
+    STATIC_REQUIRE(std::is_same<decltype(storage2.sum(&User::getConstIdByRefConst))::element_type, int>::value);
+    STATIC_REQUIRE(std::is_same<decltype(storage2.sum(&User::setIdByRef))::element_type, int>::value);
 
-    static_assert(
-        std::is_same<decltype(storage0.sum(&User::id, where(lesser_than(&User::id, 10))))::element_type, int>::value,
-        "Incorrect sum value");
-    static_assert(
+    STATIC_REQUIRE(
+        std::is_same<decltype(storage0.sum(&User::id, where(lesser_than(&User::id, 10))))::element_type, int>::value);
+    STATIC_REQUIRE(
         std::is_same<decltype(storage1.sum(&User::getIdByValConst, where(lesser_than(&User::id, 10))))::element_type,
-                     int>::value,
-        "Incorrect sum value");
-    static_assert(
+                     int>::value);
+    STATIC_REQUIRE(
         std::is_same<decltype(storage1.sum(&User::setIdByVal, where(lesser_than(&User::id, 10))))::element_type,
-                     int>::value,
-        "Incorrect sum value");
-    static_assert(std::is_same<decltype(storage2.sum(&User::getConstIdByRefConst,
-                                                     where(lesser_than(&User::id, 10))))::element_type,
-                               int>::value,
-                  "Incorrect sum value");
-    static_assert(
+                     int>::value);
+    STATIC_REQUIRE(std::is_same<decltype(storage2.sum(&User::getConstIdByRefConst,
+                                                      where(lesser_than(&User::id, 10))))::element_type,
+                                int>::value);
+    STATIC_REQUIRE(
         std::is_same<decltype(storage2.sum(&User::setIdByRef, where(lesser_than(&User::id, 10))))::element_type,
-                     int>::value,
-        "Incorrect sum value");
+                     int>::value);
 }

--- a/tests/static_tests/arithmetic_operators_result_type.cpp
+++ b/tests/static_tests/arithmetic_operators_result_type.cpp
@@ -5,16 +5,12 @@
 using namespace sqlite_orm;
 
 TEST_CASE("Arithmetic operators result type") {
-    static_assert(
-        std::is_same<internal::column_result_t<internal::storage_t<>, decltype(add(1, 2))>::type, double>::value,
-        "Incorrect add result");
-    static_assert(
-        std::is_same<internal::column_result_t<internal::storage_t<>, decltype(sub(2, 1))>::type, double>::value,
-        "Incorrect sub result");
-    static_assert(
-        std::is_same<internal::column_result_t<internal::storage_t<>, decltype(mul(2, 3))>::type, double>::value,
-        "Incorrect mul result");
-    static_assert(std::is_same<internal::column_result_t<internal::storage_t<>, decltype(sqlite_orm::div(2, 3))>::type,
-                               double>::value,
-                  "Incorrect div result");
+    STATIC_REQUIRE(
+        std::is_same<internal::column_result_t<internal::storage_t<>, decltype(add(1, 2))>::type, double>::value);
+    STATIC_REQUIRE(
+        std::is_same<internal::column_result_t<internal::storage_t<>, decltype(sub(2, 1))>::type, double>::value);
+    STATIC_REQUIRE(
+        std::is_same<internal::column_result_t<internal::storage_t<>, decltype(mul(2, 3))>::type, double>::value);
+    STATIC_REQUIRE(std::is_same<internal::column_result_t<internal::storage_t<>, decltype(sqlite_orm::div(2, 3))>::type,
+                                double>::value);
 }

--- a/tests/static_tests/column.cpp
+++ b/tests/static_tests/column.cpp
@@ -8,81 +8,75 @@ using namespace sqlite_orm;
 TEST_CASE("Column") {
     {
         using column_type = decltype(make_column("id", &User::id));
-        static_assert(std::tuple_size<column_type::constraints_type>::value == 0, "Incorrect constraints_type size");
-        static_assert(std::is_same<column_type::object_type, User>::value, "Incorrect object_type");
-        static_assert(std::is_same<column_type::field_type, int>::value, "Incorrect field_type");
-        static_assert(std::is_same<column_type::member_pointer_t, int User::*>::value, "Incorrect member pointer type");
-        static_assert(std::is_same<column_type::getter_type, const int& (User::*)() const>::value,
-                      "Incorrect getter_type");
-        static_assert(std::is_same<column_type::setter_type, void (User::*)(int)>::value, "Incorrect setter_type");
+        STATIC_REQUIRE(std::tuple_size<column_type::constraints_type>::value == 0);
+        STATIC_REQUIRE(std::is_same<column_type::object_type, User>::value);
+        STATIC_REQUIRE(std::is_same<column_type::field_type, int>::value);
+        STATIC_REQUIRE(std::is_same<column_type::member_pointer_t, int User::*>::value);
+        STATIC_REQUIRE(std::is_same<column_type::getter_type, const int& (User::*)() const>::value);
+        STATIC_REQUIRE(std::is_same<column_type::setter_type, void (User::*)(int)>::value);
     }
     {
         using column_type = decltype(make_column("id", &User::getIdByRefConst, &User::setIdByVal));
-        static_assert(std::tuple_size<column_type::constraints_type>::value == 0, "Incorrect constraints_type size");
-        static_assert(std::is_same<column_type::object_type, User>::value, "Incorrect object_type");
-        static_assert(std::is_same<column_type::field_type, int>::value, "Incorrect field_type");
-        static_assert(std::is_same<column_type::member_pointer_t, int User::*>::value, "Incorrect member pointer type");
-        static_assert(std::is_same<column_type::getter_type, const int& (User::*)() const>::value,
-                      "Incorrect getter_type");
-        static_assert(std::is_same<column_type::setter_type, void (User::*)(int)>::value, "Incorrect setter_type");
+        STATIC_REQUIRE(std::tuple_size<column_type::constraints_type>::value == 0);
+        STATIC_REQUIRE(std::is_same<column_type::object_type, User>::value);
+        STATIC_REQUIRE(std::is_same<column_type::field_type, int>::value);
+        STATIC_REQUIRE(std::is_same<column_type::member_pointer_t, int User::*>::value);
+        STATIC_REQUIRE(std::is_same<column_type::getter_type, const int& (User::*)() const>::value);
+        STATIC_REQUIRE(std::is_same<column_type::setter_type, void (User::*)(int)>::value);
     }
     {
         using column_type = decltype(make_column("id", &User::setIdByVal, &User::getIdByRefConst));
-        static_assert(std::tuple_size<column_type::constraints_type>::value == 0, "Incorrect constraints_type size");
-        static_assert(std::is_same<column_type::object_type, User>::value, "Incorrect object_type");
-        static_assert(std::is_same<column_type::field_type, int>::value, "Incorrect field_type");
-        static_assert(std::is_same<column_type::member_pointer_t, int User::*>::value, "Incorrect member pointer type");
-        static_assert(std::is_same<column_type::getter_type, const int& (User::*)() const>::value,
-                      "Incorrect getter_type");
-        static_assert(std::is_same<column_type::setter_type, void (User::*)(int)>::value, "Incorrect setter_type");
+        STATIC_REQUIRE(std::tuple_size<column_type::constraints_type>::value == 0);
+        STATIC_REQUIRE(std::is_same<column_type::object_type, User>::value);
+        STATIC_REQUIRE(std::is_same<column_type::field_type, int>::value);
+        STATIC_REQUIRE(std::is_same<column_type::member_pointer_t, int User::*>::value);
+        STATIC_REQUIRE(std::is_same<column_type::getter_type, const int& (User::*)() const>::value);
+        STATIC_REQUIRE(std::is_same<column_type::setter_type, void (User::*)(int)>::value);
     }
     {
         using column_type = decltype(make_column("id", &User::getIdByRef, &User::setIdByConstRef));
-        static_assert(std::tuple_size<column_type::constraints_type>::value == 0, "Incorrect constraints_type size");
-        static_assert(std::is_same<column_type::object_type, User>::value, "Incorrect object_type");
-        static_assert(std::is_same<column_type::field_type, int>::value, "Incorrect field_type");
-        static_assert(std::is_same<column_type::member_pointer_t, int User::*>::value, "Incorrect member pointer type");
-        static_assert(std::is_same<column_type::getter_type, const int& (User::*)()>::value, "Incorrect getter_type");
-        static_assert(std::is_same<column_type::setter_type, void (User::*)(const int&)>::value,
-                      "Incorrect setter_type");
+        STATIC_REQUIRE(std::tuple_size<column_type::constraints_type>::value == 0);
+        STATIC_REQUIRE(std::is_same<column_type::object_type, User>::value);
+        STATIC_REQUIRE(std::is_same<column_type::field_type, int>::value);
+        STATIC_REQUIRE(std::is_same<column_type::member_pointer_t, int User::*>::value);
+        STATIC_REQUIRE(std::is_same<column_type::getter_type, const int& (User::*)()>::value);
+        STATIC_REQUIRE(std::is_same<column_type::setter_type, void (User::*)(const int&)>::value);
     }
     {
         using column_type = decltype(make_column("id", &User::setIdByConstRef, &User::getIdByRef));
-        static_assert(std::tuple_size<column_type::constraints_type>::value == 0, "Incorrect constraints_type size");
-        static_assert(std::is_same<column_type::object_type, User>::value, "Incorrect object_type");
-        static_assert(std::is_same<column_type::field_type, int>::value, "Incorrect field_type");
-        static_assert(std::is_same<column_type::member_pointer_t, int User::*>::value, "Incorrect member pointer type");
-        static_assert(std::is_same<column_type::getter_type, const int& (User::*)()>::value, "Incorrect getter_type");
-        static_assert(std::is_same<column_type::setter_type, void (User::*)(const int&)>::value,
-                      "Incorrect setter_type");
+        STATIC_REQUIRE(std::tuple_size<column_type::constraints_type>::value == 0);
+        STATIC_REQUIRE(std::is_same<column_type::object_type, User>::value);
+        STATIC_REQUIRE(std::is_same<column_type::field_type, int>::value);
+        STATIC_REQUIRE(std::is_same<column_type::member_pointer_t, int User::*>::value);
+        STATIC_REQUIRE(std::is_same<column_type::getter_type, const int& (User::*)()>::value);
+        STATIC_REQUIRE(std::is_same<column_type::setter_type, void (User::*)(const int&)>::value);
     }
     {
         using column_type = decltype(make_column("id", &User::getIdByValConst, &User::setIdByRef));
-        static_assert(std::tuple_size<column_type::constraints_type>::value == 0, "Incorrect constraints_type size");
-        static_assert(std::is_same<column_type::object_type, User>::value, "Incorrect object_type");
-        static_assert(std::is_same<column_type::field_type, int>::value, "Incorrect field_type");
-        static_assert(std::is_same<column_type::member_pointer_t, int User::*>::value, "Incorrect member pointer type");
-        static_assert(std::is_same<column_type::getter_type, int (User::*)() const>::value, "Incorrect getter_type");
-        static_assert(std::is_same<column_type::setter_type, void (User::*)(int&)>::value, "Incorrect setter_type");
+        STATIC_REQUIRE(std::tuple_size<column_type::constraints_type>::value == 0);
+        STATIC_REQUIRE(std::is_same<column_type::object_type, User>::value);
+        STATIC_REQUIRE(std::is_same<column_type::field_type, int>::value);
+        STATIC_REQUIRE(std::is_same<column_type::member_pointer_t, int User::*>::value);
+        STATIC_REQUIRE(std::is_same<column_type::getter_type, int (User::*)() const>::value);
+        STATIC_REQUIRE(std::is_same<column_type::setter_type, void (User::*)(int&)>::value);
     }
     {
         using column_type = decltype(make_column("id", &User::setIdByRef, &User::getIdByValConst));
-        static_assert(std::tuple_size<column_type::constraints_type>::value == 0, "Incorrect constraints_type size");
-        static_assert(std::is_same<column_type::object_type, User>::value, "Incorrect object_type");
-        static_assert(std::is_same<column_type::field_type, int>::value, "Incorrect field_type");
-        static_assert(std::is_same<column_type::member_pointer_t, int User::*>::value, "Incorrect member pointer type");
-        static_assert(std::is_same<column_type::getter_type, int (User::*)() const>::value, "Incorrect getter_type");
-        static_assert(std::is_same<column_type::setter_type, void (User::*)(int&)>::value, "Incorrect setter_type");
+        STATIC_REQUIRE(std::tuple_size<column_type::constraints_type>::value == 0);
+        STATIC_REQUIRE(std::is_same<column_type::object_type, User>::value);
+        STATIC_REQUIRE(std::is_same<column_type::field_type, int>::value);
+        STATIC_REQUIRE(std::is_same<column_type::member_pointer_t, int User::*>::value);
+        STATIC_REQUIRE(std::is_same<column_type::getter_type, int (User::*)() const>::value);
+        STATIC_REQUIRE(std::is_same<column_type::setter_type, void (User::*)(int&)>::value);
     }
     {
         using column_type = decltype(column<Token>(&Token::id));
-        static_assert(std::is_same<column_type::type, Token>::value, "Incorrect column type");
+        STATIC_REQUIRE(std::is_same<column_type::type, Token>::value);
         using field_type = column_type::field_type;
-        static_assert(std::is_same<field_type, decltype(&Object::id)>::value, "Incorrect field type");
-        static_assert(std::is_same<internal::table_type<field_type>::type, Object>::value, "Incorrect mapped type");
-        static_assert(std::is_same<internal::column_result_t<internal::storage_t<>, field_type>::type, int>::value,
-                      "Incorrect field type");
-        static_assert(std::is_member_pointer<field_type>::value, "Field type is not a member pointer");
-        static_assert(!std::is_member_function_pointer<field_type>::value, "Field type is not a member pointer");
+        STATIC_REQUIRE(std::is_same<field_type, decltype(&Object::id)>::value);
+        STATIC_REQUIRE(std::is_same<internal::table_type<field_type>::type, Object>::value);
+        STATIC_REQUIRE(std::is_same<internal::column_result_t<internal::storage_t<>, field_type>::type, int>::value);
+        STATIC_REQUIRE(std::is_member_pointer<field_type>::value);
+        STATIC_REQUIRE(!std::is_member_function_pointer<field_type>::value);
     }
 }

--- a/tests/static_tests/column_result_t.cpp
+++ b/tests/static_tests/column_result_t.cpp
@@ -5,7 +5,7 @@
 using namespace sqlite_orm;
 
 template<class St, class E, class V>
-void runTest(V value) {
+void runTest(V /*value*/) {
     using Type = typename internal::column_result_t<St, V>::type;
     STATIC_REQUIRE(std::is_same<Type, E>::value);
 }

--- a/tests/static_tests/compound_operators.cpp
+++ b/tests/static_tests/compound_operators.cpp
@@ -7,9 +7,11 @@ using namespace sqlite_orm;
 
 TEST_CASE("Compound operators") {
     auto unionValue = union_(select(&User::id), select(&Token::id));
-    static_assert(internal::is_base_of_template<decltype(unionValue), internal::compound_operator>::value,
-                  "union must be base of compound_operator");
+    STATIC_REQUIRE(internal::is_base_of_template<decltype(unionValue), internal::compound_operator>::value);
+    auto unionAllValue = union_all(select(&User::id), select(&Token::id));
+    STATIC_REQUIRE(internal::is_base_of_template<decltype(unionAllValue), internal::compound_operator>::value);
     auto exceptValue = except(select(&User::id), select(&Token::id));
-    static_assert(internal::is_base_of_template<decltype(exceptValue), internal::compound_operator>::value,
-                  "except must be base of compound_operator");
+    STATIC_REQUIRE(internal::is_base_of_template<decltype(exceptValue), internal::compound_operator>::value);
+    auto intersectValue = intersect(select(&User::id), select(&Token::id));
+    STATIC_REQUIRE(internal::is_base_of_template<decltype(intersectValue), internal::compound_operator>::value);
 }

--- a/tests/static_tests/function_static_tests.cpp
+++ b/tests/static_tests/function_static_tests.cpp
@@ -45,9 +45,8 @@ TEST_CASE("function static") {
                 STATIC_REQUIRE(std::is_same<ArgumentsTuple, ExpectedArgumentsTuple>::value);
 
                 STATIC_REQUIRE(std::is_same<internal::callable_arguments<Function>::return_type, double>::value);
-                static_assert(
-                    std::is_same<internal::callable_arguments<Function>::args_tuple, std::tuple<double>>::value,
-                    "");
+                STATIC_REQUIRE(
+                    std::is_same<internal::callable_arguments<Function>::args_tuple, std::tuple<double>>::value);
             }
             SECTION("double(double)") {
                 struct Function {
@@ -68,9 +67,8 @@ TEST_CASE("function static") {
                 STATIC_REQUIRE(std::is_same<ArgumentsTuple, ExpectedArgumentsTuple>::value);
 
                 STATIC_REQUIRE(std::is_same<internal::callable_arguments<Function>::return_type, double>::value);
-                static_assert(
-                    std::is_same<internal::callable_arguments<Function>::args_tuple, std::tuple<double>>::value,
-                    "");
+                STATIC_REQUIRE(
+                    std::is_same<internal::callable_arguments<Function>::args_tuple, std::tuple<double>>::value);
             }
             SECTION("int(std::string) const") {
                 struct Function {
@@ -91,9 +89,8 @@ TEST_CASE("function static") {
                 STATIC_REQUIRE(std::is_same<ArgumentsTuple, ExpectedArgumentsTuple>::value);
 
                 STATIC_REQUIRE(std::is_same<internal::callable_arguments<Function>::return_type, int>::value);
-                static_assert(
-                    std::is_same<internal::callable_arguments<Function>::args_tuple, std::tuple<std::string>>::value,
-                    "");
+                STATIC_REQUIRE(
+                    std::is_same<internal::callable_arguments<Function>::args_tuple, std::tuple<std::string>>::value);
             }
             SECTION("int(std::string)") {
                 struct Function {
@@ -114,9 +111,8 @@ TEST_CASE("function static") {
                 STATIC_REQUIRE(std::is_same<ArgumentsTuple, ExpectedArgumentsTuple>::value);
 
                 STATIC_REQUIRE(std::is_same<internal::callable_arguments<Function>::return_type, int>::value);
-                static_assert(
-                    std::is_same<internal::callable_arguments<Function>::args_tuple, std::tuple<std::string>>::value,
-                    "");
+                STATIC_REQUIRE(
+                    std::is_same<internal::callable_arguments<Function>::args_tuple, std::tuple<std::string>>::value);
             }
             SECTION("std::string(const std::string &, const std::string &) const") {
                 struct Function {
@@ -136,11 +132,9 @@ TEST_CASE("function static") {
                 using ExpectedArgumentsTuple = std::tuple<std::string, std::string>;
                 STATIC_REQUIRE(std::is_same<ArgumentsTuple, ExpectedArgumentsTuple>::value);
 
-                static_assert(std::is_same<internal::callable_arguments<Function>::return_type, std::string>::value,
-                              "");
-                static_assert(std::is_same<internal::callable_arguments<Function>::args_tuple,
-                                           std::tuple<std::string, std::string>>::value,
-                              "");
+                STATIC_REQUIRE(std::is_same<internal::callable_arguments<Function>::return_type, std::string>::value);
+                STATIC_REQUIRE(std::is_same<internal::callable_arguments<Function>::args_tuple,
+                                            std::tuple<std::string, std::string>>::value);
             }
             SECTION("std::string(const std::string &, const std::string &)") {
                 struct Function {
@@ -160,11 +154,9 @@ TEST_CASE("function static") {
                 using ExpectedArgumentsTuple = std::tuple<std::string, std::string>;
                 STATIC_REQUIRE(std::is_same<ArgumentsTuple, ExpectedArgumentsTuple>::value);
 
-                static_assert(std::is_same<internal::callable_arguments<Function>::return_type, std::string>::value,
-                              "");
-                static_assert(std::is_same<internal::callable_arguments<Function>::args_tuple,
-                                           std::tuple<std::string, std::string>>::value,
-                              "");
+                STATIC_REQUIRE(std::is_same<internal::callable_arguments<Function>::return_type, std::string>::value);
+                STATIC_REQUIRE(std::is_same<internal::callable_arguments<Function>::args_tuple,
+                                            std::tuple<std::string, std::string>>::value);
             }
         }
     }
@@ -223,9 +215,8 @@ TEST_CASE("function static") {
             STATIC_REQUIRE(std::is_same<FinMemberFunctionPointer, ExpectedFinType>::value);
 
             STATIC_REQUIRE(std::is_same<internal::callable_arguments<Function>::return_type, std::string>::value);
-            static_assert(
-                std::is_same<internal::callable_arguments<Function>::args_tuple, std::tuple<std::string>>::value,
-                "");
+            STATIC_REQUIRE(
+                std::is_same<internal::callable_arguments<Function>::args_tuple, std::tuple<std::string>>::value);
         }
     }
 }

--- a/tests/static_tests/is_bindable.cpp
+++ b/tests/static_tests/is_bindable.cpp
@@ -27,78 +27,78 @@ TEST_CASE("is_bindable") {
     struct User {
         int id;
     };
-    static_assert(is_bindable_v<bool>, "bool must be bindable");
-    static_assert(is_bindable_v<char>, "char must be bindable");
-    static_assert(is_bindable_v<signed char>, "char must be bindable");
-    static_assert(is_bindable_v<unsigned char>, "char must be bindable");
-    static_assert(is_bindable_v<short>, "short must be bindable");
-    static_assert(is_bindable_v<unsigned short>, "short must be bindable");
-    static_assert(is_bindable_v<int>, "int must be bindable");
-    static_assert(is_bindable_v<unsigned int>, "int must be bindable");
-    static_assert(is_bindable_v<long>, "long must be bindable");
-    static_assert(is_bindable_v<unsigned long>, "long must be bindable");
-    static_assert(is_bindable_v<float>, "float must be bindable");
-    static_assert(is_bindable_v<long long>, "long long must be bindable");
-    static_assert(is_bindable_v<unsigned long long>, "long long must be bindable");
-    static_assert(is_bindable_v<double>, "double must be bindable");
-    static_assert(is_bindable_v<const char*>, "C string must be bindable");
-    static_assert(is_bindable_v<std::string>, "string must be bindable");
-    static_assert(is_bindable_v<StringVeneer<char>>, "Derived string must be bindable");
+    STATIC_REQUIRE(is_bindable_v<bool>);
+    STATIC_REQUIRE(is_bindable_v<char>);
+    STATIC_REQUIRE(is_bindable_v<signed char>);
+    STATIC_REQUIRE(is_bindable_v<unsigned char>);
+    STATIC_REQUIRE(is_bindable_v<short>);
+    STATIC_REQUIRE(is_bindable_v<unsigned short>);
+    STATIC_REQUIRE(is_bindable_v<int>);
+    STATIC_REQUIRE(is_bindable_v<unsigned int>);
+    STATIC_REQUIRE(is_bindable_v<long>);
+    STATIC_REQUIRE(is_bindable_v<unsigned long>);
+    STATIC_REQUIRE(is_bindable_v<float>);
+    STATIC_REQUIRE(is_bindable_v<long long>);
+    STATIC_REQUIRE(is_bindable_v<unsigned long long>);
+    STATIC_REQUIRE(is_bindable_v<double>);
+    STATIC_REQUIRE(is_bindable_v<const char*>);
+    STATIC_REQUIRE(is_bindable_v<std::string>);
+    STATIC_REQUIRE(is_bindable_v<StringVeneer<char>>);
 #ifndef SQLITE_ORM_OMITS_CODECVT
-    static_assert(is_bindable_v<const wchar_t*>, "wide C string must be bindable");
-    static_assert(is_bindable_v<std::wstring>, "wstring must be bindable");
-    static_assert(is_bindable_v<StringVeneer<wchar_t>>, "Derived wstring must be bindable");
+    STATIC_REQUIRE(is_bindable_v<const wchar_t*>);
+    STATIC_REQUIRE(is_bindable_v<std::wstring>);
+    STATIC_REQUIRE(is_bindable_v<StringVeneer<wchar_t>>);
 #endif
-    static_assert(is_bindable_v<std::nullptr_t>, "null must be bindable");
-    static_assert(is_bindable_v<std::unique_ptr<int>>, "unique_ptr must be bindable");
-    static_assert(is_bindable_v<std::shared_ptr<int>>, "shared_ptr must be bindable");
+    STATIC_REQUIRE(is_bindable_v<std::nullptr_t>);
+    STATIC_REQUIRE(is_bindable_v<std::unique_ptr<int>>);
+    STATIC_REQUIRE(is_bindable_v<std::shared_ptr<int>>);
 #ifdef SQLITE_ORM_STRING_VIEW_SUPPORTED
-    static_assert(is_bindable_v<std::string_view>, "string view must be bindable");
+    STATIC_REQUIRE(is_bindable_v<std::string_view>);
 #ifndef SQLITE_ORM_OMITS_CODECVT
-    static_assert(is_bindable_v<std::wstring_view>, "wstring view must be bindable");
+    STATIC_REQUIRE(is_bindable_v<std::wstring_view>);
 #endif
 #endif
 #ifdef SQLITE_ORM_OPTIONAL_SUPPORTED
-    static_assert(is_bindable_v<std::nullopt_t>, "nullopt must be bindable");
-    static_assert(is_bindable_v<std::optional<int>>, "optional must be bindable");
-    static_assert(is_bindable_v<std::optional<Custom>>, "optional<Custom> must be bindable");
-    static_assert(!is_bindable_v<std::optional<User>>, "optional<User> cannot be bindable");
+    STATIC_REQUIRE(is_bindable_v<std::nullopt_t>);
+    STATIC_REQUIRE(is_bindable_v<std::optional<int>>);
+    STATIC_REQUIRE(is_bindable_v<std::optional<Custom>>);
+    STATIC_REQUIRE(!is_bindable_v<std::optional<User>>);
 #endif  // SQLITE_ORM_OPTIONAL_SUPPORTED
-    static_assert(is_bindable_v<static_pointer_binding<nullptr_t, carray_pvt>>, "pointer binding must be bindable");
+    STATIC_REQUIRE(is_bindable_v<static_pointer_binding<nullptr_t, carray_pvt>>);
 
-    static_assert(is_bindable_v<Custom>, "Custom must be bindable");
-    static_assert(is_bindable_v<std::unique_ptr<Custom>>, "unique_ptr<Custom> must be bindable");
+    STATIC_REQUIRE(is_bindable_v<Custom>);
+    STATIC_REQUIRE(is_bindable_v<std::unique_ptr<Custom>>);
 
-    static_assert(!is_bindable_v<void>, "void cannot be bindable");
-    static_assert(!is_bindable_v<User>, "User cannot be bindable");
-    static_assert(!is_bindable_v<std::unique_ptr<User>>, "unique_ptr<User> cannot be bindable");
+    STATIC_REQUIRE(!is_bindable_v<void>);
+    STATIC_REQUIRE(!is_bindable_v<User>);
+    STATIC_REQUIRE(!is_bindable_v<std::unique_ptr<User>>);
     {
         auto isEqual = is_equal(&User::id, 5);
-        static_assert(!is_bindable_v<decltype(isEqual)>, "is_equal cannot be bindable");
+        STATIC_REQUIRE(!is_bindable_v<decltype(isEqual)>);
     }
     {
         auto notEqual = is_not_equal(&User::id, 10);
-        static_assert(!is_bindable_v<decltype(notEqual)>, "is_not_equal cannot be bindable");
+        STATIC_REQUIRE(!is_bindable_v<decltype(notEqual)>);
     }
     {
         auto lesserThan = lesser_than(&User::id, 10);
-        static_assert(!is_bindable_v<decltype(lesserThan)>, "lesser_than cannot be bindable");
+        STATIC_REQUIRE(!is_bindable_v<decltype(lesserThan)>);
     }
     {
         auto lesserOrEqual = lesser_or_equal(&User::id, 5);
-        static_assert(!is_bindable_v<decltype(lesserOrEqual)>, "lesser_or_equal cannot be bindable");
+        STATIC_REQUIRE(!is_bindable_v<decltype(lesserOrEqual)>);
     }
     {
         auto greaterThan = greater_than(&User::id, 5);
-        static_assert(!is_bindable_v<decltype(greaterThan)>, "greater_than cannot be bindable");
+        STATIC_REQUIRE(!is_bindable_v<decltype(greaterThan)>);
     }
     {
         auto greaterOrEqual = greater_or_equal(&User::id, 5);
-        static_assert(!is_bindable_v<decltype(greaterOrEqual)>, "greater_or_equal cannot be bindable");
+        STATIC_REQUIRE(!is_bindable_v<decltype(greaterOrEqual)>);
     }
     {
         auto func = datetime("now");
-        static_assert(!is_bindable_v<decltype(func)>, "datetime cannot be bindable");
+        STATIC_REQUIRE(!is_bindable_v<decltype(func)>);
         bool trueCalled = false;
         bool falseCalled = false;
         auto dummy = 5;  //  for gcc compilation

--- a/tests/static_tests/is_column_with_insertable_primary_key.cpp
+++ b/tests/static_tests/is_column_with_insertable_primary_key.cpp
@@ -27,20 +27,17 @@ TEST_CASE("is_column_with_insertable_primary_key") {
     );
 
     iterate_tuple(insertable, [](auto& v) {
-        static_assert(internal::is_column_with_insertable_primary_key<typename std::decay<decltype(v)>::type>::value,
-                      "");
+        STATIC_REQUIRE(internal::is_column_with_insertable_primary_key<typename std::decay<decltype(v)>::type>::value);
     });
 
     iterate_tuple(noninsertable, [](auto& v) {
-        static_assert(internal::is_column_with_noninsertable_primary_key<typename std::decay<decltype(v)>::type>::value,
-                      "");
+        STATIC_REQUIRE(
+            internal::is_column_with_noninsertable_primary_key<typename std::decay<decltype(v)>::type>::value);
     });
 
     iterate_tuple(outside, [](auto& v) {
-        static_assert(!internal::is_column_with_insertable_primary_key<typename std::decay<decltype(v)>::type>::value,
-                      "");
-        static_assert(
-            !internal::is_column_with_noninsertable_primary_key<typename std::decay<decltype(v)>::type>::value,
-            "");
+        STATIC_REQUIRE(!internal::is_column_with_insertable_primary_key<typename std::decay<decltype(v)>::type>::value);
+        STATIC_REQUIRE(
+            !internal::is_column_with_noninsertable_primary_key<typename std::decay<decltype(v)>::type>::value);
     });
 }

--- a/tests/static_tests/is_printable.cpp
+++ b/tests/static_tests/is_printable.cpp
@@ -25,48 +25,47 @@ TEST_CASE("is_printable") {
     struct User {
         int id;
     };
-    static_assert(is_printable_v<bool>, "bool must be printable");
-    static_assert(is_printable_v<char>, "char must be printable");
-    static_assert(is_printable_v<signed char>, "char must be printable");
-    static_assert(is_printable_v<unsigned char>, "char must be printable");
-    static_assert(is_printable_v<short>, "short must be printable");
-    static_assert(is_printable_v<unsigned short>, "short must be printable");
-    static_assert(is_printable_v<int>, "int must be printable");
-    static_assert(is_printable_v<unsigned int>, "int must be printable");
-    static_assert(is_printable_v<long>, "long must be printable");
-    static_assert(is_printable_v<unsigned long>, "long must be printable");
-    static_assert(is_printable_v<float>, "float must be printable");
-    static_assert(is_printable_v<long long>, "long long must be printable");
-    static_assert(is_printable_v<unsigned long long>, "long long must be printable");
-    static_assert(is_printable_v<double>, "double must be printable");
-    static_assert(!is_printable_v<const char*>, "C string must not be printable");
-    static_assert(is_printable_v<std::string>, "string must be printable");
-    static_assert(is_printable_v<StringVeneer<char>>, "Derived string must be printable");
+    STATIC_REQUIRE(is_printable_v<bool>);
+    STATIC_REQUIRE(is_printable_v<char>);
+    STATIC_REQUIRE(is_printable_v<signed char>);
+    STATIC_REQUIRE(is_printable_v<unsigned char>);
+    STATIC_REQUIRE(is_printable_v<short>);
+    STATIC_REQUIRE(is_printable_v<unsigned short>);
+    STATIC_REQUIRE(is_printable_v<int>);
+    STATIC_REQUIRE(is_printable_v<unsigned int>);
+    STATIC_REQUIRE(is_printable_v<long>);
+    STATIC_REQUIRE(is_printable_v<unsigned long>);
+    STATIC_REQUIRE(is_printable_v<float>);
+    STATIC_REQUIRE(is_printable_v<long long>);
+    STATIC_REQUIRE(is_printable_v<unsigned long long>);
+    STATIC_REQUIRE(is_printable_v<double>);
+    STATIC_REQUIRE(!is_printable_v<const char*>);
+    STATIC_REQUIRE(is_printable_v<std::string>);
+    STATIC_REQUIRE(is_printable_v<StringVeneer<char>>);
 #ifndef SQLITE_ORM_OMITS_CODECVT
-    static_assert(!is_printable_v<const wchar_t*>, "wide C string must not be printable");
-    static_assert(is_printable_v<std::wstring>, "wstring must be printable");
-    static_assert(is_printable_v<StringVeneer<wchar_t>>, "Derived wstring must be printable");
+    STATIC_REQUIRE(!is_printable_v<const wchar_t*>);
+    STATIC_REQUIRE(is_printable_v<std::wstring>);
+    STATIC_REQUIRE(is_printable_v<StringVeneer<wchar_t>>);
 #endif
-    static_assert(is_printable_v<std::nullptr_t>, "null must be printable");
-    static_assert(is_printable_v<std::unique_ptr<int>>, "unique_ptr must be printable");
-    static_assert(is_printable_v<std::shared_ptr<int>>, "shared_ptr must be printable");
+    STATIC_REQUIRE(is_printable_v<std::nullptr_t>);
+    STATIC_REQUIRE(is_printable_v<std::unique_ptr<int>>);
+    STATIC_REQUIRE(is_printable_v<std::shared_ptr<int>>);
 #ifdef SQLITE_ORM_STRING_VIEW_SUPPORTED
-    static_assert(!is_printable_v<std::string_view>, "string view must not be printable");
-    static_assert(!is_printable_v<std::wstring_view>, "wstring view must not be printable");
+    STATIC_REQUIRE(!is_printable_v<std::string_view>);
+    STATIC_REQUIRE(!is_printable_v<std::wstring_view>);
 #endif
 #ifdef SQLITE_ORM_OPTIONAL_SUPPORTED
-    static_assert(is_printable_v<std::nullopt_t>, "nullopt must be printable");
-    static_assert(is_printable_v<std::optional<int>>, "optional must be printable");
-    static_assert(is_printable_v<std::optional<Custom>>, "optional<Custom> must be printable");
-    static_assert(!is_printable_v<std::optional<User>>, "optional<User> cannot be printable");
+    STATIC_REQUIRE(is_printable_v<std::nullopt_t>);
+    STATIC_REQUIRE(is_printable_v<std::optional<int>>);
+    STATIC_REQUIRE(is_printable_v<std::optional<Custom>>);
+    STATIC_REQUIRE(!is_printable_v<std::optional<User>>);
 #endif  // SQLITE_ORM_OPTIONAL_SUPPORTED
-    static_assert(!is_printable_v<static_pointer_binding<nullptr_t, carray_pvt>>,
-                  "pointer binding must not be printable");
+    STATIC_REQUIRE(!is_printable_v<static_pointer_binding<nullptr_t, carray_pvt>>);
 
-    static_assert(is_printable_v<Custom>, "Custom must be printable");
-    static_assert(is_printable_v<std::unique_ptr<Custom>>, "unique_ptr<Custom> must be printable");
+    STATIC_REQUIRE(is_printable_v<Custom>);
+    STATIC_REQUIRE(is_printable_v<std::unique_ptr<Custom>>);
 
-    static_assert(!is_printable_v<void>, "void cannot be printable");
-    static_assert(!is_printable_v<User>, "User cannot be printable");
-    static_assert(!is_printable_v<std::unique_ptr<User>>, "unique_ptr<User> cannot be printable");
+    STATIC_REQUIRE(!is_printable_v<void>);
+    STATIC_REQUIRE(!is_printable_v<User>);
+    STATIC_REQUIRE(!is_printable_v<std::unique_ptr<User>>);
 }

--- a/tests/static_tests/iterator_t.cpp
+++ b/tests/static_tests/iterator_t.cpp
@@ -17,20 +17,17 @@ TEST_CASE("iterator_t") {
     using iter = decltype(std::declval<storage>().iterate<User>().begin());
 
     // weakly_incrementable
-    static_assert(std::is_default_constructible<iter>::value, "needs to be default constructible");
-    static_assert(std::is_same<typename iter::difference_type, std::ptrdiff_t>::value, "needs to have difference_type");
-    static_assert(std::is_same<decltype(++std::declval<iter>()), iter&>::value, "needs to be incrementable");
+    STATIC_REQUIRE(std::is_default_constructible<iter>::value);
+    STATIC_REQUIRE(std::is_same<typename iter::difference_type, std::ptrdiff_t>::value);
+    STATIC_REQUIRE(std::is_same<decltype(++std::declval<iter>()), iter&>::value);
     using check = decltype(std::declval<iter>()++);
 
     // indirectly_readable
-    static_assert(std::is_same<decltype(*std::declval<const iter>()), const User&>::value,
-                  "needs to be const dereferencable");
+    STATIC_REQUIRE(std::is_same<decltype(*std::declval<const iter>()), const User&>::value);
 
     // input_iterator
-    static_assert(std::is_same<typename iter::iterator_category, std::input_iterator_tag>::value,
-                  "needs to have iterator_category");
+    STATIC_REQUIRE(std::is_same<iter::iterator_category, std::input_iterator_tag>::value);
 
-    // sentinel
-    static_assert(std::is_same<decltype(std::declval<const iter>() == std::declval<const iter>()), bool>::value,
-                  "supports equality checking");
+    // sentinel (equality comparable)
+    STATIC_REQUIRE(std::is_same<decltype(std::declval<const iter>() == std::declval<const iter>()), bool>::value);
 }

--- a/tests/static_tests/member_traits_tests.cpp
+++ b/tests/static_tests/member_traits_tests.cpp
@@ -12,6 +12,9 @@ TEST_CASE("member_traits_tests") {
     using internal::member_traits;
     using internal::setter_traits;
     using std::is_same;
+#if __cplusplus >= 201703L  // use of C++17 or higher
+    using std::is_same_v;
+#endif
 
     struct User {
         mutable int id = 0;
@@ -178,33 +181,23 @@ TEST_CASE("member_traits_tests") {
     STATIC_REQUIRE(is_same<typename getter_traits<decltype(&User::getIdByConstRef)>::object_type, User>::value);
     STATIC_REQUIRE(is_same<typename getter_traits<decltype(&User::getIdByConstRef)>::field_type, int>::value);
 #ifdef SQLITE_ORM_NOTHROW_ALIASES_SUPPORTED
-    static_assert(is_same<typename getter_traits<decltype(&User::getIdByValConstNoexcept)>::object_type, User>::value,
-                  "");
-    static_assert(is_same<typename getter_traits<decltype(&User::getIdByValConstNoexcept)>::field_type, int>::value,
-                  "");
+    STATIC_REQUIRE(is_same_v<typename getter_traits<decltype(&User::getIdByValConstNoexcept)>::object_type, User>);
+    STATIC_REQUIRE(is_same_v<typename getter_traits<decltype(&User::getIdByValConstNoexcept)>::field_type, int>);
 
-    STATIC_REQUIRE(is_same<typename getter_traits<decltype(&User::getIdByValNoexcept)>::object_type, User>::value);
-    STATIC_REQUIRE(is_same<typename getter_traits<decltype(&User::getIdByValNoexcept)>::field_type, int>::value);
+    STATIC_REQUIRE(is_same_v<typename getter_traits<decltype(&User::getIdByValNoexcept)>::object_type, User>);
+    STATIC_REQUIRE(is_same_v<typename getter_traits<decltype(&User::getIdByValNoexcept)>::field_type, int>);
 
-    static_assert(is_same<typename getter_traits<decltype(&User::getIdByRefConstNoexcept)>::object_type, User>::value,
-                  "");
-    static_assert(is_same<typename getter_traits<decltype(&User::getIdByRefConstNoexcept)>::field_type, int>::value,
-                  "");
+    STATIC_REQUIRE(is_same_v<typename getter_traits<decltype(&User::getIdByRefConstNoexcept)>::object_type, User>);
+    STATIC_REQUIRE(is_same_v<typename getter_traits<decltype(&User::getIdByRefConstNoexcept)>::field_type, int>);
 
-    STATIC_REQUIRE(is_same<typename getter_traits<decltype(&User::getIdByRefNoexcept)>::object_type, User>::value);
-    STATIC_REQUIRE(is_same<typename getter_traits<decltype(&User::getIdByRefNoexcept)>::field_type, int>::value);
+    STATIC_REQUIRE(is_same_v<typename getter_traits<decltype(&User::getIdByRefNoexcept)>::object_type, User>);
+    STATIC_REQUIRE(is_same_v<typename getter_traits<decltype(&User::getIdByRefNoexcept)>::field_type, int>);
 
-    static_assert(
-        is_same<typename getter_traits<decltype(&User::getIdByConstRefConstNoexcept)>::object_type, User>::value,
-        "");
-    static_assert(
-        is_same<typename getter_traits<decltype(&User::getIdByConstRefConstNoexcept)>::field_type, int>::value,
-        "");
+    STATIC_REQUIRE(is_same_v<typename getter_traits<decltype(&User::getIdByConstRefConstNoexcept)>::object_type, User>);
+    STATIC_REQUIRE(is_same_v<typename getter_traits<decltype(&User::getIdByConstRefConstNoexcept)>::field_type, int>);
 
-    static_assert(is_same<typename getter_traits<decltype(&User::getIdByConstRefNoExcept)>::object_type, User>::value,
-                  "");
-    static_assert(is_same<typename getter_traits<decltype(&User::getIdByConstRefNoExcept)>::field_type, int>::value,
-                  "");
+    STATIC_REQUIRE(is_same_v<typename getter_traits<decltype(&User::getIdByConstRefNoExcept)>::object_type, User>);
+    STATIC_REQUIRE(is_same_v<typename getter_traits<decltype(&User::getIdByConstRefNoExcept)>::field_type, int>);
 #endif
     STATIC_REQUIRE(is_same<typename setter_traits<decltype(&User::setIdByVal)>::object_type, User>::value);
     STATIC_REQUIRE(is_same<typename setter_traits<decltype(&User::setIdByVal)>::field_type, int>::value);
@@ -215,16 +208,14 @@ TEST_CASE("member_traits_tests") {
     STATIC_REQUIRE(is_same<typename setter_traits<decltype(&User::setIdByConstRef)>::object_type, User>::value);
     STATIC_REQUIRE(is_same<typename setter_traits<decltype(&User::setIdByConstRef)>::field_type, int>::value);
 #ifdef SQLITE_ORM_NOTHROW_ALIASES_SUPPORTED
-    STATIC_REQUIRE(is_same<typename setter_traits<decltype(&User::setIdByValueNoexcept)>::object_type, User>::value);
-    STATIC_REQUIRE(is_same<typename setter_traits<decltype(&User::setIdByValueNoexcept)>::field_type, int>::value);
+    STATIC_REQUIRE(is_same_v<typename setter_traits<decltype(&User::setIdByValueNoexcept)>::object_type, User>);
+    STATIC_REQUIRE(is_same_v<typename setter_traits<decltype(&User::setIdByValueNoexcept)>::field_type, int>);
 
-    STATIC_REQUIRE(is_same<typename setter_traits<decltype(&User::setIdByRefNoExcept)>::object_type, User>::value);
-    STATIC_REQUIRE(is_same<typename setter_traits<decltype(&User::setIdByRefNoExcept)>::field_type, int>::value);
+    STATIC_REQUIRE(is_same_v<typename setter_traits<decltype(&User::setIdByRefNoExcept)>::object_type, User>);
+    STATIC_REQUIRE(is_same_v<typename setter_traits<decltype(&User::setIdByRefNoExcept)>::field_type, int>);
 
-    static_assert(is_same<typename setter_traits<decltype(&User::setIdByConstRefNoexcept)>::object_type, User>::value,
-                  "");
-    static_assert(is_same<typename setter_traits<decltype(&User::setIdByConstRefNoexcept)>::field_type, int>::value,
-                  "");
+    STATIC_REQUIRE(is_same_v<typename setter_traits<decltype(&User::setIdByConstRefNoexcept)>::object_type, User>);
+    STATIC_REQUIRE(is_same_v<typename setter_traits<decltype(&User::setIdByConstRefNoexcept)>::field_type, int>);
 #endif
     STATIC_REQUIRE(is_same<typename field_member_traits<decltype(&User::id)>::object_type, User>::value);
     STATIC_REQUIRE(is_same<typename field_member_traits<decltype(&User::id)>::field_type, int>::value);
@@ -247,33 +238,23 @@ TEST_CASE("member_traits_tests") {
     STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::getIdByConstRef)>::object_type, User>::value);
     STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::getIdByConstRef)>::field_type, int>::value);
 #ifdef SQLITE_ORM_NOTHROW_ALIASES_SUPPORTED
-    static_assert(is_same<typename member_traits<decltype(&User::getIdByValConstNoexcept)>::object_type, User>::value,
-                  "");
-    static_assert(is_same<typename member_traits<decltype(&User::getIdByValConstNoexcept)>::field_type, int>::value,
-                  "");
+    STATIC_REQUIRE(is_same_v<typename member_traits<decltype(&User::getIdByValConstNoexcept)>::object_type, User>);
+    STATIC_REQUIRE(is_same_v<typename member_traits<decltype(&User::getIdByValConstNoexcept)>::field_type, int>);
 
-    STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::getIdByValNoexcept)>::object_type, User>::value);
-    STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::getIdByValNoexcept)>::field_type, int>::value);
+    STATIC_REQUIRE(is_same_v<typename member_traits<decltype(&User::getIdByValNoexcept)>::object_type, User>);
+    STATIC_REQUIRE(is_same_v<typename member_traits<decltype(&User::getIdByValNoexcept)>::field_type, int>);
 
-    static_assert(is_same<typename member_traits<decltype(&User::getIdByRefConstNoexcept)>::object_type, User>::value,
-                  "");
-    static_assert(is_same<typename member_traits<decltype(&User::getIdByRefConstNoexcept)>::field_type, int>::value,
-                  "");
+    STATIC_REQUIRE(is_same_v<typename member_traits<decltype(&User::getIdByRefConstNoexcept)>::object_type, User>);
+    STATIC_REQUIRE(is_same_v<typename member_traits<decltype(&User::getIdByRefConstNoexcept)>::field_type, int>);
 
-    STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::getIdByRefNoexcept)>::object_type, User>::value);
-    STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::getIdByRefNoexcept)>::field_type, int>::value);
+    STATIC_REQUIRE(is_same_v<typename member_traits<decltype(&User::getIdByRefNoexcept)>::object_type, User>);
+    STATIC_REQUIRE(is_same_v<typename member_traits<decltype(&User::getIdByRefNoexcept)>::field_type, int>);
 
-    static_assert(
-        is_same<typename member_traits<decltype(&User::getIdByConstRefConstNoexcept)>::object_type, User>::value,
-        "");
-    static_assert(
-        is_same<typename member_traits<decltype(&User::getIdByConstRefConstNoexcept)>::field_type, int>::value,
-        "");
+    STATIC_REQUIRE(is_same_v<typename member_traits<decltype(&User::getIdByConstRefConstNoexcept)>::object_type, User>);
+    STATIC_REQUIRE(is_same_v<typename member_traits<decltype(&User::getIdByConstRefConstNoexcept)>::field_type, int>);
 
-    static_assert(is_same<typename member_traits<decltype(&User::getIdByConstRefNoExcept)>::object_type, User>::value,
-                  "");
-    static_assert(is_same<typename member_traits<decltype(&User::getIdByConstRefNoExcept)>::field_type, int>::value,
-                  "");
+    STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::getIdByConstRefNoExcept)>::object_type, User>::value);
+    STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::getIdByConstRefNoExcept)>::field_type, int>::value);
 #endif
     STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::setIdByVal)>::object_type, User>::value);
     STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::setIdByVal)>::field_type, int>::value);
@@ -284,15 +265,13 @@ TEST_CASE("member_traits_tests") {
     STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::setIdByConstRef)>::object_type, User>::value);
     STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::setIdByConstRef)>::field_type, int>::value);
 #ifdef SQLITE_ORM_NOTHROW_ALIASES_SUPPORTED
-    STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::setIdByValueNoexcept)>::object_type, User>::value);
-    STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::setIdByValueNoexcept)>::field_type, int>::value);
+    STATIC_REQUIRE(is_same_v<typename member_traits<decltype(&User::setIdByValueNoexcept)>::object_type, User>);
+    STATIC_REQUIRE(is_same_v<typename member_traits<decltype(&User::setIdByValueNoexcept)>::field_type, int>);
 
-    STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::setIdByRefNoExcept)>::object_type, User>::value);
-    STATIC_REQUIRE(is_same<typename member_traits<decltype(&User::setIdByRefNoExcept)>::field_type, int>::value);
+    STATIC_REQUIRE(is_same_v<typename member_traits<decltype(&User::setIdByRefNoExcept)>::object_type, User>);
+    STATIC_REQUIRE(is_same_v<typename member_traits<decltype(&User::setIdByRefNoExcept)>::field_type, int>);
 
-    static_assert(is_same<typename member_traits<decltype(&User::setIdByConstRefNoexcept)>::object_type, User>::value,
-                  "");
-    static_assert(is_same<typename member_traits<decltype(&User::setIdByConstRefNoexcept)>::field_type, int>::value,
-                  "");
+    STATIC_REQUIRE(is_same_v<typename member_traits<decltype(&User::setIdByConstRefNoexcept)>::object_type, User>);
+    STATIC_REQUIRE(is_same_v<typename member_traits<decltype(&User::setIdByConstRefNoexcept)>::field_type, int>);
 #endif
 }

--- a/tests/static_tests/node_tuple.cpp
+++ b/tests/static_tests/node_tuple.cpp
@@ -387,16 +387,14 @@ TEST_CASE("Node tuple") {
             replace(into<User>(), columns(&User::id, &User::name), values(std::make_tuple(1, std::string("Ellie"))));
         using Expression = decltype(expression);
         using Tuple = node_tuple<Expression>::type;
-        static_assert(is_same<Tuple, std::tuple<decltype(&User::id), decltype(&User::name), int, std::string>>::value,
-                      "");
+        STATIC_REQUIRE(is_same<Tuple, std::tuple<decltype(&User::id), decltype(&User::name), int, std::string>>::value);
     }
     SECTION("insert_raw_t") {
         auto expression =
             insert(into<User>(), columns(&User::id, &User::name), values(std::make_tuple(1, std::string("Ellie"))));
         using Expression = decltype(expression);
         using Tuple = node_tuple<Expression>::type;
-        static_assert(is_same<Tuple, std::tuple<decltype(&User::id), decltype(&User::name), int, std::string>>::value,
-                      "");
+        STATIC_REQUIRE(is_same<Tuple, std::tuple<decltype(&User::id), decltype(&User::name), int, std::string>>::value);
     }
     SECTION("tuple") {
         auto expression = std::make_tuple(1, std::string("hi"));

--- a/tests/static_tests/same_or_void.cpp
+++ b/tests/static_tests/same_or_void.cpp
@@ -10,26 +10,25 @@ TEST_CASE("same_or_void") {
     using internal::same_or_void;
 
     //  one argument
-    static_assert(std::is_same<same_or_void<int>::type, int>::value, "int");
-    static_assert(std::is_same<same_or_void<std::string>::type, std::string>::value, "std::string");
-    static_assert(std::is_same<same_or_void<long>::type, long>::value, "long");
+    STATIC_REQUIRE(std::is_same<same_or_void<int>::type, int>::value);
+    STATIC_REQUIRE(std::is_same<same_or_void<std::string>::type, std::string>::value);
+    STATIC_REQUIRE(std::is_same<same_or_void<long>::type, long>::value);
 
     //  two arguments
-    static_assert(std::is_same<same_or_void<int, int>::type, int>::value, "int, int");
-    static_assert(std::is_same<same_or_void<int, long>::type, void>::value, "int, long");
-    static_assert(std::is_same<same_or_void<std::string, std::string>::type, std::string>::value,
-                  "std::string, std::string");
-    static_assert(std::is_same<same_or_void<std::string, short>::type, void>::value, "std::string, short");
+    STATIC_REQUIRE(std::is_same<same_or_void<int, int>::type, int>::value);
+    STATIC_REQUIRE(std::is_same<same_or_void<int, long>::type, void>::value);
+    STATIC_REQUIRE(std::is_same<same_or_void<std::string, std::string>::type, std::string>::value);
+    STATIC_REQUIRE(std::is_same<same_or_void<std::string, short>::type, void>::value);
 
     //  three arguments
-    static_assert(std::is_same<same_or_void<int, int, int>::type, int>::value, "int, int, int");
-    static_assert(std::is_same<same_or_void<long, long, long>::type, long>::value, "long, long, long");
-    static_assert(std::is_same<same_or_void<int, int, long>::type, void>::value, "int, int, long");
-    static_assert(std::is_same<same_or_void<long, int, int>::type, void>::value, "long, int, int");
-    static_assert(std::is_same<same_or_void<long, int, long>::type, void>::value, "long, int, long");
+    STATIC_REQUIRE(std::is_same<same_or_void<int, int, int>::type, int>::value);
+    STATIC_REQUIRE(std::is_same<same_or_void<long, long, long>::type, long>::value);
+    STATIC_REQUIRE(std::is_same<same_or_void<int, int, long>::type, void>::value);
+    STATIC_REQUIRE(std::is_same<same_or_void<long, int, int>::type, void>::value);
+    STATIC_REQUIRE(std::is_same<same_or_void<long, int, long>::type, void>::value);
 
     //  four arguments
-    static_assert(std::is_same<same_or_void<int, int, int, int>::type, int>::value, "int, int, int, int");
-    static_assert(std::is_same<same_or_void<long, long, long, long>::type, long>::value, "long, long, long, long");
-    static_assert(std::is_same<same_or_void<int, int, int, long>::type, void>::value, "int, int, int, long");
+    STATIC_REQUIRE(std::is_same<same_or_void<int, int, int, int>::type, int>::value);
+    STATIC_REQUIRE(std::is_same<same_or_void<long, long, long, long>::type, long>::value);
+    STATIC_REQUIRE(std::is_same<same_or_void<int, int, int, long>::type, void>::value);
 }

--- a/tests/static_tests/select_return_type.cpp
+++ b/tests/static_tests/select_return_type.cpp
@@ -11,15 +11,14 @@ TEST_CASE("Select return types") {
     storage.sync_schema();
     {
         using SelectVectorInt = decltype(storage.select(&User::id));
-        static_assert(std::is_same<SelectVectorInt, std::vector<int>>::value, "Incorrect select id vector type");
+        STATIC_REQUIRE(std::is_same<SelectVectorInt, std::vector<int>>::value);
 
         using SelectVectorTuple = decltype(storage.select(columns(&User::id)));
         auto ids = storage.select(columns(&User::id));
         STATIC_REQUIRE(std::is_same<decltype(ids), SelectVectorTuple>::value);
-        static_assert(std::is_same<SelectVectorTuple, std::vector<std::tuple<int>>>::value,
-                      "Incorrect select id vector type");
+        STATIC_REQUIRE(std::is_same<SelectVectorTuple, std::vector<std::tuple<int>>>::value);
         using IdsTuple = SelectVectorTuple::value_type;
-        static_assert(std::tuple_size<IdsTuple>::value == 1, "Incorrect tuple size");
+        STATIC_REQUIRE(std::tuple_size<IdsTuple>::value == 1);
     }
     {
         //  test storage traits
@@ -30,38 +29,32 @@ TEST_CASE("Select return types") {
         using namespace sqlite_orm::internal::storage_traits;
 
         //  test type_is_mapped
-        static_assert(type_is_mapped<decltype(storage), User>::value, "User must be mapped to a storage");
-        static_assert(!type_is_mapped<decltype(storage), Visit>::value, "User must be mapped to a storage");
+        STATIC_REQUIRE(type_is_mapped<decltype(storage), User>::value);
+        STATIC_REQUIRE(!type_is_mapped<decltype(storage), Visit>::value);
 
         //  test is_storage
-        static_assert(internal::is_storage<decltype(storage)>::value, "is_storage works incorrectly");
-        static_assert(!internal::is_storage<User>::value, "is_storage works incorrectly");
-        static_assert(!internal::is_storage<int>::value, "is_storage works incorrectly");
-        static_assert(!internal::is_storage<void>::value, "is_storage works incorrectly");
+        STATIC_REQUIRE(internal::is_storage<decltype(storage)>::value);
+        STATIC_REQUIRE(!internal::is_storage<User>::value);
+        STATIC_REQUIRE(!internal::is_storage<int>::value);
+        STATIC_REQUIRE(!internal::is_storage<void>::value);
 
         auto storage2 = make_storage(
             "",
             make_table("visits", make_column("id", &Visit::id, primary_key()), make_column("date", &Visit::date)));
 
         //  test storage_columns_count
-        static_assert(storage_columns_count<decltype(storage), User>::value == 1,
-                      "Incorrect storage columns count value");
-        static_assert(storage_columns_count<decltype(storage), Visit>::value == 0,
-                      "Incorrect storage columns count value");
-        static_assert(storage_columns_count<decltype(storage2), Visit>::value == 2,
-                      "Incorrect storage columns count value");
+        STATIC_REQUIRE(storage_columns_count<decltype(storage), User>::value == 1);
+        STATIC_REQUIRE(storage_columns_count<decltype(storage), Visit>::value == 0);
+        STATIC_REQUIRE(storage_columns_count<decltype(storage2), Visit>::value == 2);
 
         //  test storage mapped columns
-        using UserColumnsTuple = storage_mapped_columns<decltype(storage), User>::type;
-        static_assert(std::is_same<UserColumnsTuple, std::tuple<int>>::value,
-                      "Incorrect storage_mapped_columns result");
+        using MappedUserColumnsTypes = storage_mapped_columns<decltype(storage), User>::type;
+        STATIC_REQUIRE(std::is_same<MappedUserColumnsTypes, std::tuple<int>>::value);
 
-        using VisitColumsEmptyType = storage_mapped_columns<decltype(storage), Visit>::type;
-        static_assert(std::is_same<VisitColumsEmptyType, std::tuple<>>::value,
-                      "Incorrect storage_mapped_columns result");
+        using MappedVisitColumnsEmpty = storage_mapped_columns<decltype(storage), Visit>::type;
+        STATIC_REQUIRE(std::is_same<MappedVisitColumnsEmpty, std::tuple<>>::value);
 
-        using VisitColumnTypes = storage_mapped_columns<decltype(storage2), Visit>::type;
-        static_assert(std::is_same<VisitColumnTypes, std::tuple<int, std::string>>::value,
-                      "Incorrect storage_mapped_columns result");
+        using MappedVisitColumnTypes = storage_mapped_columns<decltype(storage2), Visit>::type;
+        STATIC_REQUIRE(std::is_same<MappedVisitColumnTypes, std::tuple<int, std::string>>::value);
     }
 }

--- a/tests/static_tests/tuple_conc.cpp
+++ b/tests/static_tests/tuple_conc.cpp
@@ -10,52 +10,50 @@ TEST_CASE("Tuple conc") {
     {
         using TupleL = std::tuple<int>;
         using TupleR = std::tuple<std::string>;
-        using ConcRes = conc_tuple<TupleL, TupleR>::type;
-        static_assert(std::is_same<ConcRes, std::tuple<int, std::string>>::value, "int + string didn't work");
+        using IntStringTuple = conc_tuple<TupleL, TupleR>::type;
+        STATIC_REQUIRE(std::is_same<IntStringTuple, std::tuple<int, std::string>>::value);
     }
     {
         using TupleL = std::tuple<int>;
         using TupleR = std::tuple<float>;
-        using ConcRes = conc_tuple<TupleL, TupleR>::type;
-        static_assert(std::is_same<ConcRes, std::tuple<int, float>>::value, "int + float didn't work");
+        using IntFloatTuple = conc_tuple<TupleL, TupleR>::type;
+        STATIC_REQUIRE(std::is_same<IntFloatTuple, std::tuple<int, float>>::value);
     }
     {
         using TupleL = std::tuple<>;
         using TupleR = std::tuple<float>;
-        using ConcRes = conc_tuple<TupleL, TupleR>::type;
-        static_assert(std::is_same<ConcRes, std::tuple<float>>::value, "none + float didn't work");
+        using NoneFloatTuple = conc_tuple<TupleL, TupleR>::type;
+        STATIC_REQUIRE(std::is_same<NoneFloatTuple, std::tuple<float>>::value);
     }
     {
         using TupleL = std::tuple<>;
         using TupleR = std::tuple<>;
-        using ConcRes = conc_tuple<TupleL, TupleR>::type;
-        static_assert(std::is_same<ConcRes, std::tuple<>>::value, "none + none didn't work");
+        using NoneNoneTuple = conc_tuple<TupleL, TupleR>::type;
+        STATIC_REQUIRE(std::is_same<NoneNoneTuple, std::tuple<>>::value);
     }
     {
         using TupleL = std::tuple<int, float>;
         using TupleR = std::tuple<double>;
-        using ConcRes = conc_tuple<TupleL, TupleR>::type;
-        static_assert(std::is_same<ConcRes, std::tuple<int, float, double>>::value, "int, float + double didn't work");
+        using IntFloatDoubleTuple = conc_tuple<TupleL, TupleR>::type;
+        STATIC_REQUIRE(std::is_same<IntFloatDoubleTuple, std::tuple<int, float, double>>::value);
     }
     {
         using Arg = std::tuple<int>;
-        using ConcRes = conc_tuple<Arg>::type;
-        static_assert(std::is_same<Arg, ConcRes>::value, "Single argument is incorrect");
+        using SingleArgTuple = conc_tuple<Arg>::type;
+        STATIC_REQUIRE(std::is_same<Arg, SingleArgTuple>::value);
     }
     {
         using Arg1 = std::tuple<int>;
         using Arg2 = std::tuple<float>;
         using Arg3 = std::tuple<std::string>;
-        using ConcRes = conc_tuple<Arg1, Arg2, Arg3>::type;
-        using Expected = std::tuple<int, float, std::string>;
-        static_assert(std::is_same<Expected, ConcRes>::value, "int + float + std::string");
+        using IntFloatStringTuple = conc_tuple<Arg1, Arg2, Arg3>::type;
+        STATIC_REQUIRE(std::is_same<IntFloatStringTuple, std::tuple<int, float, std::string>>::value);
     }
     {
         using Arg1 = std::tuple<int>;
         using Arg2 = std::tuple<float>;
         using Arg3 = std::tuple<>;
-        using ConcRes = conc_tuple<Arg1, Arg2, Arg3>::type;
-        using Expected = std::tuple<int, float>;
-        static_assert(std::is_same<Expected, ConcRes>::value, "int + float + (empty)");
+        using IntFloatEmptyTuple = conc_tuple<Arg1, Arg2, Arg3>::type;
+        STATIC_REQUIRE(std::is_same<IntFloatEmptyTuple, std::tuple<int, float>>::value);
     }
 }

--- a/tests/tests2.cpp
+++ b/tests/tests2.cpp
@@ -726,7 +726,7 @@ TEST_CASE("obtain_xdestroy_for") {
         };
         using lambda4_2_t = std::remove_const_t<decltype(lambda4_2)>;
         constexpr xdestroy_fn_t xDestroy4_2 = obtain_xdestroy_for(lambda4_2, int_nullptr);
-        static_assert(xDestroy4_2 == xdestroy_proxy<lambda4_2_t, int>);
+        STATIC_REQUIRE(xDestroy4_2 == xdestroy_proxy<lambda4_2_t, int>);
         REQUIRE((xDestroy4_2 == xdestroy_proxy<lambda4_2_t, int>));
 #endif
 


### PR DESCRIPTION
Still missing: static assertions from _tests/static_tests/node_tuple.cpp_ due to keeping more meaningful assertion messages.