### PR TITLE
Removed dependency on RTTI

### DIFF
--- a/dev/alias.h
+++ b/dev/alias.h
@@ -4,6 +4,8 @@
 #include <sstream>  //  std::stringstream
 #include <string>  //  std::string
 
+#include "type_traits.h"
+
 namespace sqlite_orm {
 
     /**
@@ -86,10 +88,11 @@ namespace sqlite_orm {
      *  @return column with table alias attached. Place it instead of a column statement in case you need to specify a
      *  column with table alias prefix like 'a.column'. For more information please look through self_join.cpp example
      */
-    template<class T, class C>
-    internal::alias_column_t<T, C> alias_column(C c) {
-        static_assert(std::is_member_pointer<C>::value,
-                      "alias_column argument must be a member pointer mapped to a storage");
+    template<class A, class C>
+    internal::alias_column_t<A, C> alias_column(C c) {
+        using table_type = internal::type_t<A>;
+        static_assert(std::is_same<internal::table_type_of_t<C>, table_type>::value,
+                      "Column must be from aliased table");
         return {c};
     }
 

--- a/dev/ast/set.h
+++ b/dev/ast/set.h
@@ -6,7 +6,7 @@
 #include <sstream>  //  std::stringstream
 #include <type_traits>  //  std::false_type, std::true_type
 
-#include "table_name_collector.h"
+#include "../table_name_collector.h"
 
 namespace sqlite_orm {
 
@@ -40,30 +40,10 @@ namespace sqlite_orm {
 
             dynamic_set_t(const context_t& context_) : context(context_), collector(this->context.db_objects) {}
 
-            dynamic_set_t(const dynamic_set_t& other) :
-                entries(other.entries), context(other.context), collector(this->context.db_objects) {
-                collector.table_names = other.collector.table_names;
-            }
-
-            dynamic_set_t(dynamic_set_t&& other) :
-                entries(std::move(other.entries)), context(std::move(other.context)),
-                collector(this->context.db_objects) {
-                collector.table_names = std::move(other.collector.table_names);
-            }
-
-            dynamic_set_t& operator=(const dynamic_set_t& other) {
-                this->entries = other.entries;
-                this->context = other.context;
-                this->collector = table_name_collector(this->context.db_objects);
-                this->collector.table_names = other.collector.table_names;
-            }
-
-            dynamic_set_t& operator=(dynamic_set_t&& other) {
-                this->entries = std::move(other.entries);
-                this->context = std::move(other.context);
-                this->collector = table_name_collector(this->context.db_objects);
-                this->collector.table_names = std::move(other.collector.table_names);
-            }
+            dynamic_set_t(const dynamic_set_t& other) = default;
+            dynamic_set_t(dynamic_set_t&& other) = default;
+            dynamic_set_t& operator=(const dynamic_set_t& other) = default;
+            dynamic_set_t& operator=(dynamic_set_t&& other) = default;
 
             template<class L, class R>
             void push_back(assign_t<L, R> assign) {

--- a/dev/ast/set.h
+++ b/dev/ast/set.h
@@ -38,41 +38,30 @@ namespace sqlite_orm {
             using entry_t = dynamic_set_entry;
             using const_iterator = typename std::vector<entry_t>::const_iterator;
 
-            dynamic_set_t(const context_t& context_) :
-                context(context_), collector([this](const std::type_index& ti) {
-                    return find_table_name(this->context.db_objects, ti);
-                }) {}
+            dynamic_set_t(const context_t& context_) : context(context_), collector(this->context.db_objects) {}
 
             dynamic_set_t(const dynamic_set_t& other) :
-                entries(other.entries), context(other.context), collector([this](const std::type_index& ti) {
-                    return find_table_name(this->context.db_objects, ti);
-                }) {
+                entries(other.entries), context(other.context), collector(this->context.db_objects) {
                 collector.table_names = other.collector.table_names;
             }
 
             dynamic_set_t(dynamic_set_t&& other) :
                 entries(std::move(other.entries)), context(std::move(other.context)),
-                collector([this](const std::type_index& ti) {
-                    return find_table_name(this->context.db_objects, ti);
-                }) {
+                collector(this->context.db_objects) {
                 collector.table_names = std::move(other.collector.table_names);
             }
 
             dynamic_set_t& operator=(const dynamic_set_t& other) {
                 this->entries = other.entries;
                 this->context = other.context;
-                this->collector = table_name_collector([this](const std::type_index& ti) {
-                    return find_table_name(this->context.db_objects, ti);
-                });
+                this->collector = table_name_collector(this->context.db_objects);
                 this->collector.table_names = other.collector.table_names;
             }
 
             dynamic_set_t& operator=(dynamic_set_t&& other) {
                 this->entries = std::move(other.entries);
                 this->context = std::move(other.context);
-                this->collector = table_name_collector([this](const std::type_index& ti) {
-                    return find_table_name(this->context.db_objects, ti);
-                });
+                this->collector = table_name_collector(this->context.db_objects);
                 this->collector.table_names = std::move(other.collector.table_names);
             }
 
@@ -102,7 +91,7 @@ namespace sqlite_orm {
 
             std::vector<entry_t> entries;
             context_t context;
-            table_name_collector collector;
+            table_name_collector<typename context_t::db_objects_type> collector;
         };
 
         template<class C>

--- a/dev/ast_iterator.h
+++ b/dev/ast_iterator.h
@@ -28,9 +28,16 @@ namespace sqlite_orm {
          *  which will be called for any node of provided expression.
          *  E.g. if we pass `where(is_equal(5, max(&User::id, 10))` then
          *  callable object will be called with 5, &User::id and 10.
-         *  ast_iterator is used mostly in finding literals to be bound to
-         *  a statement. To use it just call `iterate_ast(object, callable);`
-         *  T is an ast element. E.g. where_t
+         *  ast_iterator is used in finding literals to be bound to
+         *  a statement, and to collect table names.
+         *  
+         *  Note that not all leaves of the expression tree are always visited:
+         *  Column expressions can be more complex, but are passed as a whole to the callable.
+         *  Examples are `column_pointer<>` and `alias_column_t<>`.
+         *  
+         *  To use `ast_iterator` call `iterate_ast(object, callable);`
+         *  
+         *  `T` is an ast element, e.g. where_t
          */
         template<class T, class SFINAE = void>
         struct ast_iterator {

--- a/dev/functional/static_magic.h
+++ b/dev/functional/static_magic.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#ifndef SQLITE_ORM_IF_CONSTEXPR_SUPPORTED
 #include <type_traits>  //  std::false_type, std::true_type, std::integral_constant
+#endif
 #include <utility>  //  std::forward
 
 namespace sqlite_orm {

--- a/dev/statement_binder.h
+++ b/dev/statement_binder.h
@@ -240,7 +240,7 @@ namespace sqlite_orm {
     template<>
     struct statement_binder<std::vector<char>, void> {
         int bind(sqlite3_stmt* stmt, int index, const std::vector<char>& value) const {
-            if(value.size()) {
+            if(!value.empty()) {
                 return sqlite3_bind_blob(stmt, index, (const void*)&value.front(), int(value.size()), SQLITE_TRANSIENT);
             } else {
                 return sqlite3_bind_blob(stmt, index, "", 0, SQLITE_TRANSIENT);
@@ -248,7 +248,7 @@ namespace sqlite_orm {
         }
 
         void result(sqlite3_context* context, const std::vector<char>& value) const {
-            if(value.size()) {
+            if(!value.empty()) {
                 sqlite3_result_blob(context, (const void*)&value.front(), int(value.size()), nullptr);
             } else {
                 sqlite3_result_blob(context, "", 0, nullptr);

--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -11,6 +11,7 @@
 #include <memory>
 #include <array>
 #include "functional/cxx_string_view.h"
+#include "functional/cxx_optional.h"
 
 #include "functional/cxx_universal.h"
 #include "functional/cxx_functional_polyfill.h"
@@ -1076,7 +1077,7 @@ namespace sqlite_orm {
             using statement_type = dynamic_set_t<C>;
 
             template<class Ctx>
-            std::string operator()(const statement_type& statement, const Ctx& context) const {
+            std::string operator()(const statement_type& statement, const Ctx&) const {
                 std::stringstream ss;
                 ss << "SET ";
                 int index = 0;

--- a/dev/storage_impl.h
+++ b/dev/storage_impl.h
@@ -26,7 +26,7 @@ namespace sqlite_orm {
             return res;
         }
 
-        template<class Lookup, class DBOs, satisfies<is_db_objects, DBOs> = true>
+        template<class Lookup, class DBOs, satisfies<is_db_objects, DBOs>>
         auto lookup_table(const DBOs& dbObjects) {
             return static_if<is_mapped_v<DBOs, Lookup>>(
                 [](const auto& dbObjects) {
@@ -35,7 +35,7 @@ namespace sqlite_orm {
                 empty_callable<nullptr_t>())(dbObjects);
         }
 
-        template<class Lookup, class DBOs, satisfies<is_db_objects, DBOs> = true>
+        template<class Lookup, class DBOs, satisfies<is_db_objects, DBOs>>
         std::string lookup_table_name(const DBOs& dbObjects) {
             return static_if<is_mapped_v<DBOs, Lookup>>(
                 [](const auto& dbObjects) {

--- a/dev/storage_impl.h
+++ b/dev/storage_impl.h
@@ -37,18 +37,6 @@ namespace sqlite_orm {
                 empty_callable<nullptr_t>())(dbObjects);
         }
 
-        template<class DBOs, satisfies<is_db_objects, DBOs> = true>
-        std::string find_table_name(const DBOs& dbObjects, const std::type_index& ti) {
-            std::string res;
-            iterate_tuple<true>(dbObjects, tables_index_sequence<DBOs>{}, [&ti, &res](const auto& table) {
-                using table_type = std::decay_t<decltype(table)>;
-                if(ti == typeid(object_type_t<table_type>)) {
-                    res = table.name;
-                }
-            });
-            return res;
-        }
-
         template<class Lookup, class DBOs, satisfies<is_db_objects, DBOs> = true>
         std::string lookup_table_name(const DBOs& dbObjects) {
             return static_if<is_mapped_v<DBOs, Lookup>>(

--- a/dev/storage_impl.h
+++ b/dev/storage_impl.h
@@ -36,9 +36,9 @@ namespace sqlite_orm {
         }
 
         template<class Lookup, class DBOs, satisfies<is_db_objects, DBOs>>
-        std::string lookup_table_name(const DBOs& dbObjects) {
+        decltype(auto) lookup_table_name(const DBOs& dbObjects) {
             return static_if<is_mapped_v<DBOs, Lookup>>(
-                [](const auto& dbObjects) {
+                [](const auto& dbObjects) -> const std::string& {
                     return pick_table<Lookup>(dbObjects).name;
                 },
                 empty_callable<std::string>())(dbObjects);

--- a/dev/storage_impl.h
+++ b/dev/storage_impl.h
@@ -1,12 +1,10 @@
 #pragma once
 
-#include <tuple>  //  std::tuple_size
-#include <typeindex>  //  std::type_index
 #include <string>  //  std::string
-#include <type_traits>  //  std::is_same, std::decay, std::make_index_sequence, std::index_sequence
 
-#include "functional/cxx_universal.h"
+#include "functional/cxx_universal.h"  //  ::nullptr_t
 #include "functional/static_magic.h"
+#include "tuple_helper/tuple_filter.h"
 #include "tuple_helper/tuple_iteration.h"
 #include "type_traits.h"
 #include "select_constraints.h"

--- a/dev/storage_lookup.h
+++ b/dev/storage_lookup.h
@@ -134,10 +134,10 @@ namespace sqlite_orm {
             return std::get<table_type>(dbObjects);
         }
 
-        template<class Lookup, class DBOs, satisfies<is_db_objects, DBOs>>
+        template<class Lookup, class DBOs, satisfies<is_db_objects, DBOs> = true>
         auto lookup_table(const DBOs& dbObjects);
 
-        template<class Lookup, class DBOs, satisfies<is_db_objects, DBOs>>
+        template<class Lookup, class DBOs, satisfies<is_db_objects, DBOs> = true>
         std::string lookup_table_name(const DBOs& dbObjects);
 
     }

--- a/dev/storage_lookup.h
+++ b/dev/storage_lookup.h
@@ -138,7 +138,7 @@ namespace sqlite_orm {
         auto lookup_table(const DBOs& dbObjects);
 
         template<class Lookup, class DBOs, satisfies<is_db_objects, DBOs> = true>
-        std::string lookup_table_name(const DBOs& dbObjects);
+        decltype(auto) lookup_table_name(const DBOs& dbObjects);
 
     }
 }

--- a/dev/storage_lookup.h
+++ b/dev/storage_lookup.h
@@ -133,5 +133,12 @@ namespace sqlite_orm {
             using table_type = storage_pick_table_t<Lookup, DBOs>;
             return std::get<table_type>(dbObjects);
         }
+
+        template<class Lookup, class DBOs, satisfies<is_db_objects, DBOs>>
+        auto lookup_table(const DBOs& dbObjects);
+
+        template<class Lookup, class DBOs, satisfies<is_db_objects, DBOs>>
+        std::string lookup_table_name(const DBOs& dbObjects);
+
     }
 }

--- a/dev/table_name_collector.h
+++ b/dev/table_name_collector.h
@@ -18,7 +18,7 @@ namespace sqlite_orm {
         struct table_name_collector_base {
             using table_name_set = std::set<std::pair<std::string, std::string>>;
 
-            mutable table_name_set table_names;
+            table_name_set table_names;
         };
 
         template<class DBOs>
@@ -35,24 +35,24 @@ namespace sqlite_orm {
             void operator()(const T&) const {}
 
             template<class F, class O>
-            void operator()(F O::*, std::string alias = {}) const {
-                this->table_names.emplace(lookup_table_name<O>(this->db_objects), std::move(alias));
+            void operator()(F O::*) {
+                this->table_names.emplace(lookup_table_name<O>(this->db_objects), "");
             }
 
             template<class T, class F>
-            void operator()(const column_pointer<T, F>&) const {
+            void operator()(const column_pointer<T, F>&) {
                 this->table_names.emplace(lookup_table_name<T>(this->db_objects), "");
             }
 
             template<class A, class C>
-            void operator()(const alias_column_t<A, C>&) const {
+            void operator()(const alias_column_t<A, C>&) {
                 // note: instead of accessing the column, we are interested in the type the column is aliased into
                 auto tableName = lookup_table_name<mapped_type_proxy_t<A>>(this->db_objects);
                 this->table_names.emplace(std::move(tableName), alias_extractor<A>::get());
             }
 
             template<class T>
-            void operator()(const count_asterisk_t<T>&) const {
+            void operator()(const count_asterisk_t<T>&) {
                 auto tableName = lookup_table_name<T>(this->db_objects);
                 if(!tableName.empty()) {
                     this->table_names.emplace(std::move(tableName), "");
@@ -60,12 +60,12 @@ namespace sqlite_orm {
             }
 
             template<class T, satisfies_not<std::is_base_of, alias_tag, T> = true>
-            void operator()(const asterisk_t<T>&) const {
-                this->table_names.emplace(lookup_table_name<T>(db_objects), "");
+            void operator()(const asterisk_t<T>&) {
+                this->table_names.emplace(lookup_table_name<T>(this->db_objects), "");
             }
 
             template<class T, satisfies<std::is_base_of, alias_tag, T> = true>
-            void operator()(const asterisk_t<T>&) const {
+            void operator()(const asterisk_t<T>&) {
                 // note: not all alias classes have a nested A::type
                 static_assert(polyfill::is_detected_v<type_t, T>,
                               "alias<O> must have a nested alias<O>::type typename");
@@ -74,22 +74,22 @@ namespace sqlite_orm {
             }
 
             template<class T>
-            void operator()(const object_t<T>&) const {
+            void operator()(const object_t<T>&) {
                 this->table_names.emplace(lookup_table_name<T>(this->db_objects), "");
             }
 
             template<class T>
-            void operator()(const table_rowid_t<T>&) const {
+            void operator()(const table_rowid_t<T>&) {
                 this->table_names.emplace(lookup_table_name<T>(this->db_objects), "");
             }
 
             template<class T>
-            void operator()(const table_oid_t<T>&) const {
+            void operator()(const table_oid_t<T>&) {
                 this->table_names.emplace(lookup_table_name<T>(this->db_objects), "");
             }
 
             template<class T>
-            void operator()(const table__rowid_t<T>&) const {
+            void operator()(const table__rowid_t<T>&) {
                 this->table_names.emplace(lookup_table_name<T>(this->db_objects), "");
             }
         };

--- a/dev/table_name_collector.h
+++ b/dev/table_name_collector.h
@@ -9,6 +9,7 @@
 #include "select_constraints.h"
 #include "alias.h"
 #include "core_functions.h"
+#include "storage_lookup.h"
 
 namespace sqlite_orm {
 
@@ -93,7 +94,7 @@ namespace sqlite_orm {
             }
         };
 
-        template<class DBOs>
+        template<class DBOs, satisfies<is_db_objects, DBOs> = true>
         table_name_collector<DBOs> make_table_name_collector(const DBOs& dbObjects) {
             return {dbObjects};
         }

--- a/dev/table_name_collector.h
+++ b/dev/table_name_collector.h
@@ -4,6 +4,7 @@
 #include <string>  //  std::string
 #include <functional>  //  std::function
 #include <typeindex>  //  std::type_index
+#include <utility>  //  std::move
 
 #include "functional/cxx_type_traits_polyfill.h"
 #include "type_traits.h"
@@ -41,9 +42,11 @@ namespace sqlite_orm {
                 table_names.emplace(this->find_table_name(typeid(T)), "");
             }
 
-            template<class T, class C>
-            void operator()(const alias_column_t<T, C>& a) const {
-                (*this)(a.column, alias_extractor<T>::get());
+            template<class A, class C>
+            void operator()(const alias_column_t<A, C>&) const {
+                // note: instead of accessing the column, we are interested in the type the column is aliased into
+                auto tableName = this->find_table_name(typeid(mapped_type_proxy_t<A>));
+                table_names.emplace(std::move(tableName), alias_extractor<A>::get());
             }
 
             template<class T>

--- a/dev/table_type_of.h
+++ b/dev/table_type_of.h
@@ -1,13 +1,14 @@
 #pragma once
 
-#include "indexed_column.h"
-
 namespace sqlite_orm {
 
     namespace internal {
 
         template<class T, class F>
         struct column_pointer;
+
+        template<class C>
+        struct indexed_column_t;
 
         /**
          *  Trait class used to define table mapped type by setter/getter/member

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -11089,7 +11089,7 @@ namespace sqlite_orm {
 #include <sstream>  //  std::stringstream
 #include <type_traits>  //  std::false_type, std::true_type
 
-// #include "table_name_collector.h"
+// #include "../table_name_collector.h"
 
 #include <set>  //  std::set
 #include <string>  //  std::string
@@ -11104,6 +11104,8 @@ namespace sqlite_orm {
 // #include "alias.h"
 
 // #include "core_functions.h"
+
+// #include "storage_lookup.h"
 
 namespace sqlite_orm {
 
@@ -11188,7 +11190,7 @@ namespace sqlite_orm {
             }
         };
 
-        template<class DBOs>
+        template<class DBOs, satisfies<is_db_objects, DBOs> = true>
         table_name_collector<DBOs> make_table_name_collector(const DBOs& dbObjects) {
             return {dbObjects};
         }
@@ -11229,30 +11231,10 @@ namespace sqlite_orm {
 
             dynamic_set_t(const context_t& context_) : context(context_), collector(this->context.db_objects) {}
 
-            dynamic_set_t(const dynamic_set_t& other) :
-                entries(other.entries), context(other.context), collector(this->context.db_objects) {
-                collector.table_names = other.collector.table_names;
-            }
-
-            dynamic_set_t(dynamic_set_t&& other) :
-                entries(std::move(other.entries)), context(std::move(other.context)),
-                collector(this->context.db_objects) {
-                collector.table_names = std::move(other.collector.table_names);
-            }
-
-            dynamic_set_t& operator=(const dynamic_set_t& other) {
-                this->entries = other.entries;
-                this->context = other.context;
-                this->collector = table_name_collector(this->context.db_objects);
-                this->collector.table_names = other.collector.table_names;
-            }
-
-            dynamic_set_t& operator=(dynamic_set_t&& other) {
-                this->entries = std::move(other.entries);
-                this->context = std::move(other.context);
-                this->collector = table_name_collector(this->context.db_objects);
-                this->collector.table_names = std::move(other.collector.table_names);
-            }
+            dynamic_set_t(const dynamic_set_t& other) = default;
+            dynamic_set_t(dynamic_set_t&& other) = default;
+            dynamic_set_t& operator=(const dynamic_set_t& other) = default;
+            dynamic_set_t& operator=(dynamic_set_t&& other) = default;
 
             template<class L, class R>
             void push_back(assign_t<L, R> assign) {

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -9390,10 +9390,10 @@ namespace sqlite_orm {
             return std::get<table_type>(dbObjects);
         }
 
-        template<class Lookup, class DBOs, satisfies<is_db_objects, DBOs>>
+        template<class Lookup, class DBOs, satisfies<is_db_objects, DBOs> = true>
         auto lookup_table(const DBOs& dbObjects);
 
-        template<class Lookup, class DBOs, satisfies<is_db_objects, DBOs>>
+        template<class Lookup, class DBOs, satisfies<is_db_objects, DBOs> = true>
         std::string lookup_table_name(const DBOs& dbObjects);
 
     }
@@ -10504,7 +10504,7 @@ namespace sqlite_orm {
             return res;
         }
 
-        template<class Lookup, class DBOs, satisfies<is_db_objects, DBOs> = true>
+        template<class Lookup, class DBOs, satisfies<is_db_objects, DBOs>>
         auto lookup_table(const DBOs& dbObjects) {
             return static_if<is_mapped_v<DBOs, Lookup>>(
                 [](const auto& dbObjects) {
@@ -10513,7 +10513,7 @@ namespace sqlite_orm {
                 empty_callable<nullptr_t>())(dbObjects);
         }
 
-        template<class Lookup, class DBOs, satisfies<is_db_objects, DBOs> = true>
+        template<class Lookup, class DBOs, satisfies<is_db_objects, DBOs>>
         std::string lookup_table_name(const DBOs& dbObjects) {
             return static_if<is_mapped_v<DBOs, Lookup>>(
                 [](const auto& dbObjects) {

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -9394,7 +9394,7 @@ namespace sqlite_orm {
         auto lookup_table(const DBOs& dbObjects);
 
         template<class Lookup, class DBOs, satisfies<is_db_objects, DBOs> = true>
-        std::string lookup_table_name(const DBOs& dbObjects);
+        decltype(auto) lookup_table_name(const DBOs& dbObjects);
 
     }
 }
@@ -10514,9 +10514,9 @@ namespace sqlite_orm {
         }
 
         template<class Lookup, class DBOs, satisfies<is_db_objects, DBOs>>
-        std::string lookup_table_name(const DBOs& dbObjects) {
+        decltype(auto) lookup_table_name(const DBOs& dbObjects) {
             return static_if<is_mapped_v<DBOs, Lookup>>(
-                [](const auto& dbObjects) {
+                [](const auto& dbObjects) -> const std::string& {
                     return pick_table<Lookup>(dbObjects).name;
                 },
                 empty_callable<std::string>())(dbObjects);

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -16275,6 +16275,14 @@ namespace sqlite_orm {
             return set.collector.table_names;
         }
 
+        template<class Ctx, class T, satisfies<is_select, T> = true>
+        std::set<std::pair<std::string, std::string>> collect_table_names(const T& sel, const Ctx& ctx) {
+            auto collector = make_table_name_collector(ctx.db_objects);
+            iterate_ast(sel.col, collector);
+            iterate_ast(sel.conditions, collector);
+            return std::move(collector.table_names);
+        }
+
         template<class S, class... Wargs>
         struct statement_serializer<update_all_t<S, Wargs...>, void> {
             using statement_type = update_all_t<S, Wargs...>;
@@ -16649,22 +16657,20 @@ namespace sqlite_orm {
                     ss << static_cast<std::string>(distinct(0)) << " ";
                 }
                 ss << streaming_serialized(get_column_names(sel.col, context));
-                auto collector = make_table_name_collector(context.db_objects);
                 constexpr bool explicitFromItemsCount = count_tuple<std::tuple<Args...>, is_from>::value;
                 if(!explicitFromItemsCount) {
-                    iterate_ast(sel.col, collector);
-                    iterate_ast(sel.conditions, collector);
-                    join_iterator<Args...>()([&collector, &context](const auto& c) {
+                    auto tableNames = collect_table_names(sel, context);
+                    join_iterator<Args...>()([&tableNames, &context](const auto& c) {
                         using original_join_type = typename std::decay_t<decltype(c)>::join_type::type;
                         using cross_join_type = mapped_type_proxy_t<original_join_type>;
                         auto crossJoinedTableName = lookup_table_name<cross_join_type>(context.db_objects);
                         auto tableAliasString = alias_extractor<original_join_type>::get();
                         std::pair<std::string, std::string> tableNameWithAlias{std::move(crossJoinedTableName),
                                                                                std::move(tableAliasString)};
-                        collector.table_names.erase(tableNameWithAlias);
+                        tableNames.erase(tableNameWithAlias);
                     });
-                    if(!collector.table_names.empty() && !isCompoundOperator) {
-                        ss << " FROM " << streaming_identifiers(collector.table_names);
+                    if(!tableNames.empty() && !isCompoundOperator) {
+                        ss << " FROM " << streaming_identifiers(tableNames);
                     }
                 }
                 ss << streaming_conditions_tuple(sel.conditions, context);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -129,6 +129,7 @@ add_executable(unit_tests
     row_id.cpp
     trigger_tests.cpp
     ast_iterator_tests.cpp
+    table_name_collector.cpp
     pointer_passing_interface.cpp
 )
 

--- a/tests/ast_iterator_tests.cpp
+++ b/tests/ast_iterator_tests.cpp
@@ -1,6 +1,8 @@
 #include <sqlite_orm/sqlite_orm.h>
 #include <catch2/catch_all.hpp>
 
+#include <typeindex>  //  std::type_index
+
 using namespace sqlite_orm;
 
 TEST_CASE("ast_iterator") {

--- a/tests/table_name_collector.cpp
+++ b/tests/table_name_collector.cpp
@@ -13,13 +13,11 @@ TEST_CASE("table name collector") {
     auto table = make_table("users", make_column("id", &User::id), make_column("name", &User::name));
     using db_objects_t = internal::db_objects_tuple<decltype(table)>;
     auto dbObjects = db_objects_t{table};
-    internal::table_name_collector::table_name_set expected;
+    internal::table_name_collector_base::table_name_set expected;
 
     SECTION("from table") {
         internal::serializer_context<db_objects_t> context{dbObjects};
-        internal::table_name_collector collector([&context](const std::type_index& ti) {
-            return internal::find_table_name(context.db_objects, ti);
-        });
+        auto collector = internal::make_table_name_collector(context.db_objects);
 
         SECTION("regular column") {
             using als = alias_z<User>;

--- a/tests/table_name_collector.cpp
+++ b/tests/table_name_collector.cpp
@@ -1,0 +1,49 @@
+#include <sqlite_orm/sqlite_orm.h>
+#include <catch2/catch_all.hpp>
+
+using namespace sqlite_orm;
+using internal::alias_extractor;
+
+TEST_CASE("table name collector") {
+    struct User {
+        int id = 0;
+        std::string name;
+    };
+
+    auto table = make_table("users", make_column("id", &User::id), make_column("name", &User::name));
+    using db_objects_t = internal::db_objects_tuple<decltype(table)>;
+    auto dbObjects = db_objects_t{table};
+    internal::table_name_collector::table_name_set expected;
+
+    SECTION("from table") {
+        internal::serializer_context<db_objects_t> context{dbObjects};
+        internal::table_name_collector collector([&context](const std::type_index& ti) {
+            return internal::find_table_name(context.db_objects, ti);
+        });
+
+        SECTION("regular column") {
+            using als = alias_z<User>;
+            auto expression = &User::id;
+            expected.emplace(table.name, "");
+            iterate_ast(expression, collector);
+        }
+        SECTION("regular column pointer") {
+            auto expression = column<User>(&User::id);
+            expected.emplace(table.name, "");
+            iterate_ast(expression, collector);
+        }
+        SECTION("aliased regular column") {
+            using als = alias_z<User>;
+            auto expression = alias_column<als>(&User::id);
+            expected.emplace(table.name, "z");
+            iterate_ast(expression, collector);
+        }
+        SECTION("aliased regular column pointer") {
+            using als = alias_z<User>;
+            auto expression = alias_column<als>(column<User>(&User::id));
+            expected.emplace(table.name, "z");
+            iterate_ast(expression, collector);
+        }
+        REQUIRE(collector.table_names == expected);
+    }
+}


### PR DESCRIPTION
Addresses #1136.

* Made inner workings of sqlite_orm independent of RTTI
* Added a few unit tests for the table name collector

Also in this PR:
* Made aliased columns work with column pointers