### PR TITLE
Fixed compiler warning/error about braces around scalar initializer

### DIFF
--- a/dev/alias.h
+++ b/dev/alias.h
@@ -229,7 +229,7 @@ namespace sqlite_orm {
 
         using C1 =
             std::conditional_t<std::is_same<O, aliased_type>::value, F O::*, column_pointer<aliased_type, F O::*>>;
-        return alias_column_t<A, C1>{{field}};
+        return alias_column_t<A, C1>{C1{field}};
     }
 
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -5237,7 +5237,7 @@ namespace sqlite_orm {
 
         using C1 =
             std::conditional_t<std::is_same<O, aliased_type>::value, F O::*, column_pointer<aliased_type, F O::*>>;
-        return alias_column_t<A, C1>{{field}};
+        return alias_column_t<A, C1>{C1{field}};
     }
 
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES


### PR DESCRIPTION
Some compilers complain about braces around scalar initializer