### PR TITLE
Explicitly set the entry point of the unit test executable for Windows Unicode builds

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -182,6 +182,11 @@ if (MSVC)
             # C4458: declaration of 'symbol' hides class member
             /wd4458)
     endif()
+    if (CMAKE_CXX_FLAGS MATCHES "/D_UNICODE")
+        # explicitly set the entry point of the executable file,
+        # otherwise for some reason the linker will not pick up `wmain`, which is provided by the static Catch2 library
+        target_link_options(unit_tests PRIVATE "/ENTRY:wmainCRTStartup")
+    endif()
 endif()
 
 target_precompile_headers(unit_tests PRIVATE


### PR DESCRIPTION
... otherwise for some reason the msvc linker will not pick up `wmain`, which is provided by the static Catch2 library. This is important for Windows Unicode builds, e.g. those performed by build environments for the Windows Store such as vcpkg's "x64-uwp" triplet.