### PR TITLE
Properly guard everywhere the availability of the 'upsert clause' feature

### DIFF
--- a/dev/ast/upsert_clause.h
+++ b/dev/ast/upsert_clause.h
@@ -1,8 +1,9 @@
 #pragma once
 
-#include <tuple>  //  std::tuple, std::make_tuple
-#include <type_traits>  //  std::false_type, std::true_type
+#if SQLITE_VERSION_NUMBER >= 3024000
+#include <tuple>  //  std::tuple
 #include <utility>  //  std::forward, std::move
+#endif
 
 #include "../functional/cxx_type_traits_polyfill.h"
 
@@ -24,7 +25,7 @@ namespace sqlite_orm {
 
             template<class... ActionsArgs>
             upsert_clause<args_tuple, std::tuple<ActionsArgs...>> do_update(ActionsArgs... actions) {
-                return {std::move(this->args), {std::make_tuple(std::forward<ActionsArgs>(actions)...)}};
+                return {std::move(this->args), {std::forward<ActionsArgs>(actions)...}};
             }
         };
 
@@ -40,8 +41,13 @@ namespace sqlite_orm {
 
         template<class T>
         using is_upsert_clause = polyfill::is_specialization_of<T, upsert_clause>;
+#else
+        template<class T>
+        struct is_upsert_clause : polyfill::bool_constant<false> {};
+#endif
     }
 
+#if SQLITE_VERSION_NUMBER >= 3024000
     /**
      *  ON CONFLICT upsert clause builder function.
      *  @example

--- a/dev/ast_iterator.h
+++ b/dev/ast_iterator.h
@@ -105,9 +105,9 @@ namespace sqlite_orm {
             }
         };
 
-        template<class... TargetArgs, class... ActionsArgs>
-        struct ast_iterator<upsert_clause<std::tuple<TargetArgs...>, std::tuple<ActionsArgs...>>, void> {
-            using node_type = upsert_clause<std::tuple<TargetArgs...>, std::tuple<ActionsArgs...>>;
+        template<class T>
+        struct ast_iterator<T, match_if<is_upsert_clause, T>> {
+            using node_type = T;
 
             template<class L>
             void operator()(const node_type& expression, L& lambda) const {

--- a/dev/node_tuple.h
+++ b/dev/node_tuple.h
@@ -54,9 +54,8 @@ namespace sqlite_orm {
             using type = tuple_cat_t<args_tuple, expression_tuple>;
         };
 
-        template<class... TargetArgs, class... ActionsArgs>
-        struct node_tuple<upsert_clause<std::tuple<TargetArgs...>, std::tuple<ActionsArgs...>>, void>
-            : node_tuple<std::tuple<ActionsArgs...>> {};
+        template<class T>
+        struct node_tuple<T, match_if<is_upsert_clause, T>> : node_tuple<typename T::actions_tuple> {};
 
         template<class... Args>
         struct node_tuple<set_t<Args...>, void> {

--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -224,9 +224,9 @@ namespace sqlite_orm {
             }
         };
 
-        template<class... TargetArgs, class... ActionsArgs>
-        struct statement_serializer<upsert_clause<std::tuple<TargetArgs...>, std::tuple<ActionsArgs...>>, void> {
-            using statement_type = upsert_clause<std::tuple<TargetArgs...>, std::tuple<ActionsArgs...>>;
+        template<class T>
+        struct statement_serializer<T, match_if<is_upsert_clause, T>> {
+            using statement_type = T;
 
             template<class Ctx>
             std::string operator()(const statement_type& statement, const Ctx& context) const {

--- a/dev/table.h
+++ b/dev/table.h
@@ -110,6 +110,8 @@ namespace sqlite_orm {
                                   constexpr size_t opIndex = first_index_sequence_value(generated_op_index_sequence{});
                                   result = &get<opIndex>(column.constraints).storage;
                               });
+#else
+                (void)name;
 #endif
                 return result;
             }

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -9765,6 +9765,8 @@ namespace sqlite_orm {
                                   constexpr size_t opIndex = first_index_sequence_value(generated_op_index_sequence{});
                                   result = &get<opIndex>(column.constraints).storage;
                               });
+#else
+                (void)name;
 #endif
                 return result;
             }

--- a/tests/ast_iterator_tests.cpp
+++ b/tests/ast_iterator_tests.cpp
@@ -207,12 +207,14 @@ TEST_CASE("ast_iterator") {
         expected.push_back(typeid(&User::id));
         iterate_ast(node, lambda);
     }
+#if SQLITE_VERSION_NUMBER >= 3024000
     SECTION("upsert_clause") {
         auto node = on_conflict(&User::id).do_update(set(c(&User::name) = excluded(&User::name)));
         expected.push_back(typeid(&User::name));
         expected.push_back(typeid(&User::name));
         iterate_ast(node, lambda);
     }
+#endif
     SECTION("into") {
         auto node = into<User>();
         iterate_ast(node, lambda);

--- a/tests/statement_serializer_tests/ast/upsert_clause.cpp
+++ b/tests/statement_serializer_tests/ast/upsert_clause.cpp
@@ -3,6 +3,7 @@
 
 using namespace sqlite_orm;
 
+#if SQLITE_VERSION_NUMBER >= 3024000
 TEST_CASE("upsert_clause") {
     using internal::serialize;
     struct Vocabulary {
@@ -102,3 +103,4 @@ TEST_CASE("upsert_clause") {
     }
     REQUIRE(value == expected);
 }
+#endif

--- a/tests/static_tests/node_tuple.cpp
+++ b/tests/static_tests/node_tuple.cpp
@@ -925,6 +925,7 @@ TEST_CASE("Node tuple") {
         using ExpectedTuple = tuple<decltype(&User::id)>;
         STATIC_REQUIRE(std::is_same<Tuple, ExpectedTuple>::value);
     }
+#if SQLITE_VERSION_NUMBER >= 3024000
     SECTION("upsert_clause") {
         auto statement = on_conflict(&User::id).do_update(set(c(&User::name) = excluded(&User::name)));
         using Statement = decltype(statement);
@@ -932,6 +933,7 @@ TEST_CASE("Node tuple") {
         using ExpectedTuple = tuple<decltype(&User::name), decltype(&User::name)>;
         STATIC_REQUIRE(std::is_same<Tuple, ExpectedTuple>::value);
     }
+#endif
     SECTION("group_by") {
         auto statement = group_by(&User::id);
         using Statement = decltype(statement);


### PR DESCRIPTION
Properly guard everywhere the availability of the 'upsert clause' feature, which is available since SQLite 3.24.

Continuation of PR #1146.