### PR TITLE
erased get_table_info() and replaced it with call to pragma.table_info()

### DIFF
--- a/dev/implementations/storage_definitions.h
+++ b/dev/implementations/storage_definitions.h
@@ -25,7 +25,8 @@ namespace sqlite_orm {
 #endif  //  SQLITE_ENABLE_DBSTAT_VTAB
             auto res = sync_schema_result::already_in_sync;
 
-            auto schema_stat = tImpl.schema_status(db, preserve);
+            auto dbTableInfo = this->pragma.table_info(tImpl.table.name);
+            auto schema_stat = tImpl.schema_status(db, preserve, dbTableInfo);
             if(schema_stat != decltype(schema_stat)::already_in_sync) {
                 if(schema_stat == decltype(schema_stat)::new_table_created) {
                     this->create_table(db, tImpl.table.name, tImpl);
@@ -39,7 +40,7 @@ namespace sqlite_orm {
                         auto storageTableInfo = tImpl.table.get_table_info();
 
                         //  now get current table info from db using `PRAGMA table_info` query..
-                        auto dbTableInfo = tImpl.get_table_info(tImpl.table.name, db);
+                        auto dbTableInfo = this->pragma.table_info(tImpl.table.name);
 
                         //  this vector will contain pointers to columns that gotta be added..
                         std::vector<table_info*> columnsToAdd;

--- a/dev/storage_impl.h
+++ b/dev/storage_impl.h
@@ -24,8 +24,6 @@ namespace sqlite_orm {
 
             void rename_table(sqlite3* db, const std::string& oldName, const std::string& newName) const;
 
-            std::vector<table_info> get_table_info(const std::string& tableName, sqlite3* db) const;
-
             static bool calculate_remove_add_columns(std::vector<table_info*>& columnsToAdd,
                                                      std::vector<table_info>& storageTableInfo,
                                                      std::vector<table_info>& dbTableInfo);
@@ -87,7 +85,7 @@ namespace sqlite_orm {
             void
             copy_table(sqlite3* db, const std::string& name, const std::vector<table_info*>& columnsToIgnore) const;
 
-            sync_schema_result schema_status(sqlite3* db, bool preserve) const;
+            sync_schema_result schema_status(sqlite3* db, bool preserve, std::vector<table_info>& columns) const;
 
           private:
             const basic_generated_always::storage_type*


### PR DESCRIPTION
also did some refactoring in schema_status()
now we don't need to invoke pragma.table_info() from inside schema_status()!