### PR TITLE
Guard the use of `upsert_clause`

### DIFF
--- a/dev/ast/upsert_clause.h
+++ b/dev/ast/upsert_clause.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <sqlite3.h>
 #if SQLITE_VERSION_NUMBER >= 3024000
 #include <tuple>  //  std::tuple
 #include <utility>  //  std::forward, std::move
@@ -38,13 +39,18 @@ namespace sqlite_orm {
 
             actions_tuple actions;
         };
+#endif
 
         template<class T>
-        using is_upsert_clause = polyfill::is_specialization_of<T, upsert_clause>;
+        SQLITE_ORM_INLINE_VAR constexpr bool is_upsert_clause_v =
+#if SQLITE_VERSION_NUMBER >= 3024000
+            polyfill::is_specialization_of<T, upsert_clause>::value;
 #else
-        template<class T>
-        struct is_upsert_clause : polyfill::bool_constant<false> {};
+            false;
 #endif
+
+        template<class T>
+        using is_upsert_clause = polyfill::bool_constant<is_upsert_clause_v<T>>;
     }
 
 #if SQLITE_VERSION_NUMBER >= 3024000
@@ -62,7 +68,7 @@ namespace sqlite_orm {
      */
     template<class... Args>
     internal::conflict_target<Args...> on_conflict(Args... args) {
-        return {std::tuple<Args...>(std::forward<Args>(args)...)};
+        return {{std::forward<Args>(args)...}};
     }
 #endif
 }

--- a/dev/node_tuple.h
+++ b/dev/node_tuple.h
@@ -62,8 +62,10 @@ namespace sqlite_orm {
         template<class T, class... Args>
         struct node_tuple<group_by_with_having<T, Args...>, void> : node_tuple_for<Args..., T> {};
 
+#if SQLITE_VERSION_NUMBER >= 3024000
         template<class Targets, class Actions>
         struct node_tuple<upsert_clause<Targets, Actions>, void> : node_tuple<Actions> {};
+#endif
 
         template<class... Args>
         struct node_tuple<set_t<Args...>, void> : node_tuple_for<Args...> {};

--- a/examples/insert.cpp
+++ b/examples/insert.cpp
@@ -110,6 +110,7 @@ int main(int, char**) {
         cout << storage.dump(employee) << endl;
     }
 
+#if SQLITE_VERSION_NUMBER >= 3024000
     //  INSERT INTO COMPANY(ID, NAME, AGE, ADDRESS, SALARY)
     //  VALUES (3, 'Sofia', 26, 'Madrid', 15000.0)
     //         (4, 'Doja', 26, 'LA', 25000.0)
@@ -127,6 +128,7 @@ int main(int, char**) {
                            c(&Employee::age) = excluded(&Employee::age),
                            c(&Employee::address) = excluded(&Employee::address),
                            c(&Employee::salary) = excluded(&Employee::salary))));
+#endif
 
     return 0;
 }


### PR DESCRIPTION
The use of `upsert_clause` was not properly guarded by `SQLITE_VERSION_NUMBER >= 3024000`, which makes it impossible to use sqlite_orm before SQLite3 3.24.