### PR TITLE
Make compilation work with msvc 141 (VC 2017)

### DIFF
--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -1211,7 +1211,7 @@ namespace sqlite_orm {
                    << streaming_non_generated_column_names(table) << ")"
                    << " VALUES ("
                    << streaming_field_values_excluding(check_if<is_generated_always>{},
-                                                       empty_callable<std::false_type>(),  //  don't exclude
+                                                       empty_callable<std::false_type>,  //  don't exclude
                                                        context,
                                                        get_ref(statement.object))
                    << ")";

--- a/dev/storage_impl.h
+++ b/dev/storage_impl.h
@@ -35,7 +35,7 @@ namespace sqlite_orm {
                 [](const auto& dbObjects) -> const std::string& {
                     return pick_table<Lookup>(dbObjects).name;
                 },
-                empty_callable<std::string>())(dbObjects);
+                empty_callable<std::string>)(dbObjects);
         }
 
         /**

--- a/dev/storage_lookup.h
+++ b/dev/storage_lookup.h
@@ -33,9 +33,11 @@ namespace sqlite_orm {
         struct is_db_objects : std::false_type {};
 
         template<class... DBO>
-        struct is_db_objects<db_objects_tuple<DBO...>> : std::true_type {};
+        struct is_db_objects<std::tuple<DBO...>> : std::true_type {};
+        // note: cannot use `db_objects_tuple` alias template because older compilers have problems
+        // to match `const db_objects_tuple`.
         template<class... DBO>
-        struct is_db_objects<const db_objects_tuple<DBO...>> : std::true_type {};
+        struct is_db_objects<const std::tuple<DBO...>> : std::true_type {};
 
         /**
          *  `std::true_type` if given object is mapped, `std::false_type` otherwise.


### PR DESCRIPTION
Older compilers like msvc 141 have problems with:
* initializing and correctly using static (lambda) variables inside template functions
* partially specializing a class template using alias templates