### PR TITLE
Correct "multi order by" and "group by"

### DIFF
--- a/dev/ast/group_by.h
+++ b/dev/ast/group_by.h
@@ -43,7 +43,7 @@ namespace sqlite_orm {
      *  Example: storage.get_all<Employee>(group_by(&Employee::name))
      */
     template<class... Args>
-    internal::group_by_t<Args...> group_by(Args&&... args) {
-        return {std::make_tuple(std::forward<Args>(args)...)};
+    internal::group_by_t<Args...> group_by(Args... args) {
+        return {{std::forward<Args>(args)...}};
     }
 }

--- a/dev/conditions.h
+++ b/dev/conditions.h
@@ -1210,8 +1210,8 @@ namespace sqlite_orm {
      * Example: storage.get_all<Singer>(multi_order_by(order_by(&Singer::name).asc(), order_by(&Singer::gender).desc())
      */
     template<class... Args>
-    internal::multi_order_by_t<Args...> multi_order_by(Args&&... args) {
-        return {std::make_tuple(std::forward<Args>(args)...)};
+    internal::multi_order_by_t<Args...> multi_order_by(Args... args) {
+        return {{std::forward<Args>(args)...}};
     }
 
     /**

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -7194,8 +7194,8 @@ namespace sqlite_orm {
      *  Example: storage.get_all<Employee>(group_by(&Employee::name))
      */
     template<class... Args>
-    internal::group_by_t<Args...> group_by(Args&&... args) {
-        return {std::make_tuple(std::forward<Args>(args)...)};
+    internal::group_by_t<Args...> group_by(Args... args) {
+        return {{std::forward<Args>(args)...}};
     }
 }
 

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -4300,8 +4300,8 @@ namespace sqlite_orm {
      * Example: storage.get_all<Singer>(multi_order_by(order_by(&Singer::name).asc(), order_by(&Singer::gender).desc())
      */
     template<class... Args>
-    internal::multi_order_by_t<Args...> multi_order_by(Args&&... args) {
-        return {std::make_tuple(std::forward<Args>(args)...)};
+    internal::multi_order_by_t<Args...> multi_order_by(Args... args) {
+        return {{std::forward<Args>(args)...}};
     }
 
     /**


### PR DESCRIPTION
The functions `multi_order_by()` and `group_by()` should decay their parameters or take arguments by value like all other functions for creating expressions.