### PR TITLE
Ability to specify a table reference for the object iteration interface

### DIFF
--- a/dev/functional/config.h
+++ b/dev/functional/config.h
@@ -54,6 +54,10 @@
 #define SQLITE_ORM_CPP20_CONCEPTS_SUPPORTED
 #endif
 
+#if __cpp_lib_ranges >= 201911L
+#define SQLITE_ORM_CPP20_RANGES_SUPPORTED
+#endif
+
 #if(defined(SQLITE_ORM_CLASSTYPE_TEMPLATE_ARGS_SUPPORTED) && defined(SQLITE_ORM_INLINE_VARIABLES_SUPPORTED) &&         \
     defined(SQLITE_ORM_CONSTEVAL_SUPPORTED)) &&                                                                        \
     (defined(SQLITE_ORM_CPP20_CONCEPTS_SUPPORTED))

--- a/dev/functional/cxx_core_features.h
+++ b/dev/functional/cxx_core_features.h
@@ -49,6 +49,10 @@
 #define SQLITE_ORM_INLINE_VARIABLES_SUPPORTED
 #endif
 
+#if __cpp_structured_bindings >= 201606L
+#define SQLITE_ORM_STRUCTURED_BINDINGS_SUPPORTED
+#endif
+
 #if __cpp_generic_lambdas >= 201707L
 #define SQLITE_ORM_EXPLICIT_GENERIC_LAMBDA_SUPPORTED
 #else

--- a/dev/iterator.h
+++ b/dev/iterator.h
@@ -1,14 +1,13 @@
 #pragma once
 
 #include <sqlite3.h>
-#include <cassert>  //  assert
 #include <memory>  //  std::shared_ptr, std::make_shared
 #include <utility>  //  std::move
 #include <iterator>  //  std::input_iterator_tag
 #include <system_error>  //  std::system_error
 #include <functional>  //  std::bind
 
-#include "functional/cxx_universal.h"
+#include "functional/cxx_universal.h"  //  ::ptrdiff_t
 #include "statement_finalizer.h"
 #include "error_code.h"
 #include "object_from_column_builder.h"
@@ -18,17 +17,26 @@
 namespace sqlite_orm {
     namespace internal {
 
+        /*  
+         *  (Legacy) Input iterator over a result set for a mapped object.
+         */
         template<class O, class DBOs>
-        struct iterator_t {
-            using value_type = O;
+        class iterator_t {
+          public:
             using db_objects_type = DBOs;
+
+            using iterator_category = std::input_iterator_tag;
+            using difference_type = ptrdiff_t;
+            using value_type = O;
+            using reference = O&;
+            using pointer = O*;
 
           private:
             /**
-                pointer to the view's db objects member variable.
+                pointer to the db objects.
                 only null for the default constructed iterator.
              */
-            const db_objects_type** db_objects = nullptr;
+            const db_objects_type* db_objects = nullptr;
 
             /**
              *  shared_ptr is used over unique_ptr here
@@ -45,8 +53,8 @@ namespace sqlite_orm {
             void extract_object() {
                 this->current = std::make_shared<value_type>();
                 object_from_column_builder<value_type> builder{*this->current, this->stmt.get()};
-                assert(*this->db_objects);
-                pick_table<value_type>(**this->db_objects).for_each_column(builder);
+                auto& table = pick_table<value_type>(*this->db_objects);
+                table.for_each_column(builder);
             }
 
             void step() {
@@ -62,25 +70,27 @@ namespace sqlite_orm {
             }
 
           public:
-            using difference_type = ptrdiff_t;
-            using pointer = value_type*;
-            using reference = value_type&;
-            using iterator_category = std::input_iterator_tag;
-
             iterator_t() = default;
 
-            iterator_t(const db_objects_type*& dbObjects, statement_finalizer stmt) :
+            iterator_t(const db_objects_type& dbObjects, statement_finalizer stmt) :
                 db_objects{&dbObjects}, stmt{std::move(stmt)} {
                 this->step();
             }
 
+            iterator_t(const iterator_t&) = default;
+            iterator_t& operator=(const iterator_t&) = default;
+            iterator_t(iterator_t&&) = default;
+            iterator_t& operator=(iterator_t&&) = default;
+
             value_type& operator*() const {
-                if(!this->stmt) {
-                    throw std::system_error{orm_error_code::trying_to_dereference_null_iterator};
-                }
+                if(!this->stmt)
+                    SQLITE_ORM_CPP_UNLIKELY {
+                        throw std::system_error{orm_error_code::trying_to_dereference_null_iterator};
+                    }
                 return *this->current;
             }
 
+            // note: should actually be only present for contiguous iterators
             value_type* operator->() const {
                 return &(this->operator*());
             }
@@ -92,7 +102,7 @@ namespace sqlite_orm {
 
             iterator_t operator++(int) {
                 auto tmp = *this;
-                this->operator++();
+                ++*this;
                 return tmp;
             }
 

--- a/dev/iterator.h
+++ b/dev/iterator.h
@@ -1,8 +1,7 @@
 #pragma once
 
 #include <sqlite3.h>
-#include <memory>  //  std::shared_ptr, std::unique_ptr, std::make_shared
-#include <type_traits>  //  std::decay
+#include <memory>  //  std::shared_ptr, std::make_shared
 #include <utility>  //  std::move
 #include <iterator>  //  std::input_iterator_tag
 #include <system_error>  //  std::system_error
@@ -63,7 +62,7 @@ namespace sqlite_orm {
             using reference = value_type&;
             using iterator_category = std::input_iterator_tag;
 
-            iterator_t(){};
+            iterator_t() = default;
 
             iterator_t(statement_finalizer stmt_, view_type& view_) : stmt{std::move(stmt_)}, view{&view_} {
                 next();
@@ -89,13 +88,15 @@ namespace sqlite_orm {
                 this->operator++();
             }
 
-            bool operator==(const iterator_t& other) const {
-                return this->current == other.current;
+            friend bool operator==(const iterator_t& lhs, const iterator_t& rhs) {
+                return lhs.current == rhs.current;
             }
 
-            bool operator!=(const iterator_t& other) const {
-                return !(*this == other);
+#ifndef SQLITE_ORM_DEFAULT_COMPARISONS_SUPPORTED
+            friend bool operator!=(const iterator_t& lhs, const iterator_t& rhs) {
+                return !(lhs == rhs);
             }
+#endif
         };
     }
 }

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -250,6 +250,13 @@ namespace sqlite_orm {
                 return {*this, std::move(con), std::forward<Args>(args)...};
             }
 
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+            template<orm_refers_to_table auto table, class... Args>
+            auto iterate(Args&&... args) {
+                return this->iterate<auto_decay_table_ref_t<table>>(std::forward<Args>(args)...);
+            }
+#endif
+
             /**
              * Delete from routine.
              * O is an object's type. Must be specified explicitly.

--- a/dev/view.h
+++ b/dev/view.h
@@ -46,7 +46,7 @@ namespace sqlite_orm {
             }
 
             size_t size() const {
-                return this->storage->template count<T>();
+                return this->storage.template count<T>();
             }
 
             bool empty() const {

--- a/dev/view.h
+++ b/dev/view.h
@@ -4,7 +4,6 @@
 #include <utility>  //  std::forward, std::move
 
 #include "row_extractor.h"
-#include "error_code.h"
 #include "iterator.h"
 #include "ast_iterator.h"
 #include "prepared_statement.h"
@@ -16,13 +15,16 @@ namespace sqlite_orm {
     namespace internal {
 
         /**
-         * This class does not related to SQL view. This is a container like class which is returned by
-         * by storage_t::iterate function. This class contains STL functions:
+         * A C++ view-like class which is returned
+         * by `storage_t::iterate()` function. This class contains STL functions:
          *  -   size_t size()
          *  -   bool empty()
          *  -   iterator end()
          *  -   iterator begin()
          *  All these functions are not right const cause all of them may open SQLite connections.
+         *  
+         *  `view_t` is also a 'borrowed range',
+         *  meaning that iterators obtained from it are not tied to the lifetime of the view instance.
          */
         template<class T, class S, class... Args>
         struct view_t {
@@ -31,19 +33,11 @@ namespace sqlite_orm {
             using db_objects_type = typename S::db_objects_type;
 
             storage_type& storage;
-            // Note: This is deliberately a pointer, so that an iterator's reference to this pointer is null if the view goes out of scope,
-            // and no dangling reference is accessed if an iterator accidentally outlives the view [lifetime]
-            const db_objects_type* db_objects;
             connection_ref connection;
             get_all_t<T, void, Args...> expression;
 
             view_t(storage_type& storage, connection_ref conn, Args&&... args) :
-                storage(storage), db_objects(&obtain_db_objects(storage)), connection(std::move(conn)),
-                expression{std::forward<Args>(args)...} {}
-
-            ~view_t() {
-                this->db_objects = nullptr;
-            }
+                storage(storage), connection(std::move(conn)), expression{std::forward<Args>(args)...} {}
 
             size_t size() const {
                 return this->storage.template count<T>();
@@ -55,13 +49,14 @@ namespace sqlite_orm {
 
             iterator_t<T, db_objects_type> begin() {
                 using context_t = serializer_context<db_objects_type>;
-                context_t context{*this->db_objects};
+                auto& dbObjects = obtain_db_objects(this->storage);
+                context_t context{dbObjects};
                 context.skip_table_name = false;
                 context.replace_bindable_with_question = true;
 
                 statement_finalizer stmt{prepare_stmt(this->connection.get(), serialize(this->expression, context))};
                 iterate_ast(this->expression.conditions, conditional_binder{stmt.get()});
-                return {this->db_objects, std::move(stmt)};
+                return {dbObjects, std::move(stmt)};
             }
 
             iterator_t<T, db_objects_type> end() {
@@ -70,3 +65,8 @@ namespace sqlite_orm {
         };
     }
 }
+
+#ifdef SQLITE_ORM_CPP20_RANGES_SUPPORTED
+template<class T, class S, class... Args>
+inline constexpr bool std::ranges::enable_borrowed_range<sqlite_orm::internal::view_t<T, S, Args...>> = true;
+#endif

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -21582,6 +21582,13 @@ namespace sqlite_orm {
                 return {*this, std::move(con), std::forward<Args>(args)...};
             }
 
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+            template<orm_refers_to_table auto table, class... Args>
+            auto iterate(Args&&... args) {
+                return this->iterate<auto_decay_table_ref_t<table>>(std::forward<Args>(args)...);
+            }
+#endif
+
             /**
              * Delete from routine.
              * O is an object's type. Must be specified explicitly.

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -13479,8 +13479,7 @@ namespace sqlite_orm {
 // #include "iterator.h"
 
 #include <sqlite3.h>
-#include <memory>  //  std::shared_ptr, std::unique_ptr, std::make_shared
-#include <type_traits>  //  std::decay
+#include <memory>  //  std::shared_ptr, std::make_shared
 #include <utility>  //  std::move
 #include <iterator>  //  std::input_iterator_tag
 #include <system_error>  //  std::system_error
@@ -13633,7 +13632,7 @@ namespace sqlite_orm {
             using reference = value_type&;
             using iterator_category = std::input_iterator_tag;
 
-            iterator_t(){};
+            iterator_t() = default;
 
             iterator_t(statement_finalizer stmt_, view_type& view_) : stmt{std::move(stmt_)}, view{&view_} {
                 next();
@@ -13659,13 +13658,15 @@ namespace sqlite_orm {
                 this->operator++();
             }
 
-            bool operator==(const iterator_t& other) const {
-                return this->current == other.current;
+            friend bool operator==(const iterator_t& lhs, const iterator_t& rhs) {
+                return lhs.current == rhs.current;
             }
 
-            bool operator!=(const iterator_t& other) const {
-                return !(*this == other);
+#ifndef SQLITE_ORM_DEFAULT_COMPARISONS_SUPPORTED
+            friend bool operator!=(const iterator_t& lhs, const iterator_t& rhs) {
+                return !(lhs == rhs);
             }
+#endif
         };
     }
 }

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -15683,7 +15683,7 @@ namespace sqlite_orm {
             }
 
             size_t size() const {
-                return this->storage->template count<T>();
+                return this->storage.template count<T>();
             }
 
             bool empty() const {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -155,6 +155,7 @@ add_executable(unit_tests
     table_name_collector.cpp
     pointer_passing_interface.cpp
     row_extractor.cpp
+    iterate.cpp
 )
 
 if(SQLITE_ORM_OMITS_CODECVT)

--- a/tests/builtin_tables.cpp
+++ b/tests/builtin_tables.cpp
@@ -22,6 +22,14 @@ TEST_CASE("builtin tables") {
 
         STATIC_REQUIRE(std::is_same_v<decltype(masterRows), decltype(schemaRows2)>);
         REQUIRE_THAT(schemaRows2, Equals(masterRows));
+
+#if __cpp_lib_containers_ranges >= 202202L
+        std::vector<sqlite_master> schemaRows3{std::from_range, storage.iterate<schema>()};
+#else
+        auto view = storage.iterate<schema>();
+        std::vector<sqlite_master> schemaRows3{view.begin(), view.end()};
+#endif
+        REQUIRE_THAT(schemaRows2, Equals(masterRows));
 #endif
     }
 

--- a/tests/iterate.cpp
+++ b/tests/iterate.cpp
@@ -1,0 +1,56 @@
+#include <sqlite_orm/sqlite_orm.h>
+#include <catch2/catch_all.hpp>
+#include <numeric>  //  std::iota
+
+using namespace sqlite_orm;
+
+TEST_CASE("Iterate mapped") {
+    struct Test {
+        int64_t id;
+        std::vector<char> key;
+
+        bool operator==(const Test& rhs) const {
+            return this->id == rhs.id && this->key == rhs.key;
+        }
+    };
+
+    auto db =
+        make_storage("",
+                     make_table("Test", make_column("id", &Test::id, primary_key()), make_column("key", &Test::key)));
+    db.sync_schema(true);
+
+    std::vector<char> key(255);
+    iota(key.begin(), key.end(), '\0');
+
+    Test expected{5, key};
+    std::vector<Test> expected_vec{expected};
+
+    db.replace(expected);
+
+    SECTION("range-based for") {
+        for(Test& obj: db.iterate<Test>()) {
+            REQUIRE(obj == expected);
+        }
+    }
+    SECTION("from iterator range") {
+        auto view = db.iterate<Test>();
+        REQUIRE(std::vector<Test>{view.begin(), view.end()} == expected_vec);
+    }
+
+#ifdef SQLITE_ORM_STRUCTURED_BINDINGS_SUPPORTED
+    SECTION("borrowed iterator") {
+        auto [begin, end] = [](auto view) {
+            return std::make_pair(view.begin(), view.end());
+        }(db.iterate<Test>());
+        REQUIRE(*begin == expected);
+        REQUIRE(++begin == end);
+    }
+#endif
+
+#if __cpp_lib_containers_ranges >= 202202L
+    SECTION("from range") {
+        auto view = db.iterate<Test>();
+        REQUIRE(std::vector<Test>{std::from_range, view} == expected_vec);
+    }
+#endif
+}

--- a/tests/static_tests/iterator_t.cpp
+++ b/tests/static_tests/iterator_t.cpp
@@ -1,36 +1,117 @@
-#include <type_traits>
-#include <utility>
 #include <sqlite_orm/sqlite_orm.h>
 #include <catch2/catch_all.hpp>
+#include <type_traits>
+#include <utility>
+#ifdef SQLITE_ORM_CPP20_CONCEPTS_SUPPORTED
+#include <concepts>
+#endif
 
 using namespace sqlite_orm;
+using internal::iterator_t;
+using internal::view_t;
+
+#ifdef SQLITE_ORM_CPP20_CONCEPTS_SUPPORTED
+template<class T>
+using with_reference = T&;
+
+template<class T>
+concept can_reference = requires { typename with_reference<T>; };
+
+template<class T>
+concept names_difference_type = requires { typename T::difference_type; };
+
+template<class T>
+concept names_value_type = requires { typename T::value_type; };
+
+// named concept of a legacy iterator
+template<class Iter>
+concept LegacyIterator = requires(Iter it) {
+    { *it } -> can_reference;
+    { ++it } -> std::same_as<Iter&>;
+    { *it++ } -> can_reference;
+} && std::copyable<Iter>;
+
+// named concept of a legacy input iterator
+template<class Iter>
+concept LegacyInputIterator =
+    LegacyIterator<Iter> && std::equality_comparable<Iter> && names_difference_type<std::incrementable_traits<Iter>> &&
+    names_value_type<std::indirectly_readable_traits<Iter>> && requires(Iter it) {
+        typename std::common_reference_t<std::iter_reference_t<Iter>&&,
+                                         typename std::indirectly_readable_traits<Iter>::value_type&>;
+        typename std::common_reference_t<decltype(*it++)&&,
+                                         typename std::indirectly_readable_traits<Iter>::value_type&>;
+        requires std::signed_integral<typename std::incrementable_traits<Iter>::difference_type>;
+    };
+
+template<class Iter, class Value>
+concept can_iterate_mapped = requires(Iter it) {
+    requires LegacyInputIterator<Iter>;
+    // explicit check of the sentinel role, since `std::ranges::borrowed_range` in `can_view_mapped`
+    // would not tell us why exactly the end iterator cannot be a sentinel
+    requires std::sentinel_for<Iter, Iter>;
+    { *it } -> std::same_as<Value&>;
+    // note: should actually be only present for contiguous iterators
+    { it.operator->() } -> std::same_as<Value*>;
+};
+
+template<class V, class O, class DBOs>
+concept can_view_mapped = requires(V view) {
+    requires std::ranges::borrowed_range<V>;
+    { view.begin() } -> std::same_as<iterator_t<O, DBOs>>;
+    { view.end() } -> std::same_as<iterator_t<O, DBOs>>;
+};
+
+template<class S, class O, class DBOs = typename S::db_objects_type>
+concept storage_iterate_mapped = requires(S& storage_type) {
+    { storage_type.iterate<O>() } -> std::same_as<view_t<O, S>>;
+    { storage_type.iterate<O>() } -> can_view_mapped<O, DBOs>;
+};
+#endif
 
 namespace {
-    struct User {
-        int id = 0;
-        std::string name;
-    };
+    struct Object {};
 }
 
-TEST_CASE("iterator_t") {
-    using storage = decltype(make_storage(
-        "aPath",
-        make_table("users", make_column("id", &User::id, primary_key()), make_column("name", &User::name))));
-    using iter = decltype(std::declval<storage>().iterate<User>().begin());
+TEST_CASE("can view and iterate mapped") {
+    using storage_type = decltype(make_storage("", make_table<Object>("")));
 
-    // weakly_incrementable
-    STATIC_REQUIRE(std::is_default_constructible<iter>::value);
-    STATIC_REQUIRE(std::is_same<typename iter::difference_type, std::ptrdiff_t>::value);
-    STATIC_REQUIRE(std::is_same<decltype(++std::declval<iter>()), iter&>::value);
-    using check = decltype(std::declval<iter>()++);
+#ifdef SQLITE_ORM_CPP20_CONCEPTS_SUPPORTED
+    using iter = iterator_t<Object, storage_type::db_objects_type>;
+    STATIC_REQUIRE(can_iterate_mapped<iter, Object>);
+    // check default initializability at runtime
+    [[maybe_unused]] const iter end;
+#else
+    using iter = decltype(std::declval<storage_type>().iterate<Object>().begin());
+    iter it;
+    const iter end;
 
-    // indirectly_readable
-    STATIC_REQUIRE(std::is_same<decltype(*std::declval<const iter>()), User&>::value);
-    STATIC_REQUIRE(std::is_same<decltype(std::declval<const iter>().operator->()), User*>::value);
+    // LegacyInputIterator
+    {
+        // LegacyIterator
+        {
+            STATIC_REQUIRE(std::is_same<decltype(*it), Object&>::value);
+            STATIC_REQUIRE(std::is_same<decltype(++it), iter&>::value);
+            STATIC_REQUIRE(std::is_same<decltype(*it++), Object&>::value);
+            // copyable (partially, as it is a rather extensive concept)
+            { STATIC_REQUIRE(std::is_copy_constructible<iter>::value); }
+        }
+        // equality_comparable (sentinel)
+        {
+            STATIC_REQUIRE(std::is_same<decltype(it == end), bool>::value);
+            STATIC_REQUIRE(std::is_same<decltype(it != end), bool>::value);
+        }
+        STATIC_REQUIRE(std::is_same<std::iterator_traits<iter>::iterator_category, std::input_iterator_tag>::value);
+        STATIC_REQUIRE(std::is_same<std::iterator_traits<iter>::value_type, Object>::value);
+        STATIC_REQUIRE(std::is_same<std::iterator_traits<iter>::difference_type, ptrdiff_t>::value);
+    }
+    // semiregular (actually sentinel_for, but the other concepts were verified above)
+    { STATIC_REQUIRE(std::is_default_constructible<iter>::value); }
+    STATIC_REQUIRE(std::is_same<std::iterator_traits<iter>::pointer, Object*>::value);
+    // note: should actually be only present for contiguous iterators
+    STATIC_REQUIRE(std::is_same<decltype(it.operator->()), Object*>::value);
+#endif
 
-    // input_iterator
-    STATIC_REQUIRE(std::is_same<iter::iterator_category, std::input_iterator_tag>::value);
-
-    // sentinel (equality comparable)
-    STATIC_REQUIRE(std::is_same<decltype(std::declval<const iter>() == std::declval<const iter>()), bool>::value);
+#ifdef SQLITE_ORM_CPP20_CONCEPTS_SUPPORTED
+    STATIC_REQUIRE(storage_iterate_mapped<storage_type, Object>);
+#endif
 }

--- a/tests/tests5.cpp
+++ b/tests/tests5.cpp
@@ -10,12 +10,6 @@ TEST_CASE("Iterate blob") {
         std::vector<char> key;
     };
 
-    struct TestComparator {
-        bool operator()(const Test& lhs, const Test& rhs) const {
-            return lhs.id == rhs.id && lhs.key == rhs.key;
-        }
-    };
-
     auto db =
         make_storage("",
                      make_table("Test", make_column("key", &Test::key), make_column("id", &Test::id, primary_key())));
@@ -28,15 +22,6 @@ TEST_CASE("Iterate blob") {
 
     db.replace(v);
 
-    TestComparator testComparator;
-    for(auto& obj: db.iterate<Test>()) {
-        REQUIRE(testComparator(obj, v));
-    }  //  test that view_t and iterator_t compile
-
-    for(const auto& obj: db.iterate<Test>()) {
-        REQUIRE(testComparator(obj, v));
-    }  //  test that view_t and iterator_t compile
-
     {
         auto keysCount = db.count<Test>(where(c(&Test::key) == key));
         auto keysCountRows = db.select(count<Test>(), where(c(&Test::key) == key));
@@ -44,14 +29,6 @@ TEST_CASE("Iterate blob") {
         REQUIRE(keysCountRows.front() == 1);
         REQUIRE(keysCount == keysCountRows.front());
         REQUIRE(db.get_all<Test>(where(c(&Test::key) == key)).size() == 1);
-    }
-    {
-        int iterationsCount = 0;
-        for(auto& w: db.iterate<Test>(where(c(&Test::key) == key))) {
-            REQUIRE(testComparator(w, v));
-            ++iterationsCount;
-        }
-        REQUIRE(iterationsCount == 1);
     }
 }
 


### PR DESCRIPTION
Originally, I wanted to extend the ‘table reference’ feature to the iteration of objects:
```c++
struct Object {};
constexpr auto object_table = c<Object>();
auto storage = make_storage("", make_table<object_table>());
storage.iterate<object_table>();
```

This PR also includes changes and improvements to the object iterator:
* Disentangled iterator from its object view: an iterator doesn't need to access the object view itself nor the storage. All it needs is access to the 'db objects'.
* Made all of `iterator_t` private, it's currently not designed for derivation.
* Removed redundant access checks.
* Ensure that `iterator_t` is a `LegacyInputIterator`
* Turned the object view into a so-called 'borrowed view', which guarantees that a function can take it by value and return iterators obtained from it without danger of dangling.