### PR TITLE
Tests for constrained join clauses with regard to table collection

### DIFF
--- a/dev/ast_iterator.h
+++ b/dev/ast_iterator.h
@@ -497,13 +497,13 @@ namespace sqlite_orm {
             }
         };
 
-        template<class T, class O>
-        struct ast_iterator<left_join_t<T, O>, void> {
-            using node_type = left_join_t<T, O>;
+        template<class Join>
+        struct ast_iterator<Join, match_if<is_constrained_join, Join>> {
+            using node_type = Join;
 
             template<class L>
-            void operator()(const node_type& j, L& lambda) const {
-                iterate_ast(j.constraint, lambda);
+            void operator()(const node_type& join, L& lambda) const {
+                iterate_ast(join.constraint, lambda);
             }
         };
 
@@ -512,8 +512,8 @@ namespace sqlite_orm {
             using node_type = on_t<T>;
 
             template<class L>
-            void operator()(const node_type& o, L& lambda) const {
-                iterate_ast(o.arg, lambda);
+            void operator()(const node_type& on, L& lambda) const {
+                iterate_ast(on.arg, lambda);
             }
         };
 
@@ -526,36 +526,6 @@ namespace sqlite_orm {
             template<class L>
             void operator()(const node_type& o, L& lambda) const {
                 iterate_ast(o.column, lambda);
-            }
-        };
-
-        template<class T, class O>
-        struct ast_iterator<join_t<T, O>, void> {
-            using node_type = join_t<T, O>;
-
-            template<class L>
-            void operator()(const node_type& j, L& lambda) const {
-                iterate_ast(j.constraint, lambda);
-            }
-        };
-
-        template<class T, class O>
-        struct ast_iterator<left_outer_join_t<T, O>, void> {
-            using node_type = left_outer_join_t<T, O>;
-
-            template<class L>
-            void operator()(const node_type& j, L& lambda) const {
-                iterate_ast(j.constraint, lambda);
-            }
-        };
-
-        template<class T, class O>
-        struct ast_iterator<inner_join_t<T, O>, void> {
-            using node_type = inner_join_t<T, O>;
-
-            template<class L>
-            void operator()(const node_type& j, L& lambda) const {
-                iterate_ast(j.constraint, lambda);
             }
         };
 

--- a/dev/conditions.h
+++ b/dev/conditions.h
@@ -813,7 +813,7 @@ namespace sqlite_orm {
         using is_from = polyfill::is_specialization_of<T, from_t>;
 
         template<class T>
-        using is_any_join = polyfill::is_detected<on_type_t, T>;
+        using is_constrained_join = polyfill::is_detected<on_type_t, T>;
     }
 
     /**

--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -1506,7 +1506,8 @@ namespace sqlite_orm {
                 constexpr bool hasExplicitFrom = tuple_has<is_from, conditions_tuple>::value;
                 if(!hasExplicitFrom) {
                     auto tableNames = collect_table_names(sel, context);
-                    using joins_index_sequence = filter_tuple_sequence_t<conditions_tuple, is_any_join>;
+                    using joins_index_sequence = filter_tuple_sequence_t<conditions_tuple, is_constrained_join>;
+                    // deduplicate table names of constrained join statements
                     iterate_tuple(sel.conditions, joins_index_sequence{}, [&tableNames, &context](auto& join) {
                         using original_join_type = typename std::decay_t<decltype(join)>::type;
                         using cross_join_type = mapped_type_proxy_t<original_join_type>;
@@ -1851,7 +1852,7 @@ namespace sqlite_orm {
                 ss << static_cast<std::string>(l) << " "
                    << streaming_identifier(lookup_table_name<mapped_type_proxy_t<T>>(context.db_objects),
                                            alias_extractor<T>::as_alias())
-                   << serialize(l.constraint, context);
+                   << " " << serialize(l.constraint, context);
                 return ss.str();
             }
         };

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -3775,7 +3775,7 @@ namespace sqlite_orm {
         using is_from = polyfill::is_specialization_of<T, from_t>;
 
         template<class T>
-        using is_any_join = polyfill::is_detected<on_type_t, T>;
+        using is_constrained_join = polyfill::is_detected<on_type_t, T>;
     }
 
     /**
@@ -16965,7 +16965,8 @@ namespace sqlite_orm {
                 constexpr bool hasExplicitFrom = tuple_has<is_from, conditions_tuple>::value;
                 if(!hasExplicitFrom) {
                     auto tableNames = collect_table_names(sel, context);
-                    using joins_index_sequence = filter_tuple_sequence_t<conditions_tuple, is_any_join>;
+                    using joins_index_sequence = filter_tuple_sequence_t<conditions_tuple, is_constrained_join>;
+                    // deduplicate table names of constrained join statements
                     iterate_tuple(sel.conditions, joins_index_sequence{}, [&tableNames, &context](auto& join) {
                         using original_join_type = typename std::decay_t<decltype(join)>::type;
                         using cross_join_type = mapped_type_proxy_t<original_join_type>;
@@ -17310,7 +17311,7 @@ namespace sqlite_orm {
                 ss << static_cast<std::string>(l) << " "
                    << streaming_identifier(lookup_table_name<mapped_type_proxy_t<T>>(context.db_objects),
                                            alias_extractor<T>::as_alias())
-                   << serialize(l.constraint, context);
+                   << " " << serialize(l.constraint, context);
                 return ss.str();
             }
         };

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -12887,13 +12887,13 @@ namespace sqlite_orm {
             }
         };
 
-        template<class T, class O>
-        struct ast_iterator<left_join_t<T, O>, void> {
-            using node_type = left_join_t<T, O>;
+        template<class Join>
+        struct ast_iterator<Join, match_if<is_constrained_join, Join>> {
+            using node_type = Join;
 
             template<class L>
-            void operator()(const node_type& j, L& lambda) const {
-                iterate_ast(j.constraint, lambda);
+            void operator()(const node_type& join, L& lambda) const {
+                iterate_ast(join.constraint, lambda);
             }
         };
 
@@ -12902,8 +12902,8 @@ namespace sqlite_orm {
             using node_type = on_t<T>;
 
             template<class L>
-            void operator()(const node_type& o, L& lambda) const {
-                iterate_ast(o.arg, lambda);
+            void operator()(const node_type& on, L& lambda) const {
+                iterate_ast(on.arg, lambda);
             }
         };
 
@@ -12916,36 +12916,6 @@ namespace sqlite_orm {
             template<class L>
             void operator()(const node_type& o, L& lambda) const {
                 iterate_ast(o.column, lambda);
-            }
-        };
-
-        template<class T, class O>
-        struct ast_iterator<join_t<T, O>, void> {
-            using node_type = join_t<T, O>;
-
-            template<class L>
-            void operator()(const node_type& j, L& lambda) const {
-                iterate_ast(j.constraint, lambda);
-            }
-        };
-
-        template<class T, class O>
-        struct ast_iterator<left_outer_join_t<T, O>, void> {
-            using node_type = left_outer_join_t<T, O>;
-
-            template<class L>
-            void operator()(const node_type& j, L& lambda) const {
-                iterate_ast(j.constraint, lambda);
-            }
-        };
-
-        template<class T, class O>
-        struct ast_iterator<inner_join_t<T, O>, void> {
-            using node_type = inner_join_t<T, O>;
-
-            template<class L>
-            void operator()(const node_type& j, L& lambda) const {
-                iterate_ast(j.constraint, lambda);
             }
         };
 
@@ -17288,30 +17258,33 @@ namespace sqlite_orm {
             }
         };
 
-        template<class O>
-        struct statement_serializer<cross_join_t<O>, void> {
-            using statement_type = cross_join_t<O>;
+        template<class Join>
+        struct statement_serializer<
+            Join,
+            std::enable_if_t<polyfill::disjunction_v<polyfill::is_specialization_of<Join, cross_join_t>,
+                                                     polyfill::is_specialization_of<Join, natural_join_t>>>> {
+            using statement_type = Join;
 
             template<class Ctx>
-            std::string operator()(const statement_type& c, const Ctx& context) const {
+            std::string operator()(const statement_type& join, const Ctx& context) const {
                 std::stringstream ss;
-                ss << static_cast<std::string>(c) << " "
-                   << streaming_identifier(lookup_table_name<O>(context.db_objects));
+                ss << static_cast<std::string>(join) << " "
+                   << streaming_identifier(lookup_table_name<type_t<Join>>(context.db_objects));
                 return ss.str();
             }
         };
 
-        template<class T, class O>
-        struct statement_serializer<inner_join_t<T, O>, void> {
-            using statement_type = inner_join_t<T, O>;
+        template<class Join>
+        struct statement_serializer<Join, match_if<is_constrained_join, Join>> {
+            using statement_type = Join;
 
             template<class Ctx>
-            std::string operator()(const statement_type& l, const Ctx& context) const {
+            std::string operator()(const statement_type& join, const Ctx& context) const {
                 std::stringstream ss;
-                ss << static_cast<std::string>(l) << " "
-                   << streaming_identifier(lookup_table_name<mapped_type_proxy_t<T>>(context.db_objects),
-                                           alias_extractor<T>::as_alias())
-                   << " " << serialize(l.constraint, context);
+                ss << static_cast<std::string>(join) << " "
+                   << streaming_identifier(lookup_table_name<mapped_type_proxy_t<type_t<Join>>>(context.db_objects),
+                                           alias_extractor<type_t<Join>>::as_alias())
+                   << " " << serialize(join.constraint, context);
                 return ss.str();
             }
         };
@@ -17321,69 +17294,11 @@ namespace sqlite_orm {
             using statement_type = on_t<T>;
 
             template<class Ctx>
-            std::string operator()(const statement_type& t, const Ctx& context) const {
+            std::string operator()(const statement_type& on, const Ctx& context) const {
                 std::stringstream ss;
                 auto newContext = context;
                 newContext.skip_table_name = false;
-                ss << static_cast<std::string>(t) << " " << serialize(t.arg, newContext) << " ";
-                return ss.str();
-            }
-        };
-
-        template<class T, class O>
-        struct statement_serializer<join_t<T, O>, void> {
-            using statement_type = join_t<T, O>;
-
-            template<class Ctx>
-            std::string operator()(const statement_type& l, const Ctx& context) const {
-                std::stringstream ss;
-                ss << static_cast<std::string>(l) << " "
-                   << streaming_identifier(lookup_table_name<mapped_type_proxy_t<T>>(context.db_objects),
-                                           alias_extractor<T>::as_alias())
-                   << " " << serialize(l.constraint, context);
-                return ss.str();
-            }
-        };
-
-        template<class T, class O>
-        struct statement_serializer<left_join_t<T, O>, void> {
-            using statement_type = left_join_t<T, O>;
-
-            template<class Ctx>
-            std::string operator()(const statement_type& l, const Ctx& context) const {
-                std::stringstream ss;
-                ss << static_cast<std::string>(l) << " "
-                   << streaming_identifier(lookup_table_name<mapped_type_proxy_t<T>>(context.db_objects),
-                                           alias_extractor<T>::as_alias())
-                   << " " << serialize(l.constraint, context);
-                return ss.str();
-            }
-        };
-
-        template<class T, class O>
-        struct statement_serializer<left_outer_join_t<T, O>, void> {
-            using statement_type = left_outer_join_t<T, O>;
-
-            template<class Ctx>
-            std::string operator()(const statement_type& l, const Ctx& context) const {
-                std::stringstream ss;
-                ss << static_cast<std::string>(l) << " "
-                   << streaming_identifier(lookup_table_name<mapped_type_proxy_t<T>>(context.db_objects),
-                                           alias_extractor<T>::as_alias())
-                   << " " << serialize(l.constraint, context);
-                return ss.str();
-            }
-        };
-
-        template<class O>
-        struct statement_serializer<natural_join_t<O>, void> {
-            using statement_type = natural_join_t<O>;
-
-            template<class Ctx>
-            std::string operator()(const statement_type& c, const Ctx& context) const {
-                std::stringstream ss;
-                ss << static_cast<std::string>(c) << " "
-                   << streaming_identifier(lookup_table_name<O>(context.db_objects));
+                ss << static_cast<std::string>(on) << " " << serialize(on.arg, newContext) << " ";
                 return ss.str();
             }
         };

--- a/tests/statement_serializer_tests/select_constraints.cpp
+++ b/tests/statement_serializer_tests/select_constraints.cpp
@@ -86,6 +86,51 @@ TEST_CASE("statement_serializer select constraints") {
         }
 #endif
     }
+    // tests whether the statement serializer for a select with joins
+    // properly deduplicates the table names when no explicit from is used
+    SECTION("deduplicated table names") {
+        struct UserProps {
+            int id = 0;
+            std::string name;
+        };
+        auto table2 =
+            make_table("user_props", make_column("id", &UserProps::id), make_column("name", &UserProps::name));
+        using db_objects_t = internal::db_objects_tuple<decltype(table), decltype(table2)>;
+        auto dbObjects = db_objects_t{table, table2};
+        internal::serializer_context<db_objects_t> context{dbObjects};
+        context.use_parentheses = false;
+
+        SECTION("left join") {
+            auto expression = select(asterisk<User>(), left_join<UserProps>(using_(&UserProps::id)));
+            value = serialize(expression, context);
+            expected = R"(SELECT "users".* FROM "users" LEFT JOIN "user_props" USING ("id"))";
+        }
+        SECTION("join") {
+            auto expression = select(asterisk<User>(), join<UserProps>(using_(&UserProps::id)));
+            value = serialize(expression, context);
+            expected = R"(SELECT "users".* FROM "users" JOIN "user_props" USING ("id"))";
+        }
+        SECTION("left outer join") {
+            auto expression = select(asterisk<User>(), left_outer_join<UserProps>(using_(&UserProps::id)));
+            value = serialize(expression, context);
+            expected = R"(SELECT "users".* FROM "users" LEFT OUTER JOIN "user_props" USING ("id"))";
+        }
+        SECTION("inner join") {
+            auto expression = select(asterisk<User>(), inner_join<UserProps>(using_(&UserProps::id)));
+            value = serialize(expression, context);
+            expected = R"(SELECT "users".* FROM "users" INNER JOIN "user_props" USING ("id"))";
+        }
+        SECTION("cross join") {
+            auto expression = select(asterisk<User>(), cross_join<UserProps>());
+            value = serialize(expression, context);
+            expected = R"(SELECT "users".* FROM "users" CROSS JOIN "user_props")";
+        }
+        SECTION("natural join") {
+            auto expression = select(asterisk<User>(), natural_join<UserProps>());
+            value = serialize(expression, context);
+            expected = R"(SELECT "users".* FROM "users" NATURAL JOIN "user_props")";
+        }
+    }
     SECTION("function_call") {
         struct Func {
             bool operator()(int arg) const {


### PR DESCRIPTION
I thought I have broken the serialization of cross and natural joins with commit 34afdf3005172761bd3b9f43c9c8669ff231d578 (RIP `join_iterator`) that was part of PR #1143.

This PR introduces dedicated unit tests for serializing table joins when not using an explicit `from<>()`, showing that fortunately I didn't break anything.