### PR TITLE
#1077 fix missing parentheses for `in` as a `check` constraint

### DIFF
--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -13685,6 +13685,9 @@ namespace sqlite_orm {
             std::string operator()(const statement_type& c, const C& context) const {
                 std::stringstream ss;
                 auto leftString = serialize(c.left, context);
+                if (context.use_parentheses) {
+                    ss << "(";
+                }
                 ss << leftString << " " << static_cast<std::string>(c) << " (";
                 for(size_t index = 0; index < c.argument.size(); ++index) {
                     auto& value = c.argument[index];
@@ -13694,6 +13697,9 @@ namespace sqlite_orm {
                     }
                 }
                 ss << ")";
+                if (context.use_parentheses) {
+                    ss << ")";
+                }
                 return ss.str();
             }
         };

--- a/tests/constraints/check.cpp
+++ b/tests/constraints/check.cpp
@@ -37,4 +37,24 @@ TEST_CASE("check") {
                                                make_column("PRICE", &Book::price, check(c(&Book::price) > 0))));
         storage.sync_schema();
     }
+    {
+        struct Rect {
+            int id = 0;
+            int x = 0;
+            int y = 0;
+            int width = 0;
+            int height = 0;
+            std::string join_type = "miter";
+        };
+        auto storage = make_storage({},
+                                    make_table("RECT",
+                                               make_column("id", &Rect::id, primary_key()),
+                                               make_column("x", &Rect::x),
+                                               make_column("y", &Rect::y),
+                                               make_column("width", &Rect::width),
+                                               make_column("height", &Rect::height),
+                                               make_column("join_type", &Rect::join_type),
+                                               check(in(&Rect::join_type, {"miter", "round", "bevel"}))));
+        storage.sync_schema();
+    }
 }


### PR DESCRIPTION
Luckily, all the infrastructure for knowing when to do parenthesis was already in place, it just needed to be applied to `in`s as well.