### PR TITLE
Fixed the construction of a named non-aggregate struct

### DIFF
--- a/dev/type_traits.h
+++ b/dev/type_traits.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <type_traits>  //  std::enable_if, std::is_same, std::is_empty
+#include <type_traits>  //  std::enable_if, std::is_same, std::is_empty, std::is_aggregate
 #if __cpp_lib_unwrap_ref >= 201811L
 #include <utility>  //  std::reference_wrapper
 #else
@@ -24,6 +24,14 @@ namespace sqlite_orm {
 
         template<class T>
         using value_unref_type_t = typename value_unref_type<T>::type;
+
+        template<class T>
+        using is_eval_order_garanteed =
+#if __cpp_lib_is_aggregate >= 201703L
+            std::is_aggregate<T>;
+#else
+            std::is_pod<T>;
+#endif
 
         // enable_if for types
         template<template<typename...> class Op, class... Args>


### PR DESCRIPTION
This PR corrects the row extractor for named non-aggregate structures, which was introduced in PR #1278.

brace-init-list initialization guarantees order of evaluation, but only for aggregates and variadic constructors it seems. At least this occurred with msvc, which ended up extracting the SQL values in the wrong order.