### PR TITLE
Fix version check guarding std::identity usage.

### DIFF
--- a/dev/functional/cxx_functional_polyfill.h
+++ b/dev/functional/cxx_functional_polyfill.h
@@ -21,7 +21,7 @@ namespace sqlite_orm {
             //
             // Another way of detection would be the constrained algorithms feature macro __cpp_lib_ranges
 #if(__cplusplus >= 202002L) &&                                                                                         \
-    ((!_LIBCPP_VERSION || _LIBCPP_VERSION >= 13) && (!_GLIBCXX_RELEASE || _GLIBCXX_RELEASE >= 10))
+    ((!_LIBCPP_VERSION || _LIBCPP_VERSION >= 13000) && (!_GLIBCXX_RELEASE || _GLIBCXX_RELEASE >= 10))
             using std::identity;
 #else
             struct identity {

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -7956,7 +7956,7 @@ namespace sqlite_orm {
             //
             // Another way of detection would be the constrained algorithms feature macro __cpp_lib_ranges
 #if(__cplusplus >= 202002L) &&                                                                                         \
-    ((!_LIBCPP_VERSION || _LIBCPP_VERSION >= 13) && (!_GLIBCXX_RELEASE || _GLIBCXX_RELEASE >= 10))
+    ((!_LIBCPP_VERSION || _LIBCPP_VERSION >= 13000) && (!_GLIBCXX_RELEASE || _GLIBCXX_RELEASE >= 10))
             using std::identity;
 #else
             struct identity {


### PR DESCRIPTION
_LIBCPP_VERSION consists of 5 digits [1].

[1]: https://github.com/llvm/llvm-project/blob/1bd7c02233969b430b2d49e95345f507fdcc9f30/libcxx/include/__config#L35