### PR TITLE
Qualifying `std::move()` 2

### DIFF
--- a/dev/ast/set.h
+++ b/dev/ast/set.h
@@ -51,11 +51,11 @@ namespace sqlite_orm {
             }
 
             dynamic_set_t(dynamic_set_t&& other) :
-                entries(move(other.entries)), context(std::move(other.context)),
+                entries(std::move(other.entries)), context(std::move(other.context)),
                 collector([this](const std::type_index& ti) {
                     return find_table_name(this->context.db_objects, ti);
                 }) {
-                collector.table_names = move(other.collector.table_names);
+                collector.table_names = std::move(other.collector.table_names);
             }
 
             dynamic_set_t& operator=(const dynamic_set_t& other) {
@@ -68,12 +68,12 @@ namespace sqlite_orm {
             }
 
             dynamic_set_t& operator=(dynamic_set_t&& other) {
-                this->entries = move(other.entries);
+                this->entries = std::move(other.entries);
                 this->context = std::move(other.context);
                 this->collector = table_name_collector([this](const std::type_index& ti) {
                     return find_table_name(this->context.db_objects, ti);
                 });
-                this->collector.table_names = move(other.collector.table_names);
+                this->collector.table_names = std::move(other.collector.table_names);
             }
 
             template<class L, class R>

--- a/dev/index.h
+++ b/dev/index.h
@@ -55,7 +55,7 @@ namespace sqlite_orm {
         static_assert(internal::count_tuple<cols_tuple, internal::is_where>::value <= 1,
                       "amount of where arguments can be 0 or 1");
         SQLITE_ORM_CLANG_SUPPRESS_MISSING_BRACES(
-            return {move(name), false, std::make_tuple(internal::make_indexed_column(std::move(cols))...)});
+            return {std::move(name), false, std::make_tuple(internal::make_indexed_column(std::move(cols))...)});
     }
 
     template<class... Cols>

--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -1117,7 +1117,7 @@ namespace sqlite_orm {
         struct table_name_collector_holder<set_t<Args...>> {
 
             table_name_collector_holder(table_name_collector::find_table_name_t find_table_name) :
-                collector(move(find_table_name)) {}
+                collector(std::move(find_table_name)) {}
 
             table_name_collector collector;
         };

--- a/examples/case.cpp
+++ b/examples/case.cpp
@@ -19,7 +19,7 @@ int main() {
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         Student() {}
         Student(int id, std::string name, std::string email, float marks) :
-            id{id}, name{move(name)}, email{move(email)}, marks{marks} {}
+            id{id}, name{std::move(name)}, email{std::move(email)}, marks{marks} {}
 #endif
     };
 

--- a/examples/check.cpp
+++ b/examples/check.cpp
@@ -17,7 +17,8 @@ int main() {
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         Contact() {}
         Contact(int id, std::string firstName, std::string lastName, std::string email, std::string phone) :
-            id{id}, firstName{move(firstName)}, lastName{move(lastName)}, email{move(email)}, phone{move(phone)} {}
+            id{id}, firstName{std::move(firstName)}, lastName{std::move(lastName)}, email{std::move(email)},
+            phone{std::move(phone)} {}
 #endif
     };
 
@@ -30,7 +31,7 @@ int main() {
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         Product() {}
         Product(int id, std::string name, float listPrice, float discount) :
-            id{id}, name{move(name)}, listPrice{listPrice}, discount{discount} {}
+            id{id}, name{std::move(name)}, listPrice{listPrice}, discount{discount} {}
 #endif
     };
 

--- a/examples/column_aliases.cpp
+++ b/examples/column_aliases.cpp
@@ -17,7 +17,7 @@ void marvel_hero_ordered_by_o_pos() {
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         MarvelHero() {}
         MarvelHero(int id, std::string name, std::string abilities, short points) :
-            id{id}, name{move(name)}, abilities{move(abilities)}, points{points} {}
+            id{id}, name{std::move(name)}, abilities{std::move(abilities)}, points{points} {}
 #endif
     };
 

--- a/examples/core_functions.cpp
+++ b/examples/core_functions.cpp
@@ -14,7 +14,7 @@ struct MarvelHero {
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
     MarvelHero() {}
     MarvelHero(int id, std::string name, std::string abilities, short points) :
-        id{id}, name{move(name)}, abilities{move(abilities)}, points{points} {}
+        id{id}, name{std::move(name)}, abilities{std::move(abilities)}, points{points} {}
 #endif
 };
 
@@ -27,7 +27,7 @@ struct Contact {
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
     Contact() {}
     Contact(int id, std::string firstName, std::string lastName, std::string phone) :
-        id{id}, firstName{move(firstName)}, lastName{move(lastName)}, phone{move(phone)} {}
+        id{id}, firstName{std::move(firstName)}, lastName{std::move(lastName)}, phone{std::move(phone)} {}
 #endif
 };
 
@@ -62,9 +62,10 @@ struct Customer {
              std::string email,
              int supportRepId) :
         id{id},
-        firstName{move(firstName)}, lastName{move(lastName)}, company{move(company)}, address{move(address)},
-        city{move(city)}, state{move(state)}, country{move(country)}, postalCode{move(postalCode)}, phone{move(phone)},
-        fax{move(fax)}, email{move(email)}, supportRepId{supportRepId} {}
+        firstName{std::move(firstName)}, lastName{std::move(lastName)}, company{std::move(company)},
+        address{std::move(address)}, city{std::move(city)}, state{std::move(state)}, country{std::move(country)},
+        postalCode{std::move(postalCode)}, phone{std::move(phone)}, fax{std::move(fax)}, email{std::move(email)},
+        supportRepId{supportRepId} {}
 #endif
 };
 

--- a/examples/custom_aliases.cpp
+++ b/examples/custom_aliases.cpp
@@ -21,7 +21,7 @@ struct Employee {
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
     Employee() {}
     Employee(int id, std::string name, int age, std::string address, float salary) :
-        id{id}, name{move(name)}, age{age}, address{move(address)}, salary{salary} {}
+        id{id}, name{std::move(name)}, age{age}, address{std::move(address)}, salary{salary} {}
 #endif
 };
 
@@ -32,7 +32,7 @@ struct Department {
 
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
     Department() {}
-    Department(int id, std::string dept, int empId) : id{id}, dept{move(dept)}, empId{empId} {}
+    Department(int id, std::string dept, int empId) : id{id}, dept{std::move(dept)}, empId{empId} {}
 #endif
 };
 

--- a/examples/except_intersection.cpp
+++ b/examples/except_intersection.cpp
@@ -14,7 +14,7 @@ struct DeptMaster {
 
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
     DeptMaster() = default;
-    DeptMaster(int deptId, std::string deptName) : deptId{deptId}, deptName{move(deptName)} {}
+    DeptMaster(int deptId, std::string deptName) : deptId{deptId}, deptName{std::move(deptName)} {}
 #endif
 };
 
@@ -33,7 +33,7 @@ struct EmpMaster {
               long salary,
               decltype(DeptMaster::deptId) deptId) :
         empId{empId},
-        firstName{move(firstName)}, lastName{move(lastName)}, salary{salary}, deptId{deptId} {}
+        firstName{std::move(firstName)}, lastName{std::move(lastName)}, salary{salary}, deptId{deptId} {}
 #endif
 };
 

--- a/examples/generated_column.cpp
+++ b/examples/generated_column.cpp
@@ -22,7 +22,7 @@ int main() {
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         Product() {}
         Product(int id, std::string name, int quantity, float price, float totalValue = 0.f) :
-            id{id}, name{move(name)}, quantity{quantity}, price{price}, totalValue{totalValue} {}
+            id{id}, name{std::move(name)}, quantity{quantity}, price{price}, totalValue{totalValue} {}
 #endif
     };
     auto storage = make_storage({},

--- a/examples/prepared_statement.cpp
+++ b/examples/prepared_statement.cpp
@@ -22,7 +22,7 @@ struct Doctor {
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
     Doctor() = default;
     Doctor(int doctor_id, std::string doctor_name, std::string degree) :
-        doctor_id{doctor_id}, doctor_name{move(doctor_name)}, degree{move(degree)} {}
+        doctor_id{doctor_id}, doctor_name{std::move(doctor_name)}, degree{std::move(degree)} {}
 #endif
 };
 
@@ -34,7 +34,7 @@ struct Speciality {
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
     Speciality() = default;
     Speciality(int spl_id, std::string spl_descrip, int doctor_id) :
-        spl_id{spl_id}, spl_descrip{move(spl_descrip)}, doctor_id{doctor_id} {}
+        spl_id{spl_id}, spl_descrip{std::move(spl_descrip)}, doctor_id{doctor_id} {}
 #endif
 };
 
@@ -46,7 +46,7 @@ struct Visit {
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
     Visit() = default;
     Visit(int doctor_id, std::string patient_name, std::string vdate) :
-        doctor_id{doctor_id}, patient_name{move(patient_name)}, vdate{move(vdate)} {}
+        doctor_id{doctor_id}, patient_name{std::move(patient_name)}, vdate{std::move(vdate)} {}
 #endif
 };
 

--- a/examples/triggers.cpp
+++ b/examples/triggers.cpp
@@ -20,7 +20,8 @@ struct Lead {
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
     Lead() = default;
     Lead(int id, std::string firstName, std::string lastName, std::string email, std::string phone) :
-        id{id}, firstName{move(firstName)}, lastName{move(lastName)}, email{move(email)}, phone{move(phone)} {}
+        id{id}, firstName{std::move(firstName)}, lastName{std::move(lastName)}, email{std::move(email)},
+        phone{std::move(phone)} {}
 #endif
 };
 

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -9078,7 +9078,7 @@ namespace sqlite_orm {
         static_assert(internal::count_tuple<cols_tuple, internal::is_where>::value <= 1,
                       "amount of where arguments can be 0 or 1");
         SQLITE_ORM_CLANG_SUPPRESS_MISSING_BRACES(
-            return {move(name), false, std::make_tuple(internal::make_indexed_column(std::move(cols))...)});
+            return {std::move(name), false, std::make_tuple(internal::make_indexed_column(std::move(cols))...)});
     }
 
     template<class... Cols>
@@ -11239,11 +11239,11 @@ namespace sqlite_orm {
             }
 
             dynamic_set_t(dynamic_set_t&& other) :
-                entries(move(other.entries)), context(std::move(other.context)),
+                entries(std::move(other.entries)), context(std::move(other.context)),
                 collector([this](const std::type_index& ti) {
                     return find_table_name(this->context.db_objects, ti);
                 }) {
-                collector.table_names = move(other.collector.table_names);
+                collector.table_names = std::move(other.collector.table_names);
             }
 
             dynamic_set_t& operator=(const dynamic_set_t& other) {
@@ -11256,12 +11256,12 @@ namespace sqlite_orm {
             }
 
             dynamic_set_t& operator=(dynamic_set_t&& other) {
-                this->entries = move(other.entries);
+                this->entries = std::move(other.entries);
                 this->context = std::move(other.context);
                 this->collector = table_name_collector([this](const std::type_index& ti) {
                     return find_table_name(this->context.db_objects, ti);
                 });
-                this->collector.table_names = move(other.collector.table_names);
+                this->collector.table_names = std::move(other.collector.table_names);
             }
 
             template<class L, class R>
@@ -16295,7 +16295,7 @@ namespace sqlite_orm {
         struct table_name_collector_holder<set_t<Args...>> {
 
             table_name_collector_holder(table_name_collector::find_table_name_t find_table_name) :
-                collector(move(find_table_name)) {}
+                collector(std::move(find_table_name)) {}
 
             table_name_collector collector;
         };
@@ -19229,7 +19229,7 @@ namespace sqlite_orm {
 
     /**
      *  Generalized form of the 'remember' SQL function that is a pass-through for values
-     *  (it returns its argument unchanged using move semantics) but also saves the
+     *  (it returns its argument unchanged using std::move semantics) but also saves the
      *  value that is passed through into a bound variable.
      */
     template<typename P>

--- a/tests/backup_tests.cpp
+++ b/tests/backup_tests.cpp
@@ -11,7 +11,7 @@ namespace {
 
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         User() = default;
-        User(int id, std::string name) : id{id}, name{move(name)} {}
+        User(int id, std::string name) : id{id}, name{std::move(name)} {}
 #endif
     };
 

--- a/tests/built_in_functions_tests/core_functions_tests.cpp
+++ b/tests/built_in_functions_tests/core_functions_tests.cpp
@@ -11,7 +11,7 @@ TEST_CASE("substr") {
 
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         Test() = default;
-        Test(std::string text, int x, int y) : text{move(text)}, x{x}, y{y} {}
+        Test(std::string text, int x, int y) : text{std::move(text)}, x{x}, y{y} {}
 #endif
     };
     auto storage = make_storage(
@@ -184,7 +184,7 @@ TEST_CASE("quote") {
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         Department() = default;
         Department(int id, std::string name, int managerId, int locationId) :
-            id{id}, name{move(name)}, managerId{managerId}, locationId{locationId} {}
+            id{id}, name{std::move(name)}, managerId{managerId}, locationId{locationId} {}
 #endif
     };
     auto storage = make_storage({},
@@ -268,7 +268,7 @@ TEST_CASE("instr") {
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         Employee() = default;
         Employee(int id, std::string firstName, std::string lastName, std::string address) :
-            id{id}, firstName{move(firstName)}, lastName{move(lastName)}, address{move(address)} {}
+            id{id}, firstName{std::move(firstName)}, lastName{std::move(lastName)}, address{std::move(address)} {}
 #endif
     };
 
@@ -340,7 +340,7 @@ namespace replace_func_local {
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         Contact() = default;
         Contact(int id, std::string firstName, std::string lastName, std::string phone) :
-            id{id}, firstName{move(firstName)}, lastName{move(lastName)}, phone{move(phone)} {}
+            id{id}, firstName{std::move(firstName)}, lastName{std::move(lastName)}, phone{std::move(phone)} {}
 #endif
     };
 
@@ -541,9 +541,10 @@ TEST_CASE("ifnull") {
                  std::string email,
                  int supportRepId) :
             id{id},
-            firstName{move(firstName)}, lastName{move(lastName)}, company{move(company)}, address{move(address)},
-            city{move(city)}, state{move(state)}, country{move(country)}, postalCode{move(postalCode)},
-            phone{move(phone)}, fax{move(fax)}, email{move(email)}, supportRepId{supportRepId} {}
+            firstName{std::move(firstName)}, lastName{std::move(lastName)}, company{std::move(company)},
+            address{std::move(address)}, city{std::move(city)}, state{std::move(state)}, country{std::move(country)},
+            postalCode{std::move(postalCode)}, phone{std::move(phone)}, fax{std::move(fax)}, email{std::move(email)},
+            supportRepId{supportRepId} {}
 #endif
     };
     auto storage = make_storage({},

--- a/tests/constraints/unique.cpp
+++ b/tests/constraints/unique.cpp
@@ -15,7 +15,7 @@ TEST_CASE("Unique") {
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         Contact() = default;
         Contact(int id, std::string firstName, std::string lastName, std::string email) :
-            id{id}, firstName{move(firstName)}, lastName{move(lastName)}, email{move(email)} {}
+            id{id}, firstName{std::move(firstName)}, lastName{std::move(lastName)}, email{std::move(email)} {}
 #endif
     };
     struct Shape {
@@ -26,7 +26,7 @@ TEST_CASE("Unique") {
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         Shape() = default;
         Shape(int id, std::string backgroundColor, std::string foregroundColor) :
-            id{id}, backgroundColor{move(backgroundColor)}, foregroundColor{move(foregroundColor)} {}
+            id{id}, backgroundColor{std::move(backgroundColor)}, foregroundColor{std::move(foregroundColor)} {}
 #endif
     };
     struct List {
@@ -35,7 +35,7 @@ TEST_CASE("Unique") {
 
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         List() = default;
-        List(int id, decltype(email) email) : id{id}, email{move(email)} {}
+        List(int id, decltype(email) email) : id{id}, email{std::move(email)} {}
 #endif
     };
 

--- a/tests/get_all_custom_containers.cpp
+++ b/tests/get_all_custom_containers.cpp
@@ -13,7 +13,7 @@ namespace {
 
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         User() = default;
-        User(int id, std::string name) : id{id}, name{move(name)} {}
+        User(int id, std::string name) : id{id}, name{std::move(name)} {}
 #endif
     };
 

--- a/tests/index_tests.cpp
+++ b/tests/index_tests.cpp
@@ -105,7 +105,7 @@ TEST_CASE("Compound index") {
 
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         User() = default;
-        User(int id, std::string name) : id{id}, name{move(name)} {}
+        User(int id, std::string name) : id{id}, name{std::move(name)} {}
 #endif
     };
     auto table = make_table("users", make_column("id", &User::id), make_column("name", &User::name));

--- a/tests/json.cpp
+++ b/tests/json.cpp
@@ -97,7 +97,7 @@ TEST_CASE("json_array_length nullable") {
         rows = storage.select(json_array_length<Type>("{\"one\":[1,2,3]}", "$.two"));
         expected = nullptr;
     }
-    value = move(rows[0]);
+    value = std::move(rows[0]);
     REQUIRE(rows.size() == 1);
     REQUIRE(bool(expected) == bool(value));
     if(expected) {

--- a/tests/operators/glob.cpp
+++ b/tests/operators/glob.cpp
@@ -19,7 +19,7 @@ namespace {
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         Employee() = default;
         Employee(int id, std::string firstName, std::string lastName, float salary, int deptId) :
-            id{id}, firstName{move(firstName)}, lastName{move(lastName)}, salary{salary}, deptId{deptId} {}
+            id{id}, firstName{std::move(firstName)}, lastName{std::move(lastName)}, salary{salary}, deptId{deptId} {}
 #endif
     };
 }

--- a/tests/operators/is_null.cpp
+++ b/tests/operators/is_null.cpp
@@ -10,7 +10,7 @@ TEST_CASE("Is null") {
 
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         User() = default;
-        User(int id, decltype(name) name = nullptr) : id{id}, name{move(name)} {}
+        User(int id, decltype(name) name = nullptr) : id{id}, name{std::move(name)} {}
 #endif
     };
     auto storage = make_storage(

--- a/tests/operators/like.cpp
+++ b/tests/operators/like.cpp
@@ -10,7 +10,7 @@ TEST_CASE("Like operator") {
 
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         User() = default;
-        User(int id, std::string name) : id{id}, name{move(name)} {}
+        User(int id, std::string name) : id{id}, name{std::move(name)} {}
 #endif
     };
     struct Pattern {

--- a/tests/pointer_passing_interface.cpp
+++ b/tests/pointer_passing_interface.cpp
@@ -112,7 +112,7 @@ TEST_CASE("pointer-passing") {
         SECTION("unbound is deleted") {
             try {
                 unique_ptr<int64, delete_int64> x{new int64(42)};
-                auto ast = select(func<fetch_from_pointer_fn>(bindable_pointer<carray_pvt>(move(x))));
+                auto ast = select(func<fetch_from_pointer_fn>(bindable_pointer<carray_pvt>(std::move(x))));
                 auto stmt = storage.prepare(std::move(ast));
                 throw std::system_error{0, std::system_category()};
             } catch(const std::system_error&) {
@@ -124,7 +124,7 @@ TEST_CASE("pointer-passing") {
         SECTION("deleted with prepared statement") {
             {
                 unique_ptr<int64, delete_int64> x{new int64(42)};
-                auto ast = select(func<fetch_from_pointer_fn>(bindable_pointer<carray_pvt>(move(x))));
+                auto ast = select(func<fetch_from_pointer_fn>(bindable_pointer<carray_pvt>(std::move(x))));
                 auto stmt = storage.prepare(std::move(ast));
 
                 storage.execute(stmt);

--- a/tests/prepared_statement_tests/insert.cpp
+++ b/tests/prepared_statement_tests/insert.cpp
@@ -15,7 +15,7 @@ TEST_CASE("Prepared insert") {
 
         Artist() = default;
 
-        Artist(decltype(id) id_, decltype(name) name_) : id(id_), name(move(name_)) {}
+        Artist(decltype(id) id_, decltype(name) name_) : id(id_), name(std::move(name_)) {}
 
         Artist(const Artist& other) :
             id(other.id), name(other.name ? std::make_unique<std::string>(*other.name) : nullptr) {}

--- a/tests/prepared_statement_tests/prepared_common.h
+++ b/tests/prepared_statement_tests/prepared_common.h
@@ -12,7 +12,7 @@ namespace PreparedStatementTests {
 
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         User() = default;
-        User(int id, std::string name) : id{id}, name{move(name)} {}
+        User(int id, std::string name) : id{id}, name{std::move(name)} {}
 #endif
     };
 
@@ -38,7 +38,7 @@ namespace PreparedStatementTests {
                      decltype(UserAndVisit::visitId) visitId,
                      std::string description) :
             userId{userId},
-            visitId{visitId}, description{move(description)} {}
+            visitId{visitId}, description{std::move(description)} {}
 #endif
     };
 

--- a/tests/private_getters_tests.cpp
+++ b/tests/private_getters_tests.cpp
@@ -9,7 +9,7 @@ TEST_CASE("Issue 343") {
       public:
         A() = default;
 
-        A(int id_, std::string name_) : name(move(name_)), id(id_) {}
+        A(int id_, std::string name_) : name(std::move(name_)), id(id_) {}
 
         int getId() const {
             return this->id;

--- a/tests/select_constraints_tests.cpp
+++ b/tests/select_constraints_tests.cpp
@@ -219,7 +219,7 @@ namespace {
 
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         User1() = default;
-        User1(int id, std::string name) : id{id}, name{move(name)} {}
+        User1(int id, std::string name) : id{id}, name{std::move(name)} {}
 #endif
     };
 
@@ -270,7 +270,7 @@ namespace {
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         User2() = default;
         User2(int id, std::string firstName, std::string lastName, std::string country) :
-            id{id}, firstName{move(firstName)}, lastName{move(lastName)}, country{country} {}
+            id{id}, firstName{std::move(firstName)}, lastName{std::move(lastName)}, country{country} {}
 #endif
     };
 
@@ -281,7 +281,8 @@ namespace {
 
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         Track2() = default;
-        Track2(int id, std::string name, long milliseconds) : id{id}, name{move(name)}, milliseconds{milliseconds} {}
+        Track2(int id, std::string name, long milliseconds) :
+            id{id}, name{std::move(name)}, milliseconds{milliseconds} {}
 #endif
     };
 
@@ -377,7 +378,7 @@ namespace {
 
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         User3() = default;
-        User3(int id, int age, std::string name) : id{id}, age{age}, name{move(name)} {}
+        User3(int id, int age, std::string name) : id{id}, age{age}, name{std::move(name)} {}
 #endif
     };
 
@@ -420,7 +421,7 @@ namespace {
 
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         User4() = default;
-        User4(int id, std::string firstName) : id{id}, firstName{move(firstName)} {}
+        User4(int id, std::string firstName) : id{id}, firstName{std::move(firstName)} {}
 #endif
 
         bool operator==(const User4& user) const {
@@ -457,7 +458,7 @@ namespace {
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         User5() = default;
         User5(int id, std::string firstName, std::string lastName, long registerTime) :
-            id{id}, firstName{move(firstName)}, lastName{move(lastName)}, registerTime{registerTime} {}
+            id{id}, firstName{std::move(firstName)}, lastName{std::move(lastName)}, registerTime{registerTime} {}
 #endif
     };
 

--- a/tests/statement_serializer_tests/column_names.cpp
+++ b/tests/statement_serializer_tests/column_names.cpp
@@ -48,7 +48,7 @@ TEST_CASE("statement_serializer column names") {
             }
 
             void setName(std::string value) {
-                this->name = move(value);
+                this->name = std::move(value);
             }
 
           private:

--- a/tests/statement_serializer_tests/foreign_key.cpp
+++ b/tests/statement_serializer_tests/foreign_key.cpp
@@ -297,7 +297,7 @@ TEST_CASE("statement_serializer foreign key") {
         struct User : Object {
             std::string name;
 
-            User(decltype(id) id_, decltype(name) name_) : Object{id_}, name(move(name_)) {}
+            User(decltype(id) id_, decltype(name) name_) : Object{id_}, name(std::move(name_)) {}
         };
 
         struct Token : Object {

--- a/tests/statement_serializer_tests/statements/insert_replace.cpp
+++ b/tests/statement_serializer_tests/statements/insert_replace.cpp
@@ -16,7 +16,7 @@ TEST_CASE("statement_serializer insert/replace") {
 
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         User() = default;
-        User(int id, std::string name) : id{id}, name{move(name)} {}
+        User(int id, std::string name) : id{id}, name{std::move(name)} {}
 #endif
     };
     struct UserBackup {
@@ -25,7 +25,7 @@ TEST_CASE("statement_serializer insert/replace") {
 
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         UserBackup() = default;
-        UserBackup(int id, std::string name) : id{id}, name{move(name)} {}
+        UserBackup(int id, std::string name) : id{id}, name{std::move(name)} {}
 #endif
     };
     auto table = make_table("users", make_column("id", &User::id), make_column("name", &User::name));

--- a/tests/static_tests/column_result_t.cpp
+++ b/tests/static_tests/column_result_t.cpp
@@ -26,7 +26,7 @@ TEST_CASE("column_result_t") {
         }
 
         void setComment(std::string comment) {
-            this->comment = move(comment);
+            this->comment = std::move(comment);
         }
 
         const std::string& getComment() const {

--- a/tests/static_tests/function_static_tests.cpp
+++ b/tests/static_tests/function_static_tests.cpp
@@ -201,7 +201,7 @@ TEST_CASE("function static") {
                 }
 
                 std::string fin() {
-                    return move(result);
+                    return std::move(result);
                 }
             };
 

--- a/tests/storage_non_crud_tests.cpp
+++ b/tests/storage_non_crud_tests.cpp
@@ -10,7 +10,7 @@ TEST_CASE("explicit from") {
 
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         User() = default;
-        User(int id, std::string name) : id{id}, name{move(name)} {}
+        User(int id, std::string name) : id{id}, name{std::move(name)} {}
 #endif
     };
     auto storage = make_storage(
@@ -80,7 +80,7 @@ TEST_CASE("update set null") {
 
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         User() = default;
-        User(int id, decltype(name) name) : id{id}, name{move(name)} {}
+        User(int id, decltype(name) name) : id{id}, name{std::move(name)} {}
 #endif
     };
 
@@ -127,7 +127,7 @@ TEST_CASE("InsertRange") {
 
 #ifndef SQLITE_ORM_AGGREGATE_PAREN_INIT_SUPPORTED
         Object() = default;
-        Object(int id, std::string name) : id{id}, name{move(name)} {}
+        Object(int id, std::string name) : id{id}, name{std::move(name)} {}
 #endif
     };
 
@@ -137,7 +137,7 @@ TEST_CASE("InsertRange") {
 
 #ifndef SQLITE_ORM_AGGREGATE_PAREN_INIT_SUPPORTED
         ObjectWithoutRowid() = default;
-        ObjectWithoutRowid(int id, std::string name) : id{id}, name{move(name)} {}
+        ObjectWithoutRowid(int id, std::string name) : id{id}, name{std::move(name)} {}
 #endif
     };
 
@@ -391,13 +391,13 @@ TEST_CASE("Replace query") {
 
 #ifndef SQLITE_ORM_AGGREGATE_PAREN_INIT_SUPPORTED
         Object() = default;
-        Object(int id, std::string name) : id{id}, name{move(name)} {}
+        Object(int id, std::string name) : id{id}, name{std::move(name)} {}
 #endif
     };
 
     struct User {
 
-        User(int id_, std::string name_) : id(id_), name(move(name_)) {}
+        User(int id_, std::string name_) : id(id_), name(std::move(name_)) {}
 
         int getId() const {
             return this->id;
@@ -412,7 +412,7 @@ TEST_CASE("Replace query") {
         }
 
         void setName(std::string name_) {
-            this->name = move(name_);
+            this->name = std::move(name_);
         }
 
       private:

--- a/tests/sync_schema_tests.cpp
+++ b/tests/sync_schema_tests.cpp
@@ -145,7 +145,7 @@ TEST_CASE("issue521") {
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         MockDatabasePoco() = default;
         MockDatabasePoco(int id, std::string name, uint32_t alpha, float beta) :
-            id{id}, name{move(name)}, alpha{alpha}, beta{beta} {}
+            id{id}, name{std::move(name)}, alpha{alpha}, beta{beta} {}
 #endif
     };
     std::vector<MockDatabasePoco> pocosToInsert;
@@ -291,7 +291,7 @@ TEST_CASE("sync_schema") {
 
         User(int id_) : id(id_) {}
 
-        User(int id_, std::string name_) : id(id_), name(move(name_)) {}
+        User(int id_, std::string name_) : id(id_), name(std::move(name_)) {}
 
         User(int id_, int age_) : id(id_), age(age_) {}
 

--- a/tests/table_tests.cpp
+++ b/tests/table_tests.cpp
@@ -57,7 +57,7 @@ TEST_CASE("table::find_column_name") {
             }
 
             void setFirstName(std::string value) {
-                this->_firstName = move(value);
+                this->_firstName = std::move(value);
             }
 
             const std::string& lastName() const {
@@ -65,7 +65,7 @@ TEST_CASE("table::find_column_name") {
             }
 
             void setLastName(std::string value) {
-                this->_lastName = move(value);
+                this->_lastName = std::move(value);
             }
 
             int countryCode() const {
@@ -81,7 +81,7 @@ TEST_CASE("table::find_column_name") {
             }
 
             void setPhoneNumber(std::string value) {
-                this->_phoneNumber = move(value);
+                this->_phoneNumber = std::move(value);
             }
 
             int visitsCount() const {

--- a/tests/tests2.cpp
+++ b/tests/tests2.cpp
@@ -79,7 +79,7 @@ TEST_CASE("insert with generated column") {
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         Product() = default;
         Product(std::string name, double price, double discount, double tax, double netPrice) :
-            name{move(name)}, price{price}, discount{discount}, tax{tax}, netPrice{netPrice} {}
+            name{std::move(name)}, price{price}, discount{discount}, tax{tax}, netPrice{netPrice} {}
 #endif
 
         bool operator==(const Product& other) const {

--- a/tests/tests4.cpp
+++ b/tests/tests4.cpp
@@ -29,7 +29,7 @@ TEST_CASE("Unique ptr in update") {
     }
     {
         std::unique_ptr<std::string> ptr;
-        storage.update_all(set(assign(&User::name, move(ptr))));
+        storage.update_all(set(assign(&User::name, std::move(ptr))));
         REQUIRE(storage.count<User>(where(is_not_null(&User::name))) == 0);
     }
 }
@@ -77,7 +77,7 @@ TEST_CASE("join") {
 
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         User() = default;
-        User(int id, std::string name) : id{id}, name{move(name)} {}
+        User(int id, std::string name) : id{id}, name{std::move(name)} {}
 #endif
     };
 

--- a/tests/transaction_tests.cpp
+++ b/tests/transaction_tests.cpp
@@ -10,7 +10,7 @@ namespace {
 
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         Object() = default;
-        Object(int id, std::string name) : id{id}, name{move(name)} {}
+        Object(int id, std::string name) : id{id}, name{std::move(name)} {}
 #endif
 
         bool operator==(const Object& other) const {
@@ -175,7 +175,7 @@ TEST_CASE("Transaction guard") {
         auto countNow = storage.count<Object>();
         REQUIRE(countNow == countBefore + 1);
     }
-    SECTION("move ctor") {
+    SECTION("std::move ctor") {
         std::vector<internal::transaction_guard_t> guards;
         auto countBefore = storage.count<Object>();
         {

--- a/tests/trigger_tests.cpp
+++ b/tests/trigger_tests.cpp
@@ -12,7 +12,7 @@ TEST_CASE("triggers_basics") {
 
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         TestInsert() = default;
-        TestInsert(int id, std::string text, int x, int y) : id{id}, text{move(text)}, x{x}, y{y} {}
+        TestInsert(int id, std::string text, int x, int y) : id{id}, text{std::move(text)}, x{x}, y{y} {}
 #endif
     };
     struct TestUpdate {
@@ -23,7 +23,7 @@ TEST_CASE("triggers_basics") {
 
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         TestUpdate() = default;
-        TestUpdate(int id, std::string text, int x, int y) : id{id}, text{move(text)}, x{x}, y{y} {}
+        TestUpdate(int id, std::string text, int x, int y) : id{id}, text{std::move(text)}, x{x}, y{y} {}
 #endif
     };
     struct TestDelete {
@@ -34,7 +34,7 @@ TEST_CASE("triggers_basics") {
 
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         TestDelete() = default;
-        TestDelete(int id, std::string text, int x, int y) : id{id}, text{move(text)}, x{x}, y{y} {}
+        TestDelete(int id, std::string text, int x, int y) : id{id}, text{std::move(text)}, x{x}, y{y} {}
 #endif
     };
 

--- a/tests/unique_cases/get_all_with_two_tables.cpp
+++ b/tests/unique_cases/get_all_with_two_tables.cpp
@@ -9,7 +9,7 @@ namespace {
 
 #ifndef SQLITE_ORM_AGGREGATE_PAREN_INIT_SUPPORTED
         Pattern() = default;
-        Pattern(std::string value) : value{move(value)} {}
+        Pattern(std::string value) : value{std::move(value)} {}
 #endif
     };
     struct Item {
@@ -18,7 +18,7 @@ namespace {
 
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         Item() = default;
-        Item(int id, std::string attributes) : id{id}, attributes{move(attributes)} {}
+        Item(int id, std::string attributes) : id{id}, attributes{std::move(attributes)} {}
 #endif
     };
 

--- a/tests/unique_cases/prepare_get_all_with_case.cpp
+++ b/tests/unique_cases/prepare_get_all_with_case.cpp
@@ -10,7 +10,7 @@ TEST_CASE("Prepare with case") {
 
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
         UserProfile() = default;
-        UserProfile(int id, std::string firstName) : id{id}, firstName{move(firstName)} {}
+        UserProfile(int id, std::string firstName) : id{id}, firstName{std::move(firstName)} {}
 #endif
     };
 


### PR DESCRIPTION
Runner-up for shuai132's PR #1130, which qualifies the call to `std::move()` for all remaining occurrences.