### PR TITLE
Use of the efficient "pack indexing" C++ language feature

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,8 @@ environment:
       CC: clang
       CXX: clang++
       SQLITE_ORM_CXX_STANDARD: "-DSQLITE_ORM_ENABLE_CXX_17=ON"
-      cmake_build_parallel: --parallel
+      # clang was stuck with a parallel build
+      cmake_build_parallel: ""
 
     - job_name: gcc, C++17
       appveyor_build_worker_image: Ubuntu

--- a/dev/functional/cxx_core_features.h
+++ b/dev/functional/cxx_core_features.h
@@ -82,6 +82,10 @@
 #define SQLITE_ORM_CLASSTYPE_TEMPLATE_ARGS_SUPPORTED
 #endif
 
-#if(__cplusplus >= 202002L)
+#if __cpp_pack_indexing >= 202311L
+#define SQLITE_ORM_PACK_INDEXING_SUPPORTED
+#endif
+
+#if __cplusplus >= 202002L
 #define SQLITE_ORM_DEFAULT_COMPARISONS_SUPPORTED
 #endif

--- a/dev/functional/index_sequence_util.h
+++ b/dev/functional/index_sequence_util.h
@@ -6,24 +6,21 @@
 
 namespace sqlite_orm {
     namespace internal {
+#if defined(SQLITE_ORM_PACK_INDEXING_SUPPORTED)
         /**
-         *  Get the first value of an index_sequence.
+         *  Get the index value of an `index_sequence` at a specific position.
          */
-        template<size_t I, size_t... Idx>
-        SQLITE_ORM_CONSTEVAL size_t first_index_sequence_value(std::index_sequence<I, Idx...>) {
-            return I;
+        template<size_t Pos, size_t... Idx>
+        SQLITE_ORM_CONSTEVAL size_t index_sequence_value_at(std::index_sequence<Idx...>) {
+            return Idx...[Pos];
         }
-
-#ifdef SQLITE_ORM_FOLD_EXPRESSIONS_SUPPORTED
+#elif defined(SQLITE_ORM_FOLD_EXPRESSIONS_SUPPORTED)
         /**
-         *  Get the index value of an index_sequence at a specific position.
+         *  Get the index value of an `index_sequence` at a specific position.
          */
-        template<size_t... Idx>
-        SQLITE_ORM_CONSTEVAL size_t index_sequence_value(size_t pos, std::index_sequence<Idx...>) {
-            static_assert(sizeof...(Idx) > 0);
-#ifdef SQLITE_ORM_PACK_INDEXING_SUPPORTED
-            return Idx...[pos];
-#else
+        template<size_t Pos, size_t... Idx>
+        SQLITE_ORM_CONSTEVAL size_t index_sequence_value_at(std::index_sequence<Idx...>) {
+            static_assert(Pos < sizeof...(Idx));
 #ifdef SQLITE_ORM_CONSTEVAL_SUPPORTED
             size_t result;
 #else
@@ -31,9 +28,18 @@ namespace sqlite_orm {
 #endif
             size_t i = 0;
             // note: `(void)` cast silences warning 'expression result unused'
-            (void)((result = Idx, i++ == pos) || ...);
+            (void)((result = Idx, i++ == Pos) || ...);
             return result;
-#endif
+        }
+#else
+        /**
+         *  Get the index value of an `index_sequence` at a specific position.
+         *  `Pos` must always be `0`.
+         */
+        template<size_t Pos, size_t I, size_t... Idx>
+        SQLITE_ORM_CONSTEVAL size_t index_sequence_value_at(std::index_sequence<I, Idx...>) {
+            static_assert(Pos == 0, "");
+            return I;
         }
 #endif
 

--- a/dev/functional/index_sequence_util.h
+++ b/dev/functional/index_sequence_util.h
@@ -16,11 +16,14 @@ namespace sqlite_orm {
 
 #ifdef SQLITE_ORM_FOLD_EXPRESSIONS_SUPPORTED
         /**
-         *  Get the value of an index_sequence at a specific position.
+         *  Get the index value of an index_sequence at a specific position.
          */
         template<size_t... Idx>
         SQLITE_ORM_CONSTEVAL size_t index_sequence_value(size_t pos, std::index_sequence<Idx...>) {
             static_assert(sizeof...(Idx) > 0);
+#ifdef SQLITE_ORM_PACK_INDEXING_SUPPORTED
+            return Idx...[pos];
+#else
 #ifdef SQLITE_ORM_CONSTEVAL_SUPPORTED
             size_t result;
 #else
@@ -30,6 +33,7 @@ namespace sqlite_orm {
             // note: `(void)` cast silences warning 'expression result unused'
             (void)((result = Idx, i++ == pos) || ...);
             return result;
+#endif
         }
 #endif
 

--- a/dev/schema/table.h
+++ b/dev/schema/table.h
@@ -158,7 +158,7 @@ namespace sqlite_orm {
                                   using generated_op_index_sequence =
                                       filter_tuple_sequence_t<std::remove_const_t<decltype(column.constraints)>,
                                                               is_generated_always>;
-                                  constexpr size_t opIndex = first_index_sequence_value(generated_op_index_sequence{});
+                                  constexpr size_t opIndex = index_sequence_value_at<0>(generated_op_index_sequence{});
                                   result = &std::get<opIndex>(column.constraints).storage;
                               });
 #else

--- a/dev/storage_impl.h
+++ b/dev/storage_impl.h
@@ -114,7 +114,7 @@ namespace sqlite_orm {
             // note: we could "materialize" the alias to an `aliased_field<>::*` and use the regular `table_t<>::find_column_name()` mechanism;
             //       however we have the column index already.
             // lookup column in table_t<>'s elements
-            constexpr size_t ColIdx = index_sequence_value(colalias_index::value, column_index_sequence{});
+            constexpr size_t ColIdx = index_sequence_value_at<colalias_index::value>(column_index_sequence{});
             auto& table = pick_table<Moniker>(dboObjects);
             return &std::get<ColIdx>(table.elements).name;
         }

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -1565,24 +1565,21 @@ namespace sqlite_orm {
 
 namespace sqlite_orm {
     namespace internal {
+#if defined(SQLITE_ORM_PACK_INDEXING_SUPPORTED)
         /**
-         *  Get the first value of an index_sequence.
+         *  Get the index value of an `index_sequence` at a specific position.
          */
-        template<size_t I, size_t... Idx>
-        SQLITE_ORM_CONSTEVAL size_t first_index_sequence_value(std::index_sequence<I, Idx...>) {
-            return I;
+        template<size_t Pos, size_t... Idx>
+        SQLITE_ORM_CONSTEVAL size_t index_sequence_value_at(std::index_sequence<Idx...>) {
+            return Idx...[Pos];
         }
-
-#ifdef SQLITE_ORM_FOLD_EXPRESSIONS_SUPPORTED
+#elif defined(SQLITE_ORM_FOLD_EXPRESSIONS_SUPPORTED)
         /**
-         *  Get the index value of an index_sequence at a specific position.
+         *  Get the index value of an `index_sequence` at a specific position.
          */
-        template<size_t... Idx>
-        SQLITE_ORM_CONSTEVAL size_t index_sequence_value(size_t pos, std::index_sequence<Idx...>) {
-            static_assert(sizeof...(Idx) > 0);
-#ifdef SQLITE_ORM_PACK_INDEXING_SUPPORTED
-            return Idx...[pos];
-#else
+        template<size_t Pos, size_t... Idx>
+        SQLITE_ORM_CONSTEVAL size_t index_sequence_value_at(std::index_sequence<Idx...>) {
+            static_assert(Pos < sizeof...(Idx));
 #ifdef SQLITE_ORM_CONSTEVAL_SUPPORTED
             size_t result;
 #else
@@ -1590,9 +1587,18 @@ namespace sqlite_orm {
 #endif
             size_t i = 0;
             // note: `(void)` cast silences warning 'expression result unused'
-            (void)((result = Idx, i++ == pos) || ...);
+            (void)((result = Idx, i++ == Pos) || ...);
             return result;
-#endif
+        }
+#else
+        /**
+         *  Get the index value of an `index_sequence` at a specific position.
+         *  `Pos` must always be `0`.
+         */
+        template<size_t Pos, size_t I, size_t... Idx>
+        SQLITE_ORM_CONSTEVAL size_t index_sequence_value_at(std::index_sequence<I, Idx...>) {
+            static_assert(Pos == 0, "");
+            return I;
         }
 #endif
 
@@ -11518,7 +11524,7 @@ namespace sqlite_orm {
                                   using generated_op_index_sequence =
                                       filter_tuple_sequence_t<std::remove_const_t<decltype(column.constraints)>,
                                                               is_generated_always>;
-                                  constexpr size_t opIndex = first_index_sequence_value(generated_op_index_sequence{});
+                                  constexpr size_t opIndex = index_sequence_value_at<0>(generated_op_index_sequence{});
                                   result = &std::get<opIndex>(column.constraints).storage;
                               });
 #else
@@ -12184,7 +12190,7 @@ namespace sqlite_orm {
             // note: we could "materialize" the alias to an `aliased_field<>::*` and use the regular `table_t<>::find_column_name()` mechanism;
             //       however we have the column index already.
             // lookup column in table_t<>'s elements
-            constexpr size_t ColIdx = index_sequence_value(colalias_index::value, column_index_sequence{});
+            constexpr size_t ColIdx = index_sequence_value_at<colalias_index::value>(column_index_sequence{});
             auto& table = pick_table<Moniker>(dboObjects);
             return &std::get<ColIdx>(table.elements).name;
         }

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -110,7 +110,11 @@ using std::nullptr_t;
 #define SQLITE_ORM_CLASSTYPE_TEMPLATE_ARGS_SUPPORTED
 #endif
 
-#if(__cplusplus >= 202002L)
+#if __cpp_pack_indexing >= 202311L
+#define SQLITE_ORM_PACK_INDEXING_SUPPORTED
+#endif
+
+#if __cplusplus >= 202002L
 #define SQLITE_ORM_DEFAULT_COMPARISONS_SUPPORTED
 #endif
 
@@ -1571,11 +1575,14 @@ namespace sqlite_orm {
 
 #ifdef SQLITE_ORM_FOLD_EXPRESSIONS_SUPPORTED
         /**
-         *  Get the value of an index_sequence at a specific position.
+         *  Get the index value of an index_sequence at a specific position.
          */
         template<size_t... Idx>
         SQLITE_ORM_CONSTEVAL size_t index_sequence_value(size_t pos, std::index_sequence<Idx...>) {
             static_assert(sizeof...(Idx) > 0);
+#ifdef SQLITE_ORM_PACK_INDEXING_SUPPORTED
+            return Idx...[pos];
+#else
 #ifdef SQLITE_ORM_CONSTEVAL_SUPPORTED
             size_t result;
 #else
@@ -1585,6 +1592,7 @@ namespace sqlite_orm {
             // note: `(void)` cast silences warning 'expression result unused'
             (void)((result = Idx, i++ == pos) || ...);
             return result;
+#endif
         }
 #endif
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(unit_tests
     static_tests/functional/static_if_tests.cpp
     static_tests/functional/mpl.cpp
     static_tests/functional/same_or_void.cpp
+    static_tests/functional/index_sequence_util.cpp
     static_tests/functional/tuple_conc.cpp
     static_tests/functional/tuple_filter.cpp
     static_tests/functional/tuple_traits.cpp

--- a/tests/static_tests/functional/index_sequence_util.cpp
+++ b/tests/static_tests/functional/index_sequence_util.cpp
@@ -1,0 +1,23 @@
+#include <sqlite_orm/sqlite_orm.h>
+#include <catch2/catch_all.hpp>
+
+using std::index_sequence;
+using namespace sqlite_orm;
+using internal::flatten_idxseq_t;
+using internal::index_sequence_value_at;
+
+TEST_CASE("index sequence value at") {
+    STATIC_REQUIRE(index_sequence_value_at<0>(index_sequence<1, 3>{}) == 1);
+#if defined(SQLITE_ORM_PACK_INDEXING_SUPPORTED) || defined(SQLITE_ORM_FOLD_EXPRESSIONS_SUPPORTED)
+    STATIC_REQUIRE(index_sequence_value_at<1>(index_sequence<1, 3>{}) == 3);
+#endif
+}
+
+TEST_CASE("flatten index sequence") {
+    STATIC_REQUIRE(std::is_same<flatten_idxseq_t<>, index_sequence<>>::value);
+    STATIC_REQUIRE(std::is_same<flatten_idxseq_t<index_sequence<1, 3>>, index_sequence<1, 3>>::value);
+    STATIC_REQUIRE(
+        std::is_same<flatten_idxseq_t<index_sequence<1, 3>, index_sequence<1, 3>>, index_sequence<1, 3, 1, 3>>::value);
+    STATIC_REQUIRE(std::is_same<flatten_idxseq_t<index_sequence<1, 3>, index_sequence<1, 3>, index_sequence<1, 3>>,
+                                index_sequence<1, 3, 1, 3, 1, 3>>::value);
+}


### PR DESCRIPTION
Use of the efficient "[pack indexing](https://en.cppreference.com/w/cpp/language/pack_indexing)", a C++26 core feature of the language, and which is already supported by Clang 19.

Bonus: newly added unit tests for index sequence utils.
