### PR TITLE
Improvements to the MPL and checking column constraints

### DIFF
--- a/dev/alias.h
+++ b/dev/alias.h
@@ -9,6 +9,7 @@
 #endif
 
 #include "functional/cxx_type_traits_polyfill.h"
+#include "functional/mpl/conditional.h"
 #include "functional/cstring_literal.h"
 #include "type_traits.h"
 #include "alias_traits.h"
@@ -228,7 +229,7 @@ namespace sqlite_orm {
         static_assert(is_field_of_v<F O::*, aliased_type>, "Column must be from aliased table");
 
         using C1 =
-            std::conditional_t<std::is_same<O, aliased_type>::value, F O::*, column_pointer<aliased_type, F O::*>>;
+            mpl::conditional_t<std::is_same<O, aliased_type>::value, F O::*, column_pointer<aliased_type, F O::*>>;
         return alias_column_t<A, C1>{C1{field}};
     }
 

--- a/dev/arithmetic_tag.h
+++ b/dev/arithmetic_tag.h
@@ -1,5 +1,7 @@
 #pragma once
-#include <type_traits>
+#include <type_traits>  // std::is_integral
+
+#include "functional/mpl/conditional.h"
 
 namespace sqlite_orm {
 
@@ -12,9 +14,9 @@ namespace sqlite_orm {
 
     template<class V>
     using arithmetic_tag_t =
-        std::conditional_t<std::is_integral<V>::value,
+        mpl::conditional_t<std::is_integral<V>::value,
                            // Integer class
-                           std::conditional_t<sizeof(V) <= sizeof(int), int_or_smaller_tag, bigint_tag>,
+                           mpl::conditional_t<sizeof(V) <= sizeof(int), int_or_smaller_tag, bigint_tag>,
                            // Floating-point class
                            real_tag>;
 }

--- a/dev/constraints.h
+++ b/dev/constraints.h
@@ -477,19 +477,16 @@ namespace sqlite_orm {
         };
 
         template<class T>
-        using is_column_constraint =
-            mpl::invoke_t<mpl::disjunction<mpl::conjunction<check_if<is_primary_key>,
-                                                            check_if_nested_is_type<std::tuple<>, columns_tuple_t>>,
-                                           check_if_is_type<null_t>,
-                                           check_if_is_type<not_null_t>,
-                                           mpl::conjunction<check_if_is_template<unique_t>,
-                                                            check_if_nested_is_type<std::tuple<>, columns_tuple_t>>,
-                                           check_if_is_template<default_t>,
-                                           check_if_is_template<check_t>,
-                                           check_if_is_type<collate_constraint_t>,
-                                           check_if<is_generated_always>,
-                                           check_if_is_type<unindexed_t>>,
-                          T>;
+        using is_column_constraint = mpl::invoke_t<mpl::disjunction<check_if<std::is_base_of, primary_key_t<>>,
+                                                                    check_if_is_type<null_t>,
+                                                                    check_if_is_type<not_null_t>,
+                                                                    check_if_is_type<unique_t<>>,
+                                                                    check_if_is_template<default_t>,
+                                                                    check_if_is_template<check_t>,
+                                                                    check_if_is_type<collate_constraint_t>,
+                                                                    check_if<is_generated_always>,
+                                                                    check_if_is_type<unindexed_t>>,
+                                                   T>;
     }
 
 #if SQLITE_VERSION_NUMBER >= 3031000

--- a/dev/constraints.h
+++ b/dev/constraints.h
@@ -464,28 +464,32 @@ namespace sqlite_orm {
         /**
          * PRIMARY KEY INSERTABLE traits.
          */
-        template<typename T>
+        template<typename Column>
         struct is_primary_key_insertable
             : polyfill::disjunction<
-                  mpl::invoke_t<mpl::disjunction<check_if_has_template<default_t>,
-                                                 check_if_has_template<primary_key_with_autoincrement>>,
-                                constraints_type_t<T>>,
-                  std::is_base_of<integer_printer, type_printer<field_type_t<T>>>> {
+                  mpl::invoke_t<mpl::disjunction<check_if_has_template<primary_key_with_autoincrement>,
+                                                 check_if_has_template<default_t>>,
+                                constraints_type_t<Column>>,
+                  std::is_base_of<integer_printer, type_printer<field_type_t<Column>>>> {
 
-            static_assert(tuple_has<constraints_type_t<T>, is_primary_key>::value, "an unexpected type was passed");
+            static_assert(tuple_has<constraints_type_t<Column>, is_primary_key>::value,
+                          "an unexpected type was passed");
         };
 
         template<class T>
-        using is_column_constraint = mpl::invoke_t<mpl::disjunction<check_if<is_primary_key>,
-                                                                    check_if_is_type<null_t>,
-                                                                    check_if_is_type<not_null_t>,
-                                                                    check_if_is_template<unique_t>,
-                                                                    check_if_is_template<default_t>,
-                                                                    check_if_is_template<check_t>,
-                                                                    check_if_is_type<collate_constraint_t>,
-                                                                    check_if<is_generated_always>,
-                                                                    check_if_is_type<unindexed_t>>,
-                                                   T>;
+        using is_column_constraint =
+            mpl::invoke_t<mpl::disjunction<mpl::conjunction<check_if<is_primary_key>,
+                                                            check_if_nested_is_type<std::tuple<>, columns_tuple_t>>,
+                                           check_if_is_type<null_t>,
+                                           check_if_is_type<not_null_t>,
+                                           mpl::conjunction<check_if_is_template<unique_t>,
+                                                            check_if_nested_is_type<std::tuple<>, columns_tuple_t>>,
+                                           check_if_is_template<default_t>,
+                                           check_if_is_template<check_t>,
+                                           check_if_is_type<collate_constraint_t>,
+                                           check_if<is_generated_always>,
+                                           check_if_is_type<unindexed_t>>,
+                          T>;
     }
 
 #if SQLITE_VERSION_NUMBER >= 3031000

--- a/dev/core_functions.h
+++ b/dev/core_functions.h
@@ -7,6 +7,7 @@
 #include <vector>  //  std::vector
 
 #include "functional/cxx_type_traits_polyfill.h"
+#include "functional/mpl/conditional.h"
 #include "is_base_of_template.h"
 #include "tuple_helper/tuple_traits.h"
 #include "conditions.h"
@@ -1672,7 +1673,7 @@ namespace sqlite_orm {
      */
     template<class R = void, class... Args>
     auto coalesce(Args... args)
-        -> internal::built_in_function_t<typename std::conditional_t<  //  choose R or common type
+        -> internal::built_in_function_t<typename mpl::conditional_t<  //  choose R or common type
                                              std::is_void<R>::value,
                                              std::common_type<internal::field_type_or_type_t<Args>...>,
                                              polyfill::type_identity<R>>::type,
@@ -1686,7 +1687,7 @@ namespace sqlite_orm {
      */
     template<class R = void, class X, class Y>
     auto ifnull(X x, Y y) -> internal::built_in_function_t<
-        typename std::conditional_t<  //  choose R or common type
+        typename mpl::conditional_t<  //  choose R or common type
             std::is_void<R>::value,
             std::common_type<internal::field_type_or_type_t<X>, internal::field_type_or_type_t<Y>>,
             polyfill::type_identity<R>>::type,

--- a/dev/function.h
+++ b/dev/function.h
@@ -10,6 +10,7 @@
 
 #include "functional/cxx_universal.h"
 #include "functional/cxx_type_traits_polyfill.h"
+#include "functional/mpl/conditional.h"
 #include "functional/cstring_literal.h"
 #include "functional/function_traits.h"
 #include "type_traits.h"
@@ -267,12 +268,12 @@ namespace sqlite_orm {
 #endif
 
         template<size_t I, class FnArg, class CallArg>
-        SQLITE_ORM_CONSTEVAL bool validate_pointer_value_type(std::false_type) {
+        SQLITE_ORM_CONSTEVAL bool validate_pointer_value_type(polyfill::bool_constant<false>) {
             return true;
         }
 
         template<size_t I, class FnArg, class CallArg>
-        SQLITE_ORM_CONSTEVAL bool validate_pointer_value_type(std::true_type) {
+        SQLITE_ORM_CONSTEVAL bool validate_pointer_value_type(polyfill::bool_constant<true>) {
             return is_same_pvt_v<I, FnArg, CallArg>;
         }
 

--- a/dev/function.h
+++ b/dev/function.h
@@ -10,7 +10,6 @@
 
 #include "functional/cxx_universal.h"
 #include "functional/cxx_type_traits_polyfill.h"
-#include "functional/mpl/conditional.h"
 #include "functional/cstring_literal.h"
 #include "functional/function_traits.h"
 #include "type_traits.h"
@@ -268,12 +267,12 @@ namespace sqlite_orm {
 #endif
 
         template<size_t I, class FnArg, class CallArg>
-        SQLITE_ORM_CONSTEVAL bool validate_pointer_value_type(polyfill::bool_constant<false>) {
+        SQLITE_ORM_CONSTEVAL bool validate_pointer_value_type(std::false_type) {
             return true;
         }
 
         template<size_t I, class FnArg, class CallArg>
-        SQLITE_ORM_CONSTEVAL bool validate_pointer_value_type(polyfill::bool_constant<true>) {
+        SQLITE_ORM_CONSTEVAL bool validate_pointer_value_type(std::true_type) {
             return is_same_pvt_v<I, FnArg, CallArg>;
         }
 

--- a/dev/functional/cxx_type_traits_polyfill.h
+++ b/dev/functional/cxx_type_traits_polyfill.h
@@ -2,6 +2,7 @@
 #include <type_traits>
 
 #include "cxx_universal.h"
+#include "mpl/conditional.h"
 
 namespace sqlite_orm {
     namespace internal {
@@ -40,7 +41,7 @@ namespace sqlite_orm {
             template<typename B1>
             struct conjunction<B1> : B1 {};
             template<typename B1, typename... Bn>
-            struct conjunction<B1, Bn...> : std::conditional_t<bool(B1::value), conjunction<Bn...>, B1> {};
+            struct conjunction<B1, Bn...> : mpl::conditional_t<bool(B1::value), conjunction<Bn...>, B1> {};
             template<typename... Bs>
             SQLITE_ORM_INLINE_VAR constexpr bool conjunction_v = conjunction<Bs...>::value;
 
@@ -49,7 +50,7 @@ namespace sqlite_orm {
             template<typename B1>
             struct disjunction<B1> : B1 {};
             template<typename B1, typename... Bn>
-            struct disjunction<B1, Bn...> : std::conditional_t<bool(B1::value), B1, disjunction<Bn...>> {};
+            struct disjunction<B1, Bn...> : mpl::conditional_t<bool(B1::value), B1, disjunction<Bn...>> {};
             template<typename... Bs>
             SQLITE_ORM_INLINE_VAR constexpr bool disjunction_v = disjunction<Bs...>::value;
 

--- a/dev/functional/mpl.h
+++ b/dev/functional/mpl.h
@@ -248,12 +248,11 @@ namespace sqlite_orm {
 
                 // match `std::true_type` and one or more remaining
                 template<class... Args, class NextQ, class... RestQ>
-                struct invoke_this_fn<pack<Args...>, std::true_type, NextQ, RestQ...> {
-                    using type = typename invoke_this_fn<pack<Args...>,
-                                                         // access resulting trait::type
-                                                         typename defer<NextQ, Args...>::type::type,
-                                                         RestQ...>::type;
-                };
+                struct invoke_this_fn<pack<Args...>, std::true_type, NextQ, RestQ...>
+                    : invoke_this_fn<pack<Args...>,
+                                     // access resulting trait::type
+                                     typename defer<NextQ, Args...>::type::type,
+                                     RestQ...> {};
 
                 template<class... Args>
                 using fn = typename invoke_this_fn<pack<Args...>,
@@ -284,12 +283,11 @@ namespace sqlite_orm {
 
                 // match `std::false_type` and one or more remaining
                 template<class... Args, class NextQ, class... RestQ>
-                struct invoke_this_fn<pack<Args...>, std::false_type, NextQ, RestQ...> {
-                    using type = typename invoke_this_fn<pack<Args...>,
-                                                         // access resulting trait::type
-                                                         typename defer<NextQ, Args...>::type::type,
-                                                         RestQ...>::type;
-                };
+                struct invoke_this_fn<pack<Args...>, std::false_type, NextQ, RestQ...>
+                    : invoke_this_fn<pack<Args...>,
+                                     // access resulting trait::type
+                                     typename defer<NextQ, Args...>::type::type,
+                                     RestQ...> {};
 
                 template<class... Args>
                 using fn = typename invoke_this_fn<pack<Args...>,

--- a/dev/functional/mpl.h
+++ b/dev/functional/mpl.h
@@ -381,7 +381,7 @@ namespace sqlite_orm {
                                           <sizeof...(T)>
 #endif
                                           ({TraitQ::template fn<typename ProjectQ::template fn<T>>::value...}));
-                    using type = polyfill::index_constant<value>;
+                    using type = polyfill::bool_constant<value>;
                 };
 
                 template<class Pack, class ProjectQ = identity>

--- a/dev/functional/mpl.h
+++ b/dev/functional/mpl.h
@@ -37,6 +37,7 @@
 
 #include "cxx_universal.h"  //  ::size_t
 #include "cxx_type_traits_polyfill.h"
+#include "mpl/conditional.h"
 
 namespace sqlite_orm {
     namespace internal {

--- a/dev/functional/mpl/conditional.h
+++ b/dev/functional/mpl/conditional.h
@@ -1,0 +1,34 @@
+#pragma once
+
+namespace sqlite_orm {
+    namespace internal {
+        namespace mpl {
+
+            /*
+             *  Binary quoted metafunction equivalent to `std::conditional`,
+             *  using an improved implementation in respect to memoization.
+             *  
+             *  Because `conditional` is only typed on a single bool non-type template parameter,
+             *  the compiler only ever needs to memoize 2 instances of this class template.
+             *  The type selection is a nested cheap alias template.
+             */
+            template<bool>
+            struct conditional {
+                template<typename A, typename>
+                using fn = A;
+            };
+
+            template<>
+            struct conditional<false> {
+                template<typename, typename B>
+                using fn = B;
+            };
+
+            // directly invoke `conditional`
+            template<bool v, typename A, typename B>
+            using conditional_t = typename conditional<v>::template fn<A, B>;
+        }
+    }
+
+    namespace mpl = internal::mpl;
+}

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -1531,9 +1531,9 @@ namespace sqlite_orm {
 #ifdef SQLITE_ORM_WITH_CTE
             template<class... CTEs, class T, class... Args>
             auto execute(const prepared_statement_t<with_t<select_t<T, Args...>, CTEs...>>& statement) {
-                using ExprDBOs =
-                    decltype(db_objects_for_expression(this->db_objects,
-                                                       std::declval<with_t<select_t<T, Args...>, CTEs...>>()));
+                using ExprDBOs = decltype(db_objects_for_expression(this->db_objects, statement.expression));
+                // note: it is enough to only use the 'expression DBOs' at compile-time to determine the column results;
+                // because we cannot select objects/structs from a CTE, the permanently defined DBOs are enough.
                 using ColResult = column_result_of_t<ExprDBOs, T>;
                 return _execute_select<ColResult>(statement);
             }

--- a/dev/tuple_helper/tuple_filter.h
+++ b/dev/tuple_helper/tuple_filter.h
@@ -4,6 +4,7 @@
 #include <tuple>  //  std::tuple
 
 #include "../functional/cxx_universal.h"  //  ::size_t
+#include "../functional/mpl/conditional.h"
 #include "../functional/index_sequence_util.h"
 
 namespace sqlite_orm {
@@ -34,7 +35,7 @@ namespace sqlite_orm {
 #ifndef SQLITE_ORM_BROKEN_VARIADIC_PACK_EXPANSION
         template<class Tpl, template<class...> class Pred, template<class...> class Proj, size_t... Idx>
         struct filter_tuple_sequence<Tpl, Pred, Proj, std::index_sequence<Idx...>>
-            : flatten_idxseq<std::conditional_t<Pred<mpl::invoke_fn_t<Proj, std::tuple_element_t<Idx, Tpl>>>::value,
+            : flatten_idxseq<mpl::conditional_t<Pred<mpl::invoke_fn_t<Proj, std::tuple_element_t<Idx, Tpl>>>::value,
                                                 std::index_sequence<Idx>,
                                                 std::index_sequence<>>...> {};
 #else

--- a/examples/common_table_expressions.cpp
+++ b/examples/common_table_expressions.cpp
@@ -99,12 +99,12 @@ void all_integers_between(int from, int end) {
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
         constexpr auto cnt = "cnt"_cte;
         constexpr auto x = "x"_col;
-        auto ast = with(cnt(x).as(union_all(select(from), select(cnt->*x + 1, limit(end)))), select(cnt->*x));
+        auto ast = with_recursive(cnt(x).as(union_all(select(from), select(cnt->*x + 1, limit(end)))), select(cnt->*x));
 #else
         using cnt = decltype(1_ctealias);
         constexpr auto x = colalias_i{};
-        auto ast = with(cte<cnt>(x).as(union_all(select(from), select(column<cnt>(x) + 1, limit(end)))),
-                        select(column<cnt>(x)));
+        auto ast = with_recursive(cte<cnt>(x).as(union_all(select(from), select(column<cnt>(x) + 1, limit(end)))),
+                                  select(column<cnt>(x)));
 #endif
 
         string sql = storage.dump(ast);

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -1135,12 +1135,11 @@ namespace sqlite_orm {
 
                 // match `std::true_type` and one or more remaining
                 template<class... Args, class NextQ, class... RestQ>
-                struct invoke_this_fn<pack<Args...>, std::true_type, NextQ, RestQ...> {
-                    using type = typename invoke_this_fn<pack<Args...>,
-                                                         // access resulting trait::type
-                                                         typename defer<NextQ, Args...>::type::type,
-                                                         RestQ...>::type;
-                };
+                struct invoke_this_fn<pack<Args...>, std::true_type, NextQ, RestQ...>
+                    : invoke_this_fn<pack<Args...>,
+                                     // access resulting trait::type
+                                     typename defer<NextQ, Args...>::type::type,
+                                     RestQ...> {};
 
                 template<class... Args>
                 using fn = typename invoke_this_fn<pack<Args...>,
@@ -1171,12 +1170,11 @@ namespace sqlite_orm {
 
                 // match `std::false_type` and one or more remaining
                 template<class... Args, class NextQ, class... RestQ>
-                struct invoke_this_fn<pack<Args...>, std::false_type, NextQ, RestQ...> {
-                    using type = typename invoke_this_fn<pack<Args...>,
-                                                         // access resulting trait::type
-                                                         typename defer<NextQ, Args...>::type::type,
-                                                         RestQ...>::type;
-                };
+                struct invoke_this_fn<pack<Args...>, std::false_type, NextQ, RestQ...>
+                    : invoke_this_fn<pack<Args...>,
+                                     // access resulting trait::type
+                                     typename defer<NextQ, Args...>::type::type,
+                                     RestQ...> {};
 
                 template<class... Args>
                 using fn = typename invoke_this_fn<pack<Args...>,
@@ -16213,6 +16211,10 @@ namespace sqlite_orm {
                 std::ostringstream ss;
                 ss << "integrity_check(" << n << ")" << std::flush;
                 return this->get_pragma<std::vector<std::string>>(ss.str());
+            }
+
+            std::vector<std::string> quick_check() {
+                return this->get_pragma<std::vector<std::string>>("quick_check");
             }
 
             // will include generated columns in response as opposed to table_info

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -1268,7 +1268,7 @@ namespace sqlite_orm {
                                           <sizeof...(T)>
 #endif
                                           ({TraitQ::template fn<typename ProjectQ::template fn<T>>::value...}));
-                    using type = polyfill::index_constant<value>;
+                    using type = polyfill::bool_constant<value>;
                 };
 
                 template<class Pack, class ProjectQ = identity>

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -12421,8 +12421,6 @@ namespace sqlite_orm {
 
 // #include "functional/cxx_type_traits_polyfill.h"
 
-// #include "functional/mpl/conditional.h"
-
 // #include "functional/cstring_literal.h"
 
 // #include "functional/function_traits.h"
@@ -12768,12 +12766,12 @@ namespace sqlite_orm {
 #endif
 
         template<size_t I, class FnArg, class CallArg>
-        SQLITE_ORM_CONSTEVAL bool validate_pointer_value_type(polyfill::bool_constant<false>) {
+        SQLITE_ORM_CONSTEVAL bool validate_pointer_value_type(std::false_type) {
             return true;
         }
 
         template<size_t I, class FnArg, class CallArg>
-        SQLITE_ORM_CONSTEVAL bool validate_pointer_value_type(polyfill::bool_constant<true>) {
+        SQLITE_ORM_CONSTEVAL bool validate_pointer_value_type(std::true_type) {
             return is_same_pvt_v<I, FnArg, CallArg>;
         }
 

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -913,7 +913,7 @@ namespace sqlite_orm {
  *  - "higher order" denotes a metafunction that operates on another metafunction (i.e. takes it as an argument).
  */
 
-#include <type_traits>  //  std::enable_if, std::is_same
+#include <type_traits>  //  std::true_type, std::false_type, std::is_same, std::negation, std::conjunction, std::disjunction
 #ifdef SQLITE_ORM_RELAXED_CONSTEXPR_SUPPORTED
 #include <initializer_list>
 #else
@@ -947,6 +947,9 @@ namespace sqlite_orm {
             template<class T>
             struct is_quoted_metafuntion : polyfill::bool_constant<is_quoted_metafuntion_v<T>> {};
 
+            /*  
+             *  Type pack.
+             */
             template<class...>
             struct pack {};
 
@@ -1122,11 +1125,12 @@ namespace sqlite_orm {
             template<class FirstQ, class... TraitQ>
             struct conjunction<FirstQ, TraitQ...> {
                 // match last or `std::false_type`
-                template<class ArgPack, class R, class...>
+                template<class ArgPack, class ResultTrait, class...>
                 struct invoke_this_fn {
-                    static_assert(std::is_same<R, std::true_type>::value || std::is_same<R, std::false_type>::value,
-                                  "Trait result must be a std::bool_constant");
-                    using type = R;
+                    static_assert(std::is_same<ResultTrait, std::true_type>::value ||
+                                      std::is_same<ResultTrait, std::false_type>::value,
+                                  "Resulting trait must be a std::bool_constant");
+                    using type = ResultTrait;
                 };
 
                 // match `std::true_type` and one or more remaining
@@ -1157,11 +1161,12 @@ namespace sqlite_orm {
             template<class FirstQ, class... TraitQ>
             struct disjunction<FirstQ, TraitQ...> {
                 // match last or `std::true_type`
-                template<class ArgPack, class R, class...>
+                template<class ArgPack, class ResultTrait, class...>
                 struct invoke_this_fn {
-                    static_assert(std::is_same<R, std::true_type>::value || std::is_same<R, std::false_type>::value,
-                                  "Trait result must be a std::bool_constant");
-                    using type = R;
+                    static_assert(std::is_same<ResultTrait, std::true_type>::value ||
+                                      std::is_same<ResultTrait, std::false_type>::value,
+                                  "Resulting trait must be a std::bool_constant");
+                    using type = ResultTrait;
                 };
 
                 // match `std::false_type` and one or more remaining
@@ -1348,8 +1353,9 @@ namespace sqlite_orm {
         /*
          *  Quoted trait metafunction that checks if a type has the specified trait.
          */
-        template<template<class...> class TraitFn>
-        using check_if = mpl::quote_fn<TraitFn>;
+        template<template<class...> class TraitFn, class... Bound>
+        using check_if =
+            mpl::conditional_t<sizeof...(Bound) == 0, mpl::quote_fn<TraitFn>, mpl::bind_front_fn<TraitFn, Bound...>>;
 
         /*
          *  Quoted trait metafunction that checks if a type doesn't have the specified trait.
@@ -1359,16 +1365,10 @@ namespace sqlite_orm {
 
         /*
          *  Quoted trait metafunction that checks if a type is the same as the specified type.
+         *  Commonly used named abbreviation for `check_if<std::is_same, Type>`.
          */
         template<class Type>
         using check_if_is_type = mpl::bind_front_fn<std::is_same, Type>;
-
-        /*
-         *  Quoted trait metafunction that checks if a nested type is the same as the specified type.
-         *  The 'nested' type is returned by the passed metafunction.
-         */
-        template<class Type, template<class...> class Fn>
-        using check_if_nested_is_type = mpl::pass_result_of_fn<check_if_is_type<Type>, Fn>;
 
         /*
          *  Quoted trait metafunction that checks if a type's template matches the specified template
@@ -2244,19 +2244,16 @@ namespace sqlite_orm {
         };
 
         template<class T>
-        using is_column_constraint =
-            mpl::invoke_t<mpl::disjunction<mpl::conjunction<check_if<is_primary_key>,
-                                                            check_if_nested_is_type<std::tuple<>, columns_tuple_t>>,
-                                           check_if_is_type<null_t>,
-                                           check_if_is_type<not_null_t>,
-                                           mpl::conjunction<check_if_is_template<unique_t>,
-                                                            check_if_nested_is_type<std::tuple<>, columns_tuple_t>>,
-                                           check_if_is_template<default_t>,
-                                           check_if_is_template<check_t>,
-                                           check_if_is_type<collate_constraint_t>,
-                                           check_if<is_generated_always>,
-                                           check_if_is_type<unindexed_t>>,
-                          T>;
+        using is_column_constraint = mpl::invoke_t<mpl::disjunction<check_if<std::is_base_of, primary_key_t<>>,
+                                                                    check_if_is_type<null_t>,
+                                                                    check_if_is_type<not_null_t>,
+                                                                    check_if_is_type<unique_t<>>,
+                                                                    check_if_is_template<default_t>,
+                                                                    check_if_is_template<check_t>,
+                                                                    check_if_is_type<collate_constraint_t>,
+                                                                    check_if<is_generated_always>,
+                                                                    check_if_is_type<unindexed_t>>,
+                                                   T>;
     }
 
 #if SQLITE_VERSION_NUMBER >= 3031000

--- a/tests/static_tests/functional/mpl.cpp
+++ b/tests/static_tests/functional/mpl.cpp
@@ -52,13 +52,26 @@ TEST_CASE("mpl") {
                                        std::index_sequence<>>::value);
     STATIC_REQUIRE_FALSE(
         mpl::invoke_t<mpl::conjunction<check_if_names_value_type, check_if_same_type<int>>, int>::value);
+    // test short-circuited evaluation: `int` doesn't have a nested `value_type` typename
+    STATIC_REQUIRE_FALSE(
+        mpl::invoke_t<
+            mpl::conjunction<check_if_same_type<long>, mpl::pass_result_of_fn<check_if_same_type<int>, value_type_t>>,
+            int>::value);
     STATIC_REQUIRE_FALSE(mpl::invoke_t<mpl::disjunction<>>::value);
     STATIC_REQUIRE(mpl::invoke_t<mpl::disjunction<check_if_same_type<int>>, int>::value);
     STATIC_REQUIRE(mpl::invoke_t<mpl::disjunction<check_if_same_template, check_if_names_value_type>,
                                  std::index_sequence<>>::value);
     STATIC_REQUIRE(mpl::invoke_t<mpl::disjunction<check_if_same_type<int>, check_if_names_value_type>, int>::value);
+    STATIC_REQUIRE(mpl::invoke_t<mpl::disjunction<check_if_names_value_type, check_if_same_type<int>>, int>::value);
     STATIC_REQUIRE(mpl::invoke_t<mpl::disjunction<check_if_names_value_type, check_if_same_type<int>>,
                                  std::index_sequence<>>::value);
+    STATIC_REQUIRE(mpl::invoke_t<mpl::disjunction<check_if_same_type<int>, check_if_names_value_type>,
+                                 std::index_sequence<>>::value);
+    // test short-circuited evaluation: `int` doesn't have a nested `value_type` typename
+    STATIC_REQUIRE(
+        mpl::invoke_t<
+            mpl::disjunction<check_if_same_type<int>, mpl::pass_result_of_fn<check_if_same_type<int>, value_type_t>>,
+            int>::value);
     STATIC_REQUIRE(mpl::invoke_t<mpl::identity, std::true_type>::value);
     STATIC_REQUIRE(mpl::invoke_t<mpl::always<std::true_type>>::value);
     STATIC_REQUIRE(std::is_same<mpl::invoke_t<mpl::pass_extracted_fn_to<mpl::identity>, std::is_void<int>>,

--- a/tests/static_tests/functional/mpl.cpp
+++ b/tests/static_tests/functional/mpl.cpp
@@ -17,9 +17,11 @@ using make_literal_holder = literal_holder<T>;
 template<class T>
 using value_type_t = typename T::value_type;
 
+template<class T>
+using check_if_same_type = mpl::bind_front_fn<std::is_same, T>;
+
 TEST_CASE("mpl") {
     using mpl_is_same = mpl::quote_fn<std::is_same>;
-    using check_if_same_type = mpl::bind_front_fn<std::is_same, int>;
     using check_if_same_template =
         mpl::pass_extracted_fn_to<mpl::bind_front_fn<std::is_same, mpl::quote_fn<std::vector>>>;
     using check_if_names_value_type = mpl::bind_front_higherorder_fn<polyfill::is_detected, value_type_t>;
@@ -39,8 +41,24 @@ TEST_CASE("mpl") {
     STATIC_REQUIRE(mpl::invoke_t<mpl::conjunction_fn<>>::value);
     STATIC_REQUIRE_FALSE(mpl::invoke_t<mpl::disjunction_fn<>>::value);
     STATIC_REQUIRE(mpl::invoke_t<mpl::conjunction_fn<std::is_same, std::is_convertible>, int, int>::value);
+    STATIC_REQUIRE(mpl::invoke_t<mpl::disjunction_fn<std::is_same, std::is_convertible>, int, long>::value);
+    STATIC_REQUIRE(mpl::invoke_t<mpl::conjunction<>>::value);
+    STATIC_REQUIRE(mpl::invoke_t<mpl::conjunction<check_if_same_type<int>>, int>::value);
+    STATIC_REQUIRE(mpl::invoke_t<mpl::conjunction<check_if_same_type<std::index_sequence<>>, check_if_names_value_type>,
+                                 std::index_sequence<>>::value);
+    STATIC_REQUIRE_FALSE(mpl::invoke_t<mpl::conjunction<check_if_same_type<int>, check_if_names_value_type>,
+                                       std::index_sequence<>>::value);
+    STATIC_REQUIRE_FALSE(mpl::invoke_t<mpl::conjunction<check_if_names_value_type, check_if_same_type<int>>,
+                                       std::index_sequence<>>::value);
     STATIC_REQUIRE_FALSE(
-        mpl::invoke_t<mpl::not_<mpl::disjunction_fn<std::is_same, std::is_convertible>>, int, int>::value);
+        mpl::invoke_t<mpl::conjunction<check_if_names_value_type, check_if_same_type<int>>, int>::value);
+    STATIC_REQUIRE_FALSE(mpl::invoke_t<mpl::disjunction<>>::value);
+    STATIC_REQUIRE(mpl::invoke_t<mpl::disjunction<check_if_same_type<int>>, int>::value);
+    STATIC_REQUIRE(mpl::invoke_t<mpl::disjunction<check_if_same_template, check_if_names_value_type>,
+                                 std::index_sequence<>>::value);
+    STATIC_REQUIRE(mpl::invoke_t<mpl::disjunction<check_if_same_type<int>, check_if_names_value_type>, int>::value);
+    STATIC_REQUIRE(mpl::invoke_t<mpl::disjunction<check_if_names_value_type, check_if_same_type<int>>,
+                                 std::index_sequence<>>::value);
     STATIC_REQUIRE(mpl::invoke_t<mpl::identity, std::true_type>::value);
     STATIC_REQUIRE(mpl::invoke_t<mpl::always<std::true_type>>::value);
     STATIC_REQUIRE(std::is_same<mpl::invoke_t<mpl::pass_extracted_fn_to<mpl::identity>, std::is_void<int>>,
@@ -48,7 +66,7 @@ TEST_CASE("mpl") {
     STATIC_REQUIRE(mpl::invoke_t<mpl::pass_extracted_fn_to<mpl_is_same>,
                                  mpl::quote_fn<std::is_void>,
                                  mpl::quote_fn<std::is_void>>::value);
-    STATIC_REQUIRE(mpl::invoke_t<check_if_same_type, int>::value);
+    STATIC_REQUIRE(mpl::invoke_t<check_if_same_type<int>, int>::value);
     STATIC_REQUIRE(mpl::invoke_t<check_if_same_template, std::vector<int>>::value);
     STATIC_REQUIRE_FALSE(mpl::invoke_t<check_if_names_value_type, int>::value);
     STATIC_REQUIRE(mpl::invoke_t<check_if_names_value_type, std::true_type>::value);

--- a/tests/static_tests/functional/mpl.cpp
+++ b/tests/static_tests/functional/mpl.cpp
@@ -75,6 +75,7 @@ TEST_CASE("mpl") {
 
     STATIC_REQUIRE(mpl::invoke_t<internal::check_if<std::is_same>, int, int>::value);
     STATIC_REQUIRE_FALSE(mpl::invoke_t<internal::check_if_not<std::is_same>, int, int>::value);
+    STATIC_REQUIRE(mpl::invoke_t<internal::check_if<std::is_same, predicate_type>, predicate_type>::value);
     STATIC_REQUIRE(mpl::invoke_t<internal::check_if_is_type<predicate_type>, predicate_type>::value);
     STATIC_REQUIRE(mpl::invoke_t<internal::check_if_is_template<std::vector>, std::vector<int>>::value);
 

--- a/tests/static_tests/static_tests_storage_traits.h
+++ b/tests/static_tests/static_tests_storage_traits.h
@@ -80,7 +80,7 @@ namespace sqlite_orm {
                                filter_tuple_sequence_t<elements_type_t<Table>, is_foreign_key>>;
 
             /*
-             *  Implementation note: must be a struct instead of an template alias because the foreign keys tuple
+             *  Implementation note: must be a struct instead of an alias template because the foreign keys tuple
              *  must be hoisted into a named alias, otherwise type replacement may fail for legacy compilers
              *  if an alias template has a dependent expression in it [SQLITE_ORM_BROKEN_VARIADIC_PACK_EXPANSION].
              */

--- a/tests/xdestroy_handling.cpp
+++ b/tests/xdestroy_handling.cpp
@@ -10,7 +10,7 @@ using std::unique_ptr;
 // Wrap std::default_delete in a function
 #ifndef SQLITE_ORM_BROKEN_VARIADIC_PACK_EXPANSION
 template<typename T>
-void delete_default(std::conditional_t<std::is_array<T>::value, std::decay_t<T>, T*> o) noexcept(
+void delete_default(mpl::conditional_t<std::is_array<T>::value, std::decay_t<T>, T*> o) noexcept(
     noexcept(std::default_delete<T>{}(o))) {
     std::default_delete<T>{}(o);
 }


### PR DESCRIPTION
This PR contains improvements to the MPL and the checking of column constraints.

* Narrowed down the check whether a column constraint is a primary key or unique constraint (since both can be used as table constraints, we check if the internal classes have no associated columns).
* The quoted metafunctions `mpl::conjunction` and `mpl::disjunction` have been short-circuited.
* New metafunction `mpl::conditional`, which uses an improved memoization technique.

And build times are faster again! 🎈 