### PR TITLE
Modernized the pointer passing interface with C++20 features

### DIFF
--- a/dev/carray.h
+++ b/dev/carray.h
@@ -38,8 +38,13 @@ namespace sqlite_orm {
      *  the deleter when the statement finishes.
      */
     template<class P, class D>
-    auto bindable_carray_pointer(P* p, D d) noexcept -> pointer_binding_t<P, carray_pointer_tag, D> {
-        return bindable_pointer<carray_pointer_tag>(p, std::move(d));
+    carray_pointer_binding<P, D> bind_carray_pointer(P* p, D d) noexcept {
+        return bind_pointer<carray_pointer_tag>(p, std::move(d));
+    }
+
+    template<class P>
+    static_carray_pointer_binding<P> bind_carray_pointer_statically(P* p) noexcept {
+        return bind_pointer_statically<carray_pointer_tag>(p);
     }
 
     /**
@@ -48,9 +53,17 @@ namespace sqlite_orm {
      *  Note: 'Static' means that ownership of the pointed-to-object won't be transferred
      *  and sqlite assumes the object pointed to is valid throughout the lifetime of a statement.
      */
+    template<class P, class D>
+    [[deprecated("Use the better named function `bind_carray_pointer(...)`")]] carray_pointer_binding<P, D>
+    bindable_carray_pointer(P* p, D d) noexcept {
+        return bind_pointer<carray_pointer_tag>(p, std::move(d));
+    }
+
     template<class P>
-    auto statically_bindable_carray_pointer(P* p) noexcept -> static_pointer_binding_t<P, carray_pointer_tag> {
-        return statically_bindable_pointer<carray_pointer_tag>(p);
+    [[deprecated(
+        "Use the better named function `bind_carray_pointer_statically(...)` ")]] static_carray_pointer_binding<P>
+    statically_bindable_carray_pointer(P* p) noexcept {
+        return bind_pointer_statically<carray_pointer_tag>(p);
     }
 #else
     inline constexpr const char carray_pointer_name[] = "carray";
@@ -73,8 +86,8 @@ namespace sqlite_orm {
      *  the deleter when the statement finishes.
      */
     template<class P, class D>
-    auto bindable_carray_pointer(P* p, D d) noexcept -> pointer_binding<P, carray_pointer_type, D> {
-        return bindable_pointer<carray_pointer_type>(p, std::move(d));
+    carray_pointer_binding<P, D> bind_carray_pointer(P* p, D d) noexcept {
+        return bind_pointer<carray_pointer_type>(p, std::move(d));
     }
 
     /**
@@ -84,8 +97,21 @@ namespace sqlite_orm {
      *  and sqlite assumes the object pointed to is valid throughout the lifetime of a statement.
      */
     template<class P>
-    auto statically_bindable_carray_pointer(P* p) noexcept -> static_pointer_binding<P, carray_pointer_type> {
-        return statically_bindable_pointer<carray_pointer_type>(p);
+    static_carray_pointer_binding<P> bind_carray_pointer_statically(P* p) noexcept {
+        return bind_pointer_statically<carray_pointer_type>(p);
+    }
+
+    template<class P, class D>
+    [[deprecated("Use the better named function `bind_carray_pointer(...)`")]] carray_pointer_binding<P, D>
+    bindable_carray_pointer(P* p, D d) noexcept {
+        return bind_carray_pointer(p, std::move(d));
+    }
+
+    template<class P>
+    [[deprecated(
+        "Use the better named function `bind_carray_pointer_statically(...)` ")]] static_carray_pointer_binding<P>
+    statically_bindable_carray_pointer(P* p) noexcept {
+        return bind_carray_pointer_statically(p);
     }
 #endif
 

--- a/dev/carray.h
+++ b/dev/carray.h
@@ -7,23 +7,28 @@
  */
 
 #ifdef SQLITE_ORM_INLINE_VARIABLES_SUPPORTED
-#include <type_traits>  //  std::integral_constant
 #include <utility>  //  std::move
+#ifndef SQLITE_ORM_WITH_CPP20_ALIASES
+#include <type_traits>  //  std::integral_constant
+#endif
+#endif
 
-#include "functional/cxx_universal.h"
 #include "pointer_value.h"
 
+#ifdef SQLITE_ORM_INLINE_VARIABLES_SUPPORTED
 namespace sqlite_orm {
 
-    inline constexpr const char carray_pvt_name[] = "carray";
-    using carray_pvt = std::integral_constant<const char*, carray_pvt_name>;
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+    inline constexpr orm_pointer_type auto carray_pointer_tag = "carray"_pointer_type;
+    // [Deprecation notice] This type is deprecated and will be removed in v1.10. Use the inline variable `carray_pointer_tag` instead.
+    using carray_pvt [[deprecated]] = decltype("carray"_pointer_type);
 
     template<typename P>
-    using carray_pointer_arg = pointer_arg<P, carray_pvt>;
+    using carray_pointer_arg = pointer_arg_t<P, carray_pointer_tag>;
     template<typename P, typename D>
-    using carray_pointer_binding = pointer_binding<P, carray_pvt, D>;
+    using carray_pointer_binding = pointer_binding_t<P, carray_pointer_tag, D>;
     template<typename P>
-    using static_carray_pointer_binding = static_pointer_binding<P, carray_pvt>;
+    using static_carray_pointer_binding = static_pointer_binding_t<P, carray_pointer_tag>;
 
     /**
      *  Wrap a pointer of type 'carray' and its deleter function for binding it to a statement.
@@ -33,8 +38,8 @@ namespace sqlite_orm {
      *  the deleter when the statement finishes.
      */
     template<class P, class D>
-    auto bindable_carray_pointer(P* p, D d) noexcept -> pointer_binding<P, carray_pvt, D> {
-        return bindable_pointer<carray_pvt>(p, std::move(d));
+    auto bindable_carray_pointer(P* p, D d) noexcept -> pointer_binding_t<P, carray_pointer_tag, D> {
+        return bindable_pointer<carray_pointer_tag>(p, std::move(d));
     }
 
     /**
@@ -44,9 +49,45 @@ namespace sqlite_orm {
      *  and sqlite assumes the object pointed to is valid throughout the lifetime of a statement.
      */
     template<class P>
-    auto statically_bindable_carray_pointer(P* p) noexcept -> static_pointer_binding<P, carray_pvt> {
-        return statically_bindable_pointer<carray_pvt>(p);
+    auto statically_bindable_carray_pointer(P* p) noexcept -> static_pointer_binding_t<P, carray_pointer_tag> {
+        return statically_bindable_pointer<carray_pointer_tag>(p);
     }
+#else
+    inline constexpr const char carray_pointer_name[] = "carray";
+    using carray_pointer_type = std::integral_constant<const char*, carray_pointer_name>;
+    // [Deprecation notice] This type is deprecated and will be removed in v1.10. Use the alias type `carray_pointer_type` instead.
+    using carray_pvt [[deprecated]] = carray_pointer_type;
+
+    template<typename P>
+    using carray_pointer_arg = pointer_arg<P, carray_pointer_type>;
+    template<typename P, typename D>
+    using carray_pointer_binding = pointer_binding<P, carray_pointer_type, D>;
+    template<typename P>
+    using static_carray_pointer_binding = static_pointer_binding<P, carray_pointer_type>;
+
+    /**
+     *  Wrap a pointer of type 'carray' and its deleter function for binding it to a statement.
+     *  
+     *  Unless the deleter yields a nullptr 'xDestroy' function the ownership of the pointed-to-object
+     *  is transferred to the pointer binding, which will delete it through
+     *  the deleter when the statement finishes.
+     */
+    template<class P, class D>
+    auto bindable_carray_pointer(P* p, D d) noexcept -> pointer_binding<P, carray_pointer_type, D> {
+        return bindable_pointer<carray_pointer_type>(p, std::move(d));
+    }
+
+    /**
+     *  Wrap a pointer of type 'carray' for binding it to a statement.
+     *  
+     *  Note: 'Static' means that ownership of the pointed-to-object won't be transferred
+     *  and sqlite assumes the object pointed to is valid throughout the lifetime of a statement.
+     */
+    template<class P>
+    auto statically_bindable_carray_pointer(P* p) noexcept -> static_pointer_binding<P, carray_pointer_type> {
+        return statically_bindable_pointer<carray_pointer_type>(p);
+    }
+#endif
 
     /**
      *  Generalized form of the 'remember' SQL function that is a pass-through for values

--- a/dev/function.h
+++ b/dev/function.h
@@ -8,7 +8,7 @@
 #include <algorithm>  //  std::min, std::copy_n
 #include <utility>  //  std::move, std::forward
 
-#include "functional/cxx_universal.h"
+#include "functional/cxx_universal.h"  //  ::size_t
 #include "functional/cxx_type_traits_polyfill.h"
 #include "functional/cstring_literal.h"
 #include "functional/function_traits.h"
@@ -19,9 +19,9 @@ namespace sqlite_orm {
 
     struct arg_values;
 
-    template<class T, class P>
+    template<class P, class T>
     struct pointer_arg;
-    template<class T, class P, class D>
+    template<class P, class T, class D>
     class pointer_binding;
 
     namespace internal {

--- a/dev/statement_binder.h
+++ b/dev/statement_binder.h
@@ -50,7 +50,7 @@ namespace sqlite_orm {
     }
 
     /**
-     *  Specialization for 'pointer-passing interface'.
+     *  Specialization for pointer bindings (part of the 'pointer-passing interface').
      */
     template<class P, class T, class D>
     struct statement_binder<pointer_binding<P, T, D>, void> {

--- a/examples/custom_aliases.cpp
+++ b/examples/custom_aliases.cpp
@@ -107,7 +107,7 @@ int main(int, char** argv) {
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
     constexpr orm_table_alias auto c_als = "c"_alias.for_<Employee>();
     constexpr orm_table_alias auto d = "d"_alias.for_<Department>();
-    static_assert(std::is_empty_v<EmployeeIdAlias>);  // note: it's
+    static_assert(std::is_empty_v<EmployeeIdAlias>);
     constexpr orm_column_alias auto empId = EmployeeIdAlias{};
     auto rowsWithTableAliases = storage.select(
         columns(c_als->*&Employee::id, c_als->*&Employee::name, c_als->*&Employee::age, d->*&Department::dept),

--- a/examples/pointer_passing_interface.cpp
+++ b/examples/pointer_passing_interface.cpp
@@ -40,12 +40,17 @@ using std::error_code;
 using std::make_unique;
 using std::min;
 
-// name for our pointer value types
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+inline constexpr orm_pointer_type auto ecat_pointer_tag = "ecat"_pointer_type;
+inline constexpr orm_pointer_type auto ecode_pointer_tag = "ecode"_pointer_type;
+#else
+// name for our pointer types
 inline constexpr const char ecat_pvt_name[] = "ecat";
 inline constexpr const char ecode_pvt_name[] = "ecode";
-// c++ integral constant for our pointer value types
-using ecat_pvt = std::integral_constant<const char*, ecat_pvt_name>;
-using ecode_pvt = std::integral_constant<const char*, ecode_pvt_name>;
+// c++ integral constant for our pointer types
+using ecat_pointer_type = std::integral_constant<const char*, ecat_pvt_name>;
+using ecode_pointer_type = std::integral_constant<const char*, ecode_pvt_name>;
+#endif
 
 // a fixed set of error categories the application is dealing with
 enum class app_error_category : unsigned int {
@@ -86,18 +91,31 @@ int main() {
         int errorValue = 0;
         unsigned int errorCategory = 0;
     };
-    using ecat_arg_t = pointer_arg<const std::error_category, ecat_pvt>;
-    using ecode_arg_t = pointer_arg<std::error_code, ecode_pvt>;
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+    using ecat_arg = pointer_arg_t<const std::error_category, ecat_pointer_tag>;
+    using ecode_arg = pointer_arg_t<std::error_code, ecode_pointer_tag>;
+#else
+    using ecat_arg = pointer_arg<const std::error_category, ecat_pointer_type>;
+    using ecode_arg = pointer_arg<std::error_code, ecode_pointer_type>;
+#endif
 
     // function returning a pointer to a std::error_category,
     // which is only visible to functions accepting pointer values of type "ecat"
     struct get_error_category_fn {
-        using ecat_binding = static_pointer_binding<const std::error_category, ecat_pvt>;
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+        using ecat_binding = static_pointer_binding_t<const std::error_category, ecat_pointer_tag>;
+#else
+        using ecat_binding = static_pointer_binding<const std::error_category, ecat_pointer_type>;
+#endif
 
         ecat_binding operator()(unsigned int errorCategory) const {
             size_t idx = min<size_t>(errorCategory, ecat_map.size());
             const error_category* ecat = idx != ecat_map.size() ? &get<const error_category&>(ecat_map[idx]) : nullptr;
-            return statically_bindable_pointer<ecat_pvt>(ecat);
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+            return statically_bindable_pointer<ecat_pointer_tag>(ecat);
+#else
+            return statically_bindable_pointer<ecat_pointer_type>(ecat);
+#endif
         }
 
         static constexpr const char* name() {
@@ -108,7 +126,7 @@ int main() {
     // function accepting a pointer to a std::error_category,
     // returns the category's name
     struct error_category_name_fn {
-        std::string operator()(ecat_arg_t pv) const {
+        std::string operator()(ecat_arg pv) const {
             if(const error_category* ec = pv) {
                 return ec->name();
             }
@@ -123,7 +141,7 @@ int main() {
     // function accepting a pointer to a std::error_category and an error code,
     // returns the error message
     struct error_category_message_fn {
-        std::string operator()(ecat_arg_t pv, int errorValue) const {
+        std::string operator()(ecat_arg pv, int errorValue) const {
             if(const error_category* ec = pv) {
                 return ec->message(errorValue);
             }
@@ -137,7 +155,13 @@ int main() {
 
     // function returning an error_code object from an error value
     struct make_error_code_fn {
-        using ecode_binding = pointer_binding<std::error_code, ecode_pvt, std::default_delete<std::error_code>>;
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+        using ecode_binding =
+            pointer_binding_t<std::error_code, ecode_pointer_tag, std::default_delete<std::error_code>>;
+#else
+        using ecode_binding =
+            pointer_binding<std::error_code, ecode_pointer_type, std::default_delete<std::error_code>>;
+#endif
 
         ecode_binding operator()(int errorValue, unsigned int errorCategory) const {
             size_t idx = min<size_t>(errorCategory, ecat_map.size());
@@ -154,7 +178,7 @@ int main() {
 
     // function comparing two error_code objects
     struct equal_error_code_fn {
-        bool operator()(ecode_arg_t pv1, ecode_arg_t pv2) const {
+        bool operator()(ecode_arg pv1, ecode_arg pv2) const {
             error_code *ec1 = pv1, *ec2 = pv2;
             if(ec1 && ec2) {
                 return *ec1 == *ec2;
@@ -207,7 +231,11 @@ int main() {
                                    &Result::errorCategory,
                                    as<str_alias<'e', 'q'>>(func<equal_error_code_fn>(
                                        func<make_error_code_fn>(&Result::errorValue, &Result::errorCategory),
-                                       bindable_pointer<ecode_pvt>(make_unique<error_code>()))),
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+                                       bindable_pointer<ecode_pointer_tag>(make_unique<error_code>()))),
+#else
+                                       bindable_pointer<ecode_pointer_type>(make_unique<error_code>()))),
+#endif
                                    func<error_category_name_fn>(func<get_error_category_fn>(&Result::errorCategory)),
                                    func<error_category_message_fn>(func<get_error_category_fn>(&Result::errorCategory),
                                                                    &Result::errorValue)),

--- a/tests/pointer_passing_interface.cpp
+++ b/tests/pointer_passing_interface.cpp
@@ -31,9 +31,9 @@ namespace {
 TEST_CASE("pointer-passing") {
     // accept and return a pointer of type "carray"
     struct pass_thru_pointer_fn {
-        using bindable_carray_ptr_t = static_carray_pointer_binding<int64>;
+        using int64_pointer_binding = static_carray_pointer_binding<int64>;
 
-        bindable_carray_ptr_t operator()(carray_pointer_arg<int64> pv) const {
+        int64_pointer_binding operator()(carray_pointer_arg<int64> pv) const {
             return rebind_statically(pv);
         }
 
@@ -44,12 +44,12 @@ TEST_CASE("pointer-passing") {
 
     // return a pointer of type "carray"
     struct make_pointer_fn {
-        using bindable_carray_ptr_t = carray_pointer_binding<int64, delete_int64>;
+        using int64_pointer_binding = carray_pointer_binding<int64, delete_int64>;
 
-        bindable_carray_ptr_t operator()() const {
-            return bindable_pointer<bindable_carray_ptr_t>(new int64{-1});
+        int64_pointer_binding operator()() const {
+            return bind_pointer<int64_pointer_binding>(new int64{-1});
             // outline: low-level; must compile
-            return bindable_carray_pointer(new int64{-1}, delete_int64{});
+            return bind_carray_pointer(new int64{-1}, delete_int64{});
         }
 
         static const char* name() {
@@ -83,34 +83,33 @@ TEST_CASE("pointer-passing") {
     storage.create_scalar_function<pass_thru_pointer_fn>();
 
     // test the note_value function
-    SECTION("note_value, statically_bindable_pointer") {
+    SECTION("note_value, bind_pointer_statically") {
         int64 lastUpdatedId = -1;
-        storage.update_all(set(c(&Object::id) = add(1ll,
-                                                    func<note_value_fn<int64>>(
-                                                        &Object::id,
-#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-                                                        statically_bindable_pointer<carray_pointer_tag>(&lastUpdatedId)
-#else
-                                                        statically_bindable_pointer<carray_pointer_type>(&lastUpdatedId)
-#endif
-                                                            ))));
-        REQUIRE(lastUpdatedId == 1);
         storage.update_all(set(
-            c(&Object::id) =
-                add(1ll, func<note_value_fn<int64>>(&Object::id, statically_bindable_carray_pointer(&lastUpdatedId)))));
+            c(&Object::id) = add(1ll,
+                                 func<note_value_fn<int64>>(&Object::id,
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+                                                            bind_pointer_statically<carray_pointer_tag>(&lastUpdatedId)
+#else
+                                                            bind_pointer_statically<carray_pointer_type>(&lastUpdatedId)
+#endif
+                                                                ))));
+        REQUIRE(lastUpdatedId == 1);
+        storage.update_all(
+            set(c(&Object::id) =
+                    add(1ll, func<note_value_fn<int64>>(&Object::id, bind_carray_pointer_statically(&lastUpdatedId)))));
         REQUIRE(lastUpdatedId == 2);
     }
 
     // test passing a pointer into another function
-    SECTION("test_pass_thru, statically_bindable_pointer") {
+    SECTION("test_pass_thru, bind_pointer_statically") {
         int64 lastSelectedId = -1;
-        auto v = storage.select(func<note_value_fn<int64>>(
-            &Object::id,
-            func<pass_thru_pointer_fn>(statically_bindable_carray_pointer(&lastSelectedId))));
+        auto v = storage.select(
+            func<note_value_fn<int64>>(&Object::id,
+                                       func<pass_thru_pointer_fn>(bind_carray_pointer_statically(&lastSelectedId))));
         REQUIRE(v.back() == lastSelectedId);
         lastSelectedId = -1;
-        v = storage.select(
-            func<note_value_fn<int64>>(&Object::id, statically_bindable_carray_pointer(&lastSelectedId)));
+        v = storage.select(func<note_value_fn<int64>>(&Object::id, bind_carray_pointer_statically(&lastSelectedId)));
     }
 
     SECTION("bindable_pointer") {
@@ -122,9 +121,9 @@ TEST_CASE("pointer-passing") {
                 unique_ptr<int64, delete_int64> x{new int64(42)};
                 auto ast = select(func<fetch_from_pointer_fn>(
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-                    bindable_pointer<carray_pointer_tag>(std::move(x))
+                    bind_pointer<carray_pointer_tag>(std::move(x))
 #else
-                    bindable_pointer<carray_pointer_type>(std::move(x))
+                    bind_pointer<carray_pointer_type>(std::move(x))
 #endif
                         ));
                 auto stmt = storage.prepare(std::move(ast));
@@ -140,9 +139,9 @@ TEST_CASE("pointer-passing") {
                 unique_ptr<int64, delete_int64> x{new int64(42)};
                 auto ast = select(func<fetch_from_pointer_fn>(
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-                    bindable_pointer<carray_pointer_tag>(std::move(x))
+                    bind_pointer<carray_pointer_tag>(std::move(x))
 #else
-                    bindable_pointer<carray_pointer_type>(std::move(x))
+                    bind_pointer<carray_pointer_type>(std::move(x))
 #endif
                         ));
                 auto stmt = storage.prepare(std::move(ast));
@@ -171,7 +170,7 @@ TEST_CASE("pointer-passing") {
         SECTION("test_pass_thru") {
             auto v = storage.select(func<note_value_fn<int64>>(
                 &Object::id,
-                func<pass_thru_pointer_fn>(bindable_carray_pointer(new int64{-1}, delete_int64{}))));
+                func<pass_thru_pointer_fn>(bind_carray_pointer(new int64{-1}, delete_int64{}))));
             REQUIRE(delete_int64::deleted == true);
             REQUIRE(v.back() == delete_int64::lastSelectedId);
         }

--- a/tests/statement_serializer_tests/bindables.cpp
+++ b/tests/statement_serializer_tests/bindables.cpp
@@ -266,27 +266,27 @@ TEST_CASE("bindables") {
 
         SECTION("null by itself") {
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-            auto v = statically_bindable_pointer<carray_pointer_tag, nullptr_t>(nullptr);
+            auto v = bind_pointer_statically<carray_pointer_tag, nullptr_t>(nullptr);
 #else
-            auto v = statically_bindable_pointer<carray_pointer_type, nullptr_t>(nullptr);
+            auto v = bind_pointer_statically<carray_pointer_type, nullptr_t>(nullptr);
 #endif
             value = serialize(v, context);
             expected = "null";
         }
         SECTION("null by itself 2") {
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-            auto v = statically_bindable_pointer<carray_pointer_tag>(&value);
+            auto v = bind_pointer_statically<carray_pointer_tag>(&value);
 #else
-            auto v = statically_bindable_pointer<carray_pointer_type>(&value);
+            auto v = bind_pointer_statically<carray_pointer_type>(&value);
 #endif
             value = serialize(v, context);
             expected = "null";
         }
         SECTION("null in select") {
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-            auto ast = select(statically_bindable_pointer<carray_pointer_tag, nullptr_t>(nullptr));
+            auto ast = select(bind_pointer_statically<carray_pointer_tag, nullptr_t>(nullptr));
 #else
-            auto ast = select(statically_bindable_pointer<carray_pointer_type, nullptr_t>(nullptr));
+            auto ast = select(bind_pointer_statically<carray_pointer_type, nullptr_t>(nullptr));
 #endif
             ast.highest_level = true;
             value = serialize(ast, context);
@@ -294,9 +294,9 @@ TEST_CASE("bindables") {
         }
         SECTION("null as function argument") {
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-            auto ast = func<remember_fn>(1, statically_bindable_pointer<carray_pointer_tag, nullptr_t>(nullptr));
+            auto ast = func<remember_fn>(1, bind_pointer_statically<carray_pointer_tag, nullptr_t>(nullptr));
 #else
-            auto ast = func<remember_fn>(1, statically_bindable_pointer<carray_pointer_type, nullptr_t>(nullptr));
+            auto ast = func<remember_fn>(1, bind_pointer_statically<carray_pointer_type, nullptr_t>(nullptr));
 #endif
             value = serialize(ast, context);
             expected = R"("remember"(1, null))";

--- a/tests/statement_serializer_tests/bindables.cpp
+++ b/tests/statement_serializer_tests/bindables.cpp
@@ -265,23 +265,39 @@ TEST_CASE("bindables") {
         context.replace_bindable_with_question = false;
 
         SECTION("null by itself") {
-            auto v = statically_bindable_pointer<carray_pvt, nullptr_t>(nullptr);
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+            auto v = statically_bindable_pointer<carray_pointer_tag, nullptr_t>(nullptr);
+#else
+            auto v = statically_bindable_pointer<carray_pointer_type, nullptr_t>(nullptr);
+#endif
             value = serialize(v, context);
             expected = "null";
         }
         SECTION("null by itself 2") {
-            auto v = statically_bindable_pointer<carray_pvt>(&value);
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+            auto v = statically_bindable_pointer<carray_pointer_tag>(&value);
+#else
+            auto v = statically_bindable_pointer<carray_pointer_type>(&value);
+#endif
             value = serialize(v, context);
             expected = "null";
         }
         SECTION("null in select") {
-            auto ast = select(statically_bindable_pointer<carray_pvt, nullptr_t>(nullptr));
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+            auto ast = select(statically_bindable_pointer<carray_pointer_tag, nullptr_t>(nullptr));
+#else
+            auto ast = select(statically_bindable_pointer<carray_pointer_type, nullptr_t>(nullptr));
+#endif
             ast.highest_level = true;
             value = serialize(ast, context);
             expected = "SELECT null";
         }
         SECTION("null as function argument") {
-            auto ast = func<remember_fn>(1, statically_bindable_pointer<carray_pvt, nullptr_t>(nullptr));
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+            auto ast = func<remember_fn>(1, statically_bindable_pointer<carray_pointer_tag, nullptr_t>(nullptr));
+#else
+            auto ast = func<remember_fn>(1, statically_bindable_pointer<carray_pointer_type, nullptr_t>(nullptr));
+#endif
             value = serialize(ast, context);
             expected = R"("remember"(1, null))";
         }

--- a/tests/static_tests/bindable_filter.cpp
+++ b/tests/static_tests/bindable_filter.cpp
@@ -66,7 +66,11 @@ TEST_CASE("bindable_filter") {
                                  std::unique_ptr<int>,
                                  std::shared_ptr<int>,
 #ifdef SQLITE_ORM_INLINE_VARIABLES_SUPPORTED
-                                 static_pointer_binding<std::nullptr_t, carray_pvt>,
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+                                 static_pointer_binding_t<std::nullptr_t, carray_pointer_tag>,
+#else
+                                 static_pointer_binding<std::nullptr_t, carray_pointer_type>,
+#endif
 #endif
                                  Custom,
                                  std::unique_ptr<Custom>>;

--- a/tests/static_tests/is_bindable.cpp
+++ b/tests/static_tests/is_bindable.cpp
@@ -68,7 +68,11 @@ TEST_CASE("is_bindable") {
     STATIC_REQUIRE_FALSE(is_bindable_v<std::optional<User>>);
 #endif  // SQLITE_ORM_OPTIONAL_SUPPORTED
 #ifdef SQLITE_ORM_INLINE_VARIABLES_SUPPORTED
-    STATIC_REQUIRE(is_bindable_v<static_pointer_binding<std::nullptr_t, carray_pvt>>);
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+    STATIC_REQUIRE(is_bindable_v<static_pointer_binding_t<std::nullptr_t, carray_pointer_tag>>);
+#else
+    STATIC_REQUIRE(is_bindable_v<static_pointer_binding<std::nullptr_t, carray_pointer_type>>);
+#endif
 #endif
 
     STATIC_REQUIRE(is_bindable_v<Custom>);

--- a/tests/static_tests/is_printable.cpp
+++ b/tests/static_tests/is_printable.cpp
@@ -64,7 +64,11 @@ TEST_CASE("is_printable") {
     STATIC_REQUIRE_FALSE(is_printable_v<std::optional<User>>);
 #endif  // SQLITE_ORM_OPTIONAL_SUPPORTED
 #ifdef SQLITE_ORM_INLINE_VARIABLES_SUPPORTED
-    STATIC_REQUIRE_FALSE(is_printable_v<static_pointer_binding<std::nullptr_t, carray_pvt>>);
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+    STATIC_REQUIRE_FALSE(is_printable_v<static_pointer_binding_t<std::nullptr_t, carray_pointer_tag>>);
+#else
+    STATIC_REQUIRE_FALSE(is_printable_v<static_pointer_binding<std::nullptr_t, carray_pointer_type>>);
+#endif
 #endif
 
     STATIC_REQUIRE(is_printable_v<Custom>);

--- a/tests/static_tests/row_extractor.cpp
+++ b/tests/static_tests/row_extractor.cpp
@@ -93,7 +93,11 @@ TEST_CASE("is_extractable") {
     check_not_extractable<std::optional<User>>();
 #endif  // SQLITE_ORM_OPTIONAL_SUPPORTED
 #ifdef SQLITE_ORM_INLINE_VARIABLES_SUPPORTED
-    check_not_extractable<static_pointer_binding<std::nullptr_t, carray_pvt>>();
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+    check_not_extractable<static_pointer_binding_t<std::nullptr_t, carray_pointer_tag>>();
+#else
+    check_not_extractable<static_pointer_binding<std::nullptr_t, carray_pointer_type>>();
+#endif
     // pointer arguments are special: they can only be passed to and from functions, but casting is prohibited
     {
         using int64_pointer_arg = carray_pointer_arg<int64>;


### PR DESCRIPTION
Pointer type tags (as part of the pointer passing interface) can also be created in the same way as table references, table aliases, CTE monikers and column aliases.

In addition, these inline variable "tags" should be used instead of type aliases.

For example, the pointer type "carray" is now defined:
```c++
inline constexpr orm_pointer_type auto carray_pointer_tag = "carray"_pointer_type;
```
instead of:
```c++
inline constexpr const char carray_pointer_name[] = "carray";
using carray_pointer_type = std::integral_constant<const char*, carray_pointer_name>;
```
