### PR TITLE
"Syntactic sugar" for user-defined function calls

### DIFF
--- a/dev/alias.h
+++ b/dev/alias.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <type_traits>  //  std::enable_if, std::is_base_of, std::is_member_pointer, std::remove_const
+#include <type_traits>  //  std::enable_if
 #include <utility>  //  std::index_sequence, std::make_index_sequence
 #include <string>  //  std::string
 #include <sstream>  //  std::stringstream
@@ -219,7 +219,7 @@ namespace sqlite_orm {
     template<orm_table_alias auto als, class C>
     constexpr auto alias_column(C field) {
         using namespace ::sqlite_orm::internal;
-        using A = std::remove_const_t<decltype(als)>;
+        using A = decltype(als);
         using aliased_type = type_t<A>;
         static_assert(is_field_of_v<C, aliased_type>, "Column must be from aliased table");
 
@@ -263,7 +263,7 @@ namespace sqlite_orm {
      */
     template<orm_column_alias auto als, class E>
     auto as(E expression) {
-        return internal::as_t<std::remove_const_t<decltype(als)>, E>{std::move(expression)};
+        return internal::as_t<decltype(als), E>{std::move(expression)};
     }
 
     /** 
@@ -283,7 +283,7 @@ namespace sqlite_orm {
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
     template<orm_column_alias auto als>
     auto get() {
-        return internal::alias_holder<std::remove_const_t<decltype(als)>>{};
+        return internal::alias_holder<decltype(als)>{};
     }
 #endif
 

--- a/dev/alias_traits.h
+++ b/dev/alias_traits.h
@@ -74,7 +74,7 @@ namespace sqlite_orm {
     template<class A>
     concept orm_alias = std::derived_from<A, alias_tag>;
 
-    /** @short Alias of a column in a record set.
+    /** @short Specifies that a type is an alias of a column in a record set.
      *
      *  A column alias has the following traits:
      *  - is derived from `alias_tag`
@@ -83,7 +83,7 @@ namespace sqlite_orm {
     template<class A>
     concept orm_column_alias = (orm_alias<A> && !orm_names_type<A>);
 
-    /** @short Alias of any type of record set.
+    /** @short Specifies that a type is an alias of any type of record set.
      *
      *  A record set alias has the following traits:
      *  - is derived from `alias_tag`.
@@ -92,7 +92,7 @@ namespace sqlite_orm {
     template<class A>
     concept orm_recordset_alias = (orm_alias<A> && orm_names_type<A>);
 
-    /** @short Alias of a concrete table.
+    /** @short Specifies that a type is an alias of a concrete table.
      *
      *  A concrete table alias has the following traits:
      *  - is derived from `alias_tag`.
@@ -101,7 +101,7 @@ namespace sqlite_orm {
     template<class A>
     concept orm_table_alias = (orm_recordset_alias<A> && !std::same_as<typename A::type, std::remove_const_t<A>>);
 
-    /** @short Reference of a concrete table, especially of a derived class.
+    /** @short Specifies that a type is a reference of a concrete table, especially of a derived class.
      *
      *  A concrete table reference has the following traits:
      *  - specialization of `table_reference`, whose `type` typename references a mapped object.
@@ -109,12 +109,18 @@ namespace sqlite_orm {
     template<class R>
     concept orm_table_reference = polyfill::is_specialization_of_v<std::remove_const_t<R>, internal::table_reference>;
 
+    /** @short Specifies that a type refers to a mapped table (possibly aliased).
+     */
     template<class T>
     concept orm_refers_to_table = (orm_table_reference<T> || orm_table_alias<T>);
 
+    /** @short Specifies that a type refers to a recordset.
+     */
     template<class T>
     concept orm_refers_to_recordset = (orm_table_reference<T> || orm_recordset_alias<T>);
 
+    /** @short Specifies that a type is a mapped recordset (table reference).
+     */
     template<class T>
     concept orm_mapped_recordset = (orm_table_reference<T>);
 #endif

--- a/dev/column_pointer.h
+++ b/dev/column_pointer.h
@@ -64,7 +64,7 @@ namespace sqlite_orm {
      */
     template<class O>
         requires(!orm_recordset_alias<O>)
-    constexpr internal::table_reference<O> column() {
+    consteval internal::table_reference<O> column() {
         return {};
     }
 
@@ -73,7 +73,7 @@ namespace sqlite_orm {
      */
     template<class O>
         requires(!orm_recordset_alias<O>)
-    constexpr internal::table_reference<O> c() {
+    consteval internal::table_reference<O> c() {
         return {};
     }
 #endif

--- a/dev/column_pointer.h
+++ b/dev/column_pointer.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <type_traits>  //  std::enable_if, std::remove_const
+#include <type_traits>  //  std::enable_if
 #include <utility>  // std::move
 
 #include "functional/cxx_type_traits_polyfill.h"
@@ -48,8 +48,7 @@ namespace sqlite_orm {
      */
     template<orm_table_reference auto table, class O, class F>
     constexpr auto column(F O::*field) {
-        using R = std::remove_const_t<decltype(table)>;
-        return column<typename R::type>(field);
+        return column<internal::auto_type_t<table>>(field);
     }
 
     /**

--- a/dev/function.h
+++ b/dev/function.h
@@ -23,23 +23,23 @@ namespace sqlite_orm {
     namespace internal {
 
         struct udf_proxy_base {
-            using func_call = std::function<
-                void(sqlite3_context* context, void* functionPointer, int argsCount, sqlite3_value** values)>;
-            using final_call = std::function<void(sqlite3_context* context, void* functionPointer)>;
+            using func_call =
+                std::function<void(sqlite3_context* context, void* udfHandle, int argsCount, sqlite3_value** values)>;
+            using final_call = std::function<void(sqlite3_context* context, void* udfHandle)>;
 
             std::string name;
             int argumentsCount = 0;
-            std::function<int*()> create;
-            void (*destroy)(int*) = nullptr;
+            std::function<void*()> create;
+            xdestroy_fn_t destroy = nullptr;
 
-#ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
             udf_proxy_base(decltype(name) name_,
                            decltype(argumentsCount) argumentsCount_,
                            decltype(create) create_,
                            decltype(destroy) destroy_) :
                 name(std::move(name_)),
                 argumentsCount(argumentsCount_), create(std::move(create_)), destroy(destroy_) {}
-#endif
+
+            virtual ~udf_proxy_base() = default;
         };
 
         struct scalar_udf_proxy : udf_proxy_base {

--- a/dev/function.h
+++ b/dev/function.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <sqlite3.h>
-#include <type_traits>
+#include <type_traits>  //  std::is_member_function_pointer, std::remove_const, std::decay, std::is_same, std::false_type, std::true_type
 #include <string>  //  std::string
-#include <tuple>  //  std::tuple
+#include <tuple>  //  std::tuple, std::tuple_size, std::tuple_element
 #include <functional>  //  std::function
 #include <algorithm>  //  std::min
 #include <utility>  //  std::move, std::forward
@@ -22,7 +22,7 @@ namespace sqlite_orm {
 
     namespace internal {
 
-        struct user_defined_function_base {
+        struct udf_proxy_base {
             using func_call = std::function<
                 void(sqlite3_context* context, void* functionPointer, int argsCount, sqlite3_value** values)>;
             using final_call = std::function<void(sqlite3_context* context, void* functionPointer)>;
@@ -33,38 +33,38 @@ namespace sqlite_orm {
             void (*destroy)(int*) = nullptr;
 
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
-            user_defined_function_base(decltype(name) name_,
-                                       decltype(argumentsCount) argumentsCount_,
-                                       decltype(create) create_,
-                                       decltype(destroy) destroy_) :
+            udf_proxy_base(decltype(name) name_,
+                           decltype(argumentsCount) argumentsCount_,
+                           decltype(create) create_,
+                           decltype(destroy) destroy_) :
                 name(std::move(name_)),
                 argumentsCount(argumentsCount_), create(std::move(create_)), destroy(destroy_) {}
 #endif
         };
 
-        struct user_defined_scalar_function_t : user_defined_function_base {
+        struct scalar_udf_proxy : udf_proxy_base {
             func_call run;
 
-            user_defined_scalar_function_t(decltype(name) name_,
-                                           int argumentsCount_,
-                                           decltype(create) create_,
-                                           decltype(run) run_,
-                                           decltype(destroy) destroy_) :
-                user_defined_function_base{std::move(name_), argumentsCount_, std::move(create_), destroy_},
+            scalar_udf_proxy(decltype(name) name_,
+                             int argumentsCount_,
+                             decltype(create) create_,
+                             decltype(run) run_,
+                             decltype(destroy) destroy_) :
+                udf_proxy_base{std::move(name_), argumentsCount_, std::move(create_), destroy_},
                 run(std::move(run_)) {}
         };
 
-        struct user_defined_aggregate_function_t : user_defined_function_base {
+        struct aggregate_udf_proxy : udf_proxy_base {
             func_call step;
             final_call finalCall;
 
-            user_defined_aggregate_function_t(decltype(name) name_,
-                                              int argumentsCount_,
-                                              decltype(create) create_,
-                                              decltype(step) step_,
-                                              decltype(finalCall) finalCall_,
-                                              decltype(destroy) destroy_) :
-                user_defined_function_base{std::move(name_), argumentsCount_, std::move(create_), destroy_},
+            aggregate_udf_proxy(decltype(name) name_,
+                                int argumentsCount_,
+                                decltype(create) create_,
+                                decltype(step) step_,
+                                decltype(finalCall) finalCall_,
+                                decltype(destroy) destroy_) :
+                udf_proxy_base{std::move(name_), argumentsCount_, std::move(create_), destroy_},
                 step(std::move(step_)), finalCall(std::move(finalCall_)) {}
         };
 
@@ -78,15 +78,14 @@ namespace sqlite_orm {
         using aggregate_fin_function_t = decltype(&F::fin);
 
         template<class F, class SFINAE = void>
-        SQLITE_ORM_INLINE_VAR constexpr bool is_scalar_function_v = false;
+        SQLITE_ORM_INLINE_VAR constexpr bool is_scalar_udf_v = false;
         template<class F>
-        SQLITE_ORM_INLINE_VAR constexpr bool is_scalar_function_v<F, polyfill::void_t<scalar_call_function_t<F>>> =
-            true;
+        SQLITE_ORM_INLINE_VAR constexpr bool is_scalar_udf_v<F, polyfill::void_t<scalar_call_function_t<F>>> = true;
 
         template<class F, class SFINAE = void>
-        SQLITE_ORM_INLINE_VAR constexpr bool is_aggregate_function_v = false;
+        SQLITE_ORM_INLINE_VAR constexpr bool is_aggregate_udf_v = false;
         template<class F>
-        SQLITE_ORM_INLINE_VAR constexpr bool is_aggregate_function_v<
+        SQLITE_ORM_INLINE_VAR constexpr bool is_aggregate_udf_v<
             F,
             polyfill::void_t<aggregate_step_function_t<F>,
                              aggregate_fin_function_t<F>,
@@ -115,13 +114,13 @@ namespace sqlite_orm {
         struct callable_arguments_impl;
 
         template<class F>
-        struct callable_arguments_impl<F, std::enable_if_t<is_scalar_function_v<F>>> {
+        struct callable_arguments_impl<F, std::enable_if_t<is_scalar_udf_v<F>>> {
             using args_tuple = typename member_function_arguments<scalar_call_function_t<F>>::tuple_type;
             using return_type = typename member_function_arguments<scalar_call_function_t<F>>::return_type;
         };
 
         template<class F>
-        struct callable_arguments_impl<F, std::enable_if_t<is_aggregate_function_v<F>>> {
+        struct callable_arguments_impl<F, std::enable_if_t<is_aggregate_udf_v<F>>> {
             using args_tuple = typename member_function_arguments<aggregate_step_function_t<F>>::tuple_type;
             using return_type = typename member_function_arguments<aggregate_fin_function_t<F>>::return_type;
         };
@@ -129,9 +128,9 @@ namespace sqlite_orm {
         template<class F>
         struct callable_arguments : callable_arguments_impl<F> {};
 
-        template<class F, class... Args>
+        template<class UDF, class... Args>
         struct function_call {
-            using function_type = F;
+            using udf_type = UDF;
             using args_tuple = std::tuple<Args...>;
 
             args_tuple args;
@@ -223,24 +222,79 @@ namespace sqlite_orm {
                        (polyfill::is_specialization_of_v<passed_arg_t, pointer_binding>) > {});
 #endif
         }
+
+        /*
+         *  Generator of a user-defined function call in a sql query expression.
+         *  Use the variable template `func<>` to instantiate.
+         *  Calling the function captures the parameters in a `function_call` node.
+         */
+        template<class UDF>
+        struct function : polyfill::type_identity<UDF> {
+            template<typename... Args>
+            function_call<UDF, Args...> operator()(Args... args) const {
+                using args_tuple = std::tuple<Args...>;
+                using function_args_tuple = typename callable_arguments<UDF>::args_tuple;
+                constexpr size_t argsCount = std::tuple_size<args_tuple>::value;
+                constexpr size_t functionArgsCount = std::tuple_size<function_args_tuple>::value;
+                static_assert((argsCount == functionArgsCount &&
+                               !std::is_same<function_args_tuple, std::tuple<arg_values>>::value &&
+                               validate_pointer_value_types<function_args_tuple, args_tuple>(
+                                   polyfill::index_constant<std::min(functionArgsCount, argsCount) - 1>{})) ||
+                                  std::is_same<function_args_tuple, std::tuple<arg_values>>::value,
+                              "The number of arguments does not match");
+                return {{std::forward<Args>(args)...}};
+            }
+        };
     }
+
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+    /** @short Specifies that a type is a user-defined scalar function.
+     */
+    template<class UDF>
+    concept orm_scalar_udf = requires {
+        UDF::name();
+        typename internal::scalar_call_function_t<UDF>;
+    };
+
+    /** @short Specifies that a type is a user-defined aggregate function.
+     */
+    template<class UDF>
+    concept orm_aggregate_udf = requires {
+        UDF::name();
+        typename internal::aggregate_step_function_t<UDF>;
+        typename internal::aggregate_fin_function_t<UDF>;
+        requires std::is_member_function_pointer_v<internal::aggregate_step_function_t<UDF>>;
+        requires std::is_member_function_pointer_v<internal::aggregate_fin_function_t<UDF>>;
+    };
+
+    /** @short Specifies that a type is a framed user-defined scalar function.
+     */
+    template<class F>
+    concept orm_scalar_function = (polyfill::is_specialization_of_v<std::remove_const_t<F>, internal::function> &&
+                                   orm_scalar_udf<typename F::type>);
+
+    /** @short Specifies that a type is a framed user-defined aggregate function.
+     */
+    template<class F>
+    concept orm_aggregate_function = (polyfill::is_specialization_of_v<std::remove_const_t<F>, internal::function> &&
+                                      orm_aggregate_udf<typename F::type>);
+#endif
 
     /**
-     *  Used to call user defined function: `func<MyFunc>(...);`
+     *  Call a user-defined function.
+     *  
+     *  Example:
+     *  struct IdFunc { int oeprator(int arg)() const { return arg; } };
+     *  // inline:
+     *  select(func<IdFunc>(42));
+     *  // As this is a variable template, you can frame the user-defined function and define a variable for syntactic sugar and legibility:
+     *  inline constexpr auto idfunc = func<IdFunc>;
+     *  select(idfunc(42));
+     *  
      */
-    template<class F, class... Args>
-    internal::function_call<F, Args...> func(Args... args) {
-        using args_tuple = std::tuple<Args...>;
-        using function_args_tuple = typename internal::callable_arguments<F>::args_tuple;
-        constexpr auto argsCount = std::tuple_size<args_tuple>::value;
-        constexpr auto functionArgsCount = std::tuple_size<function_args_tuple>::value;
-        static_assert((argsCount == functionArgsCount &&
-                       !std::is_same<function_args_tuple, std::tuple<arg_values>>::value &&
-                       internal::validate_pointer_value_types<function_args_tuple, args_tuple>(
-                           polyfill::index_constant<std::min<>(functionArgsCount, argsCount) - 1>{})) ||
-                          std::is_same<function_args_tuple, std::tuple<arg_values>>::value,
-                      "Number of arguments does not match");
-        return {std::make_tuple(std::forward<Args>(args)...)};
-    }
-
+    template<class UDF>
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+        requires(orm_scalar_udf<UDF> || orm_aggregate_udf<UDF>)
+#endif
+    SQLITE_ORM_INLINE_VAR constexpr internal::function<UDF> func{};
 }

--- a/dev/schema/table.h
+++ b/dev/schema/table.h
@@ -19,6 +19,7 @@
 #include "../member_traits/member_traits.h"
 #include "../typed_comparator.h"
 #include "../type_traits.h"
+#include "../alias_traits.h"
 #include "../constraints.h"
 #include "../table_info.h"
 #include "column.h"
@@ -407,6 +408,18 @@ namespace sqlite_orm {
         SQLITE_ORM_CLANG_SUPPRESS_MISSING_BRACES(
             return {std::move(name), std::make_tuple<Cs...>(std::forward<Cs>(args)...)});
     }
+
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+    /**
+     *  Factory function for a table definition.
+     *  
+     *  The mapped object type is explicitly specified.
+     */
+    template<orm_table_reference auto table, class... Cs>
+    auto make_table(std::string name, Cs... args) {
+        return make_table<internal::decay_table_reference_t<table>>(std::move(name), std::forward<Cs>(args)...);
+    }
+#endif
 
     template<class M>
     internal::virtual_table_t<M> make_virtual_table(std::string name, M module_details) {

--- a/dev/statement_binder.h
+++ b/dev/statement_binder.h
@@ -332,14 +332,11 @@ namespace sqlite_orm {
                 (this->bind(polyfill::invoke(project, std::get<Idx>(tpl)), Idx), ...);
             }
 #else
-            template<class Tpl, size_t I, size_t... Idx, class Projection>
-            void operator()(const Tpl& tpl, std::index_sequence<I, Idx...>, Projection project) const {
-                this->bind(polyfill::invoke(project, std::get<I>(tpl)), I);
-                (*this)(tpl, std::index_sequence<Idx...>{}, std::forward<Projection>(project));
+            template<class Tpl, size_t... Idx, class Projection>
+            void operator()(const Tpl& tpl, std::index_sequence<Idx...>, Projection project) const {
+                using Sink = int[sizeof...(Idx)];
+                (void)Sink{(this->bind(polyfill::invoke(project, std::get<Idx>(tpl)), Idx), 0)...};
             }
-
-            template<class Tpl, class Projection>
-            void operator()(const Tpl&, std::index_sequence<>, Projection) const {}
 #endif
 
             template<class T>

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -383,9 +383,9 @@ namespace sqlite_orm {
             }
 
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-            template<orm_table_reference auto mapped, class... Ids>
+            template<orm_table_reference auto table, class... Ids>
             auto get(Ids... ids) {
-                return this->get<decay_table_reference_t<mapped>>(std::forward<Ids>(ids)...);
+                return this->get<decay_table_reference_t<table>>(std::forward<Ids>(ids)...);
             }
 #endif
 
@@ -448,7 +448,7 @@ namespace sqlite_orm {
             }
 
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-            template<orm_refers_to_recordset auto mapped, class... Args>
+            template<orm_refers_to_table auto mapped, class... Args>
             int count(Args&&... args) {
                 return this->count<decay_table_reference_t<mapped>>(std::forward<Args>(args)...);
             }

--- a/dev/storage_base.h
+++ b/dev/storage_base.h
@@ -268,8 +268,8 @@ namespace sqlite_orm {
                         return (int*)(new F());
                     },
                     /* call = */
-                    [](sqlite3_context* context, void* udfVoidPointer, int argsCount, sqlite3_value** values) {
-                        F& function = *static_cast<F*>(udfVoidPointer);
+                    [](sqlite3_context* context, void* udfHandle, int argsCount, sqlite3_value** values) {
+                        F& function = *static_cast<F*>(udfHandle);
                         args_tuple argsTuple;
                         values_to_tuple{}(values, argsTuple, argsCount);
                         auto result = call(function, std::move(argsTuple));
@@ -335,15 +335,15 @@ namespace sqlite_orm {
                         return (int*)(new F());
                     },
                     /* step = */
-                    [](sqlite3_context*, void* udfVoidPointer, int argsCount, sqlite3_value** values) {
-                        F& function = *static_cast<F*>(udfVoidPointer);
+                    [](sqlite3_context*, void* udfHandle, int argsCount, sqlite3_value** values) {
+                        F& function = *static_cast<F*>(udfHandle);
                         args_tuple argsTuple;
                         values_to_tuple{}(values, argsTuple, argsCount);
                         call(function, &F::step, std::move(argsTuple));
                     },
                     /* finalCall = */
-                    [](sqlite3_context* context, void* udfVoidPointer) {
-                        F& function = *static_cast<F*>(udfVoidPointer);
+                    [](sqlite3_context* context, void* udfHandle) {
+                        F& function = *static_cast<F*>(udfHandle);
                         auto result = function.fin();
                         statement_binder<return_type>().result(context, result);
                     },
@@ -685,12 +685,12 @@ namespace sqlite_orm {
                 }
             }
 
-            void try_to_create_function(sqlite3* db, scalar_udf_proxy& function) {
+            void try_to_create_function(sqlite3* db, scalar_udf_proxy& udfProxy) {
                 auto resultCode = sqlite3_create_function_v2(db,
-                                                             function.name.c_str(),
-                                                             function.argumentsCount,
+                                                             udfProxy.name.c_str(),
+                                                             udfProxy.argumentsCount,
                                                              SQLITE_UTF8,
-                                                             &function,
+                                                             &udfProxy,
                                                              scalar_function_callback,
                                                              nullptr,
                                                              nullptr,
@@ -700,12 +700,12 @@ namespace sqlite_orm {
                 }
             }
 
-            void try_to_create_function(sqlite3* db, aggregate_udf_proxy& function) {
+            void try_to_create_function(sqlite3* db, aggregate_udf_proxy& udfProxy) {
                 auto resultCode = sqlite3_create_function(db,
-                                                          function.name.c_str(),
-                                                          function.argumentsCount,
+                                                          udfProxy.name.c_str(),
+                                                          udfProxy.argumentsCount,
                                                           SQLITE_UTF8,
-                                                          &function,
+                                                          &udfProxy,
                                                           nullptr,
                                                           aggregate_function_step_callback,
                                                           aggregate_function_final_callback);
@@ -717,20 +717,20 @@ namespace sqlite_orm {
             static void
             aggregate_function_step_callback(sqlite3_context* context, int argsCount, sqlite3_value** values) {
                 auto udfProxy = static_cast<aggregate_udf_proxy*>(sqlite3_user_data(context));
-                auto aggregateContextVoidPointer = sqlite3_aggregate_context(context, sizeof(int**));
-                auto aggregateContextIntPointer = static_cast<int**>(aggregateContextVoidPointer);
-                if(*aggregateContextIntPointer == nullptr) {
-                    *aggregateContextIntPointer = udfProxy->create();
+                auto aggregateContextHandle = sqlite3_aggregate_context(context, sizeof(int**));
+                auto aggregateContextIntHandle = static_cast<int**>(aggregateContextHandle);
+                if(*aggregateContextIntHandle == nullptr) {
+                    *aggregateContextIntHandle = udfProxy->create();
                 }
-                udfProxy->step(context, *aggregateContextIntPointer, argsCount, values);
+                udfProxy->step(context, *aggregateContextIntHandle, argsCount, values);
             }
 
             static void aggregate_function_final_callback(sqlite3_context* context) {
                 auto udfProxy = static_cast<aggregate_udf_proxy*>(sqlite3_user_data(context));
-                auto aggregateContextVoidPointer = sqlite3_aggregate_context(context, sizeof(int**));
-                auto aggregateContextIntPointer = static_cast<int**>(aggregateContextVoidPointer);
-                udfProxy->finalCall(context, *aggregateContextIntPointer);
-                udfProxy->destroy(*aggregateContextIntPointer);
+                auto aggregateContextHandle = sqlite3_aggregate_context(context, sizeof(int**));
+                auto aggregateContextIntHandle = static_cast<int**>(aggregateContextHandle);
+                udfProxy->finalCall(context, *aggregateContextIntHandle);
+                udfProxy->destroy(*aggregateContextIntHandle);
             }
 
             static void scalar_function_callback(sqlite3_context* context, int argsCount, sqlite3_value** values) {

--- a/dev/storage_base.h
+++ b/dev/storage_base.h
@@ -251,7 +251,7 @@ namespace sqlite_orm {
              */
             template<class F>
             void create_scalar_function() {
-                static_assert(is_scalar_udf_v<F>, "F cannot be an aggregate function");
+                static_assert(is_scalar_udf_v<F>, "F must be a scalar function");
 
                 std::stringstream ss;
                 ss << F::name() << std::flush;
@@ -270,10 +270,10 @@ namespace sqlite_orm {
                     },
                     /* call = */
                     [](sqlite3_context* context, void* udfHandle, int argsCount, sqlite3_value** values) {
-                        F& function = *static_cast<F*>(udfHandle);
+                        F& udf = *static_cast<F*>(udfHandle);
                         args_tuple argsTuple;
                         values_to_tuple{}(values, argsTuple, argsCount);
-                        auto result = call(function, std::move(argsTuple));
+                        auto result = call(udf, std::move(argsTuple));
                         statement_binder<return_type>().result(context, result);
                     },
                     delete_function_callback<F>));
@@ -318,7 +318,7 @@ namespace sqlite_orm {
              */
             template<class F>
             void create_aggregate_function() {
-                static_assert(is_aggregate_udf_v<F>, "F cannot be a scalar function");
+                static_assert(is_aggregate_udf_v<F>, "F must be an aggregate function");
 
                 std::stringstream ss;
                 ss << F::name() << std::flush;
@@ -337,15 +337,15 @@ namespace sqlite_orm {
                     },
                     /* step = */
                     [](sqlite3_context*, void* udfHandle, int argsCount, sqlite3_value** values) {
-                        F& function = *static_cast<F*>(udfHandle);
+                        F& udf = *static_cast<F*>(udfHandle);
                         args_tuple argsTuple;
                         values_to_tuple{}(values, argsTuple, argsCount);
-                        call(function, &F::step, std::move(argsTuple));
+                        call(udf, &F::step, std::move(argsTuple));
                     },
                     /* finalCall = */
                     [](sqlite3_context* context, void* udfHandle) {
-                        F& function = *static_cast<F*>(udfHandle);
-                        auto result = function.fin();
+                        F& udf = *static_cast<F*>(udfHandle);
+                        auto result = udf.fin();
                         statement_binder<return_type>().result(context, result);
                     },
                     delete_function_callback<F>));
@@ -689,7 +689,7 @@ namespace sqlite_orm {
                 }
             }
 
-            void try_to_create_function(sqlite3* db, scalar_udf_proxy& udfProxy) {
+            static void try_to_create_function(sqlite3* db, scalar_udf_proxy& udfProxy) {
                 int rc = sqlite3_create_function_v2(db,
                                                     udfProxy.name.c_str(),
                                                     udfProxy.argumentsCount,
@@ -704,7 +704,7 @@ namespace sqlite_orm {
                 }
             }
 
-            void try_to_create_function(sqlite3* db, aggregate_udf_proxy& udfProxy) {
+            static void try_to_create_function(sqlite3* db, aggregate_udf_proxy& udfProxy) {
                 int rc = sqlite3_create_function(db,
                                                  udfProxy.name.c_str(),
                                                  udfProxy.argumentsCount,
@@ -723,8 +723,11 @@ namespace sqlite_orm {
                 auto* udfProxy = static_cast<aggregate_udf_proxy*>(sqlite3_user_data(context));
                 // allocate or fetch pointer handle to user-defined function
                 void* aggregateStateMem = sqlite3_aggregate_context(context, sizeof(void**));
-                void* udfHandle = *static_cast<void**>(aggregateStateMem);
+                void*& udfHandle = *static_cast<void**>(aggregateStateMem);
                 if(udfHandle == nullptr) {
+                    if(udfProxy->argumentsCount != -1 && udfProxy->argumentsCount != argsCount) {
+                        throw std::system_error{orm_error_code::arguments_count_does_not_match};
+                    }
                     udfHandle = udfProxy->create();
                 }
                 udfProxy->step(context, udfHandle, argsCount, values);
@@ -734,7 +737,7 @@ namespace sqlite_orm {
                 auto* udfProxy = static_cast<aggregate_udf_proxy*>(sqlite3_user_data(context));
                 // allocate or fetch pointer handle to user-defined function
                 void* aggregateStateMem = sqlite3_aggregate_context(context, sizeof(void**));
-                void* udfHandle = *static_cast<void**>(aggregateStateMem);
+                void*& udfHandle = *static_cast<void**>(aggregateStateMem);
                 // note: it is possible that the 'step' function was never called
                 if(udfHandle == nullptr) {
                     udfHandle = udfProxy->create();
@@ -745,17 +748,17 @@ namespace sqlite_orm {
 
             static void scalar_function_callback(sqlite3_context* context, int argsCount, sqlite3_value** values) {
                 auto udfProxy = static_cast<scalar_udf_proxy*>(sqlite3_user_data(context));
-                const std::unique_ptr<void, xdestroy_fn_t> udfHandleGuard(udfProxy->create(), udfProxy->destroy);
                 if(udfProxy->argumentsCount != -1 && udfProxy->argumentsCount != argsCount) {
                     throw std::system_error{orm_error_code::arguments_count_does_not_match};
                 }
-                udfProxy->run(context, udfProxy, argsCount, values);
+                const std::unique_ptr<void, xdestroy_fn_t> udfHandle(udfProxy->create(), udfProxy->destroy);
+                udfProxy->run(context, udfHandle.get(), argsCount, values);
             }
 
             template<class F>
-            static void delete_function_callback(void* pointer) {
-                auto fPointer = static_cast<F*>(pointer);
-                delete fPointer;
+            static void delete_function_callback(void* udfHandle) {
+                F* udf = static_cast<F*>(udfHandle);
+                delete udf;
             }
 
             std::string current_time(sqlite3* db) {

--- a/dev/storage_base.h
+++ b/dev/storage_base.h
@@ -421,12 +421,12 @@ namespace sqlite_orm {
                 //  create collations if db is open
                 if(this->connection->retain_count() > 0) {
                     sqlite3* db = this->connection->get();
-                    auto resultCode = sqlite3_create_collation(db,
-                                                               name.c_str(),
-                                                               SQLITE_UTF8,
-                                                               function,
-                                                               functionExists ? collate_callback : nullptr);
-                    if(resultCode != SQLITE_OK) {
+                    int rc = sqlite3_create_collation(db,
+                                                      name.c_str(),
+                                                      SQLITE_UTF8,
+                                                      function,
+                                                      functionExists ? collate_callback : nullptr);
+                    if(rc != SQLITE_OK) {
                         throw_translated_sqlite_error(db);
                     }
                 }
@@ -628,9 +628,8 @@ namespace sqlite_orm {
                 }
 
                 for(auto& p: this->collatingFunctions) {
-                    auto resultCode =
-                        sqlite3_create_collation(db, p.first.c_str(), SQLITE_UTF8, &p.second, collate_callback);
-                    if(resultCode != SQLITE_OK) {
+                    int rc = sqlite3_create_collation(db, p.first.c_str(), SQLITE_UTF8, &p.second, collate_callback);
+                    if(rc != SQLITE_OK) {
                         throw_translated_sqlite_error(db);
                     }
                 }
@@ -667,16 +666,16 @@ namespace sqlite_orm {
 
                     if(this->connection->retain_count() > 0) {
                         sqlite3* db = this->connection->get();
-                        auto resultCode = sqlite3_create_function_v2(db,
-                                                                     name.c_str(),
-                                                                     0,
-                                                                     SQLITE_UTF8,
-                                                                     nullptr,
-                                                                     nullptr,
-                                                                     nullptr,
-                                                                     nullptr,
-                                                                     nullptr);
-                        if(resultCode != SQLITE_OK) {
+                        int rc = sqlite3_create_function_v2(db,
+                                                            name.c_str(),
+                                                            0,
+                                                            SQLITE_UTF8,
+                                                            nullptr,
+                                                            nullptr,
+                                                            nullptr,
+                                                            nullptr,
+                                                            nullptr);
+                        if(rc != SQLITE_OK) {
                             throw_translated_sqlite_error(db);
                         }
                     }
@@ -686,31 +685,31 @@ namespace sqlite_orm {
             }
 
             void try_to_create_function(sqlite3* db, scalar_udf_proxy& udfProxy) {
-                auto resultCode = sqlite3_create_function_v2(db,
-                                                             udfProxy.name.c_str(),
-                                                             udfProxy.argumentsCount,
-                                                             SQLITE_UTF8,
-                                                             &udfProxy,
-                                                             scalar_function_callback,
-                                                             nullptr,
-                                                             nullptr,
-                                                             nullptr);
-                if(resultCode != SQLITE_OK) {
+                int rc = sqlite3_create_function_v2(db,
+                                                    udfProxy.name.c_str(),
+                                                    udfProxy.argumentsCount,
+                                                    SQLITE_UTF8,
+                                                    &udfProxy,
+                                                    scalar_function_callback,
+                                                    nullptr,
+                                                    nullptr,
+                                                    nullptr);
+                if(rc != SQLITE_OK) {
                     throw_translated_sqlite_error(db);
                 }
             }
 
             void try_to_create_function(sqlite3* db, aggregate_udf_proxy& udfProxy) {
-                auto resultCode = sqlite3_create_function(db,
-                                                          udfProxy.name.c_str(),
-                                                          udfProxy.argumentsCount,
-                                                          SQLITE_UTF8,
-                                                          &udfProxy,
-                                                          nullptr,
-                                                          aggregate_function_step_callback,
-                                                          aggregate_function_final_callback);
-                if(resultCode != SQLITE_OK) {
-                    throw_translated_sqlite_error(resultCode);
+                int rc = sqlite3_create_function(db,
+                                                 udfProxy.name.c_str(),
+                                                 udfProxy.argumentsCount,
+                                                 SQLITE_UTF8,
+                                                 &udfProxy,
+                                                 nullptr,
+                                                 aggregate_function_step_callback,
+                                                 aggregate_function_final_callback);
+                if(rc != SQLITE_OK) {
+                    throw_translated_sqlite_error(rc);
                 }
             }
 

--- a/dev/storage_base.h
+++ b/dev/storage_base.h
@@ -721,6 +721,7 @@ namespace sqlite_orm {
             static void
             aggregate_function_step_callback(sqlite3_context* context, int argsCount, sqlite3_value** values) {
                 auto* udfProxy = static_cast<aggregate_udf_proxy*>(sqlite3_user_data(context));
+                // allocate or fetch pointer handle to user-defined function
                 void* aggregateStateMem = sqlite3_aggregate_context(context, sizeof(void**));
                 void* udfHandle = *static_cast<void**>(aggregateStateMem);
                 if(udfHandle == nullptr) {
@@ -731,8 +732,13 @@ namespace sqlite_orm {
 
             static void aggregate_function_final_callback(sqlite3_context* context) {
                 auto* udfProxy = static_cast<aggregate_udf_proxy*>(sqlite3_user_data(context));
+                // allocate or fetch pointer handle to user-defined function
                 void* aggregateStateMem = sqlite3_aggregate_context(context, sizeof(void**));
                 void* udfHandle = *static_cast<void**>(aggregateStateMem);
+                // note: it is possible that the 'step' function was never called
+                if(udfHandle == nullptr) {
+                    udfHandle = udfProxy->create();
+                }
                 udfProxy->finalCall(context, udfHandle);
                 udfProxy->destroy(udfHandle);
             }

--- a/dev/type_traits.h
+++ b/dev/type_traits.h
@@ -1,9 +1,6 @@
 #pragma once
 
 #include <type_traits>  //  std::enable_if, std::is_same
-#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-#include <concepts>
-#endif
 
 #include "functional/cxx_type_traits_polyfill.h"
 
@@ -42,6 +39,11 @@ namespace sqlite_orm {
     namespace internal {
         template<typename T>
         using type_t = typename T::type;
+
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+        template<auto a>
+        using auto_type_t = typename decltype(a)::type;
+#endif
 
         template<typename T>
         using field_type_t = typename T::field_type;

--- a/dev/values_to_tuple.h
+++ b/dev/values_to_tuple.h
@@ -29,13 +29,11 @@ namespace sqlite_orm {
                 (this->extract(values[Idx], std::get<Idx>(tuple)), ...);
             }
 #else
-            template<class Tpl, size_t I, size_t... Idx>
-            void operator()(sqlite3_value** values, Tpl& tuple, std::index_sequence<I, Idx...>) const {
-                this->extract(values[I], std::get<I>(tuple));
-                (*this)(values, tuple, std::index_sequence<Idx...>{});
-            }
             template<class Tpl, size_t... Idx>
-            void operator()(sqlite3_value** /*values*/, Tpl&, std::index_sequence<Idx...>) const {}
+            void operator()(sqlite3_value** values, Tpl& tuple, std::index_sequence<Idx...>) const {
+                using Sink = int[sizeof...(Idx)];
+                (void)Sink{(this->extract(values[Idx], std::get<Idx>(tuple)), 0)...};
+            }
 #endif
             template<class T>
             void extract(sqlite3_value* value, T& t) const {

--- a/dev/xdestroy_handling.h
+++ b/dev/xdestroy_handling.h
@@ -181,8 +181,8 @@ namespace sqlite_orm {
      *  
      *  Explicitly declared for better error messages.
      */
-    template<typename D, typename P>
-    constexpr xdestroy_fn_t obtain_xdestroy_for(D, P*) noexcept
+    template<typename P, typename D>
+    constexpr xdestroy_fn_t obtain_xdestroy_for(D, P* = nullptr) noexcept
         requires(internal::is_unusable_for_xdestroy<D>)
     {
         static_assert(polyfill::always_false_v<D>,
@@ -202,8 +202,8 @@ namespace sqlite_orm {
      *  Type-safety is garanteed by checking whether the deleter or yielded function pointer
      *  is invocable with the non-q-qualified pointer value.
      */
-    template<typename D, typename P>
-    constexpr xdestroy_fn_t obtain_xdestroy_for(D, P*) noexcept
+    template<typename P, typename D>
+    constexpr xdestroy_fn_t obtain_xdestroy_for(D, P* = nullptr) noexcept
         requires(internal::needs_xdestroy_proxy<D, P>)
     {
         return internal::xdestroy_proxy<D, P>;
@@ -223,27 +223,27 @@ namespace sqlite_orm {
      *  Type-safety is garanteed by checking whether the deleter or yielded function pointer
      *  is invocable with the non-q-qualified pointer value.
      */
-    template<typename D, typename P>
-    constexpr xdestroy_fn_t obtain_xdestroy_for(D d, P*) noexcept
+    template<typename P, typename D>
+    constexpr xdestroy_fn_t obtain_xdestroy_for(D d, P* = nullptr) noexcept
         requires(internal::yields_xdestroy<D>)
     {
         return d;
     }
 #else
-    template<typename D, typename P, std::enable_if_t<internal::is_unusable_for_xdestroy_v<D>, bool> = true>
-    constexpr xdestroy_fn_t obtain_xdestroy_for(D, P*) {
+    template<typename P, typename D, std::enable_if_t<internal::is_unusable_for_xdestroy_v<D>, bool> = true>
+    constexpr xdestroy_fn_t obtain_xdestroy_for(D, P* = nullptr) {
         static_assert(polyfill::always_false_v<D>,
                       "A function pointer, which is not of type xdestroy_fn_t, is prohibited.");
         return nullptr;
     }
 
-    template<typename D, typename P, std::enable_if_t<internal::needs_xdestroy_proxy_v<D, P>, bool> = true>
-    constexpr xdestroy_fn_t obtain_xdestroy_for(D, P*) noexcept {
+    template<typename P, typename D, std::enable_if_t<internal::needs_xdestroy_proxy_v<D, P>, bool> = true>
+    constexpr xdestroy_fn_t obtain_xdestroy_for(D, P* = nullptr) noexcept {
         return internal::xdestroy_proxy<D, P>;
     }
 
-    template<typename D, typename P, std::enable_if_t<internal::can_yield_xdestroy_v<D>, bool> = true>
-    constexpr xdestroy_fn_t obtain_xdestroy_for(D d, P*) noexcept {
+    template<typename P, typename D, std::enable_if_t<internal::can_yield_xdestroy_v<D>, bool> = true>
+    constexpr xdestroy_fn_t obtain_xdestroy_for(D d, P* = nullptr) noexcept {
         return d;
     }
 #endif

--- a/examples/user_defined_functions.cpp
+++ b/examples/user_defined_functions.cpp
@@ -34,6 +34,9 @@ struct SignFunction {
         return "SIGN";
     }
 };
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+inline constexpr auto sign = func<SignFunction>;
+#endif
 
 /**
  *  Aggregate function must be defined as a dedicated class with at least three functions:
@@ -77,6 +80,9 @@ struct AcceleratedSumFunction {
         return result;
     }
 };
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+inline constexpr auto accelerated_sum = func<AcceleratedSumFunction>;
+#endif
 
 /**
  *  This is also a scalar function just like `SignFunction` but this function
@@ -105,6 +111,9 @@ struct ArithmeticMeanFunction {
         return result;
     }
 };
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+inline constexpr auto arithmetic_mean = func<ArithmeticMeanFunction>;
+#endif
 
 int main() {
 
@@ -124,6 +133,49 @@ int main() {
         make_table("t", make_column("a", &Table::a), make_column("b", &Table::b), make_column("c", &Table::c)));
     storage.sync_schema();
 
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+    /**
+     *  This function can be called at any time doesn't matter whether connection is open or not.
+     *  To delete created scalar function use `storage.delete_scalar_function<T>()` function call.
+     */
+    storage.create_scalar_function<sign>();
+
+    //  SELECT SIGN(3)
+    auto signRows = storage.select(sign(3));
+    cout << "SELECT SIGN(3) = " << signRows.at(0) << endl;
+
+    storage.insert(Table{1, -1, 2});
+    storage.insert(Table{2, -2, 4});
+    storage.insert(Table{3, -3, 8});
+    storage.insert(Table{4, -4, 16});
+
+    storage.create_aggregate_function<accelerated_sum>();
+
+    //  SELECT ASUM(a), ASUM(b), ASUM(c)
+    //  FROM t
+    auto aSumRows =
+        storage.select(columns(accelerated_sum(&Table::a), accelerated_sum(&Table::b), accelerated_sum(&Table::c)));
+    cout << "SELECT ASUM(a), ASUM(b), ASUM(c) FROM t:" << endl;
+    for(auto& row: aSumRows) {
+        cout << '\t' << get<0>(row) << endl;
+        cout << '\t' << get<1>(row) << endl;
+        cout << '\t' << get<2>(row) << endl;
+    }
+
+    storage.create_scalar_function<arithmetic_mean>();
+
+    //  SELECT ARITHMETIC_MEAN(5, 6, 7)
+    auto arithmeticMeanRows1 = storage.select(arithmetic_mean(5, 6, 7));
+    cout << "SELECT ARITHMETIC_MEAN(5, 6, 7) = " << arithmeticMeanRows1.front() << endl;
+
+    //  SELECT ARITHMETIC_MEAN(-2, 1)
+    auto arithmeticMeanRows2 = storage.select(arithmetic_mean(-2, 1));
+    cout << "SELECT ARITHMETIC_MEAN(-2, 1) = " << arithmeticMeanRows2.front() << endl;
+
+    //  SELECT ARITHMETIC_MEAN(-5.5, 4, 13.2, 256.4)
+    auto arithmeticMeanRows3 = storage.select(arithmetic_mean(-5.5, 4, 13.2, 256.4));
+    cout << "SELECT ARITHMETIC_MEAN(-5.5, 4, 13.2, 256.4) = " << arithmeticMeanRows3.front() << endl;
+#else
     /**
      *  This function can be called at any time doesn't matter whether connection is open or not.
      *  To delete created scalar function use `storage.delete_scalar_function<T>()` function call.
@@ -166,6 +218,7 @@ int main() {
     //  SELECT ARITHMETIC_MEAN(-5.5, 4, 13.2, 256.4)
     auto arithmeticMeanRows3 = storage.select(func<ArithmeticMeanFunction>(-5.5, 4, 13.2, 256.4));
     cout << "SELECT ARITHMETIC_MEAN(-5.5, 4, 13.2, 256.4) = " << arithmeticMeanRows3.front() << endl;
+#endif
 
     return 0;
 }

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -8860,14 +8860,11 @@ namespace sqlite_orm {
                 (this->bind(polyfill::invoke(project, std::get<Idx>(tpl)), Idx), ...);
             }
 #else
-            template<class Tpl, size_t I, size_t... Idx, class Projection>
-            void operator()(const Tpl& tpl, std::index_sequence<I, Idx...>, Projection project) const {
-                this->bind(polyfill::invoke(project, std::get<I>(tpl)), I);
-                (*this)(tpl, std::index_sequence<Idx...>{}, std::forward<Projection>(project));
+            template<class Tpl, size_t... Idx, class Projection>
+            void operator()(const Tpl& tpl, std::index_sequence<Idx...>, Projection project) const {
+                using Sink = int[sizeof...(Idx)];
+                (void)Sink{(this->bind(polyfill::invoke(project, std::get<Idx>(tpl)), Idx), 0)...};
             }
-
-            template<class Tpl, class Projection>
-            void operator()(const Tpl&, std::index_sequence<>, Projection) const {}
 #endif
 
             template<class T>
@@ -14825,13 +14822,11 @@ namespace sqlite_orm {
                 (this->extract(values[Idx], std::get<Idx>(tuple)), ...);
             }
 #else
-            template<class Tpl, size_t I, size_t... Idx>
-            void operator()(sqlite3_value** values, Tpl& tuple, std::index_sequence<I, Idx...>) const {
-                this->extract(values[I], std::get<I>(tuple));
-                (*this)(values, tuple, std::index_sequence<Idx...>{});
-            }
             template<class Tpl, size_t... Idx>
-            void operator()(sqlite3_value** /*values*/, Tpl&, std::index_sequence<Idx...>) const {}
+            void operator()(sqlite3_value** values, Tpl& tuple, std::index_sequence<Idx...>) const {
+                using Sink = int[sizeof...(Idx)];
+                (void)Sink{(this->extract(values[Idx], std::get<Idx>(tuple)), 0)...};
+            }
 #endif
             template<class T>
             void extract(sqlite3_value* value, T& t) const {

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -18562,9 +18562,9 @@ namespace sqlite_orm {
             }
 
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-            template<orm_table_reference auto mapped, class... Ids>
+            template<orm_table_reference auto table, class... Ids>
             auto get(Ids... ids) {
-                return this->get<decay_table_reference_t<mapped>>(std::forward<Ids>(ids)...);
+                return this->get<decay_table_reference_t<table>>(std::forward<Ids>(ids)...);
             }
 #endif
 
@@ -18627,7 +18627,7 @@ namespace sqlite_orm {
             }
 
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-            template<orm_refers_to_recordset auto mapped, class... Args>
+            template<orm_refers_to_table auto mapped, class... Args>
             int count(Args&&... args) {
                 return this->count<decay_table_reference_t<mapped>>(std::forward<Args>(args)...);
             }

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -15243,12 +15243,12 @@ namespace sqlite_orm {
                 //  create collations if db is open
                 if(this->connection->retain_count() > 0) {
                     sqlite3* db = this->connection->get();
-                    auto resultCode = sqlite3_create_collation(db,
-                                                               name.c_str(),
-                                                               SQLITE_UTF8,
-                                                               function,
-                                                               functionExists ? collate_callback : nullptr);
-                    if(resultCode != SQLITE_OK) {
+                    int rc = sqlite3_create_collation(db,
+                                                      name.c_str(),
+                                                      SQLITE_UTF8,
+                                                      function,
+                                                      functionExists ? collate_callback : nullptr);
+                    if(rc != SQLITE_OK) {
                         throw_translated_sqlite_error(db);
                     }
                 }
@@ -15450,9 +15450,8 @@ namespace sqlite_orm {
                 }
 
                 for(auto& p: this->collatingFunctions) {
-                    auto resultCode =
-                        sqlite3_create_collation(db, p.first.c_str(), SQLITE_UTF8, &p.second, collate_callback);
-                    if(resultCode != SQLITE_OK) {
+                    int rc = sqlite3_create_collation(db, p.first.c_str(), SQLITE_UTF8, &p.second, collate_callback);
+                    if(rc != SQLITE_OK) {
                         throw_translated_sqlite_error(db);
                     }
                 }
@@ -15489,16 +15488,16 @@ namespace sqlite_orm {
 
                     if(this->connection->retain_count() > 0) {
                         sqlite3* db = this->connection->get();
-                        auto resultCode = sqlite3_create_function_v2(db,
-                                                                     name.c_str(),
-                                                                     0,
-                                                                     SQLITE_UTF8,
-                                                                     nullptr,
-                                                                     nullptr,
-                                                                     nullptr,
-                                                                     nullptr,
-                                                                     nullptr);
-                        if(resultCode != SQLITE_OK) {
+                        int rc = sqlite3_create_function_v2(db,
+                                                            name.c_str(),
+                                                            0,
+                                                            SQLITE_UTF8,
+                                                            nullptr,
+                                                            nullptr,
+                                                            nullptr,
+                                                            nullptr,
+                                                            nullptr);
+                        if(rc != SQLITE_OK) {
                             throw_translated_sqlite_error(db);
                         }
                     }
@@ -15508,31 +15507,31 @@ namespace sqlite_orm {
             }
 
             void try_to_create_function(sqlite3* db, scalar_udf_proxy& udfProxy) {
-                auto resultCode = sqlite3_create_function_v2(db,
-                                                             udfProxy.name.c_str(),
-                                                             udfProxy.argumentsCount,
-                                                             SQLITE_UTF8,
-                                                             &udfProxy,
-                                                             scalar_function_callback,
-                                                             nullptr,
-                                                             nullptr,
-                                                             nullptr);
-                if(resultCode != SQLITE_OK) {
+                int rc = sqlite3_create_function_v2(db,
+                                                    udfProxy.name.c_str(),
+                                                    udfProxy.argumentsCount,
+                                                    SQLITE_UTF8,
+                                                    &udfProxy,
+                                                    scalar_function_callback,
+                                                    nullptr,
+                                                    nullptr,
+                                                    nullptr);
+                if(rc != SQLITE_OK) {
                     throw_translated_sqlite_error(db);
                 }
             }
 
             void try_to_create_function(sqlite3* db, aggregate_udf_proxy& udfProxy) {
-                auto resultCode = sqlite3_create_function(db,
-                                                          udfProxy.name.c_str(),
-                                                          udfProxy.argumentsCount,
-                                                          SQLITE_UTF8,
-                                                          &udfProxy,
-                                                          nullptr,
-                                                          aggregate_function_step_callback,
-                                                          aggregate_function_final_callback);
-                if(resultCode != SQLITE_OK) {
-                    throw_translated_sqlite_error(resultCode);
+                int rc = sqlite3_create_function(db,
+                                                 udfProxy.name.c_str(),
+                                                 udfProxy.argumentsCount,
+                                                 SQLITE_UTF8,
+                                                 &udfProxy,
+                                                 nullptr,
+                                                 aggregate_function_step_callback,
+                                                 aggregate_function_final_callback);
+                if(rc != SQLITE_OK) {
+                    throw_translated_sqlite_error(rc);
                 }
             }
 

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -10907,23 +10907,23 @@ namespace sqlite_orm {
     namespace internal {
 
         struct udf_proxy_base {
-            using func_call = std::function<
-                void(sqlite3_context* context, void* functionPointer, int argsCount, sqlite3_value** values)>;
-            using final_call = std::function<void(sqlite3_context* context, void* functionPointer)>;
+            using func_call =
+                std::function<void(sqlite3_context* context, void* udfHandle, int argsCount, sqlite3_value** values)>;
+            using final_call = std::function<void(sqlite3_context* context, void* udfHandle)>;
 
             std::string name;
             int argumentsCount = 0;
-            std::function<int*()> create;
-            void (*destroy)(int*) = nullptr;
+            std::function<void*()> create;
+            xdestroy_fn_t destroy = nullptr;
 
-#ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
             udf_proxy_base(decltype(name) name_,
                            decltype(argumentsCount) argumentsCount_,
                            decltype(create) create_,
                            decltype(destroy) destroy_) :
                 name(std::move(name_)),
                 argumentsCount(argumentsCount_), create(std::move(create_)), destroy(destroy_) {}
-#endif
+
+            virtual ~udf_proxy_base() = default;
         };
 
         struct scalar_udf_proxy : udf_proxy_base {
@@ -15086,8 +15086,9 @@ namespace sqlite_orm {
                 this->scalarFunctions.push_back(std::make_unique<scalar_udf_proxy>(
                     std::move(name),
                     argsCount,
-                    []() -> int* {
-                        return (int*)(new F());
+                    /* create = */
+                    []() -> void* {
+                        return new F();
                     },
                     /* call = */
                     [](sqlite3_context* context, void* udfHandle, int argsCount, sqlite3_value** values) {
@@ -15153,8 +15154,8 @@ namespace sqlite_orm {
                     std::move(name),
                     argsCount,
                     /* create = */
-                    []() -> int* {
-                        return (int*)(new F());
+                    []() -> void* {
+                        return new F();
                     },
                     /* step = */
                     [](sqlite3_context*, void* udfHandle, int argsCount, sqlite3_value** values) {
@@ -15493,7 +15494,7 @@ namespace sqlite_orm {
                         sqlite3* db = this->connection->get();
                         int rc = sqlite3_create_function_v2(db,
                                                             name.c_str(),
-                                                            0,
+                                                            (*it)->argumentsCount,
                                                             SQLITE_UTF8,
                                                             nullptr,
                                                             nullptr,
@@ -15541,26 +15542,26 @@ namespace sqlite_orm {
 
             static void
             aggregate_function_step_callback(sqlite3_context* context, int argsCount, sqlite3_value** values) {
-                auto udfProxy = static_cast<aggregate_udf_proxy*>(sqlite3_user_data(context));
-                auto aggregateContextHandle = sqlite3_aggregate_context(context, sizeof(int**));
-                auto aggregateContextIntHandle = static_cast<int**>(aggregateContextHandle);
-                if(*aggregateContextIntHandle == nullptr) {
-                    *aggregateContextIntHandle = udfProxy->create();
+                auto* udfProxy = static_cast<aggregate_udf_proxy*>(sqlite3_user_data(context));
+                void* aggregateStateMem = sqlite3_aggregate_context(context, sizeof(void**));
+                void* udfHandle = *static_cast<void**>(aggregateStateMem);
+                if(udfHandle == nullptr) {
+                    udfHandle = udfProxy->create();
                 }
-                udfProxy->step(context, *aggregateContextIntHandle, argsCount, values);
+                udfProxy->step(context, udfHandle, argsCount, values);
             }
 
             static void aggregate_function_final_callback(sqlite3_context* context) {
-                auto udfProxy = static_cast<aggregate_udf_proxy*>(sqlite3_user_data(context));
-                auto aggregateContextHandle = sqlite3_aggregate_context(context, sizeof(int**));
-                auto aggregateContextIntHandle = static_cast<int**>(aggregateContextHandle);
-                udfProxy->finalCall(context, *aggregateContextIntHandle);
-                udfProxy->destroy(*aggregateContextIntHandle);
+                auto* udfProxy = static_cast<aggregate_udf_proxy*>(sqlite3_user_data(context));
+                void* aggregateStateMem = sqlite3_aggregate_context(context, sizeof(void**));
+                void* udfHandle = *static_cast<void**>(aggregateStateMem);
+                udfProxy->finalCall(context, udfHandle);
+                udfProxy->destroy(udfHandle);
             }
 
             static void scalar_function_callback(sqlite3_context* context, int argsCount, sqlite3_value** values) {
                 auto udfProxy = static_cast<scalar_udf_proxy*>(sqlite3_user_data(context));
-                const std::unique_ptr<int, void (*)(int*)> callableGuard(udfProxy->create(), udfProxy->destroy);
+                const std::unique_ptr<void, xdestroy_fn_t> udfHandleGuard(udfProxy->create(), udfProxy->destroy);
                 if(udfProxy->argumentsCount != -1 && udfProxy->argumentsCount != argsCount) {
                     throw std::system_error{orm_error_code::arguments_count_does_not_match};
                 }
@@ -15568,9 +15569,8 @@ namespace sqlite_orm {
             }
 
             template<class F>
-            static void delete_function_callback(int* pointer) {
-                auto voidPointer = static_cast<void*>(pointer);
-                auto fPointer = static_cast<F*>(voidPointer);
+            static void delete_function_callback(void* pointer) {
+                auto fPointer = static_cast<F*>(pointer);
                 delete fPointer;
             }
 

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -3226,7 +3226,7 @@ namespace sqlite_orm {
      */
     template<class O>
         requires(!orm_recordset_alias<O>)
-    constexpr internal::table_reference<O> column() {
+    consteval internal::table_reference<O> column() {
         return {};
     }
 
@@ -3235,7 +3235,7 @@ namespace sqlite_orm {
      */
     template<class O>
         requires(!orm_recordset_alias<O>)
-    constexpr internal::table_reference<O> c() {
+    consteval internal::table_reference<O> c() {
         return {};
     }
 #endif
@@ -10043,6 +10043,8 @@ namespace sqlite_orm {
 
 // #include "../type_traits.h"
 
+// #include "../alias_traits.h"
+
 // #include "../constraints.h"
 
 // #include "../table_info.h"
@@ -10433,6 +10435,18 @@ namespace sqlite_orm {
         SQLITE_ORM_CLANG_SUPPRESS_MISSING_BRACES(
             return {std::move(name), std::make_tuple<Cs...>(std::forward<Cs>(args)...)});
     }
+
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+    /**
+     *  Factory function for a table definition.
+     *  
+     *  The mapped object type is explicitly specified.
+     */
+    template<orm_table_reference auto table, class... Cs>
+    auto make_table(std::string name, Cs... args) {
+        return make_table<internal::decay_table_reference_t<table>>(std::move(name), std::forward<Cs>(args)...);
+    }
+#endif
 
     template<class M>
     internal::virtual_table_t<M> make_virtual_table(std::string name, M module_details) {

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -13682,7 +13682,7 @@ namespace sqlite_orm {
 #include <memory>  //  std::make_unique, std::unique_ptr
 #include <map>  //  std::map
 #include <type_traits>  //  std::is_same
-#include <algorithm>  //  std::find_if
+#include <algorithm>  //  std::find_if, std::ranges::find
 
 // #include "functional/cxx_universal.h"
 //  ::size_t
@@ -15232,12 +15232,10 @@ namespace sqlite_orm {
             }
 
             void create_collation(const std::string& name, collating_function f) {
-                collating_function* function = nullptr;
                 const auto functionExists = bool(f);
+                collating_function* function = nullptr;
                 if(functionExists) {
                     function = &(collatingFunctions[name] = std::move(f));
-                } else {
-                    collatingFunctions.erase(name);
                 }
 
                 //  create collations if db is open
@@ -15251,6 +15249,10 @@ namespace sqlite_orm {
                     if(rc != SQLITE_OK) {
                         throw_translated_sqlite_error(db);
                     }
+                }
+
+                if(!functionExists) {
+                    collatingFunctions.erase(name);
                 }
             }
 
@@ -15478,14 +15480,15 @@ namespace sqlite_orm {
             }
 
             void delete_function_impl(const std::string& name,
-                                      std::vector<std::unique_ptr<udf_proxy_base>>& functionsVector) const {
-                auto it = find_if(functionsVector.begin(), functionsVector.end(), [&name](auto& udfProxy) {
+                                      std::vector<std::unique_ptr<udf_proxy_base>>& functions) const {
+#if __cpp_lib_ranges >= 201911L
+                auto it = std::ranges::find(functions, name, &udf_proxy_base::name);
+#else
+                auto it = std::find_if(functions.begin(), functions.end(), [&name](auto& udfProxy) {
                     return udfProxy->name == name;
                 });
-                if(it != functionsVector.end()) {
-                    functionsVector.erase(it);
-                    it = functionsVector.end();
-
+#endif
+                if(it != functions.end()) {
                     if(this->connection->retain_count() > 0) {
                         sqlite3* db = this->connection->get();
                         int rc = sqlite3_create_function_v2(db,
@@ -15501,6 +15504,7 @@ namespace sqlite_orm {
                             throw_translated_sqlite_error(db);
                         }
                     }
+                    it = functions.erase(it);
                 } else {
                     throw std::system_error{orm_error_code::function_not_found};
                 }
@@ -15618,13 +15622,17 @@ namespace sqlite_orm {
                     ++storageColumnInfoIndex) {
 
                     //  get storage's column info
-                    auto& storageColumnInfo = storageTableInfo[storageColumnInfoIndex];
-                    auto& columnName = storageColumnInfo.name;
+                    table_xinfo& storageColumnInfo = storageTableInfo[storageColumnInfoIndex];
+                    const std::string& columnName = storageColumnInfo.name;
 
-                    //  search for a column in db eith the same name
+                    //  search for a column in db with the same name
+#if __cpp_lib_ranges >= 201911L
+                    auto dbColumnInfoIt = std::ranges::find(dbTableInfo, columnName, &table_xinfo::name);
+#else
                     auto dbColumnInfoIt = std::find_if(dbTableInfo.begin(), dbTableInfo.end(), [&columnName](auto& ti) {
                         return ti.name == columnName;
                     });
+#endif
                     if(dbColumnInfoIt != dbTableInfo.end()) {
                         auto& dbColumnInfo = *dbColumnInfoIt;
                         auto columnsAreEqual =

--- a/tests/ast_iterator_tests.cpp
+++ b/tests/ast_iterator_tests.cpp
@@ -272,6 +272,7 @@ TEST_CASE("ast_iterator") {
     }
     SECTION("function_call") {
         struct Func {
+            static const char* name();
             bool operator()(int value) const {
                 return value % 2 == 0;
             }

--- a/tests/static_tests/alias.cpp
+++ b/tests/static_tests/alias.cpp
@@ -47,10 +47,11 @@ TEST_CASE("aliases") {
         runTest<alias_column_t<alias_d<DerivedUser>, column_pointer<DerivedUser, int User::*>>>(
             alias_column<alias_d<DerivedUser>>(&User::id));
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-        runTest<alias_holder<column_alias<'a'>>>(get<"a"_col>());
-        runTest<column_alias<'a'>>("a"_col);
-        runTest<as_t<column_alias<'a'>, int User::*>>(as<"a"_col>(&User::id));
-        runTest<as_t<column_alias<'a'>, int User::*>>(&User::id >>= "a"_col);
+        constexpr auto a_col = "a"_col;
+        runTest<alias_holder<column_alias<'a'>>>(get<a_col>());
+        runTest<column_alias<'a'>>(a_col);
+        runTest<as_t<column_alias<'a'>, int User::*>>(as<a_col>(&User::id));
+        runTest<as_t<column_alias<'a'>, int User::*>>(&User::id >>= a_col);
         runTest<recordset_alias<User, 'a', 'l', 's'>>(alias<'a', 'l', 's'>.for_<User>());
         constexpr auto z_alias = "z"_alias.for_<User>();
         runTest<recordset_alias<User, 'z'>>(z_alias);

--- a/tests/static_tests/column_pointer.cpp
+++ b/tests/static_tests/column_pointer.cpp
@@ -94,6 +94,7 @@ TEST_CASE("column pointers") {
     }
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
     SECTION("table reference expressions") {
+        runTest<internal::table_t<DerivedUser, false>>(make_table<derived_user>("derived_user"));
         runTest<internal::from_t<DerivedUser>>(from<derived_user>());
         runTest<internal::asterisk_t<DerivedUser>>(asterisk<derived_user>());
         runTest<internal::object_t<DerivedUser>>(object<derived_user>());

--- a/tests/static_tests/column_result_t.cpp
+++ b/tests/static_tests/column_result_t.cpp
@@ -79,6 +79,7 @@ TEST_CASE("column_result_of_t") {
     runTest<db_objects_t, int>(count());
     {
         struct RandomFunc {
+            static const char* name();
             int operator()() const {
                 return 4;
             }

--- a/tests/static_tests/function_static_tests.cpp
+++ b/tests/static_tests/function_static_tests.cpp
@@ -268,5 +268,9 @@ TEST_CASE("function static") {
         STATIC_REQUIRE(storage_aggregate_callable<storage_type, aggregate>);
         STATIC_REQUIRE_FALSE(storage_scalar_callable<storage_type, aggregate>);
 #endif
+
+        // must be veneers (no additional data members)
+        STATIC_REQUIRE(sizeof(internal::scalar_udf_proxy) == sizeof(internal::udf_proxy_base));
+        STATIC_REQUIRE(sizeof(internal::aggregate_udf_proxy) == sizeof(internal::udf_proxy_base));
     }
 }

--- a/tests/static_tests/node_tuple.cpp
+++ b/tests/static_tests/node_tuple.cpp
@@ -916,6 +916,7 @@ TEST_CASE("Node tuple") {
     }
     SECTION("function_call") {
         struct Func {
+            static const char* name();
             bool operator()(int value) const {
                 return value % 2;
             }


### PR DESCRIPTION
It is possible to define the expression of a user-defined function call as a variable, which improves readability and "feels" like calling an SQL function.

E.g.
```c++
struct IdFunc {
    int operator()(int arg) { return arg; }
};
constexpr auto id_func = func<IdFunc>;

// nice:
select(id_func(42));
// instead of:
select(func<IdFunc>(42));
```

Also in this PR:
- Fixed a potential crash at the point of calling a user-defined scalar function from the SQLite callback.
- Fixed a potential crash at the point of calling the finalizer of a user-defined aggregate function from the SQLite callback.
- Fixed a memory leak that occurred everytime when deleting or cleaning up user-defined functions.
- Improved naming of variables related to the handling of user-defined functions.
- Delete user-defined functions only after successfully hitting sqlite3.
- Corrected requirement of `storage_t<>.count<>()`.
- Improved compilation times under C++14.