### PR TITLE
Uniform syntax for column pointer expressions through table references

### DIFF
--- a/dev/conditions.h
+++ b/dev/conditions.h
@@ -834,10 +834,9 @@ namespace sqlite_orm {
      *  Explicit FROM function. Usage:
      *  `storage.select(&User::id, from<"a"_alias.for_<User>>());`
      */
-    template<orm_recordset_alias auto... tables>
+    template<orm_refers_to_recordset auto... recordsets>
     auto from() {
-        static_assert(sizeof...(tables) > 0);
-        return internal::from_t<std::remove_const_t<decltype(tables)>...>{};
+        return from<internal::decay_table_reference_t<recordsets>...>();
     }
 #endif
 
@@ -954,12 +953,12 @@ namespace sqlite_orm {
     }
 
     template<class F, class O>
-    internal::using_t<O, F O::*> using_(F O::*p) {
-        return {p};
+    internal::using_t<O, F O::*> using_(F O::*field) {
+        return {field};
     }
     template<class T, class M>
-    internal::using_t<T, M> using_(internal::column_pointer<T, M> cp) {
-        return {std::move(cp)};
+    internal::using_t<T, M> using_(internal::column_pointer<T, M> field) {
+        return {std::move(field)};
     }
 
     template<class T>
@@ -983,9 +982,9 @@ namespace sqlite_orm {
     }
 
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-    template<orm_recordset_alias auto alias, class On>
+    template<orm_refers_to_recordset auto alias, class On>
     auto left_join(On on) {
-        return internal::left_join_t<std::remove_const_t<decltype(alias)>, On>{std::move(on)};
+        return left_join<internal::decay_table_reference_t<alias>, On>(std::move(on));
     }
 #endif
 
@@ -995,9 +994,9 @@ namespace sqlite_orm {
     }
 
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-    template<orm_recordset_alias auto alias, class On>
+    template<orm_refers_to_recordset auto alias, class On>
     auto join(On on) {
-        return internal::join_t<std::remove_const_t<decltype(alias)>, On>{std::move(on)};
+        return join<internal::decay_table_reference_t<alias>, On>(std::move(on));
     }
 #endif
 
@@ -1007,9 +1006,9 @@ namespace sqlite_orm {
     }
 
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-    template<orm_recordset_alias auto alias, class On>
+    template<orm_refers_to_recordset auto alias, class On>
     auto left_outer_join(On on) {
-        return internal::left_outer_join_t<std::remove_const_t<decltype(alias)>, On>{std::move(on)};
+        return left_outer_join<internal::decay_table_reference_t<alias>, On>(std::move(on));
     }
 #endif
 
@@ -1019,9 +1018,9 @@ namespace sqlite_orm {
     }
 
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-    template<orm_recordset_alias auto alias, class On>
+    template<orm_refers_to_recordset auto alias, class On>
     auto inner_join(On on) {
-        return internal::inner_join_t<std::remove_const_t<decltype(alias)>, On>{std::move(on)};
+        return inner_join<internal::decay_table_reference_t<alias>, On>(std::move(on));
     }
 #endif
 

--- a/dev/core_functions.h
+++ b/dev/core_functions.h
@@ -1845,6 +1845,17 @@ namespace sqlite_orm {
         return {};
     }
 
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+    /**
+     *  COUNT(*) with FROM function. Specified recordset will be serialized as
+     *  a from argument.
+     */
+    template<orm_refers_to_recordset auto mapped>
+    auto count() {
+        return count<internal::decay_table_reference_t<mapped>>();
+    }
+#endif
+
     /**
      *  AVG(X) aggregate function.
      */

--- a/dev/mapped_type_proxy.h
+++ b/dev/mapped_type_proxy.h
@@ -16,8 +16,13 @@ namespace sqlite_orm {
         template<class T, class SFINAE = void>
         struct mapped_type_proxy : std::remove_const<T> {};
 
-        template<class T>
-        struct mapped_type_proxy<T, match_if<is_recordset_alias, T>> : std::remove_const<type_t<T>> {};
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+        template<orm_table_reference R>
+        struct mapped_type_proxy<R, void> : R {};
+#endif
+
+        template<class A>
+        struct mapped_type_proxy<A, match_if<is_recordset_alias, A>> : std::remove_const<type_t<A>> {};
 
         template<class T>
         using mapped_type_proxy_t = typename mapped_type_proxy<T>::type;

--- a/dev/select_constraints.h
+++ b/dev/select_constraints.h
@@ -408,9 +408,9 @@ namespace sqlite_orm {
      *  auto reportingTo = 
      *      storage.select(asterisk<m>(), inner_join<m>(on(m->*&Employee::reportsTo == &Employee::employeeId)));
      */
-    template<orm_recordset_alias auto alias>
+    template<orm_refers_to_recordset auto recordset>
     auto asterisk(bool definedOrder = false) {
-        return internal::asterisk_t<std::remove_const_t<decltype(alias)>>{definedOrder};
+        return asterisk<internal::decay_table_reference_t<recordset>>(definedOrder);
     }
 #endif
 
@@ -429,4 +429,11 @@ namespace sqlite_orm {
     internal::object_t<T> object(bool definedOrder = false) {
         return {definedOrder};
     }
+
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+    template<orm_refers_to_table auto als>
+    auto object(bool definedOrder = false) {
+        return object<internal::decay_table_reference_t<als>>(definedOrder);
+    }
+#endif
 }

--- a/dev/table_type_of.h
+++ b/dev/table_type_of.h
@@ -20,6 +20,8 @@ namespace sqlite_orm {
          *  -   `table_type_of<decltype(&User::id)>::type` is `User`
          *  -   `table_type_of<decltype(&User::getName)>::type` is `User`
          *  -   `table_type_of<decltype(&User::setName)>::type` is `User`
+         *  -   `table_type_of<decltype(column<User>(&User::id))>::type` is `User`
+         *  -   `table_type_of<decltype(derived->*&User::id)>::type` is `User`
          */
         template<class T>
         struct table_type_of;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(unit_tests
     static_tests/aggregate_function_return_types.cpp
     static_tests/core_function_return_types.cpp
     static_tests/column_result_t.cpp
+    static_tests/column_pointer.cpp
     static_tests/alias.cpp
     static_tests/is_primary_key_insertable.cpp
     static_tests/is_column_with_insertable_primary_key.cpp

--- a/tests/builtin_tables.cpp
+++ b/tests/builtin_tables.cpp
@@ -16,6 +16,12 @@ TEST_CASE("builtin tables") {
 
         STATIC_REQUIRE(std::is_same_v<decltype(masterRows), decltype(schemaRows)>);
         REQUIRE_THAT(schemaRows, Equals(masterRows));
+
+        constexpr auto schema = c<sqlite_master>();
+        auto schemaRows2 = storage.get_all<schema>();
+
+        STATIC_REQUIRE(std::is_same_v<decltype(masterRows), decltype(schemaRows2)>);
+        REQUIRE_THAT(schemaRows2, Equals(masterRows));
 #endif
     }
 

--- a/tests/prepared_statement_tests/get_all.cpp
+++ b/tests/prepared_statement_tests/get_all.cpp
@@ -215,7 +215,13 @@ TEST_CASE("Prepared get all") {
         }
     }
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-    SECTION("from alias") {
+    SECTION("from table reference") {
+        constexpr auto schema = c<sqlite_master>();
+        auto statement = storage.prepare(get_all<schema>(where(schema->*&sqlite_master::type == "table")));
+        auto str = storage.dump(statement);
+        testSerializing(statement);
+    }
+    SECTION("from aliased table") {
         auto statement =
             storage.prepare(get_all<sqlite_schema>(where(sqlite_schema->*&sqlite_master::type == "table")));
         auto str = storage.dump(statement);

--- a/tests/statement_serializer_tests/aggregate_functions.cpp
+++ b/tests/statement_serializer_tests/aggregate_functions.cpp
@@ -86,6 +86,14 @@ TEST_CASE("statement_serializer aggregate functions") {
                 value = serialize(expression, context);
                 expected = R"(COUNT(*) FILTER (WHERE ("id" < 10)))";
             }
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+            SECTION("with table reference") {
+                constexpr auto user = c<User>();
+                auto expression = count<user>();
+                value = serialize(expression, context);
+                expected = R"(COUNT(*))";
+            }
+#endif
         }
     }
     SECTION("group_concat(X)") {

--- a/tests/statement_serializer_tests/select_constraints.cpp
+++ b/tests/statement_serializer_tests/select_constraints.cpp
@@ -73,6 +73,12 @@ TEST_CASE("statement_serializer select constraints") {
         }
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
         {
+            SECTION("with table reference") {
+                constexpr auto user = c<User>();
+                auto expression = from<user>();
+                value = serialize(expression, context);
+                expected = R"(FROM "users")";
+            }
             SECTION("with alias 2") {
                 auto expression = from<alias<'u'>.for_<User>()>();
                 value = serialize(expression, context);

--- a/tests/static_tests/alias.cpp
+++ b/tests/static_tests/alias.cpp
@@ -9,6 +9,7 @@ using internal::as_t;
 using internal::column_alias;
 using internal::column_pointer;
 using internal::recordset_alias;
+using internal::using_t;
 
 template<class ColAlias, class E>
 void do_assert() {
@@ -19,6 +20,14 @@ template<class E, class ColAlias>
 void runTest(ColAlias /*colRef*/) {
     do_assert<ColAlias, E>();
 }
+
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+template<class S, orm_table_alias auto als>
+concept storage_table_alias_callable = requires(S& storage) {
+    { storage.get_all<als>() };
+    { storage.count<als>() };
+};
+#endif
 
 TEST_CASE("aliases") {
     struct User {
@@ -59,4 +68,30 @@ TEST_CASE("aliases") {
         runTest<alias_column_t<alias_d<DerivedUser>, column_pointer<DerivedUser, int User::*>>>(d_alias->*&User::id);
 #endif
     }
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+    SECTION("table alias expressions") {
+        constexpr auto derived_user = c<DerivedUser>();
+        constexpr auto d_alias = "d"_alias.for_<DerivedUser>();
+        using d_alias_type = decltype("d"_alias.for_<DerivedUser>());
+        runTest<internal::from_t<d_alias_type>>(from<d_alias>());
+        runTest<internal::asterisk_t<d_alias_type>>(asterisk<d_alias>());
+        runTest<internal::object_t<d_alias_type>>(object<d_alias>());
+        runTest<internal::count_asterisk_t<d_alias_type>>(count<d_alias>());
+        runTest<internal::get_all_t<d_alias_type, std::vector<DerivedUser>>>(get_all<d_alias>());
+        runTest<internal::left_join_t<d_alias_type, using_t<DerivedUser, decltype(&DerivedUser::id)>>>(
+            left_join<d_alias>(using_(derived_user->*&DerivedUser::id)));
+        runTest<internal::join_t<d_alias_type, using_t<DerivedUser, decltype(&DerivedUser::id)>>>(
+            join<d_alias>(using_(derived_user->*&DerivedUser::id)));
+        runTest<internal::left_outer_join_t<d_alias_type, using_t<DerivedUser, decltype(&DerivedUser::id)>>>(
+            left_outer_join<d_alias>(using_(derived_user->*&DerivedUser::id)));
+        runTest<internal::inner_join_t<d_alias_type, using_t<DerivedUser, decltype(&DerivedUser::id)>>>(
+            inner_join<d_alias>(using_(derived_user->*&DerivedUser::id)));
+
+        using storage_type = decltype(make_storage(
+            "",
+            make_table<DerivedUser>("derived_user", make_column("id", &DerivedUser::id, primary_key()))));
+
+        STATIC_REQUIRE(storage_table_alias_callable<storage_type, d_alias>);
+    }
+#endif
 }

--- a/tests/static_tests/column_pointer.cpp
+++ b/tests/static_tests/column_pointer.cpp
@@ -1,0 +1,119 @@
+#include <sqlite_orm/sqlite_orm.h>
+#include <type_traits>  //  std::is_same
+#include <catch2/catch_all.hpp>
+
+using namespace sqlite_orm;
+using internal::column_pointer;
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+using internal::is_recordset_alias_v;
+using internal::is_table_alias_v;
+using internal::table_reference;
+using internal::using_t;
+#endif
+
+template<class T, class E>
+void do_assert() {
+    STATIC_REQUIRE(std::is_same<T, E>::value);
+}
+
+template<class E, class T>
+void runTest(const T& /*test*/) {
+    do_assert<T, E>();
+}
+
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+template<class C>
+concept field_callable = requires(C field) {
+    { count(field) };
+    { avg(field) };
+    { max(field) };
+    { min(field) };
+    { sum(field) };
+    { total(field) };
+    { group_concat(field) };
+};
+
+template<class S, class C>
+concept storage_field_callable = requires(S& storage, C field) {
+    { storage.count(field) };
+    { storage.avg(field) };
+    { storage.max(field) };
+    { storage.min(field) };
+    { storage.sum(field) };
+    { storage.total(field) };
+    { storage.group_concat(field) };
+    { storage.group_concat(field, "") };
+    { storage.group_concat(field, std::string{}) };
+    { storage.group_concat(field, 42) };
+};
+
+template<class S, orm_table_reference auto mapped>
+concept storage_table_reference_callable = requires(S& storage) {
+    { storage.get<mapped>(42) };
+    { storage.get_all<mapped>() };
+    { storage.count<mapped>() };
+};
+#endif
+
+TEST_CASE("column pointers") {
+    struct User {
+        int id;
+    };
+    struct DerivedUser : User {};
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+    constexpr auto derived_user = c<DerivedUser>();
+#endif
+
+    SECTION("table reference") {
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+        STATIC_REQUIRE(orm_table_reference<decltype(derived_user)>);
+        STATIC_REQUIRE_FALSE(is_table_alias_v<decltype(derived_user)>);
+        STATIC_REQUIRE_FALSE(is_recordset_alias_v<decltype(derived_user)>);
+        STATIC_REQUIRE_FALSE(orm_table_alias<decltype(derived_user)>);
+        STATIC_REQUIRE_FALSE(orm_recordset_alias<decltype(derived_user)>);
+        runTest<table_reference<DerivedUser>>(derived_user);
+        runTest<DerivedUser>(internal::decay_table_reference_t<derived_user>{});
+#endif
+    }
+    SECTION("column pointer expressions") {
+        runTest<column_pointer<User, decltype(&User::id)>>(column<User>(&User::id));
+        runTest<column_pointer<DerivedUser, decltype(&DerivedUser::id)>>(column<DerivedUser>(&DerivedUser::id));
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+        runTest<column_pointer<DerivedUser, decltype(&DerivedUser::id)>>(derived_user->*&DerivedUser::id);
+        STATIC_REQUIRE(field_callable<decltype(&User::id)>);
+        STATIC_REQUIRE(field_callable<decltype(derived_user->*&DerivedUser::id)>);
+
+        using storage_type = decltype(make_storage(
+            "",
+            make_table<User>("user", make_column("id", &User::id, primary_key())),
+            make_table<DerivedUser>("derived_user", make_column("id", &DerivedUser::id, primary_key()))));
+
+        STATIC_REQUIRE(storage_field_callable<storage_type, decltype(&User::id)>);
+        STATIC_REQUIRE(storage_field_callable<storage_type, decltype(derived_user->*&DerivedUser::id)>);
+#endif
+    }
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+    SECTION("table reference expressions") {
+        runTest<internal::from_t<DerivedUser>>(from<derived_user>());
+        runTest<internal::asterisk_t<DerivedUser>>(asterisk<derived_user>());
+        runTest<internal::object_t<DerivedUser>>(object<derived_user>());
+        runTest<internal::count_asterisk_t<DerivedUser>>(count<derived_user>());
+        runTest<internal::get_t<DerivedUser, int>>(get<derived_user>(42));
+        runTest<internal::get_all_t<DerivedUser, std::vector<DerivedUser>>>(get_all<derived_user>());
+        runTest<internal::left_join_t<DerivedUser, using_t<DerivedUser, decltype(&DerivedUser::id)>>>(
+            left_join<derived_user>(using_(derived_user->*&DerivedUser::id)));
+        runTest<internal::join_t<DerivedUser, using_t<DerivedUser, decltype(&DerivedUser::id)>>>(
+            join<derived_user>(using_(derived_user->*&DerivedUser::id)));
+        runTest<internal::left_outer_join_t<DerivedUser, using_t<DerivedUser, decltype(&DerivedUser::id)>>>(
+            left_outer_join<derived_user>(using_(derived_user->*&DerivedUser::id)));
+        runTest<internal::inner_join_t<DerivedUser, using_t<DerivedUser, decltype(&DerivedUser::id)>>>(
+            inner_join<derived_user>(using_(derived_user->*&DerivedUser::id)));
+
+        using storage_type = decltype(make_storage(
+            "",
+            make_table<DerivedUser>("derived_user", make_column("id", &DerivedUser::id, primary_key()))));
+
+        STATIC_REQUIRE(storage_table_reference_callable<storage_type, derived_user>);
+    }
+#endif
+}

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -3,10 +3,7 @@
 
 #include <vector>  //  std::vector
 #include <string>  //  std::string
-#include <memory>  //  std::unique_ptr
 #include <cstdio>  //  remove
-#include <numeric>  //  std::iota
-#include <algorithm>  //  std::fill
 
 using namespace sqlite_orm;
 


### PR DESCRIPTION
Since the advent of a new syntax for alias columns in the form of

```c++
constexpr auto z_alias = "z"_alias.for_<Object>();
select(z_alias->*&Object::id);
```

and the upcoming CTE feature that uses the same notation:

```c++
constexpr auto xaxis = "xaxis"_cte;
select(xaxis->*x);
```

it would be very convenient and again a huge improvement to the legibility of SQL statement expressions if column pointers can be formed using the same syntax.

```c++
struct Object { int64 id; };
struct Derived : Object {};
constexpr auto derived = c<Derived>();
select(derived->*&Derived::id);
```

Additionally, this PR contains the following improvements:

- A lot more expressions are now available for column pointers (e.g. `storage.count(column<Derived>(&Derived::id))` works)
- A myriad more unit tests for column pointers
- More unit tests for alias column pointers

It must be clarified how a "table reference" can be created. Currently available:
```c++
// 1.
constexpr auto derived = c<Derived>();
// 2.
constexpr auto derived = column<Derived>();
```