### PR TITLE
Simplified and extended detection of pointer-to-member of Derived

### DIFF
--- a/dev/column_pointer.h
+++ b/dev/column_pointer.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <type_traits>  //  std::enable_if
+#include <type_traits>  //  std::enable_if, std::is_convertible
 #include <utility>  // std::move
 
 #include "functional/cxx_core_features.h"
@@ -50,9 +50,9 @@ namespace sqlite_orm {
      *  struct MyType : BaseType { ... };
      *  storage.select(column<MyType>(&BaseType::id));
      */
-    template<class Object, class F, class O, internal::satisfies_not<internal::is_recordset_alias, Object> = true>
-    constexpr internal::column_pointer<Object, F O::*> column(F O::*field) {
-        static_assert(internal::is_field_of_v<F O::*, Object>, "Column must be from derived class");
+    template<class O, class Base, class F, internal::satisfies_not<internal::is_recordset_alias, O> = true>
+    constexpr internal::column_pointer<O, F Base::*> column(F Base::*field) {
+        static_assert(std::is_convertible<F Base::*, F O::*>::value, "Field must be from derived class");
         return {field};
     }
 

--- a/dev/field_printer.h
+++ b/dev/field_printer.h
@@ -28,7 +28,7 @@ namespace sqlite_orm {
         /*
          *  Implementation note: the technique of indirect expression testing is because
          *  of older compilers having problems with the detection of dependent templates [SQLITE_ORM_BROKEN_ALIAS_TEMPLATE_DEPENDENT_EXPR_SFINAE].
-         *  It must also be a type that differs from those for `is_field_of_v`, `is_preparable_v`, `is_bindable_v`.
+         *  It must also be a type that differs from those for `is_preparable_v`, `is_bindable_v`.
          */
         template<class Printer>
         struct indirectly_test_printable;

--- a/dev/statement_binder.h
+++ b/dev/statement_binder.h
@@ -34,7 +34,7 @@ namespace sqlite_orm {
         /*
          *  Implementation note: the technique of indirect expression testing is because
          *  of older compilers having problems with the detection of dependent templates [SQLITE_ORM_BROKEN_ALIAS_TEMPLATE_DEPENDENT_EXPR_SFINAE].
-         *  It must also be a type that differs from those for `is_field_of_v`, `is_printable_v`, `is_preparable_v`.
+         *  It must also be a type that differs from those for `is_printable_v`, `is_preparable_v`.
          */
         template<class Binder>
         struct indirectly_test_bindable;

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -63,7 +63,7 @@ namespace sqlite_orm {
         /*
          *  Implementation note: the technique of indirect expression testing is because
          *  of older compilers having problems with the detection of dependent templates [SQLITE_ORM_BROKEN_ALIAS_TEMPLATE_DEPENDENT_EXPR_SFINAE].
-         *  It must also be a type that differs from those for `is_field_of_v`, `is_printable_v`, `is_bindable_v`.
+         *  It must also be a type that differs from those for `is_printable_v`, `is_bindable_v`.
          */
         template<class Binder>
         struct indirectly_test_preparable;

--- a/dev/table_type_of.h
+++ b/dev/table_type_of.h
@@ -1,6 +1,5 @@
 #pragma once
-#include <type_traits>  //  std::declval
-#include "functional/cxx_type_traits_polyfill.h"
+#include <type_traits>  //  std::enable_if, std::is_convertible
 
 namespace sqlite_orm {
 
@@ -54,21 +53,11 @@ namespace sqlite_orm {
         SQLITE_ORM_INLINE_VAR constexpr bool is_field_of_v = false;
 
         /*
-         *  Implementation note: the technique of indirect expression testing is because
-         *  of older compilers having problems with the detection of dependent templates [SQLITE_ORM_BROKEN_ALIAS_TEMPLATE_DEPENDENT_EXPR_SFINAE].
-         *  It must also be a type that differs from those for `is_printable_v`, `is_bindable_v`, `is_preparable_v`.
+         *  `true` if a pointer-to-member of Base is convertible to a pointer-to-member of Derived.
          */
-        template<class FieldOf>
-        struct indirectly_test_field_of;
-
-        /*
-         *  `true` if a pointer-to-member operator is a valid expression for an object of type `T` and a member pointer of type `F O::*`.
-         */
-        template<class F, class O, class T>
-        SQLITE_ORM_INLINE_VAR constexpr bool is_field_of_v<
-            F O::*,
-            T,
-            polyfill::void_t<indirectly_test_field_of<decltype(std::declval<T>().*std::declval<F O::*>())>>> = true;
+        template<class O, class Base, class F>
+        SQLITE_ORM_INLINE_VAR constexpr bool
+            is_field_of_v<F Base::*, O, std::enable_if_t<std::is_convertible<F Base::*, F O::*>::value>> = true;
 
         template<class F, class T>
         SQLITE_ORM_INLINE_VAR constexpr bool is_field_of_v<column_pointer<T, F>, T, void> = true;

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -1727,8 +1727,7 @@ namespace sqlite_orm {
 
 // #include "table_type_of.h"
 
-#include <type_traits>  //  std::declval
-// #include "functional/cxx_type_traits_polyfill.h"
+#include <type_traits>  //  std::enable_if, std::is_convertible
 
 namespace sqlite_orm {
 
@@ -1782,21 +1781,11 @@ namespace sqlite_orm {
         SQLITE_ORM_INLINE_VAR constexpr bool is_field_of_v = false;
 
         /*
-         *  Implementation note: the technique of indirect expression testing is because
-         *  of older compilers having problems with the detection of dependent templates [SQLITE_ORM_BROKEN_ALIAS_TEMPLATE_DEPENDENT_EXPR_SFINAE].
-         *  It must also be a type that differs from those for `is_printable_v`, `is_bindable_v`, `is_preparable_v`.
+         *  `true` if a pointer-to-member of Base is convertible to a pointer-to-member of Derived.
          */
-        template<class FieldOf>
-        struct indirectly_test_field_of;
-
-        /*
-         *  `true` if a pointer-to-member operator is a valid expression for an object of type `T` and a member pointer of type `F O::*`.
-         */
-        template<class F, class O, class T>
-        SQLITE_ORM_INLINE_VAR constexpr bool is_field_of_v<
-            F O::*,
-            T,
-            polyfill::void_t<indirectly_test_field_of<decltype(std::declval<T>().*std::declval<F O::*>())>>> = true;
+        template<class O, class Base, class F>
+        SQLITE_ORM_INLINE_VAR constexpr bool
+            is_field_of_v<F Base::*, O, std::enable_if_t<std::is_convertible<F Base::*, F O::*>::value>> = true;
 
         template<class F, class T>
         SQLITE_ORM_INLINE_VAR constexpr bool is_field_of_v<column_pointer<T, F>, T, void> = true;
@@ -3249,7 +3238,7 @@ namespace sqlite_orm {
         /*
          *  Implementation note: the technique of indirect expression testing is because
          *  of older compilers having problems with the detection of dependent templates [SQLITE_ORM_BROKEN_ALIAS_TEMPLATE_DEPENDENT_EXPR_SFINAE].
-         *  It must also be a type that differs from those for `is_field_of_v`, `is_preparable_v`, `is_bindable_v`.
+         *  It must also be a type that differs from those for `is_preparable_v`, `is_bindable_v`.
          */
         template<class Printer>
         struct indirectly_test_printable;
@@ -3761,7 +3750,7 @@ namespace sqlite_orm {
 
 // #include "column_pointer.h"
 
-#include <type_traits>  //  std::enable_if
+#include <type_traits>  //  std::enable_if, std::is_convertible
 #include <utility>  // std::move
 
 // #include "functional/cxx_core_features.h"
@@ -3816,9 +3805,9 @@ namespace sqlite_orm {
      *  struct MyType : BaseType { ... };
      *  storage.select(column<MyType>(&BaseType::id));
      */
-    template<class Object, class F, class O, internal::satisfies_not<internal::is_recordset_alias, Object> = true>
-    constexpr internal::column_pointer<Object, F O::*> column(F O::*field) {
-        static_assert(internal::is_field_of_v<F O::*, Object>, "Column must be from derived class");
+    template<class O, class Base, class F, internal::satisfies_not<internal::is_recordset_alias, O> = true>
+    constexpr internal::column_pointer<O, F Base::*> column(F Base::*field) {
+        static_assert(std::is_convertible<F Base::*, F O::*>::value, "Field must be from derived class");
         return {field};
     }
 
@@ -9951,7 +9940,7 @@ namespace sqlite_orm {
         /*
          *  Implementation note: the technique of indirect expression testing is because
          *  of older compilers having problems with the detection of dependent templates [SQLITE_ORM_BROKEN_ALIAS_TEMPLATE_DEPENDENT_EXPR_SFINAE].
-         *  It must also be a type that differs from those for `is_field_of_v`, `is_printable_v`, `is_preparable_v`.
+         *  It must also be a type that differs from those for `is_printable_v`, `is_preparable_v`.
          */
         template<class Binder>
         struct indirectly_test_bindable;
@@ -21406,7 +21395,7 @@ namespace sqlite_orm {
         /*
          *  Implementation note: the technique of indirect expression testing is because
          *  of older compilers having problems with the detection of dependent templates [SQLITE_ORM_BROKEN_ALIAS_TEMPLATE_DEPENDENT_EXPR_SFINAE].
-         *  It must also be a type that differs from those for `is_field_of_v`, `is_printable_v`, `is_bindable_v`.
+         *  It must also be a type that differs from those for `is_printable_v`, `is_bindable_v`.
          */
         template<class Binder>
         struct indirectly_test_preparable;

--- a/tests/static_tests/column.cpp
+++ b/tests/static_tests/column.cpp
@@ -32,7 +32,8 @@ TEST_CASE("Column") {
         STATIC_REQUIRE(std::is_same<column_type::field_type, int>::value);
         STATIC_REQUIRE(std::is_same<column_type::member_pointer_t, const int& (User::*)() const>::value);
         STATIC_REQUIRE(std::is_same<column_type::setter_type, void (User::*)(int)>::value);
-        STATIC_REQUIRE(!internal::is_field_of_v<column_type::member_pointer_t, User>);
+        STATIC_REQUIRE(internal::is_field_of_v<column_type::member_pointer_t, User>);
+        STATIC_REQUIRE(internal::is_field_of_v<column_type::setter_type, User>);
     }
     {
         using column_type = decltype(make_column("id", &User::setIdByVal, &User::getIdByRefConst));
@@ -84,9 +85,9 @@ TEST_CASE("Column") {
         STATIC_REQUIRE(internal::is_field_of_v<column_type, Token>);
         STATIC_REQUIRE(internal::is_field_of_v<field_type, Token>);
         STATIC_REQUIRE(internal::is_field_of_v<field_type, Object>);
-        STATIC_REQUIRE(!internal::is_field_of_v<column_type, Object>);
-        STATIC_REQUIRE(!internal::is_field_of_v<column_type, User>);
-        STATIC_REQUIRE(!internal::is_field_of_v<field_type, User>);
+        STATIC_REQUIRE_FALSE(internal::is_field_of_v<column_type, Object>);
+        STATIC_REQUIRE_FALSE(internal::is_field_of_v<column_type, User>);
+        STATIC_REQUIRE_FALSE(internal::is_field_of_v<field_type, User>);
         STATIC_REQUIRE(std::is_same<internal::table_type_of<field_type>::type, Object>::value);
         STATIC_REQUIRE(std::is_same<internal::column_result_t<internal::storage_t<>, field_type>::type, int>::value);
         STATIC_REQUIRE(std::is_member_pointer<field_type>::value);


### PR DESCRIPTION
It is much easier to determine whether a base member pointer can be used as a derived member pointer by checking an implicit conversion, which also has the advantage that getters and setters can be used again for ‘column pointers’.