### PR TITLE
`EXISTS` must use parentheses

### DIFF
--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -767,8 +767,9 @@ namespace sqlite_orm {
             template<class Ctx>
             std::string operator()(const statement_type& statement, const Ctx& context) const {
                 std::stringstream ss;
-                ss << "EXISTS ";
-                ss << serialize(statement.expression, context);
+                auto newContext = context;
+                newContext.use_parentheses = true;
+                ss << "EXISTS " << serialize(statement.expression, newContext);
                 return ss.str();
             }
         };

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -15777,8 +15777,9 @@ namespace sqlite_orm {
             template<class Ctx>
             std::string operator()(const statement_type& statement, const Ctx& context) const {
                 std::stringstream ss;
-                ss << "EXISTS ";
-                ss << serialize(statement.expression, context);
+                auto newContext = context;
+                newContext.use_parentheses = true;
+                ss << "EXISTS " << serialize(statement.expression, newContext);
                 return ss.str();
             }
         };

--- a/tests/statement_serializer_tests/select_constraints.cpp
+++ b/tests/statement_serializer_tests/select_constraints.cpp
@@ -86,5 +86,12 @@ TEST_CASE("statement_serializer select constraints") {
         value = serialize(expression, context);
         expected = R"(EVEN("id"))";
     }
+    SECTION("exists") {
+        // EXISTS must use parentheses in a new context
+        context.use_parentheses = false;
+        auto expression = exists(select(1));
+        value = serialize(expression, context);
+        expected = "EXISTS (SELECT 1)";
+    }
     REQUIRE(value == expected);
 }


### PR DESCRIPTION
To be independent of the current context, the serializer for `exist_t` should always parenthesize its subselect.