### PR TITLE
Optimized application-defined functions

### DIFF
--- a/dev/functional/config.h
+++ b/dev/functional/config.h
@@ -18,6 +18,12 @@
 #define SQLITE_ORM_INLINE_VAR
 #endif
 
+#ifdef SQLITE_ORM_IF_CONSTEXPR_SUPPORTED
+#define SQLITE_ORM_CONSTEXPR_IF constexpr
+#else
+#define SQLITE_ORM_CONSTEXPR_IF
+#endif
+
 #if __cpp_lib_constexpr_functional >= 201907L
 #define SQLITE_ORM_CONSTEXPR_CPP20 constexpr
 #else

--- a/dev/functional/cxx_core_features.h
+++ b/dev/functional/cxx_core_features.h
@@ -54,6 +54,10 @@
 #else
 #endif
 
+#if __cpp_init_captures >= 201803L
+#define SQLITE_ORM_PACK_EXPANSION_IN_INIT_CAPTURE_SUPPORTED
+#endif
+
 #if __cpp_consteval >= 201811L
 #define SQLITE_ORM_CONSTEVAL_SUPPORTED
 #endif

--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -370,7 +370,7 @@ namespace sqlite_orm {
             template<class Ctx>
             std::string operator()(const statement_type& statement, const Ctx& context) const {
                 std::stringstream ss;
-                stream_identifier(ss, statement.name());
+                stream_identifier(ss, "", statement.name(), "");
                 ss << "(" << streaming_expressions_tuple(statement.callArgs, context) << ")";
                 return ss.str();
             }

--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -370,7 +370,8 @@ namespace sqlite_orm {
             template<class Ctx>
             std::string operator()(const statement_type& statement, const Ctx& context) const {
                 std::stringstream ss;
-                ss << statement.name() << "(" << streaming_expressions_tuple(statement.callArgs, context) << ")";
+                stream_identifier(ss, statement.name());
+                ss << "(" << streaming_expressions_tuple(statement.callArgs, context) << ")";
                 return ss.str();
             }
         };

--- a/dev/storage_base.h
+++ b/dev/storage_base.h
@@ -264,12 +264,18 @@ namespace sqlite_orm {
             void create_scalar_function(Args&&... constructorArgs) {
                 static_assert(is_scalar_udf_v<F>, "F must be a scalar function");
 
-                this->create_scalar_function_impl(udf_holder<F>{},
-                                                  /* constructAt */ [constructorArgs...](void* location) {
-                                                      std::allocator<F> allocator;
-                                                      using traits = std::allocator_traits<decltype(allocator)>;
-                                                      traits::construct(allocator, (F*)location, constructorArgs...);
-                                                  });
+                this->create_scalar_function_impl(
+                    udf_holder<F>{},
+#ifdef SQLITE_ORM_PACK_EXPANSION_IN_INIT_CAPTURE_SUPPORTED
+                    /* constructAt */ [... constructorArgs = std::move(constructorArgs)](void* location) {
+#else
+                    /* constructAt */
+                    [constructorArgs...](void* location) {
+#endif
+                        std::allocator<F> allocator;
+                        using traits = std::allocator_traits<decltype(allocator)>;
+                        traits::construct(allocator, (F*)location, constructorArgs...);
+                    });
             }
 
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
@@ -363,12 +369,18 @@ namespace sqlite_orm {
             void create_aggregate_function(Args&&... constructorArgs) {
                 static_assert(is_aggregate_udf_v<F>, "F must be an aggregate function");
 
-                this->create_aggregate_function_impl(udf_holder<F>{}, /* constructAt = */
-                                                     [constructorArgs...](void* location) {
-                                                         std::allocator<F> allocator;
-                                                         using traits = std::allocator_traits<decltype(allocator)>;
-                                                         traits::construct(allocator, (F*)location, constructorArgs...);
-                                                     });
+                this->create_aggregate_function_impl(
+                    udf_holder<F>{}, /* constructAt = */
+#ifdef SQLITE_ORM_PACK_EXPANSION_IN_INIT_CAPTURE_SUPPORTED
+                    /* constructAt */ [... constructorArgs = std::move(constructorArgs)](void* location) {
+#else
+                    /* constructAt */
+                    [constructorArgs...](void* location) {
+#endif
+                        std::allocator<F> allocator;
+                        using traits = std::allocator_traits<decltype(allocator)>;
+                        traits::construct(allocator, (F*)location, constructorArgs...);
+                    });
             }
 
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES

--- a/dev/storage_base.h
+++ b/dev/storage_base.h
@@ -259,8 +259,6 @@ namespace sqlite_orm {
              *      }
              *  };
              * ```
-             * 
-             * Attention: Currently, a function's name must not contain white-space characters, because it doesn't get quoted.
              */
             template<class F, class... Args>
             void create_scalar_function(Args&&... constructorArgs) {
@@ -284,8 +282,6 @@ namespace sqlite_orm {
              * If `F` is a stateless function object, an instance of the function object is created once, otherwise
              * an instance of the function object is repeatedly recreated for each result row,
              * ensuring that the calculations always start with freshly initialized values.
-             * 
-             * Attention: Currently, a function's name must not contain white-space characters, because it doesn't get quoted.
              */
             template<orm_scalar_function auto f, std::copy_constructible... Args>
             void create_scalar_function(Args&&... constructorArgs) {
@@ -299,8 +295,6 @@ namespace sqlite_orm {
              * If `quotedF` contains a freestanding function, stateless lambda or stateless function object,
              * `quoted_scalar_function::callable()` uses the original function object, assuming it is free of side effects;
              * otherwise, it repeatedly uses a copy of the contained function object, assuming possible side effects.
-             * 
-             * Attention: Currently, a function's name must not contain white-space characters, because it doesn't get quoted.
              */
             template<orm_quoted_scalar_function auto quotedF>
             void create_scalar_function() {
@@ -363,8 +357,6 @@ namespace sqlite_orm {
              *       }
              *   };
              * ```
-             * 
-             * Attention: Currently, a function's name must not contain white-space characters, because it doesn't get quoted.
              */
             template<class F, class... Args>
             void create_aggregate_function(Args&&... constructorArgs) {
@@ -387,8 +379,6 @@ namespace sqlite_orm {
              * together with a copy of the passed initialization arguments.
              * An instance of the function object is repeatedly recreated for each result row,
              * ensuring that the calculations always start with freshly initialized values.
-             * 
-             * Attention: Currently, a function's name must not contain white-space characters, because it doesn't get quoted.
              */
             template<orm_aggregate_function auto f, std::copy_constructible... Args>
             void create_aggregate_function(Args&&... constructorArgs) {

--- a/dev/tuple_helper/tuple_iteration.h
+++ b/dev/tuple_helper/tuple_iteration.h
@@ -25,11 +25,7 @@ namespace sqlite_orm {
 
         template<bool reversed = false, class Tpl, size_t I, size_t... Idx, class L>
         void iterate_tuple(Tpl& tpl, std::index_sequence<I, Idx...>, L&& lambda) {
-#ifdef SQLITE_ORM_IF_CONSTEXPR_SUPPORTED
-            if constexpr(reversed) {
-#else
-            if(reversed) {
-#endif
+            if SQLITE_ORM_CONSTEXPR_IF(reversed) {
                 iterate_tuple<reversed>(tpl, std::index_sequence<Idx...>{}, std::forward<L>(lambda));
                 lambda(std::get<I>(tpl));
             } else {

--- a/dev/udf_proxy.h
+++ b/dev/udf_proxy.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <sqlite3.h>
+#include <cassert>  //  assert
 #include <memory>  //  std::allocator, std::allocator_traits, std::unique_ptr
 #include <string>  //  std::string
 #include <functional>  //  std::function
@@ -37,12 +38,17 @@ namespace sqlite_orm {
          *  As such, it also serves as a context for aggregation operations instead of using `sqlite3_aggregate_context()`.
          */
         struct udf_proxy {
+            using sqlite_callback_fn_t = void (*)(sqlite3_context* context, int argsCount, sqlite3_value** values);
             using func_call_fn_t = void (*)(void* udfHandle,
                                             sqlite3_context* context,
                                             int argsCount,
                                             sqlite3_value** values);
             using final_call_fn_t = void (*)(void* udfHandle, sqlite3_context* context);
             using memory_space = std::pair<void* /*udfHandle*/, xdestroy_fn_t /*deallocate*/>;
+            using func_type = union {
+                func_call_fn_t intermediate;
+                sqlite_callback_fn_t direct;
+            };
 
             struct destruct_only_deleter {
                 template<class UDF>
@@ -57,7 +63,7 @@ namespace sqlite_orm {
             int argumentsCount;
             std::function<void(void* location)> constructAt;
             xdestroy_fn_t destroy;
-            func_call_fn_t func;
+            func_type func;
             final_call_fn_t finalAggregateCall;
 
             // flag whether the UDF has been constructed at `udfHandle`;
@@ -70,7 +76,7 @@ namespace sqlite_orm {
                       int argumentsCount,
                       std::function<void(void* location)> constructAt,
                       xdestroy_fn_t destroy,
-                      func_call_fn_t func,
+                      func_type func,
                       final_call_fn_t finalAggregateCall,
                       memory_space udfMemory) :
                 name{std::move(name)},
@@ -94,14 +100,20 @@ namespace sqlite_orm {
             udf_proxy& operator=(const udf_proxy&) = delete;
         };
 
-        inline void check_args_count(const udf_proxy* proxy, int argsCount) {
-            if(proxy->argumentsCount != -1) {
-                if(proxy->argumentsCount != argsCount &&
-                   /*check fin call*/ argsCount != -1)
-                    SQLITE_ORM_CPP_UNLIKELY {
-                        throw std::system_error{orm_error_code::arguments_count_does_not_match};
-                    }
-            }
+        // safety net of doing a triple check at runtime
+        inline void assert_args_count(const udf_proxy* proxy, int argsCount) {
+            assert((proxy->argumentsCount == -1) || (proxy->argumentsCount == argsCount ||
+                                                     /*check fin call*/ argsCount == -1));
+            (void)proxy;
+            (void)argsCount;
+        }
+
+        // safety net of doing a triple check at runtime
+        inline void assert_args_count(sqlite3_context* context, int argsCount) {
+            udf_proxy* proxy;
+            assert((proxy = static_cast<udf_proxy*>(sqlite3_user_data(context))) != nullptr);
+            assert_args_count(proxy, argsCount);
+            (void)context;
         }
 
         inline void ensure_udf(udf_proxy* proxy, int argsCount) {
@@ -109,7 +121,7 @@ namespace sqlite_orm {
                 SQLITE_ORM_CPP_LIKELY {
                     return;
                 }
-            check_args_count(proxy, argsCount);
+            assert_args_count(proxy, argsCount);
             // Note on the use of the `udfHandle` pointer after the object construction:
             // since we only ever cast between void* and UDF* pointer types and
             // only use the memory space for one type during the entire lifetime of a proxy,
@@ -123,9 +135,16 @@ namespace sqlite_orm {
             proxy->destroy(udfHandle(proxy));
         }
 
+        inline void
+        stateless_scalar_function_dispatch(sqlite3_context* context, int argsCount, sqlite3_value** values) {
+            udf_proxy* proxy = static_cast<udf_proxy*>(sqlite3_user_data(context));
+            assert_args_count(proxy, argsCount);
+            proxy->func.intermediate(udfHandle(proxy), context, argsCount, values);
+        }
+
         inline void scalar_function_callback(sqlite3_context* context, int argsCount, sqlite3_value** values) {
             udf_proxy* proxy = static_cast<udf_proxy*>(sqlite3_user_data(context));
-            check_args_count(proxy, argsCount);
+            assert_args_count(proxy, argsCount);
             // 1. Thread-safe with regard to the construction/destruction of the function object in the same memory space.
             //    The `udf_proxy` is one instance per database connection,
             //    and SQLite internally locks access to the database object during the generation of a result row with `sqlite3_step()`.
@@ -135,21 +154,13 @@ namespace sqlite_orm {
             //    we can use `udfHandle` interconvertibly without laundering its provenance.
             proxy->constructAt(udfHandle(proxy));
             const std::unique_ptr<void, xdestroy_fn_t> udfGuard{udfHandle(proxy), proxy->destroy};
-            proxy->func(udfHandle(proxy), context, argsCount, values);
+            proxy->func.intermediate(udfHandle(proxy), context, argsCount, values);
         }
-
-        inline void quoted_scalar_function_callback(sqlite3_context* context, int argsCount, sqlite3_value** values) {
-            udf_proxy* proxy = static_cast<udf_proxy*>(sqlite3_user_data(context));
-            check_args_count(proxy, argsCount);
-            proxy->func(udfHandle(proxy), context, argsCount, values);
-        }
-
-        SQLITE_ORM_INLINE_VAR constexpr auto stateless_scalar_function_callback = quoted_scalar_function_callback;
 
         inline void aggregate_function_step_callback(sqlite3_context* context, int argsCount, sqlite3_value** values) {
             udf_proxy* proxy = static_cast<udf_proxy*>(sqlite3_user_data(context));
             ensure_udf(proxy, argsCount);
-            proxy->func(udfHandle(proxy), context, argsCount, values);
+            proxy->func.intermediate(udfHandle(proxy), context, argsCount, values);
         }
 
         inline void aggregate_function_final_callback(sqlite3_context* context) {

--- a/dev/udf_proxy.h
+++ b/dev/udf_proxy.h
@@ -78,6 +78,9 @@ namespace sqlite_orm {
                 finalAggregateCall{finalAggregateCall}, udfConstructed{false}, udfMemory{udfMemory} {}
 
             ~udf_proxy() {
+                if(!constructAt && destroy) {
+                    destroy(udfMemory.first);
+                }
                 if(udfMemory.second) {
                     udfMemory.second(udfMemory.first);
                 }
@@ -140,6 +143,8 @@ namespace sqlite_orm {
             check_args_count(proxy, argsCount);
             proxy->func(udfHandle(proxy), context, argsCount, values);
         }
+
+        SQLITE_ORM_INLINE_VAR constexpr auto stateless_scalar_function_callback = quoted_scalar_function_callback;
 
         inline void aggregate_function_step_callback(sqlite3_context* context, int argsCount, sqlite3_value** values) {
             udf_proxy* proxy = static_cast<udf_proxy*>(sqlite3_user_data(context));

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -15606,8 +15606,6 @@ namespace sqlite_orm {
              *      }
              *  };
              * ```
-             * 
-             * Attention: Currently, a function's name must not contain white-space characters, because it doesn't get quoted.
              */
             template<class F, class... Args>
             void create_scalar_function(Args&&... constructorArgs) {
@@ -15631,8 +15629,6 @@ namespace sqlite_orm {
              * If `F` is a stateless function object, an instance of the function object is created once, otherwise
              * an instance of the function object is repeatedly recreated for each result row,
              * ensuring that the calculations always start with freshly initialized values.
-             * 
-             * Attention: Currently, a function's name must not contain white-space characters, because it doesn't get quoted.
              */
             template<orm_scalar_function auto f, std::copy_constructible... Args>
             void create_scalar_function(Args&&... constructorArgs) {
@@ -15646,8 +15642,6 @@ namespace sqlite_orm {
              * If `quotedF` contains a freestanding function, stateless lambda or stateless function object,
              * `quoted_scalar_function::callable()` uses the original function object, assuming it is free of side effects;
              * otherwise, it repeatedly uses a copy of the contained function object, assuming possible side effects.
-             * 
-             * Attention: Currently, a function's name must not contain white-space characters, because it doesn't get quoted.
              */
             template<orm_quoted_scalar_function auto quotedF>
             void create_scalar_function() {
@@ -15710,8 +15704,6 @@ namespace sqlite_orm {
              *       }
              *   };
              * ```
-             * 
-             * Attention: Currently, a function's name must not contain white-space characters, because it doesn't get quoted.
              */
             template<class F, class... Args>
             void create_aggregate_function(Args&&... constructorArgs) {
@@ -15734,8 +15726,6 @@ namespace sqlite_orm {
              * together with a copy of the passed initialization arguments.
              * An instance of the function object is repeatedly recreated for each result row,
              * ensuring that the calculations always start with freshly initialized values.
-             * 
-             * Attention: Currently, a function's name must not contain white-space characters, because it doesn't get quoted.
              */
             template<orm_aggregate_function auto f, std::copy_constructible... Args>
             void create_aggregate_function(Args&&... constructorArgs) {
@@ -17042,7 +17032,8 @@ namespace sqlite_orm {
             template<class Ctx>
             std::string operator()(const statement_type& statement, const Ctx& context) const {
                 std::stringstream ss;
-                ss << statement.name() << "(" << streaming_expressions_tuple(statement.callArgs, context) << ")";
+                stream_identifier(ss, statement.name());
+                ss << "(" << streaming_expressions_tuple(statement.callArgs, context) << ")";
                 return ss.str();
             }
         };

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -15252,17 +15252,9 @@ namespace sqlite_orm {
          *  As such, it also serves as a context for aggregation operations instead of using `sqlite3_aggregate_context()`.
          */
         struct udf_proxy {
-            using sqlite_callback_fn_t = void (*)(sqlite3_context* context, int argsCount, sqlite3_value** values);
-            using func_call_fn_t = void (*)(void* udfHandle,
-                                            sqlite3_context* context,
-                                            int argsCount,
-                                            sqlite3_value** values);
+            using sqlite_func_t = void (*)(sqlite3_context* context, int argsCount, sqlite3_value** values);
             using final_call_fn_t = void (*)(void* udfHandle, sqlite3_context* context);
             using memory_space = std::pair<void* /*udfHandle*/, xdestroy_fn_t /*deallocate*/>;
-            using func_type = union {
-                func_call_fn_t intermediate;
-                sqlite_callback_fn_t direct;
-            };
 
             struct destruct_only_deleter {
                 template<class UDF>
@@ -15277,7 +15269,7 @@ namespace sqlite_orm {
             int argumentsCount;
             std::function<void(void* location)> constructAt;
             xdestroy_fn_t destroy;
-            func_type func;
+            sqlite_func_t func;
             final_call_fn_t finalAggregateCall;
 
             // flag whether the UDF has been constructed at `udfHandle`;
@@ -15290,7 +15282,7 @@ namespace sqlite_orm {
                       int argumentsCount,
                       std::function<void(void* location)> constructAt,
                       xdestroy_fn_t destroy,
-                      func_type func,
+                      sqlite_func_t func,
                       final_call_fn_t finalAggregateCall,
                       memory_space udfMemory) :
                 name{std::move(name)},
@@ -15298,7 +15290,7 @@ namespace sqlite_orm {
                 finalAggregateCall{finalAggregateCall}, udfConstructed{false}, udfMemory{udfMemory} {}
 
             ~udf_proxy() {
-                if(!constructAt && destroy) {
+                if(/*bool constructedOnce = */ !constructAt && destroy) {
                     destroy(udfMemory.first);
                 }
                 if(udfMemory.second) {
@@ -15323,7 +15315,7 @@ namespace sqlite_orm {
         }
 
         // safety net of doing a triple check at runtime
-        inline void assert_args_count(sqlite3_context* context, int argsCount) {
+        inline void proxy_assert_args_count(sqlite3_context* context, int argsCount) {
             udf_proxy* proxy;
             assert((proxy = static_cast<udf_proxy*>(sqlite3_user_data(context))) != nullptr);
             assert_args_count(proxy, argsCount);
@@ -15349,32 +15341,35 @@ namespace sqlite_orm {
             proxy->destroy(udfHandle(proxy));
         }
 
-        inline void
-        stateless_scalar_function_dispatch(sqlite3_context* context, int argsCount, sqlite3_value** values) {
+        inline auto new_scalar_udf_handle(sqlite3_context* context, int argsCount) {
+            proxy_assert_args_count(context, argsCount);
             udf_proxy* proxy = static_cast<udf_proxy*>(sqlite3_user_data(context));
-            assert_args_count(proxy, argsCount);
-            proxy->func.intermediate(udfHandle(proxy), context, argsCount, values);
-        }
-
-        inline void scalar_function_callback(sqlite3_context* context, int argsCount, sqlite3_value** values) {
-            udf_proxy* proxy = static_cast<udf_proxy*>(sqlite3_user_data(context));
-            assert_args_count(proxy, argsCount);
-            // 1. Thread-safe with regard to the construction/destruction of the function object in the same memory space.
-            //    The `udf_proxy` is one instance per database connection,
-            //    and SQLite internally locks access to the database object during the generation of a result row with `sqlite3_step()`.
-            // 2. Note on the use of the `udfHandle` pointer after the object construction:
-            //    since we only ever cast between void* and UDF* pointer types and
-            //    only use the memory space for one type during the entire lifetime of a proxy,
-            //    we can use `udfHandle` interconvertibly without laundering its provenance.
+            // Note on the use of the `udfHandle` pointer after the object construction:
+            // since we only ever cast between void* and UDF* pointer types and
+            // only use the memory space for one type during the entire lifetime of a proxy,
+            // we can use `udfHandle` interconvertibly without laundering its provenance.
             proxy->constructAt(udfHandle(proxy));
-            const std::unique_ptr<void, xdestroy_fn_t> udfGuard{udfHandle(proxy), proxy->destroy};
-            proxy->func.intermediate(udfHandle(proxy), context, argsCount, values);
+            return std::unique_ptr<void, xdestroy_fn_t>{udfHandle(proxy), proxy->destroy};
         }
 
-        inline void aggregate_function_step_callback(sqlite3_context* context, int argsCount, sqlite3_value** values) {
+        template<class UDF>
+        inline UDF* proxy_get_scalar_udf(std::true_type /*is_stateless*/, sqlite3_context* context, int argsCount) {
+            proxy_assert_args_count(context, argsCount);
+            udf_proxy* proxy = static_cast<udf_proxy*>(sqlite3_user_data(context));
+            return static_cast<UDF*>(udfHandle(proxy));
+        }
+
+        template<class UDF>
+        inline auto proxy_get_scalar_udf(std::false_type /*is_stateless*/, sqlite3_context* context, int argsCount) {
+            std::unique_ptr<void, xdestroy_fn_t> p = new_scalar_udf_handle(context, argsCount);
+            return std::unique_ptr<UDF, xdestroy_fn_t>{static_cast<UDF*>(p.release()), p.get_deleter()};
+        }
+
+        template<class UDF>
+        inline UDF* proxy_get_aggregate_step_udf(sqlite3_context* context, int argsCount) {
             udf_proxy* proxy = static_cast<udf_proxy*>(sqlite3_user_data(context));
             ensure_udf(proxy, argsCount);
-            proxy->func.intermediate(udfHandle(proxy), context, argsCount, values);
+            return static_cast<UDF*>(udfHandle(proxy));
         }
 
         inline void aggregate_function_final_callback(sqlite3_context* context) {
@@ -15670,15 +15665,12 @@ namespace sqlite_orm {
                     /* destroy = */
                     nullptr,
                     /* call = */
-                    udf_proxy::func_type{.direct =
-                                             [](sqlite3_context* context, int argsCount, sqlite3_value** values) {
-                                                 assert_args_count(context, argsCount);
-                                                 args_tuple argsTuple =
-                                                     tuple_from_values<args_tuple>{}(values, argsCount);
-                                                 auto result =
-                                                     polyfill::apply(quotedF.callable(), std::move(argsTuple));
-                                                 statement_binder<return_type>().result(context, result);
-                                             }},
+                    [](sqlite3_context* context, int argsCount, sqlite3_value** values) {
+                        proxy_assert_args_count(context, argsCount);
+                        args_tuple argsTuple = tuple_from_values<args_tuple>{}(values, argsCount);
+                        auto result = polyfill::apply(quotedF.callable(), std::move(argsTuple));
+                        statement_binder<return_type>().result(context, result);
+                    },
                     /* finalCall = */
                     nullptr,
                     std::pair{nullptr, null_xdestroy_f});
@@ -16063,25 +16055,24 @@ namespace sqlite_orm {
                 constexpr auto argsCount = std::is_same<args_tuple, std::tuple<arg_values>>::value
                                                ? -1
                                                : int(std::tuple_size<args_tuple>::value);
-                constexpr bool isStateless = std::is_empty<F>::value;
+                using is_stateless = std::is_empty<F>;
                 auto udfStorage = allocate_udf_storage<F>();
-                if SQLITE_ORM_CONSTEXPR_IF(isStateless) {
+                if SQLITE_ORM_CONSTEXPR_IF(is_stateless::value) {
                     constructAt(udfStorage.first);
                 }
                 this->scalarFunctions.emplace_back(
                     udfName(),
                     argsCount,
-                    isStateless ? nullptr : std::move(constructAt),
+                    is_stateless::value ? nullptr : std::move(constructAt),
                     /* destroy = */
                     obtain_xdestroy_for<F>(udf_proxy::destruct_only_deleter{}),
                     /* call = */
-                    udf_proxy::func_type{
-                        [](void* udfHandle, sqlite3_context* context, int argsCount, sqlite3_value** values) {
-                            F& udf = *static_cast<F*>(udfHandle);
-                            args_tuple argsTuple = tuple_from_values<args_tuple>{}(values, argsCount);
-                            auto result = polyfill::apply(udf, std::move(argsTuple));
-                            statement_binder<return_type>().result(context, result);
-                        }},
+                    [](sqlite3_context* context, int argsCount, sqlite3_value** values) {
+                        auto udfPointer = proxy_get_scalar_udf<F>(is_stateless{}, context, argsCount);
+                        args_tuple argsTuple = tuple_from_values<args_tuple>{}(values, argsCount);
+                        auto result = polyfill::apply(*udfPointer, std::move(argsTuple));
+                        statement_binder<return_type>().result(context, result);
+                    },
                     /* finalCall = */
                     nullptr,
                     udfStorage);
@@ -16107,8 +16098,8 @@ namespace sqlite_orm {
                     /* destroy = */
                     obtain_xdestroy_for<F>(udf_proxy::destruct_only_deleter{}),
                     /* step = */
-                    udf_proxy::func_type{[](void* udfHandle, sqlite3_context*, int argsCount, sqlite3_value** values) {
-                        F& udf = *static_cast<F*>(udfHandle);
+                    [](sqlite3_context* context, int argsCount, sqlite3_value** values) {
+                        F& udf = *proxy_get_aggregate_step_udf<F>(context, argsCount);
                         args_tuple argsTuple = tuple_from_values<args_tuple>{}(values, argsCount);
 #if __cpp_lib_bind_front >= 201907L
                         std::apply(std::bind_front(&F::step, &udf), std::move(argsTuple));
@@ -16119,7 +16110,7 @@ namespace sqlite_orm {
                             },
                             std::move(argsTuple));
 #endif
-                    }},
+                    },
                     /* finalCall = */
                     [](void* udfHandle, sqlite3_context* context) {
                         F& udf = *static_cast<F*>(udfHandle);
@@ -16170,10 +16161,7 @@ namespace sqlite_orm {
                                                     udfProxy.argumentsCount,
                                                     SQLITE_UTF8,
                                                     &udfProxy,
-                                                    !udfProxy.constructAt && !udfProxy.destroy ? udfProxy.func.direct
-                                                    : !udfProxy.constructAt && udfProxy.destroy
-                                                        ? stateless_scalar_function_dispatch
-                                                        : scalar_function_callback,
+                                                    udfProxy.func,
                                                     nullptr,
                                                     nullptr,
                                                     nullptr);
@@ -16189,7 +16177,7 @@ namespace sqlite_orm {
                                                  SQLITE_UTF8,
                                                  &udfProxy,
                                                  nullptr,
-                                                 aggregate_function_step_callback,
+                                                 udfProxy.func,
                                                  aggregate_function_final_callback);
                 if(rc != SQLITE_OK) {
                     throw_translated_sqlite_error(rc);

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -17052,7 +17052,7 @@ namespace sqlite_orm {
             template<class Ctx>
             std::string operator()(const statement_type& statement, const Ctx& context) const {
                 std::stringstream ss;
-                stream_identifier(ss, statement.name());
+                stream_identifier(ss, "", statement.name(), "");
                 ss << "(" << streaming_expressions_tuple(statement.callArgs, context) << ")";
                 return ss.str();
             }

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -15215,6 +15215,7 @@ namespace sqlite_orm {
 // #include "udf_proxy.h"
 
 #include <sqlite3.h>
+#include <cassert>  //  assert
 #include <memory>  //  std::allocator, std::allocator_traits, std::unique_ptr
 #include <string>  //  std::string
 #include <functional>  //  std::function
@@ -15251,12 +15252,17 @@ namespace sqlite_orm {
          *  As such, it also serves as a context for aggregation operations instead of using `sqlite3_aggregate_context()`.
          */
         struct udf_proxy {
+            using sqlite_callback_fn_t = void (*)(sqlite3_context* context, int argsCount, sqlite3_value** values);
             using func_call_fn_t = void (*)(void* udfHandle,
                                             sqlite3_context* context,
                                             int argsCount,
                                             sqlite3_value** values);
             using final_call_fn_t = void (*)(void* udfHandle, sqlite3_context* context);
             using memory_space = std::pair<void* /*udfHandle*/, xdestroy_fn_t /*deallocate*/>;
+            using func_type = union {
+                func_call_fn_t intermediate;
+                sqlite_callback_fn_t direct;
+            };
 
             struct destruct_only_deleter {
                 template<class UDF>
@@ -15271,7 +15277,7 @@ namespace sqlite_orm {
             int argumentsCount;
             std::function<void(void* location)> constructAt;
             xdestroy_fn_t destroy;
-            func_call_fn_t func;
+            func_type func;
             final_call_fn_t finalAggregateCall;
 
             // flag whether the UDF has been constructed at `udfHandle`;
@@ -15284,7 +15290,7 @@ namespace sqlite_orm {
                       int argumentsCount,
                       std::function<void(void* location)> constructAt,
                       xdestroy_fn_t destroy,
-                      func_call_fn_t func,
+                      func_type func,
                       final_call_fn_t finalAggregateCall,
                       memory_space udfMemory) :
                 name{std::move(name)},
@@ -15308,14 +15314,20 @@ namespace sqlite_orm {
             udf_proxy& operator=(const udf_proxy&) = delete;
         };
 
-        inline void check_args_count(const udf_proxy* proxy, int argsCount) {
-            if(proxy->argumentsCount != -1) {
-                if(proxy->argumentsCount != argsCount &&
-                   /*check fin call*/ argsCount != -1)
-                    SQLITE_ORM_CPP_UNLIKELY {
-                        throw std::system_error{orm_error_code::arguments_count_does_not_match};
-                    }
-            }
+        // safety net of doing a triple check at runtime
+        inline void assert_args_count(const udf_proxy* proxy, int argsCount) {
+            assert((proxy->argumentsCount == -1) || (proxy->argumentsCount == argsCount ||
+                                                     /*check fin call*/ argsCount == -1));
+            (void)proxy;
+            (void)argsCount;
+        }
+
+        // safety net of doing a triple check at runtime
+        inline void assert_args_count(sqlite3_context* context, int argsCount) {
+            udf_proxy* proxy;
+            assert((proxy = static_cast<udf_proxy*>(sqlite3_user_data(context))) != nullptr);
+            assert_args_count(proxy, argsCount);
+            (void)context;
         }
 
         inline void ensure_udf(udf_proxy* proxy, int argsCount) {
@@ -15323,7 +15335,7 @@ namespace sqlite_orm {
                 SQLITE_ORM_CPP_LIKELY {
                     return;
                 }
-            check_args_count(proxy, argsCount);
+            assert_args_count(proxy, argsCount);
             // Note on the use of the `udfHandle` pointer after the object construction:
             // since we only ever cast between void* and UDF* pointer types and
             // only use the memory space for one type during the entire lifetime of a proxy,
@@ -15337,9 +15349,16 @@ namespace sqlite_orm {
             proxy->destroy(udfHandle(proxy));
         }
 
+        inline void
+        stateless_scalar_function_dispatch(sqlite3_context* context, int argsCount, sqlite3_value** values) {
+            udf_proxy* proxy = static_cast<udf_proxy*>(sqlite3_user_data(context));
+            assert_args_count(proxy, argsCount);
+            proxy->func.intermediate(udfHandle(proxy), context, argsCount, values);
+        }
+
         inline void scalar_function_callback(sqlite3_context* context, int argsCount, sqlite3_value** values) {
             udf_proxy* proxy = static_cast<udf_proxy*>(sqlite3_user_data(context));
-            check_args_count(proxy, argsCount);
+            assert_args_count(proxy, argsCount);
             // 1. Thread-safe with regard to the construction/destruction of the function object in the same memory space.
             //    The `udf_proxy` is one instance per database connection,
             //    and SQLite internally locks access to the database object during the generation of a result row with `sqlite3_step()`.
@@ -15349,21 +15368,13 @@ namespace sqlite_orm {
             //    we can use `udfHandle` interconvertibly without laundering its provenance.
             proxy->constructAt(udfHandle(proxy));
             const std::unique_ptr<void, xdestroy_fn_t> udfGuard{udfHandle(proxy), proxy->destroy};
-            proxy->func(udfHandle(proxy), context, argsCount, values);
+            proxy->func.intermediate(udfHandle(proxy), context, argsCount, values);
         }
-
-        inline void quoted_scalar_function_callback(sqlite3_context* context, int argsCount, sqlite3_value** values) {
-            udf_proxy* proxy = static_cast<udf_proxy*>(sqlite3_user_data(context));
-            check_args_count(proxy, argsCount);
-            proxy->func(udfHandle(proxy), context, argsCount, values);
-        }
-
-        SQLITE_ORM_INLINE_VAR constexpr auto stateless_scalar_function_callback = quoted_scalar_function_callback;
 
         inline void aggregate_function_step_callback(sqlite3_context* context, int argsCount, sqlite3_value** values) {
             udf_proxy* proxy = static_cast<udf_proxy*>(sqlite3_user_data(context));
             ensure_udf(proxy, argsCount);
-            proxy->func(udfHandle(proxy), context, argsCount, values);
+            proxy->func.intermediate(udfHandle(proxy), context, argsCount, values);
         }
 
         inline void aggregate_function_final_callback(sqlite3_context* context) {
@@ -15659,11 +15670,15 @@ namespace sqlite_orm {
                     /* destroy = */
                     nullptr,
                     /* call = */
-                    [](void* /*udfHandle*/, sqlite3_context* context, int argsCount, sqlite3_value** values) {
-                        args_tuple argsTuple = tuple_from_values<args_tuple>{}(values, argsCount);
-                        auto result = polyfill::apply(quotedF.callable(), std::move(argsTuple));
-                        statement_binder<return_type>().result(context, result);
-                    },
+                    udf_proxy::func_type{.direct =
+                                             [](sqlite3_context* context, int argsCount, sqlite3_value** values) {
+                                                 assert_args_count(context, argsCount);
+                                                 args_tuple argsTuple =
+                                                     tuple_from_values<args_tuple>{}(values, argsCount);
+                                                 auto result =
+                                                     polyfill::apply(quotedF.callable(), std::move(argsTuple));
+                                                 statement_binder<return_type>().result(context, result);
+                                             }},
                     /* finalCall = */
                     nullptr,
                     std::pair{nullptr, null_xdestroy_f});
@@ -16060,12 +16075,13 @@ namespace sqlite_orm {
                     /* destroy = */
                     obtain_xdestroy_for<F>(udf_proxy::destruct_only_deleter{}),
                     /* call = */
-                    [](void* udfHandle, sqlite3_context* context, int argsCount, sqlite3_value** values) {
-                        F& udf = *static_cast<F*>(udfHandle);
-                        args_tuple argsTuple = tuple_from_values<args_tuple>{}(values, argsCount);
-                        auto result = polyfill::apply(udf, std::move(argsTuple));
-                        statement_binder<return_type>().result(context, result);
-                    },
+                    udf_proxy::func_type{
+                        [](void* udfHandle, sqlite3_context* context, int argsCount, sqlite3_value** values) {
+                            F& udf = *static_cast<F*>(udfHandle);
+                            args_tuple argsTuple = tuple_from_values<args_tuple>{}(values, argsCount);
+                            auto result = polyfill::apply(udf, std::move(argsTuple));
+                            statement_binder<return_type>().result(context, result);
+                        }},
                     /* finalCall = */
                     nullptr,
                     udfStorage);
@@ -16091,7 +16107,7 @@ namespace sqlite_orm {
                     /* destroy = */
                     obtain_xdestroy_for<F>(udf_proxy::destruct_only_deleter{}),
                     /* step = */
-                    [](void* udfHandle, sqlite3_context*, int argsCount, sqlite3_value** values) {
+                    udf_proxy::func_type{[](void* udfHandle, sqlite3_context*, int argsCount, sqlite3_value** values) {
                         F& udf = *static_cast<F*>(udfHandle);
                         args_tuple argsTuple = tuple_from_values<args_tuple>{}(values, argsCount);
 #if __cpp_lib_bind_front >= 201907L
@@ -16103,7 +16119,7 @@ namespace sqlite_orm {
                             },
                             std::move(argsTuple));
 #endif
-                    },
+                    }},
                     /* finalCall = */
                     [](void* udfHandle, sqlite3_context* context) {
                         F& udf = *static_cast<F*>(udfHandle);
@@ -16149,18 +16165,18 @@ namespace sqlite_orm {
             }
 
             static void try_to_create_scalar_function(sqlite3* db, udf_proxy& udfProxy) {
-                int rc = sqlite3_create_function_v2(
-                    db,
-                    udfProxy.name.c_str(),
-                    udfProxy.argumentsCount,
-                    SQLITE_UTF8,
-                    &udfProxy,
-                    !udfProxy.constructAt && !udfProxy.destroy  ? quoted_scalar_function_callback
-                    : !udfProxy.constructAt && udfProxy.destroy ? stateless_scalar_function_callback
-                                                                : scalar_function_callback,
-                    nullptr,
-                    nullptr,
-                    nullptr);
+                int rc = sqlite3_create_function_v2(db,
+                                                    udfProxy.name.c_str(),
+                                                    udfProxy.argumentsCount,
+                                                    SQLITE_UTF8,
+                                                    &udfProxy,
+                                                    !udfProxy.constructAt && !udfProxy.destroy ? udfProxy.func.direct
+                                                    : !udfProxy.constructAt && udfProxy.destroy
+                                                        ? stateless_scalar_function_dispatch
+                                                        : scalar_function_callback,
+                                                    nullptr,
+                                                    nullptr,
+                                                    nullptr);
                 if(rc != SQLITE_OK) {
                     throw_translated_sqlite_error(db);
                 }

--- a/tests/statement_serializer_tests/bindables.cpp
+++ b/tests/statement_serializer_tests/bindables.cpp
@@ -283,12 +283,12 @@ TEST_CASE("bindables") {
         SECTION("null as function argument") {
             auto ast = func<remember_fn>(1, statically_bindable_pointer<carray_pvt, nullptr_t>(nullptr));
             value = serialize(ast, context);
-            expected = "remember(1, null)";
+            expected = R"("remember"(1, null))";
         }
         SECTION("null as function argument 2") {
             auto ast = func<remember_fn>(1, nullptr);
             value = serialize(ast, context);
-            expected = "remember(1, null)";
+            expected = R"("remember"(1, null))";
         }
 
         REQUIRE(value == expected);

--- a/tests/statement_serializer_tests/column_names.cpp
+++ b/tests/statement_serializer_tests/column_names.cpp
@@ -169,6 +169,14 @@ TEST_CASE("statement_serializer column names") {
                 return R"(a"s)";
             }
         };
+        struct always42_function {
+            static const char* name() {
+                return R"("always 42")";
+            }
+            int operator()() const {
+                return 42;
+            }
+        };
         auto table1 = make_table(R"(object1"")", make_column(R"(i"d)", &Object1::id));
         auto table2 = make_table(R"(ob"ject2)", make_column(R"(i"d)", &Object2::id));
         using db_objects_t = internal::db_objects_tuple<decltype(table1), decltype(table2)>;
@@ -179,14 +187,18 @@ TEST_CASE("statement_serializer column names") {
 
             using als_d = alias_d<Object2>;
             auto expression =
-                select(columns(&Object1::id, as<colalias>(&Object1::id), alias_column<als_d>(&Object2::id)),
+                select(columns(&Object1::id,
+                               as<colalias>(&Object1::id),
+                               alias_column<als_d>(&Object2::id),
+                               func<always42_function>()),
                        join<als_d>(using_(&Object1::id)),
                        multi_order_by(order_by(get<colalias>()), order_by(alias_column<als_d>(&Object2::id))));
             expression.highest_level = true;
             auto value = serialize(expression, context);
-            REQUIRE(value ==
-                    R"(SELECT "object1"""""."i""d", "object1"""""."i""d" AS "a""s", "d"."i""d" FROM "object1""""" )"
-                    R"(JOIN "ob""ject2" "d" USING ("i""d") ORDER BY "a""s", "d"."i""d")");
+            REQUIRE(
+                value ==
+                R"(SELECT "object1"""""."i""d", "object1"""""."i""d" AS "a""s", "d"."i""d", """always 42"""() FROM "object1""""" )"
+                R"(JOIN "ob""ject2" "d" USING ("i""d") ORDER BY "a""s", "d"."i""d")");
         }
     }
 }

--- a/tests/statement_serializer_tests/select_constraints.cpp
+++ b/tests/statement_serializer_tests/select_constraints.cpp
@@ -149,7 +149,7 @@ TEST_CASE("statement_serializer select constraints") {
         };
         auto expression = func<Func>(&User::id);
         value = serialize(expression, context);
-        expected = R"(EVEN("id"))";
+        expected = R"("EVEN"("id"))";
     }
     SECTION("exists") {
         // EXISTS must use parentheses in a new context

--- a/tests/user_defined_functions.cpp
+++ b/tests/user_defined_functions.cpp
@@ -586,8 +586,8 @@ TEST_CASE("generalized scalar udf") {
         constexpr auto clamp_f = R"("clamp int")"_scalar.quote(std::clamp<int>);
         storage.create_scalar_function<clamp_f>();
         {
-            auto rows = storage.select(columns(clamp_f(0, 1, 1)));
-            decltype(rows) expected{{1}};
+            auto rows = storage.select(clamp_f(0, 1, 1));
+            decltype(rows) expected{1};
             REQUIRE(rows == expected);
         }
         storage.delete_scalar_function<clamp_f>();

--- a/tests/user_defined_functions.cpp
+++ b/tests/user_defined_functions.cpp
@@ -18,28 +18,52 @@ struct SqrtFunction {
 
 int SqrtFunction::callsCount = 0;
 
-struct HasPrefixFunction {
+struct StatelessHasPrefixFunction {
     static int callsCount;
     static int objectsCount;
 
-    HasPrefixFunction() {
+    StatelessHasPrefixFunction() {
         ++objectsCount;
     }
 
-    HasPrefixFunction(const HasPrefixFunction&) {
-        ++objectsCount;
-    }
+    StatelessHasPrefixFunction(const StatelessHasPrefixFunction&) = delete;
 
-    HasPrefixFunction(HasPrefixFunction&&) {
-        ++objectsCount;
-    }
-
-    ~HasPrefixFunction() {
+    ~StatelessHasPrefixFunction() {
         --objectsCount;
     }
 
     bool operator()(const std::string& str, const std::string& prefix) {
         ++callsCount;
+        return str.compare(0, prefix.size(), prefix) == 0;
+    }
+
+    static std::string name() {
+        return "STATELESS_HAS_PREFIX";
+    }
+};
+
+int StatelessHasPrefixFunction::callsCount = 0;
+int StatelessHasPrefixFunction::objectsCount = 0;
+
+struct HasPrefixFunction {
+    static int callsCount;
+    static int objectsCount;
+
+    int& staticCallsCount;
+    int& staticObjectsCount;
+
+    HasPrefixFunction() : staticCallsCount{callsCount}, staticObjectsCount{objectsCount} {
+        ++staticObjectsCount;
+    }
+
+    HasPrefixFunction(const HasPrefixFunction&) = delete;
+
+    ~HasPrefixFunction() {
+        --staticObjectsCount;
+    }
+
+    bool operator()(const std::string& str, const std::string& prefix) {
+        ++staticCallsCount;
         return str.compare(0, prefix.size(), prefix) == 0;
     }
 
@@ -61,13 +85,7 @@ struct MeanFunction {
         ++objectsCount;
     }
 
-    MeanFunction(const MeanFunction&) {
-        ++objectsCount;
-    }
-
-    MeanFunction(MeanFunction&&) {
-        ++objectsCount;
-    }
+    MeanFunction(const MeanFunction&) = delete;
 
     ~MeanFunction() {
         --objectsCount;
@@ -93,24 +111,21 @@ struct FirstFunction {
     static int objectsCount;
     static int callsCount;
 
-    FirstFunction() {
-        ++objectsCount;
+    int& staticObjectsCount;
+    int& staticCallsCount;
+
+    FirstFunction() : staticObjectsCount{objectsCount}, staticCallsCount{callsCount} {
+        ++staticObjectsCount;
     }
 
-    FirstFunction(const MeanFunction&) {
-        ++objectsCount;
-    }
-
-    FirstFunction(MeanFunction&&) {
-        ++objectsCount;
-    }
+    FirstFunction(const FirstFunction&) = delete;
 
     ~FirstFunction() {
-        --objectsCount;
+        --staticObjectsCount;
     }
 
     std::string operator()(const arg_values& args) const {
-        ++callsCount;
+        ++staticCallsCount;
         std::string res;
         res.reserve(args.size());
         for(auto value: args) {
@@ -232,6 +247,7 @@ TEST_CASE("custom functions") {
     using Catch::Matchers::ContainsSubstring;
 
     SqrtFunction::callsCount = 0;
+    StatelessHasPrefixFunction::callsCount = 0;
     HasPrefixFunction::callsCount = 0;
     FirstFunction::callsCount = 0;
 
@@ -278,33 +294,68 @@ TEST_CASE("custom functions") {
         REQUIRE(rows == expected);
     }
 
-    //  create function
-    REQUIRE(HasPrefixFunction::callsCount == 0);
-    REQUIRE(HasPrefixFunction::objectsCount == 0);
-    storage.create_scalar_function<HasPrefixFunction>();
-    REQUIRE(HasPrefixFunction::callsCount == 0);
-    REQUIRE(HasPrefixFunction::objectsCount == 0);
-
-    //  call after creation
     {
-        auto rows = storage.select(func<HasPrefixFunction>("one", "o"));
-        decltype(rows) expected;
-        expected.push_back(true);
-        REQUIRE(rows == expected);
-    }
-    REQUIRE(HasPrefixFunction::callsCount == 1);
-    REQUIRE(HasPrefixFunction::objectsCount == 0);
-    {
-        auto rows = storage.select(func<HasPrefixFunction>("two", "b"));
-        decltype(rows) expected;
-        expected.push_back(false);
-        REQUIRE(rows == expected);
-    }
-    REQUIRE(HasPrefixFunction::callsCount == 2);
-    REQUIRE(HasPrefixFunction::objectsCount == 0);
+        //  create function
+        REQUIRE(StatelessHasPrefixFunction::callsCount == 0);
+        REQUIRE(StatelessHasPrefixFunction::objectsCount == 0);
+        storage.create_scalar_function<StatelessHasPrefixFunction>();
+        REQUIRE(StatelessHasPrefixFunction::callsCount == 0);
+        // function object created
+        REQUIRE(StatelessHasPrefixFunction::objectsCount == 1);
 
-    //  delete function
-    storage.delete_scalar_function<HasPrefixFunction>();
+        //  call after creation
+        {
+            auto rows = storage.select(func<StatelessHasPrefixFunction>("one", "o"));
+            decltype(rows) expected;
+            expected.push_back(true);
+            REQUIRE(rows == expected);
+        }
+        REQUIRE(StatelessHasPrefixFunction::callsCount == 1);
+        REQUIRE(StatelessHasPrefixFunction::objectsCount == 1);
+        {
+            auto rows = storage.select(func<StatelessHasPrefixFunction>("two", "b"));
+            decltype(rows) expected;
+            expected.push_back(false);
+            REQUIRE(rows == expected);
+        }
+        REQUIRE(StatelessHasPrefixFunction::callsCount == 2);
+        REQUIRE(StatelessHasPrefixFunction::objectsCount == 1);
+
+        //  delete function
+        storage.delete_scalar_function<StatelessHasPrefixFunction>();
+        // function object destroyed
+        REQUIRE(StatelessHasPrefixFunction::objectsCount == 0);
+    }
+
+    {
+        //  create function
+        REQUIRE(HasPrefixFunction::callsCount == 0);
+        REQUIRE(HasPrefixFunction::objectsCount == 0);
+        storage.create_scalar_function<HasPrefixFunction>();
+        REQUIRE(HasPrefixFunction::callsCount == 0);
+        REQUIRE(HasPrefixFunction::objectsCount == 0);
+
+        //  call after creation
+        {
+            auto rows = storage.select(func<HasPrefixFunction>("one", "o"));
+            decltype(rows) expected;
+            expected.push_back(true);
+            REQUIRE(rows == expected);
+        }
+        REQUIRE(HasPrefixFunction::callsCount == 1);
+        REQUIRE(HasPrefixFunction::objectsCount == 0);
+        {
+            auto rows = storage.select(func<HasPrefixFunction>("two", "b"));
+            decltype(rows) expected;
+            expected.push_back(false);
+            REQUIRE(rows == expected);
+        }
+        REQUIRE(HasPrefixFunction::callsCount == 2);
+        REQUIRE(HasPrefixFunction::objectsCount == 0);
+
+        //  delete function
+        storage.delete_scalar_function<HasPrefixFunction>();
+    }
 
     //  delete function
     storage.delete_scalar_function<SqrtFunction>();

--- a/tests/user_defined_functions.cpp
+++ b/tests/user_defined_functions.cpp
@@ -582,5 +582,15 @@ TEST_CASE("generalized scalar udf") {
         }
         storage.delete_scalar_function<offset0_f>();
     }
+    SECTION("escaped function identifier") {
+        constexpr auto clamp_f = R"("clamp int")"_scalar.quote(std::clamp<int>);
+        storage.create_scalar_function<clamp_f>();
+        {
+            auto rows = storage.select(columns(clamp_f(0, 1, 1)));
+            decltype(rows) expected{{1}};
+            REQUIRE(rows == expected);
+        }
+        storage.delete_scalar_function<clamp_f>();
+    }
 }
 #endif


### PR DESCRIPTION
This PR contains the following improvements and optimizations to application-defined functions
- Application-defined function names can now contain spaces or quotation marks
- Move-capture construction arguments for traditional application-defined functions
- Reorganized dispatch-based sqlite function callbacks to direct calls
- Traditional stateless application-defined functions are constructed only once
- Runtime check of the number of function arguments replaced by a runtime assertion