### PR TITLE
Namespaces for the most recent operators

### DIFF
--- a/dev/alias.h
+++ b/dev/alias.h
@@ -212,17 +212,17 @@ namespace sqlite_orm {
     }
 
     /**
-        *  Create a column reference to an aliased table column.
-        *  
-        *  @note An object member pointer can be from a derived class without explicitly forming a column pointer.
-        *  
-        *  @note (internal) Intentionally not placed in the internal namespace for ADL (Argument Dependent Lookup)
-        *  because recordset aliases are derived from `sqlite_orm::alias_tag`
-        *  
-        *  Example:
-        *  constexpr auto als = "u"_alias.for_<User>();
-        *  select(als->*&User::id)
-        */
+     *  Create a column reference to an aliased table column.
+     *  
+     *  @note An object member pointer can be from a derived class without explicitly forming a column pointer.
+     *  
+     *  @note (internal) Intentionally not placed in the internal namespace for ADL (Argument Dependent Lookup)
+     *  because recordset aliases are derived from `sqlite_orm::alias_tag`
+     *  
+     *  Example:
+     *  constexpr auto als = "u"_alias.for_<User>();
+     *  select(als->*&User::id)
+     */
     template<orm_table_alias A, class F>
     constexpr auto operator->*(const A& /*tableAlias*/, F field) {
         return alias_column<A>(std::move(field));

--- a/dev/alias.h
+++ b/dev/alias.h
@@ -216,8 +216,11 @@ namespace sqlite_orm {
      *  
      *  @note An object member pointer can be from a derived class without explicitly forming a column pointer.
      *  
-     *  Example:
-     *  constexpr auto als = "u"_alias.for_<User>();
+        *  @note (internal) Intentionally not placed in the internal namespace for ADL (Argument Dependent Lookup)
+        *  because recordset aliases are derived from `sqlite_orm::alias_tag`
+        *  
+        *  Example:
+        *  constexpr auto als = "u"_alias.for_<User>();
      *  select(als->*&User::id)
      */
     template<orm_table_alias A, class F>

--- a/dev/alias.h
+++ b/dev/alias.h
@@ -216,7 +216,7 @@ namespace sqlite_orm {
      *  
      *  @note An object member pointer can be from a derived class without explicitly forming a column pointer.
      *  
-     *  @note (internal) Intentionally not placed in the internal namespace for ADL (Argument Dependent Lookup)
+     *  @note (internal) Intentionally place in the sqlite_orm namespace for ADL (Argument Dependent Lookup)
      *  because recordset aliases are derived from `sqlite_orm::alias_tag`
      *  
      *  Example:

--- a/dev/alias.h
+++ b/dev/alias.h
@@ -212,17 +212,17 @@ namespace sqlite_orm {
     }
 
     /**
-     *  Create a column reference to an aliased table column.
-     *  
-     *  @note An object member pointer can be from a derived class without explicitly forming a column pointer.
-     *  
+        *  Create a column reference to an aliased table column.
+        *  
+        *  @note An object member pointer can be from a derived class without explicitly forming a column pointer.
+        *  
         *  @note (internal) Intentionally not placed in the internal namespace for ADL (Argument Dependent Lookup)
         *  because recordset aliases are derived from `sqlite_orm::alias_tag`
         *  
         *  Example:
         *  constexpr auto als = "u"_alias.for_<User>();
-     *  select(als->*&User::id)
-     */
+        *  select(als->*&User::id)
+        */
     template<orm_table_alias A, class F>
     constexpr auto operator->*(const A& /*tableAlias*/, F field) {
         return alias_column<A>(std::move(field));
@@ -339,23 +339,26 @@ namespace sqlite_orm {
     template<char A, char... X>
     inline constexpr internal::recordset_alias_builder<A, X...> alias{};
 
-    /** @short Create a table alias.
-     *
-     *  Examples:
-     *  constexpr auto z_alias = "z"_alias.for_<User>();
-     */
-    template<internal::cstring_literal name>
-    [[nodiscard]] consteval auto operator"" _alias() {
-        return internal::explode_into<internal::recordset_alias_builder, name>(std::make_index_sequence<name.size()>{});
-    }
+    inline namespace literals {
+        /** @short Create a table alias.
+         *
+         *  Examples:
+         *  constexpr auto z_alias = "z"_alias.for_<User>();
+         */
+        template<internal::cstring_literal name>
+        [[nodiscard]] consteval auto operator"" _alias() {
+            return internal::explode_into<internal::recordset_alias_builder, name>(
+                std::make_index_sequence<name.size()>{});
+        }
 
-    /** @short Create a column alias.
-     *  column_alias<'a'[, ...]> from a string literal.
-     *  E.g. "a"_col, "b"_col
-     */
-    template<internal::cstring_literal name>
-    [[nodiscard]] consteval auto operator"" _col() {
-        return internal::explode_into<internal::column_alias, name>(std::make_index_sequence<name.size()>{});
+        /** @short Create a column alias.
+         *  column_alias<'a'[, ...]> from a string literal.
+         *  E.g. "a"_col, "b"_col
+         */
+        template<internal::cstring_literal name>
+        [[nodiscard]] consteval auto operator"" _col() {
+            return internal::explode_into<internal::column_alias, name>(std::make_index_sequence<name.size()>{});
+        }
     }
 #endif
 }

--- a/dev/column_pointer.h
+++ b/dev/column_pointer.h
@@ -51,12 +51,16 @@ namespace sqlite_orm {
         return column<internal::auto_type_t<table>>(field);
     }
 
-    /**
-     *  Explicitly refer to a column.
-     */
-    template<orm_table_reference R, class O, class F>
-    constexpr auto operator->*(const R& /*table*/, F O::*field) {
-        return column<typename R::type>(field);
+    // Intentionally place pointer-to-member operator for table references in the internal namespace
+    // to facilitate ADL (Argument Dependent Lookup)
+    namespace internal {
+        /**
+         *  Explicitly refer to a column.
+         */
+        template<orm_table_reference R, class O, class F>
+        constexpr auto operator->*(const R& /*table*/, F O::*field) {
+            return column<typename R::type>(field);
+        }
     }
 
     /**

--- a/dev/function.h
+++ b/dev/function.h
@@ -483,41 +483,43 @@ namespace sqlite_orm {
     SQLITE_ORM_INLINE_VAR constexpr internal::function<UDF> func{};
 
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-    /*  @short Create a scalar function from a freestanding function, stateless lambda or function object,
-     *  and call such a user-defined function.
-     *  
-     *  If you need to pick a function or method from an overload set, or pick a template function you can
-     *  specify an explicit function signature in the call to `from()`.
-     *  
-     *  Examples:
-     *  // freestanding function from a library
-     *  constexpr auto clamp_int_f = "clamp_int"_scalar.quote(std::clamp<int>);
-     *  // stateless lambda
-     *  constexpr auto is_fatal_error_f = "IS_FATAL_ERROR"_scalar.quote([](unsigned long errcode) {
-     *      return errcode != 0;
-     *  });
-     *  // function object instance
-     *  constexpr auto equal_to_int_f = "equal_to"_scalar.quote(std::equal_to<int>{});
-     *  // function object
-     *  constexpr auto equal_to_int_2_f = "equal_to"_scalar.quote<std::equal_to<int>>();
-     *  // pick function object's template call operator
-     *  constexpr auto equal_to_int_3_f = "equal_to"_scalar.quote<bool(const int&, const int&) const>(std::equal_to<void>{});
-     *
-     *  storage.create_scalar_function<clamp_int_f>();
-     *  storage.create_scalar_function<is_fatal_error_f>();
-     *  storage.create_scalar_function<equal_to_int_f>();
-     *  storage.create_scalar_function<equal_to_int_2_f>();
-     *  storage.create_scalar_function<equal_to_int_3_f>();
-     *
-     *  auto rows = storage.select(clamp_int_f(0, 1, 1));
-     *  auto rows = storage.select(is_fatal_error_f(1));
-     *  auto rows = storage.select(equal_to_int_f(1, 1));
-     *  auto rows = storage.select(equal_to_int_2_f(1, 1));
-     *  auto rows = storage.select(equal_to_int_3_f(1, 1));
-     */
-    template<internal::quoted_function_builder builder>
-    [[nodiscard]] consteval auto operator"" _scalar() {
-        return builder;
+    inline namespace literals {
+        /*  @short Create a scalar function from a freestanding function, stateless lambda or function object,
+         *  and call such a user-defined function.
+         *  
+         *  If you need to pick a function or method from an overload set, or pick a template function you can
+         *  specify an explicit function signature in the call to `from()`.
+         *  
+         *  Examples:
+         *  // freestanding function from a library
+         *  constexpr auto clamp_int_f = "clamp_int"_scalar.quote(std::clamp<int>);
+         *  // stateless lambda
+         *  constexpr auto is_fatal_error_f = "IS_FATAL_ERROR"_scalar.quote([](unsigned long errcode) {
+         *      return errcode != 0;
+         *  });
+         *  // function object instance
+         *  constexpr auto equal_to_int_f = "equal_to"_scalar.quote(std::equal_to<int>{});
+         *  // function object
+         *  constexpr auto equal_to_int_2_f = "equal_to"_scalar.quote<std::equal_to<int>>();
+         *  // pick function object's template call operator
+         *  constexpr auto equal_to_int_3_f = "equal_to"_scalar.quote<bool(const int&, const int&) const>(std::equal_to<void>{});
+         *
+         *  storage.create_scalar_function<clamp_int_f>();
+         *  storage.create_scalar_function<is_fatal_error_f>();
+         *  storage.create_scalar_function<equal_to_int_f>();
+         *  storage.create_scalar_function<equal_to_int_2_f>();
+         *  storage.create_scalar_function<equal_to_int_3_f>();
+         *
+         *  auto rows = storage.select(clamp_int_f(0, 1, 1));
+         *  auto rows = storage.select(is_fatal_error_f(1));
+         *  auto rows = storage.select(equal_to_int_f(1, 1));
+         *  auto rows = storage.select(equal_to_int_2_f(1, 1));
+         *  auto rows = storage.select(equal_to_int_3_f(1, 1));
+         */
+        template<internal::quoted_function_builder builder>
+        [[nodiscard]] consteval auto operator"" _scalar() {
+            return builder;
+        }
     }
 #endif
 }

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -4813,17 +4813,17 @@ namespace sqlite_orm {
     }
 
     /**
-        *  Create a column reference to an aliased table column.
-        *  
-        *  @note An object member pointer can be from a derived class without explicitly forming a column pointer.
-        *  
-        *  @note (internal) Intentionally not placed in the internal namespace for ADL (Argument Dependent Lookup)
-        *  because recordset aliases are derived from `sqlite_orm::alias_tag`
-        *  
-        *  Example:
-        *  constexpr auto als = "u"_alias.for_<User>();
-        *  select(als->*&User::id)
-        */
+     *  Create a column reference to an aliased table column.
+     *  
+     *  @note An object member pointer can be from a derived class without explicitly forming a column pointer.
+     *  
+     *  @note (internal) Intentionally not placed in the internal namespace for ADL (Argument Dependent Lookup)
+     *  because recordset aliases are derived from `sqlite_orm::alias_tag`
+     *  
+     *  Example:
+     *  constexpr auto als = "u"_alias.for_<User>();
+     *  select(als->*&User::id)
+     */
     template<orm_table_alias A, class F>
     constexpr auto operator->*(const A& /*tableAlias*/, F field) {
         return alias_column<A>(std::move(field));

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -4817,7 +4817,7 @@ namespace sqlite_orm {
      *  
      *  @note An object member pointer can be from a derived class without explicitly forming a column pointer.
      *  
-     *  @note (internal) Intentionally not placed in the internal namespace for ADL (Argument Dependent Lookup)
+     *  @note (internal) Intentionally place in the sqlite_orm namespace for ADL (Argument Dependent Lookup)
      *  because recordset aliases are derived from `sqlite_orm::alias_tag`
      *  
      *  Example:

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -4813,17 +4813,17 @@ namespace sqlite_orm {
     }
 
     /**
-     *  Create a column reference to an aliased table column.
-     *  
-     *  @note An object member pointer can be from a derived class without explicitly forming a column pointer.
-     *  
+        *  Create a column reference to an aliased table column.
+        *  
+        *  @note An object member pointer can be from a derived class without explicitly forming a column pointer.
+        *  
         *  @note (internal) Intentionally not placed in the internal namespace for ADL (Argument Dependent Lookup)
         *  because recordset aliases are derived from `sqlite_orm::alias_tag`
         *  
         *  Example:
         *  constexpr auto als = "u"_alias.for_<User>();
-     *  select(als->*&User::id)
-     */
+        *  select(als->*&User::id)
+        */
     template<orm_table_alias A, class F>
     constexpr auto operator->*(const A& /*tableAlias*/, F field) {
         return alias_column<A>(std::move(field));
@@ -4940,23 +4940,26 @@ namespace sqlite_orm {
     template<char A, char... X>
     inline constexpr internal::recordset_alias_builder<A, X...> alias{};
 
-    /** @short Create a table alias.
-     *
-     *  Examples:
-     *  constexpr auto z_alias = "z"_alias.for_<User>();
-     */
-    template<internal::cstring_literal name>
-    [[nodiscard]] consteval auto operator"" _alias() {
-        return internal::explode_into<internal::recordset_alias_builder, name>(std::make_index_sequence<name.size()>{});
-    }
+    inline namespace literals {
+        /** @short Create a table alias.
+         *
+         *  Examples:
+         *  constexpr auto z_alias = "z"_alias.for_<User>();
+         */
+        template<internal::cstring_literal name>
+        [[nodiscard]] consteval auto operator"" _alias() {
+            return internal::explode_into<internal::recordset_alias_builder, name>(
+                std::make_index_sequence<name.size()>{});
+        }
 
-    /** @short Create a column alias.
-     *  column_alias<'a'[, ...]> from a string literal.
-     *  E.g. "a"_col, "b"_col
-     */
-    template<internal::cstring_literal name>
-    [[nodiscard]] consteval auto operator"" _col() {
-        return internal::explode_into<internal::column_alias, name>(std::make_index_sequence<name.size()>{});
+        /** @short Create a column alias.
+         *  column_alias<'a'[, ...]> from a string literal.
+         *  E.g. "a"_col, "b"_col
+         */
+        template<internal::cstring_literal name>
+        [[nodiscard]] consteval auto operator"" _col() {
+            return internal::explode_into<internal::column_alias, name>(std::make_index_sequence<name.size()>{});
+        }
     }
 #endif
 }
@@ -11484,41 +11487,43 @@ namespace sqlite_orm {
     SQLITE_ORM_INLINE_VAR constexpr internal::function<UDF> func{};
 
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-    /*  @short Create a scalar function from a freestanding function, stateless lambda or function object,
-     *  and call such a user-defined function.
-     *  
-     *  If you need to pick a function or method from an overload set, or pick a template function you can
-     *  specify an explicit function signature in the call to `from()`.
-     *  
-     *  Examples:
-     *  // freestanding function from a library
-     *  constexpr auto clamp_int_f = "clamp_int"_scalar.quote(std::clamp<int>);
-     *  // stateless lambda
-     *  constexpr auto is_fatal_error_f = "IS_FATAL_ERROR"_scalar.quote([](unsigned long errcode) {
-     *      return errcode != 0;
-     *  });
-     *  // function object instance
-     *  constexpr auto equal_to_int_f = "equal_to"_scalar.quote(std::equal_to<int>{});
-     *  // function object
-     *  constexpr auto equal_to_int_2_f = "equal_to"_scalar.quote<std::equal_to<int>>();
-     *  // pick function object's template call operator
-     *  constexpr auto equal_to_int_3_f = "equal_to"_scalar.quote<bool(const int&, const int&) const>(std::equal_to<void>{});
-     *
-     *  storage.create_scalar_function<clamp_int_f>();
-     *  storage.create_scalar_function<is_fatal_error_f>();
-     *  storage.create_scalar_function<equal_to_int_f>();
-     *  storage.create_scalar_function<equal_to_int_2_f>();
-     *  storage.create_scalar_function<equal_to_int_3_f>();
-     *
-     *  auto rows = storage.select(clamp_int_f(0, 1, 1));
-     *  auto rows = storage.select(is_fatal_error_f(1));
-     *  auto rows = storage.select(equal_to_int_f(1, 1));
-     *  auto rows = storage.select(equal_to_int_2_f(1, 1));
-     *  auto rows = storage.select(equal_to_int_3_f(1, 1));
-     */
-    template<internal::quoted_function_builder builder>
-    [[nodiscard]] consteval auto operator"" _scalar() {
-        return builder;
+    inline namespace literals {
+        /*  @short Create a scalar function from a freestanding function, stateless lambda or function object,
+         *  and call such a user-defined function.
+         *  
+         *  If you need to pick a function or method from an overload set, or pick a template function you can
+         *  specify an explicit function signature in the call to `from()`.
+         *  
+         *  Examples:
+         *  // freestanding function from a library
+         *  constexpr auto clamp_int_f = "clamp_int"_scalar.quote(std::clamp<int>);
+         *  // stateless lambda
+         *  constexpr auto is_fatal_error_f = "IS_FATAL_ERROR"_scalar.quote([](unsigned long errcode) {
+         *      return errcode != 0;
+         *  });
+         *  // function object instance
+         *  constexpr auto equal_to_int_f = "equal_to"_scalar.quote(std::equal_to<int>{});
+         *  // function object
+         *  constexpr auto equal_to_int_2_f = "equal_to"_scalar.quote<std::equal_to<int>>();
+         *  // pick function object's template call operator
+         *  constexpr auto equal_to_int_3_f = "equal_to"_scalar.quote<bool(const int&, const int&) const>(std::equal_to<void>{});
+         *
+         *  storage.create_scalar_function<clamp_int_f>();
+         *  storage.create_scalar_function<is_fatal_error_f>();
+         *  storage.create_scalar_function<equal_to_int_f>();
+         *  storage.create_scalar_function<equal_to_int_2_f>();
+         *  storage.create_scalar_function<equal_to_int_3_f>();
+         *
+         *  auto rows = storage.select(clamp_int_f(0, 1, 1));
+         *  auto rows = storage.select(is_fatal_error_f(1));
+         *  auto rows = storage.select(equal_to_int_f(1, 1));
+         *  auto rows = storage.select(equal_to_int_2_f(1, 1));
+         *  auto rows = storage.select(equal_to_int_3_f(1, 1));
+         */
+        template<internal::quoted_function_builder builder>
+        [[nodiscard]] consteval auto operator"" _scalar() {
+            return builder;
+        }
     }
 #endif
 }

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -3252,12 +3252,16 @@ namespace sqlite_orm {
         return column<internal::auto_type_t<table>>(field);
     }
 
-    /**
-     *  Explicitly refer to a column.
-     */
-    template<orm_table_reference R, class O, class F>
-    constexpr auto operator->*(const R& /*table*/, F O::*field) {
-        return column<typename R::type>(field);
+    // Intentionally place pointer-to-member operator for table references in the internal namespace
+    // to facilitate ADL (Argument Dependent Lookup)
+    namespace internal {
+        /**
+         *  Explicitly refer to a column.
+         */
+        template<orm_table_reference R, class O, class F>
+        constexpr auto operator->*(const R& /*table*/, F O::*field) {
+            return column<typename R::type>(field);
+        }
     }
 
     /**
@@ -4813,8 +4817,11 @@ namespace sqlite_orm {
      *  
      *  @note An object member pointer can be from a derived class without explicitly forming a column pointer.
      *  
-     *  Example:
-     *  constexpr auto als = "u"_alias.for_<User>();
+        *  @note (internal) Intentionally not placed in the internal namespace for ADL (Argument Dependent Lookup)
+        *  because recordset aliases are derived from `sqlite_orm::alias_tag`
+        *  
+        *  Example:
+        *  constexpr auto als = "u"_alias.for_<User>();
      *  select(als->*&User::id)
      */
     template<orm_table_alias A, class F>

--- a/tests/static_tests/operators_adl.cpp
+++ b/tests/static_tests/operators_adl.cpp
@@ -2,6 +2,7 @@
 #include <catch2/catch_all.hpp>
 
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+using sqlite_orm::operator"" _alias;
 using sqlite_orm::operator"" _col;
 #endif
 using sqlite_orm::alias_a;
@@ -103,6 +104,19 @@ void runTests(E expression) {
     STATIC_REQUIRE(is_specialization_of_v<decltype((expression && 42) || !expression), or_condition_t>);
     STATIC_REQUIRE(is_specialization_of_v<decltype(!expression || (expression && 42)), or_condition_t>);
 }
+
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+TEST_CASE("ADL and pointer-to-member expressions") {
+    struct User {
+        int id;
+    };
+    constexpr auto user_table = c<User>();
+    constexpr auto u_alias = "u"_alias.for_<User>();
+
+    user_table->*&User::id;
+    u_alias->*&User::id;
+}
+#endif
 
 TEST_CASE("ADL and expression operators") {
     struct User {

--- a/tests/static_tests/operators_adl.cpp
+++ b/tests/static_tests/operators_adl.cpp
@@ -2,8 +2,7 @@
 #include <catch2/catch_all.hpp>
 
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-using sqlite_orm::operator"" _alias;
-using sqlite_orm::operator"" _col;
+using namespace sqlite_orm::literals;
 #endif
 using sqlite_orm::alias_a;
 using sqlite_orm::alias_column;
@@ -106,6 +105,12 @@ void runTests(E expression) {
 }
 
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+TEST_CASE("inline namespace literals expressions") {
+    constexpr auto u_alias_builder = "u"_alias;
+    constexpr auto c_alias = "c"_col;
+    constexpr auto f_scalar_builder = "f"_scalar;
+}
+
 TEST_CASE("ADL and pointer-to-member expressions") {
     struct User {
         int id;


### PR DESCRIPTION
The pointer-to-member operator syntax should also work for people not `using namespace sqlite_orm`.

In this sense,
- Corrected namespace of `operator->*` for the use of table references.: ```constexpr auto user_table = sqlite_orm::c<User>(); user_table->*&User::id```.
- `operator->*` for the use of table aliases already works as expected because aliases are derived from `sqlite_orm::alias_tag`.
- Moved the "string literal operators" into an inline namespace, such that one can write ```using namespace sqlite_orm::literals; "u"_alias.for_<User>(); "c"_col;```
