### PR TITLE
Improving parenthesizing of binary expressions

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -107,7 +107,7 @@ for:
   install:
     - |-
       cd C:\Tools\vcpkg
-      git fetch --tags && git checkout 2023.11.20
+      git fetch --tags && git checkout 2023.12.12
       cd %APPVEYOR_BUILD_FOLDER%
       C:\Tools\vcpkg\bootstrap-vcpkg.bat -disableMetrics
       C:\Tools\vcpkg\vcpkg integrate install
@@ -140,7 +140,7 @@ for:
   install:
     - |-
       pushd $HOME/vcpkg
-      git fetch --tags && git checkout 2023.11.20
+      git fetch --tags && git checkout 2023.12.12
       popd
       $HOME/vcpkg/bootstrap-vcpkg.sh -disableMetrics
       $HOME/vcpkg/vcpkg integrate install --overlay-triplets=vcpkg/triplets
@@ -168,7 +168,7 @@ for:
   # using custom vcpkg triplets for building and linking dynamic dependent libraries
   install:
     - |-
-      git clone --depth 1 --branch 2023.11.20 https://github.com/microsoft/vcpkg.git $HOME/vcpkg
+      git clone --depth 1 --branch 2023.12.12 https://github.com/microsoft/vcpkg.git $HOME/vcpkg
       $HOME/vcpkg/bootstrap-vcpkg.sh -disableMetrics
       $HOME/vcpkg/vcpkg integrate install --overlay-triplets=vcpkg/triplets
       vcpkg install sqlite3[core,dbstat,math,json1,fts5] catch2 --overlay-triplets=vcpkg/triplets

--- a/dev/ast_iterator.h
+++ b/dev/ast_iterator.h
@@ -150,22 +150,12 @@ namespace sqlite_orm {
         };
 
         template<class T>
-        struct ast_iterator<T, match_if<is_binary_condition, T>> {
+        struct ast_iterator<T,
+                            std::enable_if_t<polyfill::disjunction_v<is_binary_condition<T>, is_binary_operator<T>>>> {
             using node_type = T;
 
             template<class L>
-            void operator()(const node_type& binaryCondition, L& lambda) const {
-                iterate_ast(binaryCondition.l, lambda);
-                iterate_ast(binaryCondition.r, lambda);
-            }
-        };
-
-        template<class T>
-        struct ast_iterator<T, match_if<is_binary_operator, T>> {
-            using node_type = T;
-
-            template<class C>
-            void operator()(const node_type& node, C& lambda) const {
+            void operator()(const node_type& node, L& lambda) const {
                 iterate_ast(node.lhs, lambda);
                 iterate_ast(node.rhs, lambda);
             }

--- a/dev/conditions.h
+++ b/dev/conditions.h
@@ -15,6 +15,7 @@
 #include "constraints.h"
 #include "optional_container.h"
 #include "serializer_context.h"
+#include "serialize_result_type.h"
 #include "tags.h"
 #include "alias_traits.h"
 #include "expression.h"
@@ -127,12 +128,12 @@ namespace sqlite_orm {
             using right_type = R;
             using result_type = Res;
 
-            left_type l;
-            right_type r;
+            left_type lhs;
+            right_type rhs;
 
             binary_condition() = default;
 
-            binary_condition(left_type l_, right_type r_) : l(std::move(l_)), r(std::move(r_)) {}
+            binary_condition(left_type l_, right_type r_) : lhs(std::move(l_)), rhs(std::move(r_)) {}
         };
 
         template<class T>
@@ -142,7 +143,7 @@ namespace sqlite_orm {
         using is_binary_condition = polyfill::bool_constant<is_binary_condition_v<T>>;
 
         struct and_condition_string {
-            operator std::string() const {
+            serialize_result_type serialize() const {
                 return "AND";
             }
         };
@@ -158,7 +159,7 @@ namespace sqlite_orm {
         };
 
         struct or_condition_string {
-            operator std::string() const {
+            serialize_result_type serialize() const {
                 return "OR";
             }
         };
@@ -174,7 +175,7 @@ namespace sqlite_orm {
         };
 
         struct is_equal_string {
-            operator std::string() const {
+            serialize_result_type serialize() const {
                 return "=";
             }
         };
@@ -223,7 +224,7 @@ namespace sqlite_orm {
         };
 
         struct is_not_equal_string {
-            operator std::string() const {
+            serialize_result_type serialize() const {
                 return "!=";
             }
         };
@@ -251,7 +252,7 @@ namespace sqlite_orm {
         };
 
         struct greater_than_string {
-            operator std::string() const {
+            serialize_result_type serialize() const {
                 return ">";
             }
         };
@@ -279,7 +280,7 @@ namespace sqlite_orm {
         };
 
         struct greater_or_equal_string {
-            operator std::string() const {
+            serialize_result_type serialize() const {
                 return ">=";
             }
         };
@@ -307,7 +308,7 @@ namespace sqlite_orm {
         };
 
         struct less_than_string {
-            operator std::string() const {
+            serialize_result_type serialize() const {
                 return "<";
             }
         };
@@ -335,7 +336,7 @@ namespace sqlite_orm {
         };
 
         struct less_or_equal_string {
-            operator std::string() const {
+            serialize_result_type serialize() const {
                 return "<=";
             }
         };

--- a/dev/conditions.h
+++ b/dev/conditions.h
@@ -898,6 +898,8 @@ namespace sqlite_orm {
                  class R,
                  std::enable_if_t<polyfill::disjunction_v<std::is_base_of<arithmetic_t, L>,
                                                           std::is_base_of<arithmetic_t, R>,
+                                                          std::is_base_of<condition_t, L>,
+                                                          std::is_base_of<condition_t, R>,
                                                           is_operator_argument<L>,
                                                           is_operator_argument<R>>,
                                   bool> = true>
@@ -909,6 +911,8 @@ namespace sqlite_orm {
                  class R,
                  std::enable_if_t<polyfill::disjunction_v<std::is_base_of<arithmetic_t, L>,
                                                           std::is_base_of<arithmetic_t, R>,
+                                                          std::is_base_of<condition_t, L>,
+                                                          std::is_base_of<condition_t, R>,
                                                           is_operator_argument<L>,
                                                           is_operator_argument<R>>,
                                   bool> = true>

--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -348,13 +348,7 @@ namespace sqlite_orm {
             template<class Ctx>
             std::string operator()(const statement_type& statement, const Ctx& context) const {
                 std::stringstream ss;
-                if(context.use_parentheses) {
-                    ss << '(';
-                }
                 ss << statement.serialize() << "(" << streaming_expressions_tuple(statement.args, context) << ")";
-                if(context.use_parentheses) {
-                    ss << ')';
-                }
                 return ss.str();
             }
         };

--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -1332,12 +1332,15 @@ namespace sqlite_orm {
 
             template<class Ctx>
             std::string operator()(const statement_type& statement, const Ctx& context) const {
+                // subqueries should always use parentheses in column names
+                auto subCtx = context;
+                subCtx.use_parentheses = true;
+
                 std::stringstream ss;
                 if(context.use_parentheses) {
                     ss << '(';
                 }
-                // note: pass `statement` itself
-                ss << streaming_serialized(get_column_names(statement, context));
+                ss << streaming_serialized(get_column_names(statement, subCtx));
                 if(context.use_parentheses) {
                     ss << ')';
                 }
@@ -1605,6 +1608,9 @@ namespace sqlite_orm {
             template<class Ctx>
             std::string operator()(const statement_type& sel, Ctx context) const {
                 context.skip_table_name = false;
+                // subqueries should always use parentheses in column names
+                auto subCtx = context;
+                subCtx.use_parentheses = true;
 
                 std::stringstream ss;
                 if(!is_compound_operator_v<T>) {
@@ -1616,7 +1622,7 @@ namespace sqlite_orm {
                 if(get_distinct(sel.col)) {
                     ss << static_cast<std::string>(distinct(0)) << " ";
                 }
-                ss << streaming_serialized(get_column_names(sel.col, context));
+                ss << streaming_serialized(get_column_names(sel.col, subCtx));
                 using conditions_tuple = typename statement_type::conditions_type;
                 constexpr bool hasExplicitFrom = tuple_has<is_from, conditions_tuple>::value;
                 if(!hasExplicitFrom) {

--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -701,13 +701,15 @@ namespace sqlite_orm {
 
             template<class Ctx>
             std::string operator()(const statement_type& c, const Ctx& context) const {
-                auto leftString = serialize(c.l, context);
-                auto rightString = serialize(c.r, context);
+                // subqueries should always use parentheses in binary conditions
+                auto subCtx = context;
+                subCtx.use_parentheses = true;
+
                 std::stringstream ss;
                 if(context.use_parentheses) {
                     ss << "(";
                 }
-                ss << leftString << " " << static_cast<std::string>(c) << " " << rightString;
+                ss << serialize(c.l, subCtx) << " " << static_cast<std::string>(c) << " " << serialize(c.r, subCtx);
                 if(context.use_parentheses) {
                     ss << ")";
                 }

--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -681,10 +681,10 @@ namespace sqlite_orm {
                 auto subCtx = context;
                 subCtx.use_parentheses = true;
                 // parentheses for sub-trees to ensure the order of precedence
-                constexpr bool parenthesizeLeft = is_binary_condition_v<typename statement_type::left_type> ||
-                                                  is_binary_operator_v<typename statement_type::left_type>;
-                constexpr bool parenthesizeRight = is_binary_condition_v<typename statement_type::right_type> ||
-                                                   is_binary_operator_v<typename statement_type::right_type>;
+                constexpr bool parenthesizeLeft = is_binary_condition_v<left_type_t<statement_type>> ||
+                                                  is_binary_operator_v<left_type_t<statement_type>>;
+                constexpr bool parenthesizeRight = is_binary_condition_v<right_type_t<statement_type>> ||
+                                                   is_binary_operator_v<right_type_t<statement_type>>;
 
                 std::stringstream ss;
                 if SQLITE_ORM_CONSTEXPR_IF(parenthesizeLeft) {

--- a/examples/left_and_inner_join.cpp
+++ b/examples/left_and_inner_join.cpp
@@ -60,6 +60,7 @@ inline auto initStorage(const std::string& path) {
 int main(int, char**) {
 
     auto storage = initStorage("chinook.db");
+    storage.sync_schema();
 
     using namespace sqlite_orm;
 

--- a/examples/left_and_inner_join.cpp
+++ b/examples/left_and_inner_join.cpp
@@ -60,7 +60,6 @@ inline auto initStorage(const std::string& path) {
 int main(int, char**) {
 
     auto storage = initStorage("chinook.db");
-    storage.sync_schema();
 
     using namespace sqlite_orm;
 

--- a/examples/subquery.cpp
+++ b/examples/subquery.cpp
@@ -1306,8 +1306,8 @@ int main(int, char**) {
         }
     }
     {
-        //  SELECT employee_id,first_name,last_name,salary,avg(salary),salary>avg(salary)
-        //  FROM employees;
+        //  SELECT employee_id, first_name, last_name, salary, (SELECT AVG(salary) FROM employees), salary > (SELECT AVG(salary) FROM employees)
+        //  FROM "employees";
         auto rows = storage.select(columns(&Employee::id,
                                            &Employee::firstName,
                                            &Employee::lastName,

--- a/examples/subquery.cpp
+++ b/examples/subquery.cpp
@@ -1306,6 +1306,22 @@ int main(int, char**) {
         }
     }
     {
+        //  SELECT employee_id,first_name,last_name,salary,avg(salary),salary>avg(salary)
+        //  FROM employees;
+        auto rows = storage.select(columns(&Employee::id,
+                                           &Employee::firstName,
+                                           &Employee::lastName,
+                                           &Employee::salary,
+                                           select(avg(&Employee::salary)),
+                                           greater_than(&Employee::salary, select(avg(&Employee::salary)))));
+        cout << "employee_id  first_name  last_name   salary      avg_salary  salary>avg" << endl;
+        cout << "-----------  ----------  ----------  ----------  ----------  ----------" << endl;
+        for(auto& row: rows) {
+            cout << std::get<0>(row) << '\t' << std::get<1>(row) << '\t' << std::get<2>(row) << '\t' << std::get<3>(row)
+                 << '\t' << std::get<4>(row) << '\t' << std::get<5>(row) << endl;
+        }
+    }
+    {
         //  SELECT first_name, last_name, department_id
         //  FROM employees
         //  WHERE department_id IN

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -17371,10 +17371,10 @@ namespace sqlite_orm {
                 auto subCtx = context;
                 subCtx.use_parentheses = true;
                 // parentheses for sub-trees to ensure the order of precedence
-                constexpr bool parenthesizeLeft = is_binary_condition_v<typename statement_type::left_type> ||
-                                                  is_binary_operator_v<typename statement_type::left_type>;
-                constexpr bool parenthesizeRight = is_binary_condition_v<typename statement_type::right_type> ||
-                                                   is_binary_operator_v<typename statement_type::right_type>;
+                constexpr bool parenthesizeLeft = is_binary_condition_v<left_type_t<statement_type>> ||
+                                                  is_binary_operator_v<left_type_t<statement_type>>;
+                constexpr bool parenthesizeRight = is_binary_condition_v<right_type_t<statement_type>> ||
+                                                   is_binary_operator_v<right_type_t<statement_type>>;
 
                 std::stringstream ss;
                 if SQLITE_ORM_CONSTEXPR_IF(parenthesizeLeft) {

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -18022,12 +18022,15 @@ namespace sqlite_orm {
 
             template<class Ctx>
             std::string operator()(const statement_type& statement, const Ctx& context) const {
+                // subqueries should always use parentheses in column names
+                auto subCtx = context;
+                subCtx.use_parentheses = true;
+
                 std::stringstream ss;
                 if(context.use_parentheses) {
                     ss << '(';
                 }
-                // note: pass `statement` itself
-                ss << streaming_serialized(get_column_names(statement, context));
+                ss << streaming_serialized(get_column_names(statement, subCtx));
                 if(context.use_parentheses) {
                     ss << ')';
                 }
@@ -18295,6 +18298,9 @@ namespace sqlite_orm {
             template<class Ctx>
             std::string operator()(const statement_type& sel, Ctx context) const {
                 context.skip_table_name = false;
+                // subqueries should always use parentheses in column names
+                auto subCtx = context;
+                subCtx.use_parentheses = true;
 
                 std::stringstream ss;
                 if(!is_compound_operator_v<T>) {
@@ -18306,7 +18312,7 @@ namespace sqlite_orm {
                 if(get_distinct(sel.col)) {
                     ss << static_cast<std::string>(distinct(0)) << " ";
                 }
-                ss << streaming_serialized(get_column_names(sel.col, context));
+                ss << streaming_serialized(get_column_names(sel.col, subCtx));
                 using conditions_tuple = typename statement_type::conditions_type;
                 constexpr bool hasExplicitFrom = tuple_has<is_from, conditions_tuple>::value;
                 if(!hasExplicitFrom) {

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -4181,6 +4181,8 @@ namespace sqlite_orm {
                  class R,
                  std::enable_if_t<polyfill::disjunction_v<std::is_base_of<arithmetic_t, L>,
                                                           std::is_base_of<arithmetic_t, R>,
+                                                          std::is_base_of<condition_t, L>,
+                                                          std::is_base_of<condition_t, R>,
                                                           is_operator_argument<L>,
                                                           is_operator_argument<R>>,
                                   bool> = true>
@@ -4192,6 +4194,8 @@ namespace sqlite_orm {
                  class R,
                  std::enable_if_t<polyfill::disjunction_v<std::is_base_of<arithmetic_t, L>,
                                                           std::is_base_of<arithmetic_t, R>,
+                                                          std::is_base_of<condition_t, L>,
+                                                          std::is_base_of<condition_t, R>,
                                                           is_operator_argument<L>,
                                                           is_operator_argument<R>>,
                                   bool> = true>

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -17395,13 +17395,15 @@ namespace sqlite_orm {
 
             template<class Ctx>
             std::string operator()(const statement_type& c, const Ctx& context) const {
-                auto leftString = serialize(c.l, context);
-                auto rightString = serialize(c.r, context);
+                // subqueries should always use parentheses in binary conditions
+                auto subCtx = context;
+                subCtx.use_parentheses = true;
+
                 std::stringstream ss;
                 if(context.use_parentheses) {
                     ss << "(";
                 }
-                ss << leftString << " " << static_cast<std::string>(c) << " " << rightString;
+                ss << serialize(c.l, subCtx) << " " << static_cast<std::string>(c) << " " << serialize(c.r, subCtx);
                 if(context.use_parentheses) {
                     ss << ")";
                 }

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -17220,15 +17220,30 @@ namespace sqlite_orm {
 
             template<class Ctx>
             std::string operator()(const statement_type& statement, const Ctx& context) const {
-                auto lhs = serialize(statement.lhs, context);
-                auto rhs = serialize(statement.rhs, context);
+                // subqueries should always use parentheses in binary expressions
+                auto subCtx = context;
+                subCtx.use_parentheses = true;
+                // parentheses for sub-trees to ensure the order of precedence
+                constexpr bool parenthesizeLeft = is_binary_condition_v<typename statement_type::left_type> ||
+                                                  is_binary_operator_v<typename statement_type::left_type>;
+                constexpr bool parenthesizeRight = is_binary_condition_v<typename statement_type::right_type> ||
+                                                   is_binary_operator_v<typename statement_type::right_type>;
+
                 std::stringstream ss;
-                if(context.use_parentheses) {
-                    ss << '(';
+                if SQLITE_ORM_CONSTEXPR_IF(parenthesizeLeft) {
+                    ss << "(";
                 }
-                ss << lhs << " " << statement.serialize() << " " << rhs;
-                if(context.use_parentheses) {
-                    ss << ')';
+                ss << serialize(statement.lhs, subCtx);
+                if SQLITE_ORM_CONSTEXPR_IF(parenthesizeLeft) {
+                    ss << ")";
+                }
+                ss << " " << statement.serialize() << " ";
+                if SQLITE_ORM_CONSTEXPR_IF(parenthesizeRight) {
+                    ss << "(";
+                }
+                ss << serialize(statement.rhs, subCtx);
+                if SQLITE_ORM_CONSTEXPR_IF(parenthesizeRight) {
+                    ss << ")";
                 }
                 return ss.str();
             }
@@ -17389,16 +17404,29 @@ namespace sqlite_orm {
 
             template<class Ctx>
             std::string operator()(const statement_type& c, const Ctx& context) const {
-                // subqueries should always use parentheses in binary conditions
+                // subqueries should always use parentheses in binary expressions
                 auto subCtx = context;
                 subCtx.use_parentheses = true;
+                // parentheses for sub-trees to ensure the order of precedence
+                constexpr bool parenthesizeLeft = is_binary_condition_v<typename statement_type::left_type> ||
+                                                  is_binary_operator_v<typename statement_type::left_type>;
+                constexpr bool parenthesizeRight = is_binary_condition_v<typename statement_type::right_type> ||
+                                                   is_binary_operator_v<typename statement_type::right_type>;
 
                 std::stringstream ss;
-                if(context.use_parentheses) {
+                if SQLITE_ORM_CONSTEXPR_IF(parenthesizeLeft) {
                     ss << "(";
                 }
-                ss << serialize(c.l, subCtx) << " " << static_cast<std::string>(c) << " " << serialize(c.r, subCtx);
-                if(context.use_parentheses) {
+                ss << serialize(c.l, subCtx);
+                if SQLITE_ORM_CONSTEXPR_IF(parenthesizeLeft) {
+                    ss << ")";
+                }
+                ss << " " << static_cast<std::string>(c) << " ";
+                if SQLITE_ORM_CONSTEXPR_IF(parenthesizeRight) {
+                    ss << "(";
+                }
+                ss << serialize(c.r, subCtx);
+                if SQLITE_ORM_CONSTEXPR_IF(parenthesizeRight) {
                     ss << ")";
                 }
                 return ss.str();

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -17042,13 +17042,7 @@ namespace sqlite_orm {
             template<class Ctx>
             std::string operator()(const statement_type& statement, const Ctx& context) const {
                 std::stringstream ss;
-                if(context.use_parentheses) {
-                    ss << '(';
-                }
                 ss << statement.serialize() << "(" << streaming_expressions_tuple(statement.args, context) << ")";
-                if(context.use_parentheses) {
-                    ss << ')';
-                }
                 return ss.str();
             }
         };

--- a/tests/statement_serializer_tests/aggregate_functions.cpp
+++ b/tests/statement_serializer_tests/aggregate_functions.cpp
@@ -24,7 +24,7 @@ TEST_CASE("statement_serializer aggregate functions") {
                 auto expression = avg(&User::id);
                 SECTION("use_parentheses") {
                     context.use_parentheses = true;
-                    expected = R"((AVG("id")))";
+                    expected = R"(AVG("id"))";
                 }
                 SECTION("!use_parentheses") {
                     context.use_parentheses = false;
@@ -36,7 +36,7 @@ TEST_CASE("statement_serializer aggregate functions") {
                 auto expression = avg(&User::id).filter(where(less_than(&User::id, 10)));
                 SECTION("use_parentheses") {
                     context.use_parentheses = true;
-                    expected = R"((AVG("id")) FILTER (WHERE ("id" < 10)))";
+                    expected = R"(AVG("id") FILTER (WHERE ("id" < 10)))";
                 }
                 SECTION("!use_parentheses") {
                     context.use_parentheses = false;
@@ -52,7 +52,7 @@ TEST_CASE("statement_serializer aggregate functions") {
                 auto expression = count(&User::id);
                 SECTION("use_parentheses") {
                     context.use_parentheses = true;
-                    expected = R"((COUNT("id")))";
+                    expected = R"(COUNT("id"))";
                 }
                 SECTION("!use_parentheses") {
                     context.use_parentheses = false;
@@ -64,7 +64,7 @@ TEST_CASE("statement_serializer aggregate functions") {
                 auto expression = count(&User::id).filter(where(less_than(&User::id, 10)));
                 SECTION("use_parentheses") {
                     context.use_parentheses = true;
-                    expected = R"((COUNT("id")) FILTER (WHERE ("id" < 10)))";
+                    expected = R"(COUNT("id") FILTER (WHERE ("id" < 10)))";
                 }
                 SECTION("!use_parentheses") {
                     context.use_parentheses = false;
@@ -102,7 +102,7 @@ TEST_CASE("statement_serializer aggregate functions") {
                 auto expression = group_concat(&User::id);
                 SECTION("use_parentheses") {
                     context.use_parentheses = true;
-                    expected = R"((GROUP_CONCAT("id")))";
+                    expected = R"(GROUP_CONCAT("id"))";
                 }
                 SECTION("!use_parentheses") {
                     context.use_parentheses = false;
@@ -114,7 +114,7 @@ TEST_CASE("statement_serializer aggregate functions") {
                 auto expression = group_concat(&User::id).filter(where(less_than(&User::id, 10)));
                 SECTION("use_parentheses") {
                     context.use_parentheses = true;
-                    expected = R"((GROUP_CONCAT("id")) FILTER (WHERE ("id" < 10)))";
+                    expected = R"(GROUP_CONCAT("id") FILTER (WHERE ("id" < 10)))";
                 }
                 SECTION("!use_parentheses") {
                     context.use_parentheses = false;
@@ -130,7 +130,7 @@ TEST_CASE("statement_serializer aggregate functions") {
                 auto expression = group_concat(&User::id, "-");
                 SECTION("use_parentheses") {
                     context.use_parentheses = true;
-                    expected = R"((GROUP_CONCAT("id", '-')))";
+                    expected = R"(GROUP_CONCAT("id", '-'))";
                 }
                 SECTION("!use_parentheses") {
                     context.use_parentheses = false;
@@ -142,7 +142,7 @@ TEST_CASE("statement_serializer aggregate functions") {
                 auto expression = group_concat(&User::id, "-").filter(where(less_than(&User::id, 10)));
                 SECTION("use_parentheses") {
                     context.use_parentheses = true;
-                    expected = R"((GROUP_CONCAT("id", '-')) FILTER (WHERE ("id" < 10)))";
+                    expected = R"(GROUP_CONCAT("id", '-') FILTER (WHERE ("id" < 10)))";
                 }
                 SECTION("!use_parentheses") {
                     context.use_parentheses = false;
@@ -158,7 +158,7 @@ TEST_CASE("statement_serializer aggregate functions") {
                 auto expression = max(&User::id);
                 SECTION("use_parentheses") {
                     context.use_parentheses = true;
-                    expected = R"((MAX("id")))";
+                    expected = R"(MAX("id"))";
                 }
                 SECTION("!use_parentheses") {
                     context.use_parentheses = false;
@@ -170,7 +170,7 @@ TEST_CASE("statement_serializer aggregate functions") {
                 auto expression = max(&User::id).filter(where(less_than(&User::id, 10)));
                 SECTION("use_parentheses") {
                     context.use_parentheses = true;
-                    expected = R"((MAX("id")) FILTER (WHERE ("id" < 10)))";
+                    expected = R"(MAX("id") FILTER (WHERE ("id" < 10)))";
                 }
                 SECTION("!use_parentheses") {
                     context.use_parentheses = false;
@@ -186,7 +186,7 @@ TEST_CASE("statement_serializer aggregate functions") {
                 auto expression = min(&User::id);
                 SECTION("use_parentheses") {
                     context.use_parentheses = true;
-                    expected = R"((MIN("id")))";
+                    expected = R"(MIN("id"))";
                 }
                 SECTION("!use_parentheses") {
                     context.use_parentheses = false;
@@ -198,7 +198,7 @@ TEST_CASE("statement_serializer aggregate functions") {
                 auto expression = min(&User::id).filter(where(less_than(&User::id, 10)));
                 SECTION("use_parentheses") {
                     context.use_parentheses = true;
-                    expected = R"((MIN("id")) FILTER (WHERE ("id" < 10)))";
+                    expected = R"(MIN("id") FILTER (WHERE ("id" < 10)))";
                 }
                 SECTION("!use_parentheses") {
                     context.use_parentheses = false;
@@ -214,7 +214,7 @@ TEST_CASE("statement_serializer aggregate functions") {
                 auto expression = sum(&User::id);
                 SECTION("use_parentheses") {
                     context.use_parentheses = true;
-                    expected = R"((SUM("id")))";
+                    expected = R"(SUM("id"))";
                 }
                 SECTION("!use_parentheses") {
                     context.use_parentheses = false;
@@ -226,7 +226,7 @@ TEST_CASE("statement_serializer aggregate functions") {
                 auto expression = sum(&User::id).filter(where(less_than(&User::id, 10)));
                 SECTION("use_parentheses") {
                     context.use_parentheses = true;
-                    expected = R"((SUM("id")) FILTER (WHERE ("id" < 10)))";
+                    expected = R"(SUM("id") FILTER (WHERE ("id" < 10)))";
                 }
                 SECTION("!use_parentheses") {
                     context.use_parentheses = false;
@@ -242,7 +242,7 @@ TEST_CASE("statement_serializer aggregate functions") {
                 auto expression = total(&User::id);
                 SECTION("use_parentheses") {
                     context.use_parentheses = true;
-                    expected = R"((TOTAL("id")))";
+                    expected = R"(TOTAL("id"))";
                 }
                 SECTION("!use_parentheses") {
                     context.use_parentheses = false;
@@ -254,7 +254,7 @@ TEST_CASE("statement_serializer aggregate functions") {
                 auto expression = total(&User::id).filter(where(less_than(&User::id, 10)));
                 SECTION("use_parentheses") {
                     context.use_parentheses = true;
-                    expected = R"((TOTAL("id")) FILTER (WHERE ("id" < 10)))";
+                    expected = R"(TOTAL("id") FILTER (WHERE ("id" < 10)))";
                 }
                 SECTION("!use_parentheses") {
                     context.use_parentheses = false;

--- a/tests/statement_serializer_tests/aggregate_functions.cpp
+++ b/tests/statement_serializer_tests/aggregate_functions.cpp
@@ -36,7 +36,7 @@ TEST_CASE("statement_serializer aggregate functions") {
                 auto expression = avg(&User::id).filter(where(less_than(&User::id, 10)));
                 SECTION("use_parentheses") {
                     context.use_parentheses = true;
-                    expected = R"(AVG("id") FILTER (WHERE ("id" < 10)))";
+                    expected = R"(AVG("id") FILTER (WHERE "id" < 10))";
                 }
                 SECTION("!use_parentheses") {
                     context.use_parentheses = false;
@@ -64,7 +64,7 @@ TEST_CASE("statement_serializer aggregate functions") {
                 auto expression = count(&User::id).filter(where(less_than(&User::id, 10)));
                 SECTION("use_parentheses") {
                     context.use_parentheses = true;
-                    expected = R"(COUNT("id") FILTER (WHERE ("id" < 10)))";
+                    expected = R"(COUNT("id") FILTER (WHERE "id" < 10))";
                 }
                 SECTION("!use_parentheses") {
                     context.use_parentheses = false;
@@ -84,7 +84,7 @@ TEST_CASE("statement_serializer aggregate functions") {
             SECTION("without filter") {
                 auto expression = count<User>().filter(where(less_than(&User::id, 10)));
                 value = serialize(expression, context);
-                expected = R"(COUNT(*) FILTER (WHERE ("id" < 10)))";
+                expected = R"(COUNT(*) FILTER (WHERE "id" < 10))";
             }
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
             SECTION("with table reference") {
@@ -114,7 +114,7 @@ TEST_CASE("statement_serializer aggregate functions") {
                 auto expression = group_concat(&User::id).filter(where(less_than(&User::id, 10)));
                 SECTION("use_parentheses") {
                     context.use_parentheses = true;
-                    expected = R"(GROUP_CONCAT("id") FILTER (WHERE ("id" < 10)))";
+                    expected = R"(GROUP_CONCAT("id") FILTER (WHERE "id" < 10))";
                 }
                 SECTION("!use_parentheses") {
                     context.use_parentheses = false;
@@ -142,7 +142,7 @@ TEST_CASE("statement_serializer aggregate functions") {
                 auto expression = group_concat(&User::id, "-").filter(where(less_than(&User::id, 10)));
                 SECTION("use_parentheses") {
                     context.use_parentheses = true;
-                    expected = R"(GROUP_CONCAT("id", '-') FILTER (WHERE ("id" < 10)))";
+                    expected = R"(GROUP_CONCAT("id", '-') FILTER (WHERE "id" < 10))";
                 }
                 SECTION("!use_parentheses") {
                     context.use_parentheses = false;
@@ -170,7 +170,7 @@ TEST_CASE("statement_serializer aggregate functions") {
                 auto expression = max(&User::id).filter(where(less_than(&User::id, 10)));
                 SECTION("use_parentheses") {
                     context.use_parentheses = true;
-                    expected = R"(MAX("id") FILTER (WHERE ("id" < 10)))";
+                    expected = R"(MAX("id") FILTER (WHERE "id" < 10))";
                 }
                 SECTION("!use_parentheses") {
                     context.use_parentheses = false;
@@ -198,7 +198,7 @@ TEST_CASE("statement_serializer aggregate functions") {
                 auto expression = min(&User::id).filter(where(less_than(&User::id, 10)));
                 SECTION("use_parentheses") {
                     context.use_parentheses = true;
-                    expected = R"(MIN("id") FILTER (WHERE ("id" < 10)))";
+                    expected = R"(MIN("id") FILTER (WHERE "id" < 10))";
                 }
                 SECTION("!use_parentheses") {
                     context.use_parentheses = false;
@@ -226,7 +226,7 @@ TEST_CASE("statement_serializer aggregate functions") {
                 auto expression = sum(&User::id).filter(where(less_than(&User::id, 10)));
                 SECTION("use_parentheses") {
                     context.use_parentheses = true;
-                    expected = R"(SUM("id") FILTER (WHERE ("id" < 10)))";
+                    expected = R"(SUM("id") FILTER (WHERE "id" < 10))";
                 }
                 SECTION("!use_parentheses") {
                     context.use_parentheses = false;
@@ -254,7 +254,7 @@ TEST_CASE("statement_serializer aggregate functions") {
                 auto expression = total(&User::id).filter(where(less_than(&User::id, 10)));
                 SECTION("use_parentheses") {
                     context.use_parentheses = true;
-                    expected = R"(TOTAL("id") FILTER (WHERE ("id" < 10)))";
+                    expected = R"(TOTAL("id") FILTER (WHERE "id" < 10))";
                 }
                 SECTION("!use_parentheses") {
                     context.use_parentheses = false;

--- a/tests/statement_serializer_tests/arithmetic_operators.cpp
+++ b/tests/statement_serializer_tests/arithmetic_operators.cpp
@@ -15,7 +15,7 @@ TEST_CASE("statement_serializer arithmetic operators") {
         SECTION("operator") {
             value = serialize(c(3) + 5, context);
         }
-        expected = "(3 + 5)";
+        expected = "3 + 5";
     }
     SECTION("sub") {
         SECTION("func") {
@@ -24,7 +24,7 @@ TEST_CASE("statement_serializer arithmetic operators") {
         SECTION("operator") {
             value = serialize(c(5) - -9, context);
         }
-        expected = "(5 - -9)";
+        expected = "5 - -9";
     }
     SECTION("mul") {
         SECTION("func") {
@@ -33,7 +33,7 @@ TEST_CASE("statement_serializer arithmetic operators") {
         SECTION("operator") {
             value = serialize(c(10) * 0.5, context);
         }
-        expected = "(10 * 0.5)";
+        expected = "10 * 0.5";
     }
     SECTION("div") {
         SECTION("func") {
@@ -42,7 +42,7 @@ TEST_CASE("statement_serializer arithmetic operators") {
         SECTION("operator") {
             value = serialize(c(10) / 2, context);
         }
-        expected = "(10 / 2)";
+        expected = "10 / 2";
     }
     SECTION("mod") {
         SECTION("func") {
@@ -51,7 +51,21 @@ TEST_CASE("statement_serializer arithmetic operators") {
         SECTION("operator") {
             value = serialize(c(20) % 3, context);
         }
-        expected = "(20 % 3)";
+        expected = "20 % 3";
+    }
+    SECTION("parentheses keeping order of precedence") {
+        SECTION("1") {
+            value = serialize(c(4) + 5 + 3, context);
+            expected = "(4 + 5) + 3";
+        }
+        SECTION("2") {
+            value = serialize(4 + (c(5) + 3), context);
+            expected = "4 + (5 + 3)";
+        }
+        SECTION("3") {
+            value = serialize(4 + c(5) * 3 + 1, context);
+            expected = "(4 + (5 * 3)) + 1";
+        }
     }
     REQUIRE(value == expected);
 }

--- a/tests/statement_serializer_tests/column_constraints/check.cpp
+++ b/tests/statement_serializer_tests/column_constraints/check.cpp
@@ -25,12 +25,12 @@ TEST_CASE("statement_serializer check") {
         context_t context{dbObjects};
         std::string value;
         std::string expected;
-        SECTION("with parentheses") {
+        SECTION("use_parentheses") {
             context.use_parentheses = true;
             value = serialize(ch, context);
-            expected = R"(CHECK (("col3" > 0)))";
+            expected = R"(CHECK ("col3" > 0))";
         }
-        SECTION("without parentheses") {
+        SECTION("!use_parentheses") {
             context.use_parentheses = false;
             value = serialize(ch, context);
             expected = R"(CHECK ("col3" > 0))";
@@ -59,12 +59,12 @@ TEST_CASE("statement_serializer check") {
         context_t context{dbObjects};
         std::string value;
         std::string expected;
-        SECTION("with parentheses") {
+        SECTION("use_parentheses") {
             context.use_parentheses = true;
             value = serialize(ch, context);
-            expected = R"(CHECK ((0 < "PRICE")))";
+            expected = R"(CHECK (0 < "PRICE"))";
         }
-        SECTION("without parentheses") {
+        SECTION("!use_parentheses") {
             context.use_parentheses = false;
             value = serialize(ch, context);
             expected = R"(CHECK (0 < "PRICE"))";

--- a/tests/statement_serializer_tests/column_constraints/default.cpp
+++ b/tests/statement_serializer_tests/column_constraints/default.cpp
@@ -22,7 +22,7 @@ TEST_CASE("statement_serializer default") {
         auto def = default_value(datetime("now"));
         SECTION("use_parentheses") {
             context.use_parentheses = true;
-            expected = "DEFAULT ((DATETIME('now')))";
+            expected = "DEFAULT (DATETIME('now'))";
         }
         SECTION("!use_parentheses") {
             context.use_parentheses = false;

--- a/tests/statement_serializer_tests/column_constraints/generated.cpp
+++ b/tests/statement_serializer_tests/column_constraints/generated.cpp
@@ -44,32 +44,32 @@ TEST_CASE("statement_serializer generated") {
     SECTION("full") {
         auto constraint = generated_always_as(&Type::a * sqlite_orm::abs(&Type::b));
         value = serialize(constraint, context);
-        expected = R"(GENERATED ALWAYS AS (("a" * ABS("b"))))";
+        expected = R"(GENERATED ALWAYS AS ("a" * ABS("b")))";
     }
     SECTION("full virtual") {
         auto constraint = generated_always_as(&Type::a * sqlite_orm::abs(&Type::b)).virtual_();
         value = serialize(constraint, context);
-        expected = R"(GENERATED ALWAYS AS (("a" * ABS("b"))) VIRTUAL)";
+        expected = R"(GENERATED ALWAYS AS ("a" * ABS("b")) VIRTUAL)";
     }
     SECTION("full stored") {
         auto constraint = generated_always_as(&Type::a * sqlite_orm::abs(&Type::b)).stored();
         value = serialize(constraint, context);
-        expected = R"(GENERATED ALWAYS AS (("a" * ABS("b"))) STORED)";
+        expected = R"(GENERATED ALWAYS AS ("a" * ABS("b")) STORED)";
     }
     SECTION("not full") {
         auto constraint = as(&Type::a * sqlite_orm::abs(&Type::b));
         value = serialize(constraint, context);
-        expected = R"(AS (("a" * ABS("b"))))";
+        expected = R"(AS ("a" * ABS("b")))";
     }
     SECTION("not full virtual") {
         auto constraint = as(&Type::a * sqlite_orm::abs(&Type::b)).virtual_();
         value = serialize(constraint, context);
-        expected = R"(AS (("a" * ABS("b"))) VIRTUAL)";
+        expected = R"(AS ("a" * ABS("b")) VIRTUAL)";
     }
     SECTION("not full stored") {
         auto constraint = as(&Type::a * sqlite_orm::abs(&Type::b)).stored();
         value = serialize(constraint, context);
-        expected = R"(AS (("a" * ABS("b"))) STORED)";
+        expected = R"(AS ("a" * ABS("b")) STORED)";
     }
     SECTION("length") {
         auto constraint = generated_always_as(length(&Type::a));

--- a/tests/statement_serializer_tests/column_constraints/generated.cpp
+++ b/tests/statement_serializer_tests/column_constraints/generated.cpp
@@ -44,37 +44,37 @@ TEST_CASE("statement_serializer generated") {
     SECTION("full") {
         auto constraint = generated_always_as(&Type::a * sqlite_orm::abs(&Type::b));
         value = serialize(constraint, context);
-        expected = R"(GENERATED ALWAYS AS (("a" * (ABS("b")))))";
+        expected = R"(GENERATED ALWAYS AS (("a" * ABS("b"))))";
     }
     SECTION("full virtual") {
         auto constraint = generated_always_as(&Type::a * sqlite_orm::abs(&Type::b)).virtual_();
         value = serialize(constraint, context);
-        expected = R"(GENERATED ALWAYS AS (("a" * (ABS("b")))) VIRTUAL)";
+        expected = R"(GENERATED ALWAYS AS (("a" * ABS("b"))) VIRTUAL)";
     }
     SECTION("full stored") {
         auto constraint = generated_always_as(&Type::a * sqlite_orm::abs(&Type::b)).stored();
         value = serialize(constraint, context);
-        expected = R"(GENERATED ALWAYS AS (("a" * (ABS("b")))) STORED)";
+        expected = R"(GENERATED ALWAYS AS (("a" * ABS("b"))) STORED)";
     }
     SECTION("not full") {
         auto constraint = as(&Type::a * sqlite_orm::abs(&Type::b));
         value = serialize(constraint, context);
-        expected = R"(AS (("a" * (ABS("b")))))";
+        expected = R"(AS (("a" * ABS("b"))))";
     }
     SECTION("not full virtual") {
         auto constraint = as(&Type::a * sqlite_orm::abs(&Type::b)).virtual_();
         value = serialize(constraint, context);
-        expected = R"(AS (("a" * (ABS("b")))) VIRTUAL)";
+        expected = R"(AS (("a" * ABS("b"))) VIRTUAL)";
     }
     SECTION("not full stored") {
         auto constraint = as(&Type::a * sqlite_orm::abs(&Type::b)).stored();
         value = serialize(constraint, context);
-        expected = R"(AS (("a" * (ABS("b")))) STORED)";
+        expected = R"(AS (("a" * ABS("b"))) STORED)";
     }
     SECTION("length") {
         auto constraint = generated_always_as(length(&Type::a));
         value = serialize(constraint, context);
-        expected = R"(GENERATED ALWAYS AS ((LENGTH("a"))))";
+        expected = R"(GENERATED ALWAYS AS (LENGTH("a")))";
     }
     REQUIRE(value == expected);
 }

--- a/tests/statement_serializer_tests/column_names.cpp
+++ b/tests/statement_serializer_tests/column_names.cpp
@@ -116,6 +116,14 @@ TEST_CASE("statement_serializer column names") {
             REQUIRE(value == expected);
         }
     }
+    SECTION("subquery") {
+        internal::db_objects_tuple<> dbObjects;
+        using context_t = internal::serializer_context<internal::db_objects_tuple<>>;
+        context_t context{dbObjects};
+        context.use_parentheses = false;
+        std::string value = serialize(select(select(1)), context);
+        REQUIRE(value == "SELECT (SELECT 1)");
+    }
     // note: here we test whether the serializer serializes the correct column
     //       even if the object in question isn't the first in the table definition
     SECTION("by explicit column pointer") {

--- a/tests/statement_serializer_tests/comparison_operators.cpp
+++ b/tests/statement_serializer_tests/comparison_operators.cpp
@@ -89,7 +89,12 @@ TEST_CASE("statement_serializer comparison operators") {
     }
     SECTION("is_equal_with_table_t") {
         value = serialize(is_equal<User>("Tom Gregory"), context);
-        expected = "\"users\" = 'Tom Gregory'";
+        expected = R"("users" = 'Tom Gregory')";
+    }
+    SECTION("subquery") {
+        context.use_parentheses = false;
+        value = serialize(greater_than(&User::id, select(avg(&User::id))), context);
+        expected = R"("id" > (SELECT (AVG("users"."id")) FROM "users"))";
     }
     REQUIRE(value == expected);
 }

--- a/tests/statement_serializer_tests/comparison_operators.cpp
+++ b/tests/statement_serializer_tests/comparison_operators.cpp
@@ -25,7 +25,7 @@ TEST_CASE("statement_serializer comparison operators") {
         SECTION("operator") {
             value = serialize(c(4) < 5, context);
         }
-        expected = "(4 < 5)";
+        expected = "4 < 5";
     }
     SECTION("less_or_equal") {
         SECTION("func") {
@@ -37,7 +37,7 @@ TEST_CASE("statement_serializer comparison operators") {
         SECTION("operator") {
             value = serialize(c(10) <= 15, context);
         }
-        expected = "(10 <= 15)";
+        expected = "10 <= 15";
     }
     SECTION("greater_than") {
         SECTION("func") {
@@ -49,7 +49,7 @@ TEST_CASE("statement_serializer comparison operators") {
         SECTION("operator") {
             value = serialize(c(1) > 0.5, context);
         }
-        expected = "(1 > 0.5)";
+        expected = "1 > 0.5";
     }
     SECTION("greater_or_equal") {
         SECTION("func") {
@@ -61,7 +61,7 @@ TEST_CASE("statement_serializer comparison operators") {
         SECTION("operator") {
             value = serialize(c(10) >= -5, context);
         }
-        expected = "(10 >= -5)";
+        expected = "10 >= -5";
     }
     SECTION("is_equal") {
         SECTION("func") {
@@ -73,7 +73,7 @@ TEST_CASE("statement_serializer comparison operators") {
         SECTION("operator") {
             value = serialize(c("ototo") == "Hey", context);
         }
-        expected = "('ototo' = 'Hey')";
+        expected = "'ototo' = 'Hey'";
     }
     SECTION("is_not_equal") {
         SECTION("func") {
@@ -85,7 +85,7 @@ TEST_CASE("statement_serializer comparison operators") {
         SECTION("operator") {
             value = serialize(c("lala") != 7, context);
         }
-        expected = "('lala' != 7)";
+        expected = "'lala' != 7";
     }
     SECTION("is_equal_with_table_t") {
         value = serialize(is_equal<User>("Tom Gregory"), context);
@@ -95,6 +95,16 @@ TEST_CASE("statement_serializer comparison operators") {
         context.use_parentheses = false;
         value = serialize(greater_than(&User::id, select(avg(&User::id))), context);
         expected = R"("id" > (SELECT AVG("users"."id") FROM "users"))";
+    }
+    SECTION("parentheses keeping order of precedence") {
+        SECTION("1") {
+            value = serialize(c(true) == c(5) > 3, context);
+            expected = "1 = (5 > 3)";
+        }
+        SECTION("2") {
+            value = serialize(c(5) > 3 == c(true), context);
+            expected = "(5 > 3) = 1";
+        }
     }
     REQUIRE(value == expected);
 }

--- a/tests/statement_serializer_tests/comparison_operators.cpp
+++ b/tests/statement_serializer_tests/comparison_operators.cpp
@@ -98,11 +98,11 @@ TEST_CASE("statement_serializer comparison operators") {
     }
     SECTION("parentheses keeping order of precedence") {
         SECTION("1") {
-            value = serialize(c(true) == c(5) > 3, context);
+            value = serialize(true == c(5) > 3, context);
             expected = "1 = (5 > 3)";
         }
         SECTION("2") {
-            value = serialize(c(5) > 3 == c(true), context);
+            value = serialize(c(5) > 3 == true, context);
             expected = "(5 > 3) = 1";
         }
     }

--- a/tests/statement_serializer_tests/comparison_operators.cpp
+++ b/tests/statement_serializer_tests/comparison_operators.cpp
@@ -94,7 +94,7 @@ TEST_CASE("statement_serializer comparison operators") {
     SECTION("subquery") {
         context.use_parentheses = false;
         value = serialize(greater_than(&User::id, select(avg(&User::id))), context);
-        expected = R"("id" > (SELECT (AVG("users"."id")) FROM "users"))";
+        expected = R"("id" > (SELECT AVG("users"."id") FROM "users"))";
     }
     REQUIRE(value == expected);
 }

--- a/tests/statement_serializer_tests/core_functions.cpp
+++ b/tests/statement_serializer_tests/core_functions.cpp
@@ -24,7 +24,7 @@ TEST_CASE("statement_serializer core functions") {
         auto expression = length("hi");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
-            expected = "(LENGTH('hi'))";
+            expected = "LENGTH('hi')";
         }
         SECTION("!use_parentheses") {
             context.use_parentheses = false;
@@ -36,7 +36,7 @@ TEST_CASE("statement_serializer core functions") {
         auto expression = sqlite_orm::abs(-100);
         SECTION("use_parentheses") {
             context.use_parentheses = true;
-            expected = "(ABS(-100))";
+            expected = "ABS(-100)";
         }
         SECTION("!use_parentheses") {
             context.use_parentheses = false;
@@ -48,7 +48,7 @@ TEST_CASE("statement_serializer core functions") {
         auto expression = lower("dancefloor");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
-            expected = "(LOWER('dancefloor'))";
+            expected = "LOWER('dancefloor')";
         }
         SECTION("!use_parentheses") {
             context.use_parentheses = false;
@@ -60,7 +60,7 @@ TEST_CASE("statement_serializer core functions") {
         auto expression = upper("call");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
-            expected = "(UPPER('call'))";
+            expected = "UPPER('call')";
         }
         SECTION("!use_parentheses") {
             context.use_parentheses = false;
@@ -72,7 +72,7 @@ TEST_CASE("statement_serializer core functions") {
         auto expression = total_changes();
         SECTION("use_parentheses") {
             context.use_parentheses = true;
-            expected = "(TOTAL_CHANGES())";
+            expected = "TOTAL_CHANGES()";
         }
         SECTION("!use_parentheses") {
             context.use_parentheses = false;
@@ -84,7 +84,7 @@ TEST_CASE("statement_serializer core functions") {
         auto expression = changes();
         SECTION("use_parentheses") {
             context.use_parentheses = true;
-            expected = "(CHANGES())";
+            expected = "CHANGES()";
         }
         SECTION("!use_parentheses") {
             context.use_parentheses = false;
@@ -96,7 +96,7 @@ TEST_CASE("statement_serializer core functions") {
         auto expression = trim("hey");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
-            expected = "(TRIM('hey'))";
+            expected = "TRIM('hey')";
         }
         SECTION("!use_parentheses") {
             context.use_parentheses = false;
@@ -108,7 +108,7 @@ TEST_CASE("statement_serializer core functions") {
         auto expression = trim("hey", "h");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
-            expected = "(TRIM('hey', 'h'))";
+            expected = "TRIM('hey', 'h')";
         }
         SECTION("!use_parentheses") {
             context.use_parentheses = false;
@@ -120,7 +120,7 @@ TEST_CASE("statement_serializer core functions") {
         auto expression = ltrim("hey");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
-            expected = "(LTRIM('hey'))";
+            expected = "LTRIM('hey')";
         }
         SECTION("!use_parentheses") {
             context.use_parentheses = false;
@@ -132,7 +132,7 @@ TEST_CASE("statement_serializer core functions") {
         auto expression = ltrim("hey", "h");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
-            expected = "(LTRIM('hey', 'h'))";
+            expected = "LTRIM('hey', 'h')";
         }
         SECTION("!use_parentheses") {
             context.use_parentheses = false;
@@ -144,7 +144,7 @@ TEST_CASE("statement_serializer core functions") {
         auto expression = rtrim("hey");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
-            expected = "(RTRIM('hey'))";
+            expected = "RTRIM('hey')";
         }
         SECTION("!use_parentheses") {
             context.use_parentheses = false;
@@ -156,7 +156,7 @@ TEST_CASE("statement_serializer core functions") {
         auto expression = rtrim("hey", "h");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
-            expected = "(RTRIM('hey', 'h'))";
+            expected = "RTRIM('hey', 'h')";
         }
         SECTION("!use_parentheses") {
             context.use_parentheses = false;
@@ -168,7 +168,7 @@ TEST_CASE("statement_serializer core functions") {
         auto expression = hex("love");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
-            expected = "(HEX('love'))";
+            expected = "HEX('love')";
         }
         SECTION("!use_parentheses") {
             context.use_parentheses = false;
@@ -180,8 +180,7 @@ TEST_CASE("statement_serializer core functions") {
         auto expression = quote("one");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
-            expected = "(QUOTE('one'))";
-            ;
+            expected = "QUOTE('one')";
         }
         SECTION("!use_parentheses") {
             context.use_parentheses = false;
@@ -193,7 +192,7 @@ TEST_CASE("statement_serializer core functions") {
         auto expression = randomblob(5);
         SECTION("use_parentheses") {
             context.use_parentheses = true;
-            expected = "(RANDOMBLOB(5))";
+            expected = "RANDOMBLOB(5)";
         }
         SECTION("!use_parentheses") {
             context.use_parentheses = false;
@@ -205,7 +204,7 @@ TEST_CASE("statement_serializer core functions") {
         auto expression = instr("hi", "i");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
-            expected = "(INSTR('hi', 'i'))";
+            expected = "INSTR('hi', 'i')";
         }
         SECTION("!use_parentheses") {
             context.use_parentheses = false;
@@ -217,7 +216,7 @@ TEST_CASE("statement_serializer core functions") {
         auto expression = replace("contigo", "o", "a");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
-            expected = "(REPLACE('contigo', 'o', 'a'))";
+            expected = "REPLACE('contigo', 'o', 'a')";
         }
         SECTION("!use_parentheses") {
             context.use_parentheses = false;
@@ -229,7 +228,7 @@ TEST_CASE("statement_serializer core functions") {
         auto expression = sqlite_orm::round(10.5);
         SECTION("use_parentheses") {
             context.use_parentheses = true;
-            expected = "(ROUND(10.5))";
+            expected = "ROUND(10.5)";
         }
         SECTION("!use_parentheses") {
             context.use_parentheses = false;
@@ -241,7 +240,7 @@ TEST_CASE("statement_serializer core functions") {
         auto expression = sqlite_orm::round(10.5, 0.5);
         SECTION("use_parentheses") {
             context.use_parentheses = true;
-            expected = "(ROUND(10.5, 0.5))";
+            expected = "ROUND(10.5, 0.5)";
         }
         SECTION("!use_parentheses") {
             context.use_parentheses = false;
@@ -254,7 +253,7 @@ TEST_CASE("statement_serializer core functions") {
         auto expression = char_(40, 45);
         SECTION("use_parentheses") {
             context.use_parentheses = true;
-            expected = "(CHAR(40, 45))";
+            expected = "CHAR(40, 45)";
         }
         SECTION("!use_parentheses") {
             context.use_parentheses = false;
@@ -266,7 +265,7 @@ TEST_CASE("statement_serializer core functions") {
         auto expression = sqlite_orm::random();
         SECTION("use_parentheses") {
             context.use_parentheses = true;
-            expected = "(RANDOM())";
+            expected = "RANDOM()";
         }
         SECTION("!use_parentheses") {
             context.use_parentheses = false;
@@ -279,7 +278,7 @@ TEST_CASE("statement_serializer core functions") {
         auto expression = coalesce<std::string>(10, 15);
         SECTION("use_parentheses") {
             context.use_parentheses = true;
-            expected = "(COALESCE(10, 15))";
+            expected = "COALESCE(10, 15)";
         }
         SECTION("!use_parentheses") {
             context.use_parentheses = false;
@@ -291,7 +290,7 @@ TEST_CASE("statement_serializer core functions") {
         auto expression = date("now");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
-            expected = "(DATE('now'))";
+            expected = "DATE('now')";
         }
         SECTION("!use_parentheses") {
             context.use_parentheses = false;
@@ -303,7 +302,7 @@ TEST_CASE("statement_serializer core functions") {
         auto expression = time("12:00", "localtime");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
-            expected = "(TIME('12:00', 'localtime'))";
+            expected = "TIME('12:00', 'localtime')";
         }
         SECTION("!use_parentheses") {
             context.use_parentheses = false;
@@ -315,7 +314,7 @@ TEST_CASE("statement_serializer core functions") {
         auto expression = datetime("now");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
-            expected = "(DATETIME('now'))";
+            expected = "DATETIME('now')";
         }
         SECTION("!use_parentheses") {
             context.use_parentheses = false;
@@ -327,7 +326,7 @@ TEST_CASE("statement_serializer core functions") {
         auto expression = julianday("now");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
-            expected = "(JULIANDAY('now'))";
+            expected = "JULIANDAY('now')";
         }
         SECTION("!use_parentheses") {
             context.use_parentheses = false;
@@ -339,7 +338,7 @@ TEST_CASE("statement_serializer core functions") {
         auto expression = strftime("%s", "2014-10-07 02:34:56");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
-            expected = "(STRFTIME('%s', '2014-10-07 02:34:56'))";
+            expected = "STRFTIME('%s', '2014-10-07 02:34:56')";
         }
         SECTION("!use_parentheses") {
             context.use_parentheses = false;
@@ -351,7 +350,7 @@ TEST_CASE("statement_serializer core functions") {
         auto expression = zeroblob(5);
         SECTION("use_parentheses") {
             context.use_parentheses = true;
-            expected = "(ZEROBLOB(5))";
+            expected = "ZEROBLOB(5)";
         }
         SECTION("!use_parentheses") {
             context.use_parentheses = false;
@@ -363,7 +362,7 @@ TEST_CASE("statement_serializer core functions") {
         auto expression = substr("Zara", 2);
         SECTION("use_parentheses") {
             context.use_parentheses = true;
-            expected = "(SUBSTR('Zara', 2))";
+            expected = "SUBSTR('Zara', 2)";
         }
         SECTION("!use_parentheses") {
             context.use_parentheses = false;
@@ -375,7 +374,7 @@ TEST_CASE("statement_serializer core functions") {
         auto expression = substr("Natasha", 3, 2);
         SECTION("use_parentheses") {
             context.use_parentheses = true;
-            expected = "(SUBSTR('Natasha', 3, 2))";
+            expected = "SUBSTR('Natasha', 3, 2)";
         }
         SECTION("!use_parentheses") {
             context.use_parentheses = false;
@@ -388,7 +387,7 @@ TEST_CASE("statement_serializer core functions") {
         auto expression = soundex("Vaso");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
-            expected = "(SOUNDEX('Vaso'))";
+            expected = "SOUNDEX('Vaso')";
         }
         SECTION("!use_parentheses") {
             context.use_parentheses = false;

--- a/tests/statement_serializer_tests/logical_operators.cpp
+++ b/tests/statement_serializer_tests/logical_operators.cpp
@@ -31,7 +31,7 @@ TEST_CASE("statement_serializer logical operators") {
             SECTION("member function") {
                 stringValue = internal::serialize(c(0).and_(0), context);
             }
-            expected = "(0 AND 0)";
+            expected = "0 AND 0";
         }
         SECTION("complex") {
             SECTION("operators") {
@@ -40,7 +40,7 @@ TEST_CASE("statement_serializer logical operators") {
             SECTION("functions") {
                 stringValue = internal::serialize(is_equal(&User::id, 5) and is_equal(&User::name, "Ariana"), context);
             }
-            expected = R"((("id" = 5) AND ("name" = 'Ariana')))";
+            expected = R"(("id" = 5) AND ("name" = 'Ariana'))";
         }
     }
     SECTION("or") {
@@ -51,7 +51,7 @@ TEST_CASE("statement_serializer logical operators") {
             SECTION("member function") {
                 stringValue = internal::serialize(c(0).or_(0), context);
             }
-            expected = "(0 OR 0)";
+            expected = "0 OR 0";
         }
         SECTION("complex") {
             SECTION("operators") {
@@ -60,7 +60,7 @@ TEST_CASE("statement_serializer logical operators") {
             SECTION("functions") {
                 stringValue = internal::serialize(is_equal(&User::id, 5) or is_equal(&User::name, "Ariana"), context);
             }
-            expected = R"((("id" = 5) OR ("name" = 'Ariana')))";
+            expected = R"(("id" = 5) OR ("name" = 'Ariana'))";
         }
     }
     SECTION("in") {
@@ -95,6 +95,20 @@ TEST_CASE("statement_serializer logical operators") {
             auto inValue = not_in(&User::id, {1, 2, 3});
             stringValue = internal::serialize(inValue, context);
             expected = R"("id" NOT IN (1, 2, 3))";
+        }
+    }
+    SECTION("parentheses keeping order of precedence") {
+        SECTION("1") {
+            stringValue = serialize(c(0) and 0, context);
+            expected = "0 AND 0";
+        }
+        SECTION("2") {
+            stringValue = serialize(c(0) and 0 or 1, context);
+            expected = "(0 AND 0) OR 1";
+        }
+        SECTION("3") {
+            stringValue = serialize(c(0) and 0 or c(1) and 1, context);
+            expected = "(0 AND 0) OR (1 AND 1)";
         }
     }
     REQUIRE(stringValue == expected);

--- a/tests/statement_serializer_tests/statements/remove_all.cpp
+++ b/tests/statement_serializer_tests/statements/remove_all.cpp
@@ -26,12 +26,12 @@ TEST_CASE("statement_serializer remove_all") {
     SECTION("where") {
         auto statement = remove_all<User>(where(&User::id == c(1)));
         value = serialize(statement, context);
-        expected = R"(DELETE FROM "users" WHERE (("id" = 1)))";
+        expected = R"(DELETE FROM "users" WHERE ("id" = 1))";
     }
     SECTION("conditions") {
         auto statement = remove_all<User>(where(&User::id == c(1)), limit(1));
         value = serialize(statement, context);
-        expected = R"(DELETE FROM "users" WHERE (("id" = 1)) LIMIT 1)";
+        expected = R"(DELETE FROM "users" WHERE ("id" = 1) LIMIT 1)";
     }
     REQUIRE(value == expected);
 }

--- a/tests/statement_serializer_tests/statements/select.cpp
+++ b/tests/statement_serializer_tests/statements/select.cpp
@@ -48,12 +48,12 @@ TEST_CASE("statement_serializer select_t") {
         SECTION("!highest_level") {
             statement.highest_level = false;
             stringValue = serialize(statement, context);
-            expected = "(SELECT ((1, 2, 3) = (4, 5, 6)))";
+            expected = "(SELECT (1, 2, 3) = (4, 5, 6))";
         }
         SECTION("highest_level") {
             statement.highest_level = true;
             stringValue = serialize(statement, context);
-            expected = "SELECT ((1, 2, 3) = (4, 5, 6))";
+            expected = "SELECT (1, 2, 3) = (4, 5, 6)";
         }
     }
     SECTION("compound operators") {
@@ -212,7 +212,7 @@ TEST_CASE("statement_serializer select_t") {
                 context.skip_table_name = false;
                 stringValue = serialize(expression, context);
                 expected =
-                    R"(SELECT "d".* FROM "Dept" "d" LEFT JOIN "Emp" "e" ON ("d"."deptno" = "e"."deptno")  WHERE ("e"."deptno" IS NULL))";
+                    R"(SELECT "d".* FROM "Dept" "d" LEFT JOIN "Emp" "e" ON "d"."deptno" = "e"."deptno"  WHERE ("e"."deptno" IS NULL))";
             }
         }
     }

--- a/tests/statement_serializer_tests/statements/update.cpp
+++ b/tests/statement_serializer_tests/statements/update.cpp
@@ -48,11 +48,11 @@ TEST_CASE("statement_serializer update") {
                     auto expression = update_all(set(assign(&A::value, 5)), where(is_equal(&A::address, 1)));
                     SECTION("with question marks") {
                         context.replace_bindable_with_question = true;
-                        expected = R"(UPDATE "table" SET "value" = ? WHERE (("address" = ?)))";
+                        expected = R"(UPDATE "table" SET "value" = ? WHERE ("address" = ?))";
                     }
                     SECTION("without question marks") {
                         context.replace_bindable_with_question = false;
-                        expected = R"(UPDATE "table" SET "value" = 5 WHERE (("address" = 1)))";
+                        expected = R"(UPDATE "table" SET "value" = 5 WHERE ("address" = 1))";
                     }
                     value = serialize(expression, context);
                 }
@@ -62,7 +62,7 @@ TEST_CASE("statement_serializer update") {
                     dynamicSet.push_back(assign(&A::value, 5));
                     auto expression = update_all(dynamicSet, where(is_equal(&A::address, 1)));
                     context.replace_bindable_with_question = false;
-                    expected = R"(UPDATE "table" SET "value" = 5 WHERE (("address" = 1)))";
+                    expected = R"(UPDATE "table" SET "value" = 5 WHERE ("address" = 1))";
                     value = serialize(expression, context);
                 }
             }

--- a/tests/statement_serializer_tests/statements/update_all.cpp
+++ b/tests/statement_serializer_tests/statements/update_all.cpp
@@ -55,6 +55,6 @@ TEST_CASE("statement_serializer update_all") {
         update_all(set(c(&Contact::phone) = select(&Customer::phone, from<Customer>(), where(c(&Customer::id) == 1))));
     auto value = serialize(statement, context);
     decltype(value) expected =
-        R"(UPDATE "contacts" SET "phone" = (SELECT "customers"."Phone" FROM "customers" WHERE (("customers"."CustomerId" = 1))))";
+        R"(UPDATE "contacts" SET "phone" = (SELECT "customers"."Phone" FROM "customers" WHERE ("customers"."CustomerId" = 1)))";
     REQUIRE(value == expected);
 }

--- a/tests/static_tests/operators_adl.cpp
+++ b/tests/static_tests/operators_adl.cpp
@@ -46,10 +46,14 @@ void runTests(E expression) {
     STATIC_REQUIRE(is_specialization_of_v<decltype(expression == 42), is_equal_t>);
     STATIC_REQUIRE(is_specialization_of_v<decltype(42 == expression), is_equal_t>);
     STATIC_REQUIRE(is_specialization_of_v<decltype(expression == expression), is_equal_t>);
+    STATIC_REQUIRE(is_specialization_of_v<decltype(expression == 42 == 1), is_equal_t>);
+    STATIC_REQUIRE(is_specialization_of_v<decltype(1 == (42 == expression)), is_equal_t>);
 
     STATIC_REQUIRE(is_specialization_of_v<decltype(expression != 42), is_not_equal_t>);
     STATIC_REQUIRE(is_specialization_of_v<decltype(42 != expression), is_not_equal_t>);
     STATIC_REQUIRE(is_specialization_of_v<decltype(expression != expression), is_not_equal_t>);
+    STATIC_REQUIRE(is_specialization_of_v<decltype(expression != 42 != 0), is_not_equal_t>);
+    STATIC_REQUIRE(is_specialization_of_v<decltype(0 != (42 != expression)), is_not_equal_t>);
 
     STATIC_REQUIRE(is_specialization_of_v<decltype(expression || 42), binary_operator>);
     STATIC_REQUIRE(is_specialization_of_v<decltype(42 || expression), binary_operator>);


### PR DESCRIPTION
The serialization of binary expressions currently suffers from two problems:

1. The statement serializer too eagerly puts parentheses around every built-in function and binary expression (comparison, logic, arithmetic, bitwise operators) and is additionally dependent on a flag provided by the outer context.
2. Subqueries in binary expressions in columns currently only work because the outer expressions do not change the `serializer_context<>::use_parentheses=true` flag. As soon as it is changed, as in CTEs, the serialization goes wrong.

1) can be improved and 2) remedied in the following ways:

* Binary operators/conditions: Parentheses are only needed to preserve precedence by following simple logic: only "subtree" expressions need to be parenthesized, "leaf" expressions do not.
* No parentheses around built-in functions necessary - they are already independent expressions (and the outer expression already takes over the parentheses, e.g. `check()`, `default()`).
* Establishing a parenthesized subcontext for potential subqueries in binary expressions, such that `select(&Employee::salary >= select(avg(&Employee::salary)))` works.

This leads to a simplified approach, as the serializer is independent of the context.
In addition, fewer characters are serialized with simple binary expressions, which also improves the readability of statements when they are examined.

Also in this PR:
* Allow conditional expressions to be equality-comparable, so expressions like `select(c(5) > 3 == true)` are possible instead of `select(c(5) > 3 == c(true))`
* Merged handling of binary conditions and operators (AST iteration, serialization)
* Appveyor vcpkg environmnent updated to 2023.12.12.
* Fixed "left_and_inner_join" example
