### PR TITLE
Amending select * from table alias

### DIFF
--- a/dev/column_names_getter.h
+++ b/dev/column_names_getter.h
@@ -34,8 +34,8 @@ namespace sqlite_orm {
 
         template<class T, class C>
         std::vector<std::string> get_column_names(const T& t, const C& context) {
-            column_names_getter<T> serializator;
-            return serializator(t, context);
+            column_names_getter<T> serializer;
+            return serializer(t, context);
         }
 
         template<class T>

--- a/dev/column_names_getter.h
+++ b/dev/column_names_getter.h
@@ -49,14 +49,22 @@ namespace sqlite_orm {
         };
 
         template<class T>
-        struct column_names_getter<asterisk_t<T>, void> {
+        struct column_names_getter<asterisk_t<T>, match_if_not<std::is_base_of, alias_tag, T>> {
             using expression_type = asterisk_t<T>;
 
             template<class C>
-            std::vector<std::string> operator()(const expression_type&, const C&) const {
-                std::vector<std::string> res;
-                res.push_back("*");
-                return res;
+            std::vector<std::string> operator()(const expression_type&, const C&) {
+                return {"*"};
+            }
+        };
+
+        template<class A>
+        struct column_names_getter<asterisk_t<A>, match_if<std::is_base_of, alias_tag, A>> {
+            using expression_type = asterisk_t<A>;
+
+            template<class C>
+            std::vector<std::string> operator()(const expression_type&, const C&) {
+                return {"'" + alias_extractor<A>::get() + "'.*"};
             }
         };
 
@@ -66,9 +74,7 @@ namespace sqlite_orm {
 
             template<class C>
             std::vector<std::string> operator()(const expression_type&, const C&) const {
-                std::vector<std::string> res;
-                res.push_back("*");
-                return res;
+                return {"*"};
             }
         };
 

--- a/dev/column_names_getter.h
+++ b/dev/column_names_getter.h
@@ -20,7 +20,7 @@ namespace sqlite_orm {
             using expression_type = T;
 
             template<class C>
-            std::vector<std::string> operator()(const expression_type& t, const C& context) {
+            std::vector<std::string> operator()(const expression_type& t, const C& context) const {
                 auto newContext = context;
                 newContext.skip_table_name = false;
                 auto columnName = serialize(t, newContext);
@@ -43,7 +43,7 @@ namespace sqlite_orm {
             using expression_type = std::reference_wrapper<T>;
 
             template<class C>
-            std::vector<std::string> operator()(const expression_type& expression, const C& context) {
+            std::vector<std::string> operator()(const expression_type& expression, const C& context) const {
                 return get_column_names(expression.get(), context);
             }
         };
@@ -53,7 +53,7 @@ namespace sqlite_orm {
             using expression_type = asterisk_t<T>;
 
             template<class C>
-            std::vector<std::string> operator()(const expression_type&, const C&) {
+            std::vector<std::string> operator()(const expression_type&, const C&) const {
                 std::vector<std::string> res;
                 res.push_back("*");
                 return res;
@@ -65,7 +65,7 @@ namespace sqlite_orm {
             using expression_type = object_t<T>;
 
             template<class C>
-            std::vector<std::string> operator()(const expression_type&, const C&) {
+            std::vector<std::string> operator()(const expression_type&, const C&) const {
                 std::vector<std::string> res;
                 res.push_back("*");
                 return res;
@@ -77,7 +77,7 @@ namespace sqlite_orm {
             using expression_type = columns_t<Args...>;
 
             template<class C>
-            std::vector<std::string> operator()(const expression_type& cols, const C& context) {
+            std::vector<std::string> operator()(const expression_type& cols, const C& context) const {
                 std::vector<std::string> columnNames;
                 columnNames.reserve(static_cast<size_t>(cols.count));
                 auto newContext = context;

--- a/dev/column_result.h
+++ b/dev/column_result.h
@@ -4,6 +4,7 @@
 #include <tuple>  //  std::tuple
 #include <functional>  //  std::reference_wrapper
 
+#include "type_traits.h"
 #include "core_functions.h"
 #include "select_constraints.h"
 #include "operators.h"
@@ -267,8 +268,13 @@ namespace sqlite_orm {
         struct column_result_t<St, as_t<T, E>, void> : column_result_t<St, typename std::decay<E>::type, void> {};
 
         template<class St, class T>
-        struct column_result_t<St, asterisk_t<T>, void> {
-            using type = typename storage_traits::storage_mapped_columns<St, typename mapped_type_proxy<T>::type>::type;
+        struct column_result_t<St, asterisk_t<T>, match_if_not<std::is_base_of, alias_tag, T>> {
+            using type = typename storage_traits::storage_mapped_columns<St, T>::type;
+        };
+
+        template<class St, class A>
+        struct column_result_t<St, asterisk_t<A>, match_if<std::is_base_of, alias_tag, A>> {
+            using type = typename storage_traits::storage_mapped_columns<St, type_t<A>>::type;
         };
 
         template<class St, class T>

--- a/dev/conditions.h
+++ b/dev/conditions.h
@@ -511,7 +511,7 @@ namespace sqlite_orm {
         };
 
         /**
-         *  C - serializator context class
+         *  C - serializer context class
          */
         template<class C>
         struct dynamic_order_by_t : order_by_string {

--- a/dev/cxx_polyfill.h
+++ b/dev/cxx_polyfill.h
@@ -48,6 +48,43 @@ namespace sqlite_orm {
 #else
             using std::is_specialization_of, std::is_specialization_of_t, std::is_specialization_of_v;
 #endif
+#if 1  // library fundamentals TS v2, [meta.detect]
+            struct nonesuch {
+                ~nonesuch() = delete;
+                nonesuch(const nonesuch&) = delete;
+                void operator=(const nonesuch&) = delete;
+            };
+
+            template<class Default, class AlwaysVoid, template<class...> class Op, class... Args>
+            struct detector {
+                using value_t = std::false_type;
+                using type = Default;
+            };
+
+            template<class Default, template<class...> class Op, class... Args>
+            struct detector<Default, polyfill::void_t<Op<Args...>>, Op, Args...> {
+                using value_t = std::true_type;
+                using type = Op<Args...>;
+            };
+
+            template<template<class...> class Op, class... Args>
+            using is_detected = typename detector<nonesuch, void, Op, Args...>::value_t;
+
+            template<template<class...> class Op, class... Args>
+            using detected = detector<nonesuch, void, Op, Args...>;
+
+            template<template<class...> class Op, class... Args>
+            using detected_t = typename detector<nonesuch, void, Op, Args...>::type;
+
+            template<class Default, template<class...> class Op, class... Args>
+            using detected_or = detector<Default, void, Op, Args...>;
+
+            template<class Default, template<class...> class Op, class... Args>
+            using detected_or_t = typename detected_or<Default, Op, Args...>::type;
+
+            template<template<class...> class Op, class... Args>
+            SQLITE_ORM_INLINE_VAR constexpr bool is_detected_v = is_detected<Op, Args...>::value;
+#endif
 
             template<typename...>
             SQLITE_ORM_INLINE_VAR constexpr bool always_false_v = false;

--- a/dev/order_by_serializator.h
+++ b/dev/order_by_serializator.h
@@ -13,8 +13,8 @@ namespace sqlite_orm {
 
         template<class T, class C>
         std::string serialize_order_by(const T& t, const C& context) {
-            order_by_serializator<T> serializator;
-            return serializator(t, context);
+            order_by_serializator<T> serializer;
+            return serializer(t, context);
         }
 
         template<class O>

--- a/dev/order_by_serializator.h
+++ b/dev/order_by_serializator.h
@@ -28,15 +28,15 @@ namespace sqlite_orm {
                 newContext.skip_table_name = false;
                 auto columnName = serialize(orderBy.expression, newContext);
                 ss << columnName << " ";
-                if(orderBy._collate_argument.length()) {
-                    ss << "COLLATE " << orderBy._collate_argument << " ";
+                if(!orderBy._collate_argument.empty()) {
+                    ss << " COLLATE " << orderBy._collate_argument;
                 }
                 switch(orderBy.asc_desc) {
                     case 1:
-                        ss << "ASC";
+                        ss << " ASC";
                         break;
                     case -1:
-                        ss << "DESC";
+                        ss << " DESC";
                         break;
                 }
                 return ss.str();

--- a/dev/statement_serializator.h
+++ b/dev/statement_serializator.h
@@ -47,8 +47,8 @@ namespace sqlite_orm {
 
         template<class T, class C>
         std::string serialize(const T& t, const C& context) {
-            statement_serializator<T> serializator;
-            return serializator(t, context);
+            statement_serializator<T> serializer;
+            return serializer(t, context);
         }
 
         /**

--- a/dev/statement_serializator.h
+++ b/dev/statement_serializator.h
@@ -316,7 +316,7 @@ namespace sqlite_orm {
             std::string operator()(const statement_type& m, const C& context) const {
                 std::stringstream ss;
                 if(!context.skip_table_name) {
-                    ss << "\"" << context.impl.find_table_name(typeid(O)) << "\".";
+                    ss << "'" << context.impl.find_table_name(typeid(O)) << "'.";
                 }
                 if(auto columnnamePointer = context.column_name(m)) {
                     ss << "\"" << *columnnamePointer << "\"";

--- a/dev/statement_serializator.h
+++ b/dev/statement_serializator.h
@@ -1773,7 +1773,7 @@ namespace sqlite_orm {
                             auto& tableNamePair = tableNames[i];
                             ss << "'" << tableNamePair.first << "'";
                             if(!tableNamePair.second.empty()) {
-                                ss << ' ' << tableNamePair.second;
+                                ss << " '" << tableNamePair.second << "'";
                             }
                             if(int(i) < int(tableNames.size()) - 1) {
                                 ss << ", ";
@@ -1878,10 +1878,10 @@ namespace sqlite_orm {
                 iterate_tuple<tuple>([&context, &ss, &index](auto* itemPointer) {
                     using mapped_type = typename std::remove_pointer<decltype(itemPointer)>::type;
 
-                    auto aliasString = alias_extractor<mapped_type>::get();
                     ss << "'" << context.impl.find_table_name(typeid(typename mapped_type_proxy<mapped_type>::type))
                        << "'";
-                    if(aliasString.length()) {
+                    auto aliasString = alias_extractor<mapped_type>::get();
+                    if(!aliasString.empty()) {
                         ss << " '" << aliasString << "'";
                     }
                     if(index < std::tuple_size<tuple>::value - 1) {
@@ -2136,7 +2136,7 @@ namespace sqlite_orm {
             template<class C>
             std::string operator()(const statement_type& c, const C& context) const {
                 std::stringstream ss;
-                ss << static_cast<std::string>(c) << " ";
+                ss << static_cast<std::string>(c);
                 ss << " '" << context.impl.find_table_name(typeid(O)) << "'";
                 return ss.str();
             }
@@ -2149,10 +2149,10 @@ namespace sqlite_orm {
             template<class C>
             std::string operator()(const statement_type& l, const C& context) const {
                 std::stringstream ss;
-                ss << static_cast<std::string>(l) << " ";
-                auto aliasString = alias_extractor<T>::get();
+                ss << static_cast<std::string>(l);
                 ss << " '" << context.impl.find_table_name(typeid(typename mapped_type_proxy<T>::type)) << "' ";
-                if(aliasString.length()) {
+                auto aliasString = alias_extractor<T>::get();
+                if(!aliasString.empty()) {
                     ss << "'" << aliasString << "' ";
                 }
                 ss << serialize(l.constraint, context);
@@ -2181,10 +2181,10 @@ namespace sqlite_orm {
             template<class C>
             std::string operator()(const statement_type& l, const C& context) const {
                 std::stringstream ss;
-                ss << static_cast<std::string>(l) << " ";
-                auto aliasString = alias_extractor<T>::get();
+                ss << static_cast<std::string>(l);
                 ss << " '" << context.impl.find_table_name(typeid(typename mapped_type_proxy<T>::type)) << "' ";
-                if(aliasString.length()) {
+                auto aliasString = alias_extractor<T>::get();
+                if(!aliasString.empty()) {
                     ss << "'" << aliasString << "' ";
                 }
                 ss << serialize(l.constraint, context);
@@ -2199,10 +2199,10 @@ namespace sqlite_orm {
             template<class C>
             std::string operator()(const statement_type& l, const C& context) const {
                 std::stringstream ss;
-                ss << static_cast<std::string>(l) << " ";
-                auto aliasString = alias_extractor<T>::get();
+                ss << static_cast<std::string>(l);
                 ss << " '" << context.impl.find_table_name(typeid(typename mapped_type_proxy<T>::type)) << "' ";
-                if(aliasString.length()) {
+                auto aliasString = alias_extractor<T>::get();
+                if(!aliasString.empty()) {
                     ss << "'" << aliasString << "' ";
                 }
                 ss << serialize(l.constraint, context);
@@ -2217,10 +2217,10 @@ namespace sqlite_orm {
             template<class C>
             std::string operator()(const statement_type& l, const C& context) const {
                 std::stringstream ss;
-                ss << static_cast<std::string>(l) << " ";
-                auto aliasString = alias_extractor<T>::get();
+                ss << static_cast<std::string>(l);
                 ss << " '" << context.impl.find_table_name(typeid(typename mapped_type_proxy<T>::type)) << "' ";
-                if(aliasString.length()) {
+                auto aliasString = alias_extractor<T>::get();
+                if(!aliasString.empty()) {
                     ss << "'" << aliasString << "' ";
                 }
                 ss << serialize(l.constraint, context);
@@ -2235,7 +2235,7 @@ namespace sqlite_orm {
             template<class C>
             std::string operator()(const statement_type& c, const C& context) const {
                 std::stringstream ss;
-                ss << static_cast<std::string>(c) << " ";
+                ss << static_cast<std::string>(c);
                 ss << " '" << context.impl.find_table_name(typeid(O)) << "'";
                 return ss.str();
             }

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -566,6 +566,8 @@ namespace sqlite_orm {
             dump(const T& preparedStatement) const {
                 using context_t = serializator_context<impl_type>;
                 context_t context{this->impl};
+                // just like prepare_impl()
+                context.skip_table_name = false;
                 return serialize(preparedStatement.expression, context);
             }
 

--- a/dev/type_traits.h
+++ b/dev/type_traits.h
@@ -35,6 +35,9 @@ namespace sqlite_orm {
     // type name template aliases for syntactic sugar
     namespace internal {
         template<typename T>
+        using type_t = typename T::type;
+
+        template<typename T>
         using object_type_t = typename T::object_type;
     }
 }

--- a/examples/subquery.cpp
+++ b/examples/subquery.cpp
@@ -1351,7 +1351,6 @@ int main(int, char**) {
             columns(alias_column<als>(&Employee::lastName),
                     alias_column<als>(&Employee::salary),
                     alias_column<als>(&Employee::departmentId)),
-            from<als>(),
             where(greater_than(
                 alias_column<als>(&Employee::salary),
                 select(avg(&Employee::salary),

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -8801,6 +8801,8 @@ namespace sqlite_orm {
 #include <tuple>  //  std::tuple
 #include <functional>  //  std::reference_wrapper
 
+// #include "type_traits.h"
+
 // #include "core_functions.h"
 
 // #include "select_constraints.h"
@@ -9723,8 +9725,13 @@ namespace sqlite_orm {
         struct column_result_t<St, as_t<T, E>, void> : column_result_t<St, typename std::decay<E>::type, void> {};
 
         template<class St, class T>
-        struct column_result_t<St, asterisk_t<T>, void> {
-            using type = typename storage_traits::storage_mapped_columns<St, typename mapped_type_proxy<T>::type>::type;
+        struct column_result_t<St, asterisk_t<T>, match_if_not<std::is_base_of, alias_tag, T>> {
+            using type = typename storage_traits::storage_mapped_columns<St, T>::type;
+        };
+
+        template<class St, class A>
+        struct column_result_t<St, asterisk_t<A>, match_if<std::is_base_of, alias_tag, A>> {
+            using type = typename storage_traits::storage_mapped_columns<St, type_t<A>>::type;
         };
 
         template<class St, class T>

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -87,6 +87,43 @@ __pragma(push_macro("min"))
 #else
             using std::is_specialization_of, std::is_specialization_of_t, std::is_specialization_of_v;
 #endif
+#if 1  // library fundamentals TS v2, [meta.detect]
+            struct nonesuch {
+                ~nonesuch() = delete;
+                nonesuch(const nonesuch&) = delete;
+                void operator=(const nonesuch&) = delete;
+            };
+
+            template<class Default, class AlwaysVoid, template<class...> class Op, class... Args>
+            struct detector {
+                using value_t = std::false_type;
+                using type = Default;
+            };
+
+            template<class Default, template<class...> class Op, class... Args>
+            struct detector<Default, polyfill::void_t<Op<Args...>>, Op, Args...> {
+                using value_t = std::true_type;
+                using type = Op<Args...>;
+            };
+
+            template<template<class...> class Op, class... Args>
+            using is_detected = typename detector<nonesuch, void, Op, Args...>::value_t;
+
+            template<template<class...> class Op, class... Args>
+            using detected = detector<nonesuch, void, Op, Args...>;
+
+            template<template<class...> class Op, class... Args>
+            using detected_t = typename detector<nonesuch, void, Op, Args...>::type;
+
+            template<class Default, template<class...> class Op, class... Args>
+            using detected_or = detector<Default, void, Op, Args...>;
+
+            template<class Default, template<class...> class Op, class... Args>
+            using detected_or_t = typename detected_or<Default, Op, Args...>::type;
+
+            template<template<class...> class Op, class... Args>
+            SQLITE_ORM_INLINE_VAR constexpr bool is_detected_v = is_detected<Op, Args...>::value;
+#endif
 
             template<typename...>
             SQLITE_ORM_INLINE_VAR constexpr bool always_false_v = false;
@@ -127,6 +164,9 @@ namespace sqlite_orm {
 
     // type name template aliases for syntactic sugar
     namespace internal {
+        template<typename T>
+        using type_t = typename T::type;
+
         template<typename T>
         using object_type_t = typename T::object_type;
     }
@@ -3239,7 +3279,7 @@ namespace sqlite_orm {
         };
 
         /**
-         *  C - serializator context class
+         *  C - serializer context class
          */
         template<class C>
         struct dynamic_order_by_t : order_by_string {
@@ -14224,6 +14264,10 @@ namespace sqlite_orm {
 #include <functional>  //  std::function
 #include <typeindex>  //  std::type_index
 
+// #include "cxx_polyfill.h"
+
+// #include "type_traits.h"
+
 // #include "select_constraints.h"
 
 // #include "alias.h"
@@ -14243,7 +14287,7 @@ namespace sqlite_orm {
 
             table_name_collector() = default;
 
-            table_name_collector(find_table_name_t _find_table_name) : find_table_name(std::move(_find_table_name)) {}
+            table_name_collector(find_table_name_t find_table_name) : find_table_name(move(find_table_name)) {}
 
             template<class T>
             table_name_set operator()(const T&) const {
@@ -14279,11 +14323,22 @@ namespace sqlite_orm {
                 }
             }
 
-            template<class T>
+            template<class T, satisfies_not<std::is_base_of, alias_tag, T> = true>
             void operator()(const asterisk_t<T>&) const {
                 if(this->find_table_name) {
                     auto tableName = this->find_table_name(typeid(T));
                     table_names.insert(std::make_pair(move(tableName), ""));
+                }
+            }
+
+            template<class T, satisfies<std::is_base_of, alias_tag, T> = true>
+            void operator()(const asterisk_t<T>&) const {
+                if(this->find_table_name) {
+                    // note: not all alias classes have a nested A::type
+                    static_assert(polyfill::is_detected_v<type_t, T>,
+                                  "alias<O> must have a nested alias<O>::type typename");
+                    auto tableName = this->find_table_name(typeid(type_t<T>));
+                    table_names.insert(std::make_pair(move(tableName), alias_extractor<T>::get()));
                 }
             }
 
@@ -14347,7 +14402,7 @@ namespace sqlite_orm {
             using expression_type = T;
 
             template<class C>
-            std::vector<std::string> operator()(const expression_type& t, const C& context) {
+            std::vector<std::string> operator()(const expression_type& t, const C& context) const {
                 auto newContext = context;
                 newContext.skip_table_name = false;
                 auto columnName = serialize(t, newContext);
@@ -14361,8 +14416,8 @@ namespace sqlite_orm {
 
         template<class T, class C>
         std::vector<std::string> get_column_names(const T& t, const C& context) {
-            column_names_getter<T> serializator;
-            return serializator(t, context);
+            column_names_getter<T> serializer;
+            return serializer(t, context);
         }
 
         template<class T>
@@ -14370,20 +14425,28 @@ namespace sqlite_orm {
             using expression_type = std::reference_wrapper<T>;
 
             template<class C>
-            std::vector<std::string> operator()(const expression_type& expression, const C& context) {
+            std::vector<std::string> operator()(const expression_type& expression, const C& context) const {
                 return get_column_names(expression.get(), context);
             }
         };
 
         template<class T>
-        struct column_names_getter<asterisk_t<T>, void> {
+        struct column_names_getter<asterisk_t<T>, match_if_not<std::is_base_of, alias_tag, T>> {
             using expression_type = asterisk_t<T>;
 
             template<class C>
             std::vector<std::string> operator()(const expression_type&, const C&) {
-                std::vector<std::string> res;
-                res.push_back("*");
-                return res;
+                return {"*"};
+            }
+        };
+
+        template<class A>
+        struct column_names_getter<asterisk_t<A>, match_if<std::is_base_of, alias_tag, A>> {
+            using expression_type = asterisk_t<A>;
+
+            template<class C>
+            std::vector<std::string> operator()(const expression_type&, const C&) {
+                return {"'" + alias_extractor<A>::get() + "'.*"};
             }
         };
 
@@ -14392,10 +14455,8 @@ namespace sqlite_orm {
             using expression_type = object_t<T>;
 
             template<class C>
-            std::vector<std::string> operator()(const expression_type&, const C&) {
-                std::vector<std::string> res;
-                res.push_back("*");
-                return res;
+            std::vector<std::string> operator()(const expression_type&, const C&) const {
+                return {"*"};
             }
         };
 
@@ -14404,7 +14465,7 @@ namespace sqlite_orm {
             using expression_type = columns_t<Args...>;
 
             template<class C>
-            std::vector<std::string> operator()(const expression_type& cols, const C& context) {
+            std::vector<std::string> operator()(const expression_type& cols, const C& context) const {
                 std::vector<std::string> columnNames;
                 columnNames.reserve(static_cast<size_t>(cols.count));
                 auto newContext = context;
@@ -14439,8 +14500,8 @@ namespace sqlite_orm {
 
         template<class T, class C>
         std::string serialize_order_by(const T& t, const C& context) {
-            order_by_serializator<T> serializator;
-            return serializator(t, context);
+            order_by_serializator<T> serializer;
+            return serializer(t, context);
         }
 
         template<class O>
@@ -14454,15 +14515,15 @@ namespace sqlite_orm {
                 newContext.skip_table_name = false;
                 auto columnName = serialize(orderBy.expression, newContext);
                 ss << columnName << " ";
-                if(orderBy._collate_argument.length()) {
-                    ss << "COLLATE " << orderBy._collate_argument << " ";
+                if(!orderBy._collate_argument.empty()) {
+                    ss << " COLLATE " << orderBy._collate_argument;
                 }
                 switch(orderBy.asc_desc) {
                     case 1:
-                        ss << "ASC";
+                        ss << " ASC";
                         break;
                     case -1:
-                        ss << "DESC";
+                        ss << " DESC";
                         break;
                 }
                 return ss.str();
@@ -14531,8 +14592,8 @@ namespace sqlite_orm {
 
         template<class T, class C>
         std::string serialize(const T& t, const C& context) {
-            statement_serializator<T> serializator;
-            return serializator(t, context);
+            statement_serializator<T> serializer;
+            return serializer(t, context);
         }
 
         /**
@@ -14800,7 +14861,7 @@ namespace sqlite_orm {
             std::string operator()(const statement_type& m, const C& context) const {
                 std::stringstream ss;
                 if(!context.skip_table_name) {
-                    ss << "\"" << context.impl.find_table_name(typeid(O)) << "\".";
+                    ss << "'" << context.impl.find_table_name(typeid(O)) << "'.";
                 }
                 if(auto columnnamePointer = context.column_name(m)) {
                     ss << "\"" << *columnnamePointer << "\"";
@@ -16257,7 +16318,7 @@ namespace sqlite_orm {
                             auto& tableNamePair = tableNames[i];
                             ss << "'" << tableNamePair.first << "'";
                             if(!tableNamePair.second.empty()) {
-                                ss << ' ' << tableNamePair.second;
+                                ss << " '" << tableNamePair.second << "'";
                             }
                             if(int(i) < int(tableNames.size()) - 1) {
                                 ss << ", ";
@@ -16362,10 +16423,10 @@ namespace sqlite_orm {
                 iterate_tuple<tuple>([&context, &ss, &index](auto* itemPointer) {
                     using mapped_type = typename std::remove_pointer<decltype(itemPointer)>::type;
 
-                    auto aliasString = alias_extractor<mapped_type>::get();
                     ss << "'" << context.impl.find_table_name(typeid(typename mapped_type_proxy<mapped_type>::type))
                        << "'";
-                    if(aliasString.length()) {
+                    auto aliasString = alias_extractor<mapped_type>::get();
+                    if(!aliasString.empty()) {
                         ss << " '" << aliasString << "'";
                     }
                     if(index < std::tuple_size<tuple>::value - 1) {
@@ -16620,7 +16681,7 @@ namespace sqlite_orm {
             template<class C>
             std::string operator()(const statement_type& c, const C& context) const {
                 std::stringstream ss;
-                ss << static_cast<std::string>(c) << " ";
+                ss << static_cast<std::string>(c);
                 ss << " '" << context.impl.find_table_name(typeid(O)) << "'";
                 return ss.str();
             }
@@ -16633,10 +16694,10 @@ namespace sqlite_orm {
             template<class C>
             std::string operator()(const statement_type& l, const C& context) const {
                 std::stringstream ss;
-                ss << static_cast<std::string>(l) << " ";
-                auto aliasString = alias_extractor<T>::get();
+                ss << static_cast<std::string>(l);
                 ss << " '" << context.impl.find_table_name(typeid(typename mapped_type_proxy<T>::type)) << "' ";
-                if(aliasString.length()) {
+                auto aliasString = alias_extractor<T>::get();
+                if(!aliasString.empty()) {
                     ss << "'" << aliasString << "' ";
                 }
                 ss << serialize(l.constraint, context);
@@ -16665,10 +16726,10 @@ namespace sqlite_orm {
             template<class C>
             std::string operator()(const statement_type& l, const C& context) const {
                 std::stringstream ss;
-                ss << static_cast<std::string>(l) << " ";
-                auto aliasString = alias_extractor<T>::get();
+                ss << static_cast<std::string>(l);
                 ss << " '" << context.impl.find_table_name(typeid(typename mapped_type_proxy<T>::type)) << "' ";
-                if(aliasString.length()) {
+                auto aliasString = alias_extractor<T>::get();
+                if(!aliasString.empty()) {
                     ss << "'" << aliasString << "' ";
                 }
                 ss << serialize(l.constraint, context);
@@ -16683,10 +16744,10 @@ namespace sqlite_orm {
             template<class C>
             std::string operator()(const statement_type& l, const C& context) const {
                 std::stringstream ss;
-                ss << static_cast<std::string>(l) << " ";
-                auto aliasString = alias_extractor<T>::get();
+                ss << static_cast<std::string>(l);
                 ss << " '" << context.impl.find_table_name(typeid(typename mapped_type_proxy<T>::type)) << "' ";
-                if(aliasString.length()) {
+                auto aliasString = alias_extractor<T>::get();
+                if(!aliasString.empty()) {
                     ss << "'" << aliasString << "' ";
                 }
                 ss << serialize(l.constraint, context);
@@ -16701,10 +16762,10 @@ namespace sqlite_orm {
             template<class C>
             std::string operator()(const statement_type& l, const C& context) const {
                 std::stringstream ss;
-                ss << static_cast<std::string>(l) << " ";
-                auto aliasString = alias_extractor<T>::get();
+                ss << static_cast<std::string>(l);
                 ss << " '" << context.impl.find_table_name(typeid(typename mapped_type_proxy<T>::type)) << "' ";
-                if(aliasString.length()) {
+                auto aliasString = alias_extractor<T>::get();
+                if(!aliasString.empty()) {
                     ss << "'" << aliasString << "' ";
                 }
                 ss << serialize(l.constraint, context);
@@ -16719,7 +16780,7 @@ namespace sqlite_orm {
             template<class C>
             std::string operator()(const statement_type& c, const C& context) const {
                 std::stringstream ss;
-                ss << static_cast<std::string>(c) << " ";
+                ss << static_cast<std::string>(c);
                 ss << " '" << context.impl.find_table_name(typeid(O)) << "'";
                 return ss.str();
             }
@@ -17456,6 +17517,8 @@ namespace sqlite_orm {
             dump(const T& preparedStatement) const {
                 using context_t = serializator_context<impl_type>;
                 context_t context{this->impl};
+                // just like prepare_impl()
+                context.skip_table_name = false;
                 return serialize(preparedStatement.expression, context);
             }
 

--- a/tests/select_constraints_tests.cpp
+++ b/tests/select_constraints_tests.cpp
@@ -63,14 +63,7 @@ TEST_CASE("select constraints") {
         }
         SECTION("object") {
             auto allEmployees = storage.select(object<Employee>());
-            std::vector<Employee> expected;
-            expected.push_back(paul);
-            expected.push_back(allen);
-            expected.push_back(teddy);
-            expected.push_back(mark);
-            expected.push_back(david);
-            expected.push_back(kim);
-            expected.push_back(james);
+            std::vector<Employee> expected{paul, allen, teddy, mark, david, kim, james};
             REQUIRE_THAT(allEmployees, UnorderedEquals(expected));
         }
     }
@@ -528,7 +521,7 @@ TEST_CASE("Dynamic order by") {
 
     auto rows = storage.get_all<User>(orderBy);
     REQUIRE(rows.size() == 4);
-    for(auto i = 0; i < int(rows.size()); ++i) {
+    for(size_t i = 0; i < rows.size(); ++i) {
         auto& row = rows[i];
         REQUIRE(row.id == expectedIds[i]);
     }
@@ -540,7 +533,6 @@ TEST_CASE("rows") {
     auto storage = make_storage({});
 
     auto rows = storage.select(is_equal(std::make_tuple(1, 2, 3), std::make_tuple(1, 2, 3)));
-    decltype(rows) expected;
-    expected.push_back(true);
+    decltype(rows) expected{true};
     REQUIRE(rows == expected);
 }

--- a/tests/statement_serializator_tests/column_names.cpp
+++ b/tests/statement_serializator_tests/column_names.cpp
@@ -23,7 +23,7 @@ TEST_CASE("statement_serializator column names") {
                 SECTION("don't skip table name") {
                     context.skip_table_name = false;
                     auto value = serialize(&User::id, context);
-                    REQUIRE(value == "\"users\".\"id\"");
+                    REQUIRE(value == "'users'.\"id\"");
                 }
             }
             SECTION("name") {

--- a/tests/statement_serializator_tests/select_constraints.cpp
+++ b/tests/statement_serializator_tests/select_constraints.cpp
@@ -12,8 +12,7 @@ TEST_CASE("statement_serializator select constraints") {
     auto table = make_table("users", make_column("id", &User::id), make_column("name", &User::name));
     using storage_impl_t = internal::storage_impl<decltype(table)>;
     auto storageImpl = storage_impl_t{table};
-    using context_t = internal::serializator_context<storage_impl_t>;
-    context_t context{storageImpl};
+    internal::serializator_context<storage_impl_t> context{storageImpl};
 
     std::string value;
     decltype(value) expected;

--- a/tests/statement_serializator_tests/statements/insert_replace.cpp
+++ b/tests/statement_serializator_tests/statements/insert_replace.cpp
@@ -262,25 +262,22 @@ TEST_CASE("statement_serializator insert/replace") {
                     auto statement =
                         insert(or_abort(), into<User>(), select(columns(&UserBackup::id, &UserBackup::name)));
                     value = serialize(statement, context);
-                    expected =
-                        "INSERT OR ABORT INTO users SELECT 'users_backup'.\"id\", 'users_backup'.\"name\" FROM "
-                        "'users_backup'";
+                    expected = "INSERT OR ABORT INTO users SELECT 'users_backup'.\"id\", 'users_backup'.\"name\" FROM "
+                               "'users_backup'";
                 }
                 SECTION("or fail") {
                     auto statement =
                         insert(or_fail(), into<User>(), select(columns(&UserBackup::id, &UserBackup::name)));
                     value = serialize(statement, context);
-                    expected =
-                        "INSERT OR FAIL INTO users SELECT 'users_backup'.\"id\", 'users_backup'.\"name\" FROM "
-                        "'users_backup'";
+                    expected = "INSERT OR FAIL INTO users SELECT 'users_backup'.\"id\", 'users_backup'.\"name\" FROM "
+                               "'users_backup'";
                 }
                 SECTION("or ignore") {
                     auto statement =
                         insert(or_ignore(), into<User>(), select(columns(&UserBackup::id, &UserBackup::name)));
                     value = serialize(statement, context);
-                    expected =
-                        "INSERT OR IGNORE INTO users SELECT 'users_backup'.\"id\", 'users_backup'.\"name\" FROM "
-                        "'users_backup'";
+                    expected = "INSERT OR IGNORE INTO users SELECT 'users_backup'.\"id\", 'users_backup'.\"name\" FROM "
+                               "'users_backup'";
                 }
                 SECTION("or replace") {
                     auto statement =

--- a/tests/statement_serializator_tests/statements/insert_replace.cpp
+++ b/tests/statement_serializator_tests/statements/insert_replace.cpp
@@ -63,7 +63,7 @@ TEST_CASE("statement_serializator insert/replace") {
                 auto statement = replace(into<User>(), select(columns(&UserBackup::id, &UserBackup::name)));
                 value = serialize(statement, context);
                 expected =
-                    "REPLACE INTO users SELECT \"users_backup\".\"id\", \"users_backup\".\"name\" FROM 'users_backup'";
+                    "REPLACE INTO users SELECT 'users_backup'.\"id\", 'users_backup'.\"name\" FROM 'users_backup'";
             }
         }
     }
@@ -255,7 +255,7 @@ TEST_CASE("statement_serializator insert/replace") {
                 SECTION("no constraint") {
                     auto statement = insert(into<User>(), select(columns(&UserBackup::id, &UserBackup::name)));
                     value = serialize(statement, context);
-                    expected = "INSERT INTO users SELECT \"users_backup\".\"id\", \"users_backup\".\"name\" FROM "
+                    expected = "INSERT INTO users SELECT 'users_backup'.\"id\", 'users_backup'.\"name\" FROM "
                                "'users_backup'";
                 }
                 SECTION("or abort") {
@@ -263,7 +263,7 @@ TEST_CASE("statement_serializator insert/replace") {
                         insert(or_abort(), into<User>(), select(columns(&UserBackup::id, &UserBackup::name)));
                     value = serialize(statement, context);
                     expected =
-                        "INSERT OR ABORT INTO users SELECT \"users_backup\".\"id\", \"users_backup\".\"name\" FROM "
+                        "INSERT OR ABORT INTO users SELECT 'users_backup'.\"id\", 'users_backup'.\"name\" FROM "
                         "'users_backup'";
                 }
                 SECTION("or fail") {
@@ -271,7 +271,7 @@ TEST_CASE("statement_serializator insert/replace") {
                         insert(or_fail(), into<User>(), select(columns(&UserBackup::id, &UserBackup::name)));
                     value = serialize(statement, context);
                     expected =
-                        "INSERT OR FAIL INTO users SELECT \"users_backup\".\"id\", \"users_backup\".\"name\" FROM "
+                        "INSERT OR FAIL INTO users SELECT 'users_backup'.\"id\", 'users_backup'.\"name\" FROM "
                         "'users_backup'";
                 }
                 SECTION("or ignore") {
@@ -279,7 +279,7 @@ TEST_CASE("statement_serializator insert/replace") {
                         insert(or_ignore(), into<User>(), select(columns(&UserBackup::id, &UserBackup::name)));
                     value = serialize(statement, context);
                     expected =
-                        "INSERT OR IGNORE INTO users SELECT \"users_backup\".\"id\", \"users_backup\".\"name\" FROM "
+                        "INSERT OR IGNORE INTO users SELECT 'users_backup'.\"id\", 'users_backup'.\"name\" FROM "
                         "'users_backup'";
                 }
                 SECTION("or replace") {
@@ -287,7 +287,7 @@ TEST_CASE("statement_serializator insert/replace") {
                         insert(or_replace(), into<User>(), select(columns(&UserBackup::id, &UserBackup::name)));
                     value = serialize(statement, context);
                     expected =
-                        "INSERT OR REPLACE INTO users SELECT \"users_backup\".\"id\", \"users_backup\".\"name\" FROM "
+                        "INSERT OR REPLACE INTO users SELECT 'users_backup'.\"id\", 'users_backup'.\"name\" FROM "
                         "'users_backup'";
                 }
                 SECTION("or rollback") {
@@ -295,7 +295,7 @@ TEST_CASE("statement_serializator insert/replace") {
                         insert(or_rollback(), into<User>(), select(columns(&UserBackup::id, &UserBackup::name)));
                     value = serialize(statement, context);
                     expected =
-                        "INSERT OR ROLLBACK INTO users SELECT \"users_backup\".\"id\", \"users_backup\".\"name\" FROM "
+                        "INSERT OR ROLLBACK INTO users SELECT 'users_backup'.\"id\", 'users_backup'.\"name\" FROM "
                         "'users_backup'";
                 }
             }

--- a/tests/statement_serializator_tests/statements/select.cpp
+++ b/tests/statement_serializator_tests/statements/select.cpp
@@ -80,12 +80,12 @@ TEST_CASE("statement_serializator select_t") {
             SECTION("!highest_level") {
                 statement.highest_level = false;
                 stringValue = serialize(statement, context);
-                expected = "(SELECT \"users\".\"id\" FROM 'users')";
+                expected = "(SELECT 'users'.\"id\" FROM 'users')";
             }
             SECTION("highest_level") {
                 statement.highest_level = true;
                 stringValue = serialize(statement, context);
-                expected = "SELECT \"users\".\"id\" FROM 'users'";
+                expected = "SELECT 'users'.\"id\" FROM 'users'";
             }
         }
         SECTION("null") {

--- a/tests/statement_serializator_tests/statements/update_all.cpp
+++ b/tests/statement_serializator_tests/statements/update_all.cpp
@@ -54,7 +54,7 @@ TEST_CASE("statement_serializator update_all") {
     auto statement =
         update_all(set(c(&Contact::phone) = select(&Customer::phone, from<Customer>(), where(c(&Customer::id) == 1))));
     auto value = serialize(statement, context);
-    decltype(value) expected = "UPDATE 'contacts' SET \"phone\" = (SELECT \"customers\".\"Phone\" FROM 'customers' "
+    decltype(value) expected = "UPDATE 'contacts' SET \"phone\" = (SELECT 'customers'.\"Phone\" FROM 'customers' "
                                "WHERE ((\"CustomerId\" = 1)))";
     REQUIRE(expected == value);
 }


### PR DESCRIPTION
You made `select * from table alias` work to some extent with PR #952 (addressing issue #945), by doing the `column_result_t` handling right.

In order to make `select * from table alias` fully functional, the table name collector and column names getter should be amended as well.

* `select(asterisk<als_a>())` possible w/o explicit `from<als_a>()`; [see table name collector](https://github.com/FireDaemon/sqlite_orm/blob/c4beb0c80b2cdd5883d533bfaf50bbfb97b998e7/dev/table_name_collector.h#L71).
* always include alias name in column specifier, i.e. `a.*` instead of `*`; [see column names getter](https://github.com/FireDaemon/sqlite_orm/blob/c4beb0c80b2cdd5883d533bfaf50bbfb97b998e7/dev/column_names_getter.h#L61).
* `storage_t::dump()` now serializes with `context.skip_table_names = false` just like `storage_t::prepare_impl()` [see `storage_t::dump()`](https://github.com/FireDaemon/sqlite_orm/blob/c4beb0c80b2cdd5883d533bfaf50bbfb97b998e7/dev/storage.h#L569)

Question: wouldn't it be safer that `statement_serializator<alias_column_t<>>` always qualifies the column with the table name (as if by seralizing with `context.skip_table_names = false`) since it is an aliased column?
