### PR TITLE
added explicit null and not null

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ auto storage = make_storage("db.sqlite",
                                        make_column("name", &UserType::name, default_value("name_placeholder"))));
 ```
 
-Too easy isn't it? You do not have to specify mapped type explicitly - it is deduced from your member pointers you pass during making a column (for example: `&User::id`). To create a column you have to pass two arguments at least: its name in the table and your mapped class member pointer. You can also add extra arguments to tell your storage about column's constraints like `primary_key`, `autoincrement`, `default_value`, `unique` or `generated_always_as` (order isn't important; `not_null` is deduced from type automatically).
+Too easy isn't it? You do not have to specify mapped type explicitly - it is deduced from your member pointers you pass during making a column (for example: `&User::id`). To create a column you have to pass two arguments at least: its name in the table and your mapped class member pointer. You can also add extra arguments to tell your storage about column's constraints like `primary_key`, `autoincrement`, `default_value`, `unique` or `generated_always_as` (order isn't important; `not_null`/`null` are deduced from type automatically but can be added manually if you wish with `null()` and `not_null()`).
 
 More details about making storage can be found in [tutorial](https://github.com/fnc12/sqlite_orm/wiki/Making-a-storage).
 

--- a/dev/constraints.h
+++ b/dev/constraints.h
@@ -412,6 +412,9 @@ namespace sqlite_orm {
             }
         };
 
+        struct null_t {};
+
+        struct not_null_t {};
     }
 
     namespace internal {
@@ -440,6 +443,12 @@ namespace sqlite_orm {
         template<class T>
         SQLITE_ORM_INLINE_VAR constexpr bool is_generated_always_v = is_generated_always<T>::value;
 
+        template<class T>
+        using is_null = std::is_same<null_t, T>;
+
+        template<class T>
+        using is_not_null = std::is_same<not_null_t, T>;
+
         /**
          * PRIMARY KEY INSERTABLE traits.
          */
@@ -458,6 +467,8 @@ namespace sqlite_orm {
         using is_constraint =
             mpl::instantiate<mpl::disjunction<check_if<is_primary_key>,
                                               check_if<is_foreign_key>,
+                                              check_if<is_null>,
+                                              check_if<is_not_null>,
                                               check_if_is_template<unique_t>,
                                               check_if_is_template<default_t>,
                                               check_if_is_template<check_t>,
@@ -535,5 +546,13 @@ namespace sqlite_orm {
     template<class T>
     internal::check_t<T> check(T t) {
         return {std::move(t)};
+    }
+
+    inline internal::null_t null() {
+        return {};
+    }
+
+    inline internal::not_null_t not_null() {
+        return {};
     }
 }

--- a/dev/constraints.h
+++ b/dev/constraints.h
@@ -443,12 +443,6 @@ namespace sqlite_orm {
         template<class T>
         SQLITE_ORM_INLINE_VAR constexpr bool is_generated_always_v = is_generated_always<T>::value;
 
-        template<class T>
-        using is_null = std::is_same<null_t, T>;
-
-        template<class T>
-        using is_not_null = std::is_same<not_null_t, T>;
-
         /**
          * PRIMARY KEY INSERTABLE traits.
          */
@@ -467,8 +461,8 @@ namespace sqlite_orm {
         using is_constraint =
             mpl::instantiate<mpl::disjunction<check_if<is_primary_key>,
                                               check_if<is_foreign_key>,
-                                              check_if<is_null>,
-                                              check_if<is_not_null>,
+                                              check_if_is_type<null_t>,
+                                              check_if_is_type<not_null_t>,
                                               check_if_is_template<unique_t>,
                                               check_if_is_template<default_t>,
                                               check_if_is_template<check_t>,

--- a/dev/serializing_util.h
+++ b/dev/serializing_util.h
@@ -372,12 +372,11 @@ namespace sqlite_orm {
                 ss << sep[std::exchange(first, false)];
                 ss << serialize(constraint, context);
             });
-            using ConstraintsTuple = decltype(column.constraints);
-            constexpr bool constraintsHaveNullConstraint =
-                mpl::invoke_t<check_if_tuple_has_type<null_t>, ConstraintsTuple>::value;
-            constexpr bool constraintsHaveNotNullConstraint =
-                mpl::invoke_t<check_if_tuple_has_type<not_null_t>, ConstraintsTuple>::value;
-            if(!constraintsHaveNullConstraint && !constraintsHaveNotNullConstraint) {
+            using constraints_tuple = decltype(column.constraints);
+            constexpr bool hasExplicitNullableConstraint =
+                mpl::invoke_t<mpl::disjunction<check_if_tuple_has_type<null_t>, check_if_tuple_has_type<not_null_t>>,
+                              constraints_tuple>::value;
+            if(!hasExplicitNullableConstraint) {
                 ss << sep[std::exchange(first, false)];
                 if(isNotNull) {
                     ss << "NOT NULL";

--- a/dev/serializing_util.h
+++ b/dev/serializing_util.h
@@ -366,11 +366,24 @@ namespace sqlite_orm {
             const bool& isNotNull = get<2>(tpl);
             auto& context = get<3>(tpl);
 
-            iterate_tuple(column.constraints, [&ss, &context](auto& constraint) {
-                ss << serialize(constraint, context) << ' ';
+            auto first = true;
+            constexpr std::array<const char*, 2> sep = {" ", ""};
+            iterate_tuple(column.constraints, [&ss, &context, &first, &sep](auto& constraint) {
+                ss << sep[std::exchange(first, false)];
+                ss << serialize(constraint, context);
             });
-            if(isNotNull) {
-                ss << "NOT NULL";
+            using ConstraintsTuple = decltype(column.constraints);
+            constexpr bool constraintsHaveNullConstraint =
+                mpl::invoke_t<check_if_tuple_has_type<null_t>, ConstraintsTuple>::value;
+            constexpr bool constraintsHaveNotNullConstraint =
+                mpl::invoke_t<check_if_tuple_has_type<not_null_t>, ConstraintsTuple>::value;
+            if(!constraintsHaveNullConstraint && !constraintsHaveNotNullConstraint) {
+                ss << sep[std::exchange(first, false)];
+                if(isNotNull) {
+                    ss << "NOT NULL";
+                } else {
+                    ss << "NULL";
+                }
             }
 
             return ss;

--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -891,7 +891,7 @@ namespace sqlite_orm {
             using statement_type = null_t;
 
             template<class Ctx>
-            std::string operator()(const statement_type& statement, const Ctx& context) const {
+            std::string operator()(const statement_type& /*statement*/, const Ctx& /*context*/) const {
                 return "NULL";
             }
         };
@@ -901,7 +901,7 @@ namespace sqlite_orm {
             using statement_type = not_null_t;
 
             template<class Ctx>
-            std::string operator()(const statement_type& statement, const Ctx& context) const {
+            std::string operator()(const statement_type& /*statement*/, const Ctx& /*context*/) const {
                 return "NOT NULL";
             }
         };

--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -1050,11 +1050,10 @@ namespace sqlite_orm {
                 ss << streaming_identifier(column.name);
                 if(!context.skip_types_and_constraints) {
                     ss << " " << type_printer<field_type_t<column_type>>().print();
-                    const bool columnIsNotNull = column.is_not_null();
                     ss << " "
                        << streaming_column_constraints(
                               call_as_template_base<column_constraints>(polyfill::identity{})(column),
-                              columnIsNotNull,
+                              column.is_not_null(),
                               context);
                 }
                 return ss.str();

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -13682,12 +13682,11 @@ namespace sqlite_orm {
                 ss << sep[std::exchange(first, false)];
                 ss << serialize(constraint, context);
             });
-            using ConstraintsTuple = decltype(column.constraints);
-            constexpr bool constraintsHaveNullConstraint =
-                mpl::invoke_t<check_if_tuple_has_type<null_t>, ConstraintsTuple>::value;
-            constexpr bool constraintsHaveNotNullConstraint =
-                mpl::invoke_t<check_if_tuple_has_type<not_null_t>, ConstraintsTuple>::value;
-            if(!constraintsHaveNullConstraint && !constraintsHaveNotNullConstraint) {
+            using constraints_tuple = decltype(column.constraints);
+            constexpr bool hasExplicitNullableConstraint =
+                mpl::invoke_t<mpl::disjunction<check_if_tuple_has_type<null_t>, check_if_tuple_has_type<not_null_t>>,
+                              constraints_tuple>::value;
+            if(!hasExplicitNullableConstraint) {
                 ss << sep[std::exchange(first, false)];
                 if(isNotNull) {
                     ss << "NOT NULL";

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -16464,7 +16464,7 @@ namespace sqlite_orm {
             using statement_type = null_t;
 
             template<class Ctx>
-            std::string operator()(const statement_type& statement, const Ctx& context) const {
+            std::string operator()(const statement_type& /*statement*/, const Ctx& /*context*/) const {
                 return "NULL";
             }
         };
@@ -16474,7 +16474,7 @@ namespace sqlite_orm {
             using statement_type = not_null_t;
 
             template<class Ctx>
-            std::string operator()(const statement_type& statement, const Ctx& context) const {
+            std::string operator()(const statement_type& /*statement*/, const Ctx& /*context*/) const {
                 return "NOT NULL";
             }
         };

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -1729,12 +1729,6 @@ namespace sqlite_orm {
         template<class T>
         SQLITE_ORM_INLINE_VAR constexpr bool is_generated_always_v = is_generated_always<T>::value;
 
-        template<class T>
-        using is_null = std::is_same<null_t, T>;
-
-        template<class T>
-        using is_not_null = std::is_same<not_null_t, T>;
-
         /**
          * PRIMARY KEY INSERTABLE traits.
          */
@@ -1753,8 +1747,8 @@ namespace sqlite_orm {
         using is_constraint =
             mpl::instantiate<mpl::disjunction<check_if<is_primary_key>,
                                               check_if<is_foreign_key>,
-                                              check_if<is_null>,
-                                              check_if<is_not_null>,
+                                              check_if_is_type<null_t>,
+                                              check_if_is_type<not_null_t>,
                                               check_if_is_template<unique_t>,
                                               check_if_is_template<default_t>,
                                               check_if_is_template<check_t>,
@@ -16629,11 +16623,10 @@ namespace sqlite_orm {
                 ss << streaming_identifier(column.name);
                 if(!context.skip_types_and_constraints) {
                     ss << " " << type_printer<field_type_t<column_type>>().print();
-                    const bool columnIsNotNull = column.is_not_null();
                     ss << " "
                        << streaming_column_constraints(
                               call_as_template_base<column_constraints>(polyfill::identity{})(column),
-                              columnIsNotNull,
+                              column.is_not_null(),
                               context);
                 }
                 return ss.str();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -87,6 +87,8 @@ add_executable(unit_tests
     statement_serializer_tests/column_constraints/primary_key.cpp
     statement_serializer_tests/column_constraints/unique.cpp
     statement_serializer_tests/column_constraints/check.cpp
+    statement_serializer_tests/column_constraints/null.cpp
+    statement_serializer_tests/column_constraints/not_null.cpp
     statement_serializer_tests/bindables.cpp
     statement_serializer_tests/ast/upsert_clause.cpp
     statement_serializer_tests/ast/excluded.cpp

--- a/tests/schema/column_tests.cpp
+++ b/tests/schema/column_tests.cpp
@@ -36,12 +36,32 @@ TEST_CASE("column is_not_null") {
         int id = 0;
         std::unique_ptr<std::string> name;
     };
-    SECTION("not null") {
-        auto column = make_column("id", &User::id);
-        REQUIRE(column.is_not_null());
+    SECTION("non-nullable") {
+        SECTION("implicit") {
+            auto column = make_column("id", &User::id);
+            REQUIRE(column.is_not_null());
+        }
+        SECTION("explicit not null") {
+            auto column = make_column("id", &User::id, not_null());
+            REQUIRE(column.is_not_null());
+        }
+        SECTION("explicit null") {
+            auto column = make_column("id", &User::id, null());
+            REQUIRE(column.is_not_null());
+        }
     }
-    SECTION("null") {
-        auto column = make_column("name", &User::name);
-        REQUIRE(!column.is_not_null());
+    SECTION("nullable") {
+        SECTION("implicit") {
+            auto column = make_column("name", &User::name);
+            REQUIRE(!column.is_not_null());
+        }
+        SECTION("explicit not null") {
+            auto column = make_column("name", &User::name, not_null());
+            REQUIRE(!column.is_not_null());
+        }
+        SECTION("explicit null") {
+            auto column = make_column("name", &User::name, null());
+            REQUIRE(!column.is_not_null());
+        }
     }
 }

--- a/tests/statement_serializer_tests/column_constraints/not_null.cpp
+++ b/tests/statement_serializer_tests/column_constraints/not_null.cpp
@@ -1,0 +1,12 @@
+#include <sqlite_orm/sqlite_orm.h>
+#include <catch2/catch_all.hpp>
+
+using namespace sqlite_orm;
+
+TEST_CASE("statement_serializer not null") {
+    internal::db_objects_tuple<> storage;
+    internal::serializer_context<internal::db_objects_tuple<>> context{storage};
+    auto statement = not_null();
+    auto value = serialize(statement, context);
+    REQUIRE(value == "NOT NULL");
+}

--- a/tests/statement_serializer_tests/column_constraints/null.cpp
+++ b/tests/statement_serializer_tests/column_constraints/null.cpp
@@ -1,0 +1,12 @@
+#include <sqlite_orm/sqlite_orm.h>
+#include <catch2/catch_all.hpp>
+
+using namespace sqlite_orm;
+
+TEST_CASE("statement_serializer null") {
+    internal::db_objects_tuple<> storage;
+    internal::serializer_context<internal::db_objects_tuple<>> context{storage};
+    auto statement = null();
+    auto value = serialize(statement, context);
+    REQUIRE(value == "NULL");
+}

--- a/tests/statement_serializer_tests/schema/column.cpp
+++ b/tests/statement_serializer_tests/schema/column.cpp
@@ -15,20 +15,50 @@ TEST_CASE("statement_serializer column") {
     std::string expected;
     SECTION("with types and constraints") {
         context.skip_types_and_constraints = false;
-        SECTION("id INTEGER NOT NULL") {
+        SECTION("id INTEGER (implicit) NOT NULL") {
             auto column = make_column("id", &User::id);
             value = serialize(column, context);
             expected = "\"id\" INTEGER NOT NULL";
         }
-        SECTION("name TEXT NOT NULL") {
+        SECTION("id INTEGER (explicit) NOT NULL") {
+            auto column = make_column("id", &User::id, not_null());
+            value = serialize(column, context);
+            expected = "\"id\" INTEGER NOT NULL";
+        }
+        SECTION("id INTEGER (explicit) NULL") {
+            auto column = make_column("id", &User::id, null());
+            value = serialize(column, context);
+            expected = "\"id\" INTEGER NULL";
+        }
+        SECTION("name TEXT (implicit) NOT NULL") {
             auto column = make_column("name", &User::name);
             value = serialize(column, context);
             expected = "\"name\" TEXT NOT NULL";
         }
-        SECTION("nullable text") {
+        SECTION("name TEXT (explicit) NOT NULL") {
+            auto column = make_column("name", &User::name, not_null());
+            value = serialize(column, context);
+            expected = "\"name\" TEXT NOT NULL";
+        }
+        SECTION("name TEXT (explicit) NULL") {
+            auto column = make_column("name", &User::name, null());
+            value = serialize(column, context);
+            expected = "\"name\" TEXT NULL";
+        }
+        SECTION("nullable text (implicit) NULL") {
             auto column = make_column("nullable_text", &User::nullableText);
             value = serialize(column, context);
-            expected = "\"nullable_text\" TEXT ";
+            expected = "\"nullable_text\" TEXT NULL";
+        }
+        SECTION("nullable text (explicit) NOT NULL") {
+            auto column = make_column("nullable_text", &User::nullableText, not_null());
+            value = serialize(column, context);
+            expected = "\"nullable_text\" TEXT NOT NULL";
+        }
+        SECTION("nullable text (explicit) NULL") {
+            auto column = make_column("nullable_text", &User::nullableText, null());
+            value = serialize(column, context);
+            expected = "\"nullable_text\" TEXT NULL";
         }
     }
     SECTION("without types and constraints") {


### PR DESCRIPTION
1. Added `null()` and `not_null()` public API for specifying explicitly how you want the column to be serialized during `sync_schema` call;
2. changed README according to the changes
3. covered with unit tests all the cases of column serialization with nullable and non-nullable types
4. changed serialization algo for `column_t`