### PR TITLE
Corrected the detection of the availability of `std::identity`

### DIFF
--- a/dev/functional/cxx_functional_polyfill.h
+++ b/dev/functional/cxx_functional_polyfill.h
@@ -14,9 +14,14 @@ namespace sqlite_orm {
     namespace internal {
         namespace polyfill {
             // C++20 or later (unfortunately there's no feature test macro).
-            // Stupidly, clang says C++20, but `std::identity` was only implemented in libc++ 13.
+            // Stupidly, clang says C++20, but `std::identity` was only implemented in libc++ 13 and libstd++-v3 10
+            // (the latter is used on Linux).
+            // gcc got it right and reports C++20 only starting with v10.
+            // The check here doesn't care and checks the library versions in use.
+            //
             // Another way of detection would be the constrained algorithms feature macro __cpp_lib_ranges
-#if(__cplusplus >= 202002L) && (!_LIBCPP_VERSION || _LIBCPP_VERSION >= 13)
+#if(__cplusplus >= 202002L) &&                                                                                         \
+    ((!_LIBCPP_VERSION || _LIBCPP_VERSION >= 13) && (!_GLIBCXX_RELEASE || _GLIBCXX_RELEASE >= 10))
             using std::identity;
 #else
             struct identity {

--- a/dev/functional/cxx_functional_polyfill.h
+++ b/dev/functional/cxx_functional_polyfill.h
@@ -14,9 +14,9 @@ namespace sqlite_orm {
     namespace internal {
         namespace polyfill {
             // C++20 or later (unfortunately there's no feature test macro).
-            // Stupidly, clang < 11 says C++20, but comes w/o std::identity.
+            // Stupidly, clang says C++20, but `std::identity` was only implemented in libc++ 13.
             // Another way of detection would be the constrained algorithms feature macro __cpp_lib_ranges
-#if(__cplusplus >= 202002L) && (!__clang_major__ || __clang_major__ >= 11)
+#if(__cplusplus >= 202002L) && (!_LIBCPP_VERSION || _LIBCPP_VERSION >= 13)
             using std::identity;
 #else
             struct identity {

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -7932,9 +7932,14 @@ namespace sqlite_orm {
     namespace internal {
         namespace polyfill {
             // C++20 or later (unfortunately there's no feature test macro).
-            // Stupidly, clang says C++20, but `std::identity` was only implemented in libc++ 13.
+            // Stupidly, clang says C++20, but `std::identity` was only implemented in libc++ 13 and libstd++-v3 10
+            // (the latter is used on Linux).
+            // gcc got it right and reports C++20 only starting with v10.
+            // The check here doesn't care and checks the library versions in use.
+            //
             // Another way of detection would be the constrained algorithms feature macro __cpp_lib_ranges
-#if(__cplusplus >= 202002L) && (!_LIBCPP_VERSION || _LIBCPP_VERSION >= 13)
+#if(__cplusplus >= 202002L) &&                                                                                         \
+    ((!_LIBCPP_VERSION || _LIBCPP_VERSION >= 13) && (!_GLIBCXX_RELEASE || _GLIBCXX_RELEASE >= 10))
             using std::identity;
 #else
             struct identity {

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -7932,9 +7932,9 @@ namespace sqlite_orm {
     namespace internal {
         namespace polyfill {
             // C++20 or later (unfortunately there's no feature test macro).
-            // Stupidly, clang < 11 says C++20, but comes w/o std::identity.
+            // Stupidly, clang says C++20, but `std::identity` was only implemented in libc++ 13.
             // Another way of detection would be the constrained algorithms feature macro __cpp_lib_ranges
-#if(__cplusplus >= 202002L) && (!__clang_major__ || __clang_major__ >= 11)
+#if(__cplusplus >= 202002L) && (!_LIBCPP_VERSION || _LIBCPP_VERSION >= 13)
             using std::identity;
 #else
             struct identity {


### PR DESCRIPTION
Addresses #1139.

Whether `std::identity` is available does not depend on the Clang version, but either on the version of libc++, which must be 13 or higher, or on the version of libstdc++-v3, which must be 10 or higher.
Interestingly, other SDKs like the Android NDK 25 come with clang 14 but libc++ 11.

So this PR corrects the detection of the availability of `std::identity`.