### PR TITLE
Pragma table info: corrected version of schema_status with only 2 parameters

### DIFF
--- a/dev/storage.h
+++ b/dev/storage.h
@@ -837,7 +837,8 @@ namespace sqlite_orm {
             sync_schema_result schema_status(const storage_impl<table_t<T, WithoutRowId, Cs...>, Tss...>& tImpl,
                                              sqlite3* db,
                                              bool preserve) {
-                return tImpl.schema_status(db, preserve);
+                auto dbTableInfo = this->pragma.table_info(tImpl.table.name);
+                return tImpl.schema_status(db, preserve, dbTableInfo);
             }
 
             template<class... Tss, class... Cols>

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -17815,7 +17815,8 @@ namespace sqlite_orm {
             sync_schema_result schema_status(const storage_impl<table_t<T, WithoutRowId, Cs...>, Tss...>& tImpl,
                                              sqlite3* db,
                                              bool preserve) {
-                return tImpl.schema_status(db, preserve);
+                auto dbTableInfo = this->pragma.table_info(tImpl.table.name);
+                return tImpl.schema_status(db, preserve, dbTableInfo);
             }
 
             template<class... Tss, class... Cols>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required (VERSION 3.2)
 option(SQLITE_ORM_OMITS_CODECVT "Omits codec testing" OFF)
 
 add_executable(unit_tests
+	sync_schema_tests.cpp
 	tests.cpp
 	tests2.cpp
 	tests3.cpp


### PR DESCRIPTION
Also corrected tests/CMakeLists.txt that forgot to include sync_schema_tests.cpp as part of the unit tests
and corrected dev/storage.h
