### PR TITLE
Added first draft DbConnection.h and added an overload for make_storage()

### DIFF
--- a/dev/DbConnection.h
+++ b/dev/DbConnection.h
@@ -1,0 +1,30 @@
+#pragma once
+#include <string>
+#include "connection_holder.h"
+
+namespace sqlite_orm {
+
+    struct DbConnection {
+        DbConnection(const std::string& filename) : m_filename(filename) {}
+
+        const std::string m_filename;
+
+        // internal::connection_ref& access_connection_ref() {
+        //     return holds_connection;
+        // }
+        std::string filename() const {  // so we can access filename from make_storage(DbConnection,...)
+            return m_filename;  // make_storage(DbConnection con,...) ==> calls make_storage(con.filename(), ....)
+        }
+
+        // internal::connection_ref get_connection() {
+        //     internal::connection_ref res{ *this->connection };
+        //     if (1 == this->connection->retain_count()) {
+        //         // this->on_open_internal(this->connection->get()); // must be able to call it!
+        //     }
+        //     return res;
+        // }
+        // std::unique_ptr<internal::connection_holder> connection;
+        internal::connection_ref* holds_connection = nullptr;  // make connection stay alive...
+    };
+
+}

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -54,6 +54,9 @@
 #include "column.h"
 #include "index.h"
 #include "util.h"
+// jdh
+#include "DbConnection.h"
+// end
 
 namespace sqlite_orm {
 
@@ -83,6 +86,11 @@ namespace sqlite_orm {
                 storage_base{filename, foreign_keys_count(impl_)}, impl(std::move(impl_)) {}
 
             storage_t(const storage_t& other) : storage_base(other), impl(other.impl) {}
+
+            // jdh
+            storage_t(const DbConnection& con, impl_type impl_) :
+                storage_base(con, foreign_keys_count(impl_)), impl(std::move(impl_)) {}
+            // end
 
           protected:
             impl_type impl;
@@ -1757,6 +1765,13 @@ namespace sqlite_orm {
     internal::storage_t<Ts...> make_storage(const std::string& filename, Ts... tables) {
         return {filename, internal::storage_impl<Ts...>(std::forward<Ts>(tables)...)};
     }
+
+    // jdh
+    template<class... Ts>
+    internal::storage_t<Ts...> make_storage(const DbConnection& con, Ts... tables) {
+        return {con, internal::storage_impl<Ts...>(std::forward<Ts>(tables)...)};
+    }
+    // end jdh
 
     /**
      *  sqlite3_threadsafe() interface.

--- a/dev/storage_base.h
+++ b/dev/storage_base.h
@@ -25,6 +25,9 @@
 #include "function.h"
 #include "values_to_tuple.h"
 #include "arg_values.h"
+// jdh
+#include "DbConnection.h"
+// end
 
 namespace sqlite_orm {
 
@@ -508,6 +511,17 @@ namespace sqlite_orm {
             }
 
           protected:
+            // jdh
+            storage_base(const DbConnection& con, int foreignKeysCount) :
+                pragma(std::bind(&storage_base::get_connection, this)),
+                limit(std::bind(&storage_base::get_connection, this)),
+                inMemory(con.filename().empty() || con.filename() == ":memory:"),
+                connection(std::make_unique<connection_holder>(con.filename())),
+                cachedForeignKeysCount(foreignKeysCount) {
+                this->connection->retain();  // make connection stay open
+                this->on_open_internal(this->connection->get());
+            }
+            // end jdh
             storage_base(const std::string& filename_, int foreignKeysCount) :
                 pragma(std::bind(&storage_base::get_connection, this)),
                 limit(std::bind(&storage_base::get_connection, this)),


### PR DESCRIPTION
 so the connection stays open  when made through DcConnection overload.

Please see changes to storage_base protected constructor: 

```C++
            storage_base(const DbConnection& con, int foreignKeysCount) :
                pragma(std::bind(&storage_base::get_connection, this)),
                limit(std::bind(&storage_base::get_connection, this)),
                inMemory(con.filename().empty() || con.filename() == ":memory:"),
                connection(std::make_unique<connection_holder>(con.filename())),
                cachedForeignKeysCount(foreignKeysCount) {
                this->connection->retain();  // make connection stay open!!! Look HERE!
                this->on_open_internal(this->connection->get());
            }
```