### PR TITLE
Removed `prefix` from column constraints

### DIFF
--- a/dev/constraints.h
+++ b/dev/constraints.h
@@ -3,7 +3,7 @@
 #include <system_error>  //  std::system_error
 #include <ostream>  //  std::ostream
 #include <string>  //  std::string
-#include <tuple>  //  std::tuple, std::make_tuple
+#include <tuple>  //  std::tuple
 #include <type_traits>  //  std::is_base_of, std::false_type, std::true_type
 
 #include "functional/cxx_universal.h"
@@ -356,7 +356,7 @@ namespace sqlite_orm {
 
             template<class... Rs>
             foreign_key_t<std::tuple<Cs...>, std::tuple<Rs...>> references(Rs... refs) {
-                return {std::move(this->columns), std::make_tuple(std::forward<Rs>(refs)...)};
+                return {std::move(this->columns), {std::forward<Rs>(refs)...}};
             }
         };
 #endif
@@ -476,17 +476,16 @@ namespace sqlite_orm {
         };
 
         template<class T>
-        using is_constraint = mpl::invoke_t<mpl::disjunction<check_if<is_primary_key>,
-                                                             check_if<is_foreign_key>,
-                                                             check_if_is_type<null_t>,
-                                                             check_if_is_type<not_null_t>,
-                                                             check_if_is_type<unindexed_t>,
-                                                             check_if_is_template<unique_t>,
-                                                             check_if_is_template<default_t>,
-                                                             check_if_is_template<check_t>,
-                                                             check_if_is_type<collate_constraint_t>,
-                                                             check_if<is_generated_always>>,
-                                            T>;
+        using is_column_constraint = mpl::invoke_t<mpl::disjunction<check_if<is_primary_key>,
+                                                                    check_if_is_type<null_t>,
+                                                                    check_if_is_type<not_null_t>,
+                                                                    check_if_is_template<unique_t>,
+                                                                    check_if_is_template<default_t>,
+                                                                    check_if_is_template<check_t>,
+                                                                    check_if_is_type<collate_constraint_t>,
+                                                                    check_if<is_generated_always>,
+                                                                    check_if_is_type<unindexed_t>>,
+                                                   T>;
     }
 
 #if SQLITE_VERSION_NUMBER >= 3031000
@@ -500,32 +499,35 @@ namespace sqlite_orm {
         return {std::move(expression), false, internal::basic_generated_always::storage_type::not_specified};
     }
 #endif
-#if SQLITE_VERSION_NUMBER >= 3006019
 
+#if SQLITE_VERSION_NUMBER >= 3006019
     /**
      *  FOREIGN KEY constraint construction function that takes member pointer as argument
      *  Available in SQLite 3.6.19 or higher
      */
     template<class... Cs>
     internal::foreign_key_intermediate_t<Cs...> foreign_key(Cs... columns) {
-        return {std::make_tuple(std::forward<Cs>(columns)...)};
+        return {{std::forward<Cs>(columns)...}};
     }
 #endif
 
     /**
-     *  UNIQUE constraint builder function.
+     *  UNIQUE table constraint builder function.
      */
     template<class... Args>
     internal::unique_t<Args...> unique(Args... args) {
         return {{std::forward<Args>(args)...}};
     }
 
+    /**
+     *  UNIQUE column constraint builder function.
+     */
     inline internal::unique_t<> unique() {
         return {{}};
     }
 
     /**
-     *  UNINDEXED constraint builder function. Used in FTS virtual tables.
+     *  UNINDEXED column constraint builder function. Used in FTS virtual tables.
      * 
      *  https://www.sqlite.org/fts5.html#the_unindexed_column_option
      */
@@ -534,7 +536,7 @@ namespace sqlite_orm {
     }
 
     /**
-     *  prefix=N constraint builder function. Used in FTS virtual tables.
+     *  prefix=N table constraint builder function. Used in FTS virtual tables.
      * 
      *  https://www.sqlite.org/fts5.html#prefix_indexes
      */
@@ -543,11 +545,17 @@ namespace sqlite_orm {
         return {std::move(value)};
     }
 
+    /**
+     *  PRIMARY KEY table constraint builder function.
+     */
     template<class... Cs>
     internal::primary_key_t<Cs...> primary_key(Cs... cs) {
-        return {std::make_tuple(std::forward<Cs>(cs)...)};
+        return {{std::forward<Cs>(cs)...}};
     }
 
+    /**
+     *  PRIMARY KEY column constraint builder function.
+     */
     inline internal::primary_key_t<> primary_key() {
         return {{}};
     }

--- a/dev/constraints.h
+++ b/dev/constraints.h
@@ -481,7 +481,6 @@ namespace sqlite_orm {
                                                              check_if_is_type<null_t>,
                                                              check_if_is_type<not_null_t>,
                                                              check_if_is_type<unindexed_t>,
-                                                             check_if_is_template<prefix_t>,
                                                              check_if_is_template<unique_t>,
                                                              check_if_is_template<default_t>,
                                                              check_if_is_template<check_t>,

--- a/dev/schema/column.h
+++ b/dev/schema/column.h
@@ -149,7 +149,7 @@ namespace sqlite_orm {
     template<class M, class... Op, internal::satisfies<std::is_member_object_pointer, M> = true>
     internal::column_t<M, internal::empty_setter, Op...>
     make_column(std::string name, M memberPointer, Op... constraints) {
-        static_assert(polyfill::conjunction_v<internal::is_constraint<Op>...>, "Incorrect constraints pack");
+        static_assert(polyfill::conjunction_v<internal::is_column_constraint<Op>...>, "Incorrect constraints pack");
 
         // attention: do not use `std::make_tuple()` for constructing the tuple member `[[no_unique_address]] column_constraints::constraints`,
         // as this will lead to UB with Clang on MinGW!
@@ -168,7 +168,7 @@ namespace sqlite_orm {
     internal::column_t<G, S, Op...> make_column(std::string name, S setter, G getter, Op... constraints) {
         static_assert(std::is_same<internal::setter_field_type_t<S>, internal::getter_field_type_t<G>>::value,
                       "Getter and setter must get and set same data type");
-        static_assert(polyfill::conjunction_v<internal::is_constraint<Op>...>, "Incorrect constraints pack");
+        static_assert(polyfill::conjunction_v<internal::is_column_constraint<Op>...>, "Incorrect constraints pack");
 
         // attention: do not use `std::make_tuple()` for constructing the tuple member `[[no_unique_address]] column_constraints::constraints`,
         // as this will lead to UB with Clang on MinGW!
@@ -187,7 +187,7 @@ namespace sqlite_orm {
     internal::column_t<G, S, Op...> make_column(std::string name, G getter, S setter, Op... constraints) {
         static_assert(std::is_same<internal::setter_field_type_t<S>, internal::getter_field_type_t<G>>::value,
                       "Getter and setter must get and set same data type");
-        static_assert(polyfill::conjunction_v<internal::is_constraint<Op>...>, "Incorrect constraints pack");
+        static_assert(polyfill::conjunction_v<internal::is_column_constraint<Op>...>, "Incorrect constraints pack");
 
         // attention: do not use `std::make_tuple()` for constructing the tuple member `[[no_unique_address]] column_constraints::constraints`,
         // as this will lead to UB with Clang on MinGW!

--- a/dev/schema/table.h
+++ b/dev/schema/table.h
@@ -28,6 +28,16 @@ namespace sqlite_orm {
 
     namespace internal {
 
+        template<class T>
+        using is_table_element_or_constraint = mpl::invoke_t<mpl::disjunction<check_if<is_column>,
+                                                                              check_if<is_primary_key>,
+                                                                              check_if<is_foreign_key>,
+                                                                              check_if_is_template<index_t>,
+                                                                              check_if_is_template<unique_t>,
+                                                                              check_if_is_template<check_t>,
+                                                                              check_if_is_template<prefix_t>>,
+                                                             T>;
+
 #ifdef SQLITE_ORM_WITH_CTE
         /**
          *  A subselect mapper's CTE moniker, void otherwise.
@@ -402,11 +412,17 @@ namespace sqlite_orm {
 
     template<class... Cs, class T = typename std::tuple_element_t<0, std::tuple<Cs...>>::object_type>
     internal::using_fts5_t<T, Cs...> using_fts5(Cs... columns) {
+        static_assert(polyfill::conjunction_v<internal::is_table_element_or_constraint<Cs>...>,
+                      "Incorrect table elements or constraints");
+
         SQLITE_ORM_CLANG_SUPPRESS_MISSING_BRACES(return {std::make_tuple(std::forward<Cs>(columns)...)});
     }
 
     template<class T, class... Cs>
     internal::using_fts5_t<T, Cs...> using_fts5(Cs... columns) {
+        static_assert(polyfill::conjunction_v<internal::is_table_element_or_constraint<Cs>...>,
+                      "Incorrect table elements or constraints");
+
         SQLITE_ORM_CLANG_SUPPRESS_MISSING_BRACES(return {std::make_tuple(std::forward<Cs>(columns)...)});
     }
 
@@ -417,6 +433,9 @@ namespace sqlite_orm {
      */
     template<class... Cs, class T = typename std::tuple_element_t<0, std::tuple<Cs...>>::object_type>
     internal::table_t<T, false, Cs...> make_table(std::string name, Cs... args) {
+        static_assert(polyfill::conjunction_v<internal::is_table_element_or_constraint<Cs>...>,
+                      "Incorrect table elements or constraints");
+
         SQLITE_ORM_CLANG_SUPPRESS_MISSING_BRACES(
             return {std::move(name), std::make_tuple<Cs...>(std::forward<Cs>(args)...)});
     }
@@ -428,6 +447,9 @@ namespace sqlite_orm {
      */
     template<class T, class... Cs>
     internal::table_t<T, false, Cs...> make_table(std::string name, Cs... args) {
+        static_assert(polyfill::conjunction_v<internal::is_table_element_or_constraint<Cs>...>,
+                      "Incorrect table elements or constraints");
+
         SQLITE_ORM_CLANG_SUPPRESS_MISSING_BRACES(
             return {std::move(name), std::make_tuple<Cs...>(std::forward<Cs>(args)...)});
     }

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -841,7 +841,7 @@ namespace sqlite_orm {
 #include <system_error>  //  std::system_error
 #include <ostream>  //  std::ostream
 #include <string>  //  std::string
-#include <tuple>  //  std::tuple, std::make_tuple
+#include <tuple>  //  std::tuple
 #include <type_traits>  //  std::is_base_of, std::false_type, std::true_type
 
 // #include "functional/cxx_universal.h"
@@ -2016,7 +2016,7 @@ namespace sqlite_orm {
 
             template<class... Rs>
             foreign_key_t<std::tuple<Cs...>, std::tuple<Rs...>> references(Rs... refs) {
-                return {std::move(this->columns), std::make_tuple(std::forward<Rs>(refs)...)};
+                return {std::move(this->columns), {std::forward<Rs>(refs)...}};
             }
         };
 #endif
@@ -2136,17 +2136,16 @@ namespace sqlite_orm {
         };
 
         template<class T>
-        using is_constraint = mpl::invoke_t<mpl::disjunction<check_if<is_primary_key>,
-                                                             check_if<is_foreign_key>,
-                                                             check_if_is_type<null_t>,
-                                                             check_if_is_type<not_null_t>,
-                                                             check_if_is_type<unindexed_t>,
-                                                             check_if_is_template<unique_t>,
-                                                             check_if_is_template<default_t>,
-                                                             check_if_is_template<check_t>,
-                                                             check_if_is_type<collate_constraint_t>,
-                                                             check_if<is_generated_always>>,
-                                            T>;
+        using is_column_constraint = mpl::invoke_t<mpl::disjunction<check_if<is_primary_key>,
+                                                                    check_if_is_type<null_t>,
+                                                                    check_if_is_type<not_null_t>,
+                                                                    check_if_is_template<unique_t>,
+                                                                    check_if_is_template<default_t>,
+                                                                    check_if_is_template<check_t>,
+                                                                    check_if_is_type<collate_constraint_t>,
+                                                                    check_if<is_generated_always>,
+                                                                    check_if_is_type<unindexed_t>>,
+                                                   T>;
     }
 
 #if SQLITE_VERSION_NUMBER >= 3031000
@@ -2160,32 +2159,35 @@ namespace sqlite_orm {
         return {std::move(expression), false, internal::basic_generated_always::storage_type::not_specified};
     }
 #endif
-#if SQLITE_VERSION_NUMBER >= 3006019
 
+#if SQLITE_VERSION_NUMBER >= 3006019
     /**
      *  FOREIGN KEY constraint construction function that takes member pointer as argument
      *  Available in SQLite 3.6.19 or higher
      */
     template<class... Cs>
     internal::foreign_key_intermediate_t<Cs...> foreign_key(Cs... columns) {
-        return {std::make_tuple(std::forward<Cs>(columns)...)};
+        return {{std::forward<Cs>(columns)...}};
     }
 #endif
 
     /**
-     *  UNIQUE constraint builder function.
+     *  UNIQUE table constraint builder function.
      */
     template<class... Args>
     internal::unique_t<Args...> unique(Args... args) {
         return {{std::forward<Args>(args)...}};
     }
 
+    /**
+     *  UNIQUE column constraint builder function.
+     */
     inline internal::unique_t<> unique() {
         return {{}};
     }
 
     /**
-     *  UNINDEXED constraint builder function. Used in FTS virtual tables.
+     *  UNINDEXED column constraint builder function. Used in FTS virtual tables.
      * 
      *  https://www.sqlite.org/fts5.html#the_unindexed_column_option
      */
@@ -2194,7 +2196,7 @@ namespace sqlite_orm {
     }
 
     /**
-     *  prefix=N constraint builder function. Used in FTS virtual tables.
+     *  prefix=N table constraint builder function. Used in FTS virtual tables.
      * 
      *  https://www.sqlite.org/fts5.html#prefix_indexes
      */
@@ -2203,11 +2205,17 @@ namespace sqlite_orm {
         return {std::move(value)};
     }
 
+    /**
+     *  PRIMARY KEY table constraint builder function.
+     */
     template<class... Cs>
     internal::primary_key_t<Cs...> primary_key(Cs... cs) {
-        return {std::make_tuple(std::forward<Cs>(cs)...)};
+        return {{std::forward<Cs>(cs)...}};
     }
 
+    /**
+     *  PRIMARY KEY column constraint builder function.
+     */
     inline internal::primary_key_t<> primary_key() {
         return {{}};
     }
@@ -2985,7 +2993,7 @@ namespace sqlite_orm {
     template<class M, class... Op, internal::satisfies<std::is_member_object_pointer, M> = true>
     internal::column_t<M, internal::empty_setter, Op...>
     make_column(std::string name, M memberPointer, Op... constraints) {
-        static_assert(polyfill::conjunction_v<internal::is_constraint<Op>...>, "Incorrect constraints pack");
+        static_assert(polyfill::conjunction_v<internal::is_column_constraint<Op>...>, "Incorrect constraints pack");
 
         // attention: do not use `std::make_tuple()` for constructing the tuple member `[[no_unique_address]] column_constraints::constraints`,
         // as this will lead to UB with Clang on MinGW!
@@ -3004,7 +3012,7 @@ namespace sqlite_orm {
     internal::column_t<G, S, Op...> make_column(std::string name, S setter, G getter, Op... constraints) {
         static_assert(std::is_same<internal::setter_field_type_t<S>, internal::getter_field_type_t<G>>::value,
                       "Getter and setter must get and set same data type");
-        static_assert(polyfill::conjunction_v<internal::is_constraint<Op>...>, "Incorrect constraints pack");
+        static_assert(polyfill::conjunction_v<internal::is_column_constraint<Op>...>, "Incorrect constraints pack");
 
         // attention: do not use `std::make_tuple()` for constructing the tuple member `[[no_unique_address]] column_constraints::constraints`,
         // as this will lead to UB with Clang on MinGW!
@@ -3023,7 +3031,7 @@ namespace sqlite_orm {
     internal::column_t<G, S, Op...> make_column(std::string name, G getter, S setter, Op... constraints) {
         static_assert(std::is_same<internal::setter_field_type_t<S>, internal::getter_field_type_t<G>>::value,
                       "Getter and setter must get and set same data type");
-        static_assert(polyfill::conjunction_v<internal::is_constraint<Op>...>, "Incorrect constraints pack");
+        static_assert(polyfill::conjunction_v<internal::is_column_constraint<Op>...>, "Incorrect constraints pack");
 
         // attention: do not use `std::make_tuple()` for constructing the tuple member `[[no_unique_address]] column_constraints::constraints`,
         // as this will lead to UB with Clang on MinGW!
@@ -11260,6 +11268,16 @@ namespace sqlite_orm {
 
     namespace internal {
 
+        template<class T>
+        using is_table_element_or_constraint = mpl::invoke_t<mpl::disjunction<check_if<is_column>,
+                                                                              check_if<is_primary_key>,
+                                                                              check_if<is_foreign_key>,
+                                                                              check_if_is_template<index_t>,
+                                                                              check_if_is_template<unique_t>,
+                                                                              check_if_is_template<check_t>,
+                                                                              check_if_is_template<prefix_t>>,
+                                                             T>;
+
 #ifdef SQLITE_ORM_WITH_CTE
         /**
          *  A subselect mapper's CTE moniker, void otherwise.
@@ -11634,11 +11652,17 @@ namespace sqlite_orm {
 
     template<class... Cs, class T = typename std::tuple_element_t<0, std::tuple<Cs...>>::object_type>
     internal::using_fts5_t<T, Cs...> using_fts5(Cs... columns) {
+        static_assert(polyfill::conjunction_v<internal::is_table_element_or_constraint<Cs>...>,
+                      "Incorrect table elements or constraints");
+
         SQLITE_ORM_CLANG_SUPPRESS_MISSING_BRACES(return {std::make_tuple(std::forward<Cs>(columns)...)});
     }
 
     template<class T, class... Cs>
     internal::using_fts5_t<T, Cs...> using_fts5(Cs... columns) {
+        static_assert(polyfill::conjunction_v<internal::is_table_element_or_constraint<Cs>...>,
+                      "Incorrect table elements or constraints");
+
         SQLITE_ORM_CLANG_SUPPRESS_MISSING_BRACES(return {std::make_tuple(std::forward<Cs>(columns)...)});
     }
 
@@ -11649,6 +11673,9 @@ namespace sqlite_orm {
      */
     template<class... Cs, class T = typename std::tuple_element_t<0, std::tuple<Cs...>>::object_type>
     internal::table_t<T, false, Cs...> make_table(std::string name, Cs... args) {
+        static_assert(polyfill::conjunction_v<internal::is_table_element_or_constraint<Cs>...>,
+                      "Incorrect table elements or constraints");
+
         SQLITE_ORM_CLANG_SUPPRESS_MISSING_BRACES(
             return {std::move(name), std::make_tuple<Cs...>(std::forward<Cs>(args)...)});
     }
@@ -11660,6 +11687,9 @@ namespace sqlite_orm {
      */
     template<class T, class... Cs>
     internal::table_t<T, false, Cs...> make_table(std::string name, Cs... args) {
+        static_assert(polyfill::conjunction_v<internal::is_table_element_or_constraint<Cs>...>,
+                      "Incorrect table elements or constraints");
+
         SQLITE_ORM_CLANG_SUPPRESS_MISSING_BRACES(
             return {std::move(name), std::make_tuple<Cs...>(std::forward<Cs>(args)...)});
     }

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -2141,7 +2141,6 @@ namespace sqlite_orm {
                                                              check_if_is_type<null_t>,
                                                              check_if_is_type<not_null_t>,
                                                              check_if_is_type<unindexed_t>,
-                                                             check_if_is_template<prefix_t>,
                                                              check_if_is_template<unique_t>,
                                                              check_if_is_template<default_t>,
                                                              check_if_is_template<check_t>,


### PR DESCRIPTION
Introduces the checking of elements and constraints that are passed to the table factory functions.