### PR TITLE
Preferred concept names over auto for variables in examples

### DIFF
--- a/dev/alias.h
+++ b/dev/alias.h
@@ -240,7 +240,7 @@ namespace sqlite_orm {
      *  @note An object member pointer can be from a derived class without explicitly forming a column pointer.
      *  
      *  Example:
-     *  constexpr auto als = "u"_alias.for_<User>();
+     *  constexpr orm_table_alias auto als = "u"_alias.for_<User>();
      *  select(alias_column<als>(&User::id))
      */
     template<orm_table_alias auto als, class C>
@@ -446,7 +446,7 @@ namespace sqlite_orm {
     /** @short Create a table alias.
      *
      *  Examples:
-     *  constexpr auto z_alias = alias<'z'>.for_<User>();
+     *  constexpr orm_table_alias auto z_alias = alias<'z'>.for_<User>();
      */
     template<char A, char... X>
     inline constexpr internal::recordset_alias_builder<A, X...> alias{};
@@ -455,7 +455,7 @@ namespace sqlite_orm {
         /** @short Create a table alias.
          *
          *  Examples:
-         *  constexpr auto z_alias = "z"_alias.for_<User>();
+         *  constexpr orm_table_alias auto z_alias = "z"_alias.for_<User>();
          */
         template<internal::cstring_literal name>
         [[nodiscard]] consteval auto operator"" _alias() {

--- a/dev/function.h
+++ b/dev/function.h
@@ -478,7 +478,7 @@ namespace sqlite_orm {
      *  // inline:
      *  select(func<IdFunc>(42));
      *  // As this is a variable template, you can frame the user-defined function and define a variable for syntactic sugar and legibility:
-     *  inline constexpr auto idfunc = func<IdFunc>;
+     *  inline constexpr orm_scalar_function auto idfunc = func<IdFunc>;
      *  select(idfunc(42));
      *  
      */
@@ -498,17 +498,17 @@ namespace sqlite_orm {
          *  
          *  Examples:
          *  // freestanding function from a library
-         *  constexpr auto clamp_int_f = "clamp_int"_scalar.quote(std::clamp<int>);
+         *  constexpr orm_quoted_scalar_function auto clamp_int_f = "clamp_int"_scalar.quote(std::clamp<int>);
          *  // stateless lambda
-         *  constexpr auto is_fatal_error_f = "IS_FATAL_ERROR"_scalar.quote([](unsigned long errcode) {
+         *  constexpr orm_quoted_scalar_function auto is_fatal_error_f = "IS_FATAL_ERROR"_scalar.quote([](unsigned long errcode) {
          *      return errcode != 0;
          *  });
          *  // function object instance
-         *  constexpr auto equal_to_int_f = "equal_to"_scalar.quote(std::equal_to<int>{});
+         *  constexpr orm_quoted_scalar_function auto equal_to_int_f = "equal_to"_scalar.quote(std::equal_to<int>{});
          *  // function object
-         *  constexpr auto equal_to_int_2_f = "equal_to"_scalar.quote<std::equal_to<int>>();
+         *  constexpr orm_quoted_scalar_function auto equal_to_int_2_f = "equal_to"_scalar.quote<std::equal_to<int>>();
          *  // pick function object's template call operator
-         *  constexpr auto equal_to_int_3_f = "equal_to"_scalar.quote<bool(const int&, const int&) const>(std::equal_to<void>{});
+         *  constexpr orm_quoted_scalar_function auto equal_to_int_3_f = "equal_to"_scalar.quote<bool(const int&, const int&) const>(std::equal_to<void>{});
          *
          *  storage.create_scalar_function<clamp_int_f>();
          *  storage.create_scalar_function<is_fatal_error_f>();

--- a/dev/select_constraints.h
+++ b/dev/select_constraints.h
@@ -657,7 +657,7 @@ namespace sqlite_orm {
      *  Despite the missing `RECURSIVE` keyword, the CTE can be recursive.
      *  
      *  Example:
-     *  constexpr auto cte_1 = 1_ctealias;
+     *  constexpr orm_cte_moniker auto cte_1 = 1_ctealias;
      *  with(cte_1().as(select(&Object::id)), select(cte_1->*1_colalias));
      */
     template<class E,
@@ -674,7 +674,7 @@ namespace sqlite_orm {
      *  Despite the missing `RECURSIVE` keyword, the CTE can be recursive.
      *  
      *  Example:
-     *  constexpr auto cte_1 = 1_ctealias;
+     *  constexpr orm_cte_moniker auto cte_1 = 1_ctealias;
      *  with(cte_1().as(select(&Object::id)), select(cte_1->*1_colalias));
      */
     template<class Compound,
@@ -712,7 +712,7 @@ namespace sqlite_orm {
      *  @note The use of RECURSIVE does not force common table expressions to be recursive.
      *  
      *  Example:
-     *  constexpr auto cte_1 = 1_ctealias;
+     *  constexpr orm_cte_moniker auto cte_1 = 1_ctealias;
      *  with_recursive(cte_1().as(select(&Object::id)), select(cte_1->*1_colalias));
      */
     template<class E,
@@ -729,7 +729,7 @@ namespace sqlite_orm {
      *  @note The use of RECURSIVE does not force common table expressions to be recursive.
      *  
      *  Example:
-     *  constexpr auto cte_1 = 1_ctealias;
+     *  constexpr orm_cte_moniker auto cte_1 = 1_ctealias;
      *  with_recursive(cte_1().as(select(&Object::id)), select(cte_1->*1_colalias));
      */
     template<class Compound,
@@ -768,7 +768,7 @@ namespace sqlite_orm {
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
     /**
      *  Example:
-     *  constexpr auto m = "m"_alias.for_<Employee>();
+     *  constexpr orm_table_alias auto m = "m"_alias.for_<Employee>();
      *  auto reportingTo = 
      *      storage.select(asterisk<m>(), inner_join<m>(on(m->*&Employee::reportsTo == &Employee::employeeId)));
      */

--- a/dev/sqlite_schema_table.h
+++ b/dev/sqlite_schema_table.h
@@ -38,6 +38,6 @@ namespace sqlite_orm {
     }
 
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-    inline constexpr auto sqlite_schema = "sqlite_schema"_alias.for_<sqlite_master>();
+    inline constexpr orm_table_alias auto sqlite_schema = "sqlite_schema"_alias.for_<sqlite_master>();
 #endif
 }

--- a/examples/column_aliases.cpp
+++ b/examples/column_aliases.cpp
@@ -60,7 +60,7 @@ void marvel_hero_ordered_by_o_pos() {
     cout << endl;
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
     {
-        constexpr auto i = "i"_col;
+        constexpr orm_column_alias auto i = "i"_col;
         //  SELECT name, instr(abilities, 'o') i
         //  FROM marvel
         //  WHERE i > 0
@@ -94,7 +94,7 @@ void cpp20_column_pointer() {
     };
 
     struct LastResult : Result {};
-    constexpr auto last_result = c<LastResult>();
+    constexpr orm_table_reference auto last_result = c<LastResult>();
 
     auto storage = make_storage(
         "",

--- a/examples/common_table_expressions.cpp
+++ b/examples/common_table_expressions.cpp
@@ -36,7 +36,7 @@ void all_integers_between(int from, int end) {
         //    cnt(x) AS(VALUES(1) UNION ALL SELECT x + 1 FROM cnt WHERE x < 1000000)
         //    SELECT x FROM cnt;
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-        constexpr auto cnt = "cnt"_cte;
+        constexpr orm_cte_moniker auto cnt = "cnt"_cte;
         auto ast = with_recursive(
             cnt().as(union_all(select(from), select(cnt->*1_colalias + 1, where(cnt->*1_colalias < end)))),
             select(cnt->*1_colalias));
@@ -71,8 +71,8 @@ void all_integers_between(int from, int end) {
         //    )
         //    SELECT x FROM cnt;
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-        constexpr auto cnt = "cnt"_cte;
-        constexpr auto x = "x"_col;
+        constexpr orm_cte_moniker auto cnt = "cnt"_cte;
+        constexpr orm_column_alias auto x = "x"_col;
         auto ast =
             with_recursive(cnt().as(union_all(select(from >>= x), select(cnt->*x + 1, limit(end)))), select(cnt->*x));
 #else
@@ -97,8 +97,8 @@ void all_integers_between(int from, int end) {
     // variant 3, limit-clause, explicit column spec
     {
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-        constexpr auto cnt = "cnt"_cte;
-        constexpr auto x = "x"_col;
+        constexpr orm_cte_moniker auto cnt = "cnt"_cte;
+        constexpr orm_column_alias auto x = "x"_col;
         auto ast = with_recursive(cnt(x).as(union_all(select(from), select(cnt->*x + 1, limit(end)))), select(cnt->*x));
 #else
         using cnt = decltype(1_ctealias);
@@ -166,8 +166,8 @@ void supervisor_chain() {
         //    )
         //    SELECT name FROM chain;
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-        constexpr auto chain = "chain"_cte;
-        constexpr auto parent = "parent"_alias.for_<Org>();
+        constexpr orm_cte_moniker auto chain = "chain"_cte;
+        constexpr orm_table_alias auto parent = "parent"_alias.for_<Org>();
         auto ast = with_recursive(
             chain().as(union_all(select(asterisk<Org>(), where(&Org::name == c("Fred"))),
                                  select(asterisk<parent>(), where(parent->*&Org::name == chain->*&Org::boss)))),
@@ -234,7 +234,7 @@ void works_for_alice() {
         //    SELECT avg(height) FROM org
         //    WHERE org.name IN works_for_alice;
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-        constexpr auto works_for_alice = "works_for_alice"_cte;
+        constexpr orm_cte_moniker auto works_for_alice = "works_for_alice"_cte;
         auto ast = with_recursive(
             works_for_alice(&Org::name)
                 .as(union_(select("Alice"), select(&Org::name, where(&Org::boss == works_for_alice->*&Org::name)))),
@@ -321,10 +321,10 @@ void family_tree() {
     //    AND died IS NULL
     //    ORDER BY born;
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-    constexpr auto parent_of = "parent_of"_cte;
-    constexpr auto ancestor_of_alice = "ancestor_of_alice"_cte;
-    constexpr auto parent = "parent"_col;
-    constexpr auto name = "name"_col;
+    constexpr orm_cte_moniker auto parent_of = "parent_of"_cte;
+    constexpr orm_cte_moniker auto ancestor_of_alice = "ancestor_of_alice"_cte;
+    constexpr orm_column_alias auto parent = "parent"_col;
+    constexpr orm_column_alias auto name = "name"_col;
     auto ast = with_recursive(
         make_tuple(
             parent_of(&Family::name, parent)
@@ -446,8 +446,8 @@ void depth_or_breadth_first() {
         //    )
         //    SELECT substr('..........', 1, level * 3) || name FROM under_alice;
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-        constexpr auto under_alice = "under_alice"_cte;
-        constexpr auto level = "level"_col;
+        constexpr orm_cte_moniker auto under_alice = "under_alice"_cte;
+        constexpr orm_column_alias auto level = "level"_col;
         auto ast =
             with_recursive(under_alice(&Org::name, level)
                                .as(union_all(select(columns("Alice", 0)),
@@ -490,8 +490,8 @@ void depth_or_breadth_first() {
         //    )
         //    SELECT substr('..........', 1, level * 3) || name FROM under_alice;
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-        constexpr auto under_alice = "under_alice"_cte;
-        constexpr auto level = "level"_col;
+        constexpr orm_cte_moniker auto under_alice = "under_alice"_cte;
+        constexpr orm_column_alias auto level = "level"_col;
         auto ast =
             with_recursive(under_alice(&Org::name, level)
                                .as(union_all(select(columns("Alice", 0)),
@@ -557,7 +557,7 @@ void select_from_subselect() {
     //     )
     //  SELECT * from sub;
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-    constexpr auto sub = "sub"_cte;
+    constexpr orm_cte_moniker auto sub = "sub"_cte;
     auto expression = with(sub().as(select(columns(&Employee::m_salary, &Employee::m_commission))),
                            select(asterisk<sub>(), where(sub->*&Employee::m_salary < 5000)));
 #else
@@ -599,17 +599,17 @@ void apfelmaennchen() {
     //    )
     //    SELECT group_concat(rtrim(t), x'0a') FROM a;
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-    constexpr auto xaxis = "xaxis"_cte;
-    constexpr auto yaxis = "yaxis"_cte;
-    constexpr auto m = "m"_cte;
-    constexpr auto m2 = "m2"_cte;
-    constexpr auto a = "string"_cte;
-    constexpr auto x = "x"_col;
-    constexpr auto y = "y"_col;
-    constexpr auto iter = "iter"_col;
-    constexpr auto cx = "cx"_col;
-    constexpr auto cy = "cy"_col;
-    constexpr auto t = "t"_col;
+    constexpr orm_cte_moniker auto xaxis = "xaxis"_cte;
+    constexpr orm_cte_moniker auto yaxis = "yaxis"_cte;
+    constexpr orm_cte_moniker auto m = "m"_cte;
+    constexpr orm_cte_moniker auto m2 = "m2"_cte;
+    constexpr orm_cte_moniker auto a = "string"_cte;
+    constexpr orm_column_alias auto x = "x"_col;
+    constexpr orm_column_alias auto y = "y"_col;
+    constexpr orm_column_alias auto iter = "iter"_col;
+    constexpr orm_column_alias auto cx = "cx"_col;
+    constexpr orm_column_alias auto cy = "cy"_col;
+    constexpr orm_column_alias auto t = "t"_col;
     auto ast = with_recursive(
         make_tuple(
             xaxis(x).as(union_all(select(-2.0), select(xaxis->*x + 0.05, where(xaxis->*x < 1.2)))),
@@ -712,15 +712,15 @@ void sudoku() {
     //    )
     //    SELECT s FROM x WHERE ind = 0;
 
-    constexpr auto input = "input"_cte;
-    constexpr auto digits = "digits"_cte;
-    constexpr auto z_alias = "z"_alias.for_<digits>();
-    constexpr auto x = "x"_cte;
-    constexpr auto sud = "sud"_col;
-    constexpr auto z = "z"_col;
-    constexpr auto lp = "lp"_col;
-    constexpr auto s = "s"_col;
-    constexpr auto ind = "ind"_col;
+    constexpr orm_cte_moniker auto input = "input"_cte;
+    constexpr orm_cte_moniker auto digits = "digits"_cte;
+    constexpr orm_table_alias auto z_alias = "z"_alias.for_<digits>();
+    constexpr orm_cte_moniker auto x = "x"_cte;
+    constexpr orm_column_alias auto sud = "sud"_col;
+    constexpr orm_column_alias auto z = "z"_col;
+    constexpr orm_column_alias auto lp = "lp"_col;
+    constexpr orm_column_alias auto s = "s"_col;
+    constexpr orm_column_alias auto ind = "ind"_col;
     auto ast = with_recursive(
         make_tuple(
             cte<input>(sud).as(
@@ -765,7 +765,7 @@ void show_optimization_fence() {
         //WITH
         //    cnt(x) AS MATERIALIZED(VALUES(1))
         //    SELECT x FROM cnt;
-        constexpr auto cnt = "cnt"_cte;
+        constexpr orm_cte_moniker auto cnt = "cnt"_cte;
         auto ast = with(cnt().as<materialized()>(select(1)), select(cnt->*1_colalias));
 
         [[maybe_unused]] string sql = storage.dump(ast);
@@ -777,7 +777,7 @@ void show_optimization_fence() {
         //WITH
         //    cnt(x) AS NOT MATERIALIZED(VALUES(1))
         //    SELECT x FROM cnt;
-        constexpr auto cnt = "cnt"_cte;
+        constexpr orm_cte_moniker auto cnt = "cnt"_cte;
         auto ast = with(cnt().as<not_materialized()>(select(1)), select(cnt->*1_colalias));
 
         [[maybe_unused]] string sql = storage.dump(ast);
@@ -932,11 +932,11 @@ void neevek_issue_222() {
         return true;
     });
 
-    constexpr auto register_user = "register_user"_cte;
-    constexpr auto registered_cnt = "registered_cnt"_cte;
-    constexpr auto register_date = "register_date"_col;
-    constexpr auto user_count = "user_count"_col;
-    constexpr auto ndays = "ndays"_col;
+    constexpr orm_cte_moniker auto register_user = "register_user"_cte;
+    constexpr orm_cte_moniker auto registered_cnt = "registered_cnt"_cte;
+    constexpr orm_column_alias auto register_date = "register_date"_col;
+    constexpr orm_column_alias auto user_count = "user_count"_col;
+    constexpr orm_column_alias auto ndays = "ndays"_col;
     auto expression = with(
         make_tuple(
             register_user().as(select(
@@ -1026,8 +1026,8 @@ void greatest_n_per_group() {
     //    and r.timestamp = wnd.max_date
     //    -- other conditions
     //where r.flag = 1
-    constexpr auto wnd = "wnd"_cte;
-    constexpr auto max_date = "max_date"_col;
+    constexpr orm_cte_moniker auto wnd = "wnd"_cte;
+    constexpr orm_column_alias auto max_date = "max_date"_col;
     auto expression = with(
         wnd(&some_result::item_id, max_date)
             .as(select(columns(&some_result::item_id, max(&some_result::timestamp)), group_by(&some_result::item_id))),

--- a/examples/custom_aliases.cpp
+++ b/examples/custom_aliases.cpp
@@ -105,10 +105,10 @@ int main(int, char** argv) {
     //  FROM COMPANY AS C, DEPARTMENT AS D
     //  WHERE  C.ID = D.EMP_ID;
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-    constexpr auto c_als = "c"_alias.for_<Employee>();
-    constexpr auto d = "d"_alias.for_<Department>();
-    static_assert(std::is_empty_v<EmployeeIdAlias>);
-    constexpr auto empId = EmployeeIdAlias{};
+    constexpr orm_table_alias auto c_als = "c"_alias.for_<Employee>();
+    constexpr orm_table_alias auto d = "d"_alias.for_<Department>();
+    static_assert(std::is_empty_v<EmployeeIdAlias>);  // note: it's
+    constexpr orm_column_alias auto empId = EmployeeIdAlias{};
     auto rowsWithTableAliases = storage.select(
         columns(c_als->*&Employee::id, c_als->*&Employee::name, c_als->*&Employee::age, d->*&Department::dept),
         where(is_equal(c_als->*&Employee::id, d->*&Department::empId)));

--- a/examples/exists.cpp
+++ b/examples/exists.cpp
@@ -476,8 +476,8 @@ int main(int, char**) {
         //  ORDER BY 'c'."PAYMENT_AMT"
 
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-        constexpr auto c_als = "c"_alias.for_<Customer>();
-        constexpr auto d = "d"_alias.for_<Customer>();
+        constexpr orm_table_alias auto c_als = "c"_alias.for_<Customer>();
+        constexpr orm_table_alias auto d = "d"_alias.for_<Customer>();
 
         double amount = 2000;
         auto where_clause = select(d->*&Customer::agentCode,

--- a/examples/self_join.cpp
+++ b/examples/self_join.cpp
@@ -200,7 +200,7 @@ int main() {
         //  INNER JOIN employees m
         //  ON m.ReportsTo = employees.EmployeeId
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-        constexpr auto m = "m"_alias.for_<Employee>();
+        constexpr orm_table_alias auto m = "m"_alias.for_<Employee>();
         auto firstNames = storage.select(columns(m->*&Employee::firstName || " " || m->*&Employee::lastName,
                                                  &Employee::firstName || " " || &Employee::lastName),
                                          inner_join<m>(on(m->*&Employee::reportsTo == &Employee::employeeId)));
@@ -232,7 +232,7 @@ int main() {
         //  ON emp.ReportsTo = employees.EmployeeId
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
         static_assert(std::is_empty_v<custom_alias<Employee>>);
-        constexpr auto emp = custom_alias<Employee>{};
+        constexpr orm_table_alias auto emp = custom_alias<Employee>{};
         auto firstNames = storage.select(columns(emp->*&Employee::firstName || " " || emp->*&Employee::lastName,
                                                  &Employee::firstName || " " || &Employee::lastName),
                                          inner_join<emp>(on(emp->*&Employee::reportsTo == &Employee::employeeId)));

--- a/examples/subquery.cpp
+++ b/examples/subquery.cpp
@@ -1363,7 +1363,7 @@ int main(int, char**) {
         //      FROM employees
         //      WHERE department_id = e.department_id);
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-        constexpr auto e = "e"_alias.for_<Employee>();
+        constexpr orm_table_alias auto e = "e"_alias.for_<Employee>();
         auto rows = storage.select(
             columns(e->*&Employee::lastName, e->*&Employee::salary, e->*&Employee::departmentId),
             from<e>(),

--- a/examples/user_defined_functions.cpp
+++ b/examples/user_defined_functions.cpp
@@ -35,7 +35,7 @@ struct SignFunction {
     }
 };
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-inline constexpr auto sign = func<SignFunction>;
+inline constexpr orm_scalar_function auto sign = func<SignFunction>;
 #endif
 
 /**
@@ -81,7 +81,7 @@ struct AcceleratedSumFunction {
     }
 };
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-inline constexpr auto accelerated_sum = func<AcceleratedSumFunction>;
+inline constexpr orm_aggregate_function auto accelerated_sum = func<AcceleratedSumFunction>;
 #endif
 
 /**
@@ -112,7 +112,7 @@ struct ArithmeticMeanFunction {
     }
 };
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-inline constexpr auto arithmetic_mean = func<ArithmeticMeanFunction>;
+inline constexpr orm_scalar_function auto arithmetic_mean = func<ArithmeticMeanFunction>;
 #endif
 
 int main() {

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -5488,7 +5488,7 @@ namespace sqlite_orm {
      *  @note An object member pointer can be from a derived class without explicitly forming a column pointer.
      *  
      *  Example:
-     *  constexpr auto als = "u"_alias.for_<User>();
+     *  constexpr orm_table_alias auto als = "u"_alias.for_<User>();
      *  select(alias_column<als>(&User::id))
      */
     template<orm_table_alias auto als, class C>
@@ -5694,7 +5694,7 @@ namespace sqlite_orm {
     /** @short Create a table alias.
      *
      *  Examples:
-     *  constexpr auto z_alias = alias<'z'>.for_<User>();
+     *  constexpr orm_table_alias auto z_alias = alias<'z'>.for_<User>();
      */
     template<char A, char... X>
     inline constexpr internal::recordset_alias_builder<A, X...> alias{};
@@ -5703,7 +5703,7 @@ namespace sqlite_orm {
         /** @short Create a table alias.
          *
          *  Examples:
-         *  constexpr auto z_alias = "z"_alias.for_<User>();
+         *  constexpr orm_table_alias auto z_alias = "z"_alias.for_<User>();
          */
         template<internal::cstring_literal name>
         [[nodiscard]] consteval auto operator"" _alias() {
@@ -8956,7 +8956,7 @@ namespace sqlite_orm {
      *  Despite the missing `RECURSIVE` keyword, the CTE can be recursive.
      *  
      *  Example:
-     *  constexpr auto cte_1 = 1_ctealias;
+     *  constexpr orm_cte_moniker auto cte_1 = 1_ctealias;
      *  with(cte_1().as(select(&Object::id)), select(cte_1->*1_colalias));
      */
     template<class E,
@@ -8973,7 +8973,7 @@ namespace sqlite_orm {
      *  Despite the missing `RECURSIVE` keyword, the CTE can be recursive.
      *  
      *  Example:
-     *  constexpr auto cte_1 = 1_ctealias;
+     *  constexpr orm_cte_moniker auto cte_1 = 1_ctealias;
      *  with(cte_1().as(select(&Object::id)), select(cte_1->*1_colalias));
      */
     template<class Compound,
@@ -9011,7 +9011,7 @@ namespace sqlite_orm {
      *  @note The use of RECURSIVE does not force common table expressions to be recursive.
      *  
      *  Example:
-     *  constexpr auto cte_1 = 1_ctealias;
+     *  constexpr orm_cte_moniker auto cte_1 = 1_ctealias;
      *  with_recursive(cte_1().as(select(&Object::id)), select(cte_1->*1_colalias));
      */
     template<class E,
@@ -9028,7 +9028,7 @@ namespace sqlite_orm {
      *  @note The use of RECURSIVE does not force common table expressions to be recursive.
      *  
      *  Example:
-     *  constexpr auto cte_1 = 1_ctealias;
+     *  constexpr orm_cte_moniker auto cte_1 = 1_ctealias;
      *  with_recursive(cte_1().as(select(&Object::id)), select(cte_1->*1_colalias));
      */
     template<class Compound,
@@ -9067,7 +9067,7 @@ namespace sqlite_orm {
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
     /**
      *  Example:
-     *  constexpr auto m = "m"_alias.for_<Employee>();
+     *  constexpr orm_table_alias auto m = "m"_alias.for_<Employee>();
      *  auto reportingTo = 
      *      storage.select(asterisk<m>(), inner_join<m>(on(m->*&Employee::reportsTo == &Employee::employeeId)));
      */
@@ -13078,7 +13078,7 @@ namespace sqlite_orm {
      *  // inline:
      *  select(func<IdFunc>(42));
      *  // As this is a variable template, you can frame the user-defined function and define a variable for syntactic sugar and legibility:
-     *  inline constexpr auto idfunc = func<IdFunc>;
+     *  inline constexpr orm_scalar_function auto idfunc = func<IdFunc>;
      *  select(idfunc(42));
      *  
      */
@@ -13098,17 +13098,17 @@ namespace sqlite_orm {
          *  
          *  Examples:
          *  // freestanding function from a library
-         *  constexpr auto clamp_int_f = "clamp_int"_scalar.quote(std::clamp<int>);
+         *  constexpr orm_quoted_scalar_function auto clamp_int_f = "clamp_int"_scalar.quote(std::clamp<int>);
          *  // stateless lambda
-         *  constexpr auto is_fatal_error_f = "IS_FATAL_ERROR"_scalar.quote([](unsigned long errcode) {
+         *  constexpr orm_quoted_scalar_function auto is_fatal_error_f = "IS_FATAL_ERROR"_scalar.quote([](unsigned long errcode) {
          *      return errcode != 0;
          *  });
          *  // function object instance
-         *  constexpr auto equal_to_int_f = "equal_to"_scalar.quote(std::equal_to<int>{});
+         *  constexpr orm_quoted_scalar_function auto equal_to_int_f = "equal_to"_scalar.quote(std::equal_to<int>{});
          *  // function object
-         *  constexpr auto equal_to_int_2_f = "equal_to"_scalar.quote<std::equal_to<int>>();
+         *  constexpr orm_quoted_scalar_function auto equal_to_int_2_f = "equal_to"_scalar.quote<std::equal_to<int>>();
          *  // pick function object's template call operator
-         *  constexpr auto equal_to_int_3_f = "equal_to"_scalar.quote<bool(const int&, const int&) const>(std::equal_to<void>{});
+         *  constexpr orm_quoted_scalar_function auto equal_to_int_3_f = "equal_to"_scalar.quote<bool(const int&, const int&) const>(std::equal_to<void>{});
          *
          *  storage.create_scalar_function<clamp_int_f>();
          *  storage.create_scalar_function<is_fatal_error_f>();
@@ -23591,7 +23591,7 @@ namespace sqlite_orm {
     }
 
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-    inline constexpr auto sqlite_schema = "sqlite_schema"_alias.for_<sqlite_master>();
+    inline constexpr orm_table_alias auto sqlite_schema = "sqlite_schema"_alias.for_<sqlite_master>();
 #endif
 }
 #pragma once


### PR DESCRIPTION
Following [C++ core guideline T.12](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rt-auto).