### PR TITLE
Small improvement of hot code path when streaming identifiers

### DIFF
--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -86,6 +86,8 @@ namespace sqlite_orm {
                                       const std::string& identifier,
                                       const std::string& alias) {
             constexpr char quoteChar = '"';
+            constexpr char qualified[] = {quoteChar, '.', '\0'};
+            constexpr char aliased[] = {' ', quoteChar, '\0'};
 
             // note: In practice, escaping double quotes in identifiers is arguably overkill,
             // but since the SQLite grammar allows it, it's better to be safe than sorry.
@@ -93,7 +95,7 @@ namespace sqlite_orm {
             if(!qualifier.empty()) {
                 ss << quoteChar;
                 stream_sql_escaped(ss, qualifier, quoteChar);
-                ss << std::string{quoteChar, '.'};
+                ss << qualified;
             }
             {
                 ss << quoteChar;
@@ -101,7 +103,7 @@ namespace sqlite_orm {
                 ss << quoteChar;
             }
             if(!alias.empty()) {
-                ss << std::string{' ', quoteChar};
+                ss << aliased;
                 stream_sql_escaped(ss, alias, quoteChar);
                 ss << quoteChar;
             }

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -14640,6 +14640,8 @@ namespace sqlite_orm {
                                       const std::string& identifier,
                                       const std::string& alias) {
             constexpr char quoteChar = '"';
+            constexpr char qualified[] = {quoteChar, '.', '\0'};
+            constexpr char aliased[] = {' ', quoteChar, '\0'};
 
             // note: In practice, escaping double quotes in identifiers is arguably overkill,
             // but since the SQLite grammar allows it, it's better to be safe than sorry.
@@ -14647,7 +14649,7 @@ namespace sqlite_orm {
             if(!qualifier.empty()) {
                 ss << quoteChar;
                 stream_sql_escaped(ss, qualifier, quoteChar);
-                ss << std::string{quoteChar, '.'};
+                ss << qualified;
             }
             {
                 ss << quoteChar;
@@ -14655,7 +14657,7 @@ namespace sqlite_orm {
                 ss << quoteChar;
             }
             if(!alias.empty()) {
-                ss << std::string{' ', quoteChar};
+                ss << aliased;
                 stream_sql_escaped(ss, alias, quoteChar);
                 ss << quoteChar;
             }


### PR DESCRIPTION
Skipping std::string creation/destruction by using a constexpr built-in character array instead.
(Addresses [review comment](https://github.com/fnc12/sqlite_orm/pull/993/files/5b6398729e08fbc31606571704adef305485bd25..d759da0a67e39bdb074506d6ed5681545bdd1f7f#r841985192) on PR #993)