### PR TITLE
Fix  `_colalias` namespace

### DIFF
--- a/dev/alias.h
+++ b/dev/alias.h
@@ -475,16 +475,18 @@ namespace sqlite_orm {
 #endif
 
 #ifdef SQLITE_ORM_WITH_CTE
-    /**
-     *  column_alias<'1'[, ...]> from a numeric literal.
-     *  E.g. 1_colalias, 2_colalias
-     */
-    template<char... Chars>
-    [[nodiscard]] SQLITE_ORM_CONSTEVAL auto operator"" _colalias() {
-        // numeric identifiers are used for automatically assigning implicit aliases to unaliased column expressions,
-        // which start at "1".
-        static_assert(std::array{Chars...}[0] > '0');
-        return internal::column_alias<Chars...>{};
+    inline namespace literals {
+        /**
+         *  column_alias<'1'[, ...]> from a numeric literal.
+         *  E.g. 1_colalias, 2_colalias
+         */
+        template<char... Chars>
+        [[nodiscard]] SQLITE_ORM_CONSTEVAL auto operator"" _colalias() {
+            // numeric identifiers are used for automatically assigning implicit aliases to unaliased column expressions,
+            // which start at "1".
+            static_assert(std::array{Chars...}[0] > '0');
+            return internal::column_alias<Chars...>{};
+        }
     }
 #endif
 }

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -5723,16 +5723,18 @@ namespace sqlite_orm {
 #endif
 
 #ifdef SQLITE_ORM_WITH_CTE
-    /**
-     *  column_alias<'1'[, ...]> from a numeric literal.
-     *  E.g. 1_colalias, 2_colalias
-     */
-    template<char... Chars>
-    [[nodiscard]] SQLITE_ORM_CONSTEVAL auto operator"" _colalias() {
-        // numeric identifiers are used for automatically assigning implicit aliases to unaliased column expressions,
-        // which start at "1".
-        static_assert(std::array{Chars...}[0] > '0');
-        return internal::column_alias<Chars...>{};
+    inline namespace literals {
+        /**
+         *  column_alias<'1'[, ...]> from a numeric literal.
+         *  E.g. 1_colalias, 2_colalias
+         */
+        template<char... Chars>
+        [[nodiscard]] SQLITE_ORM_CONSTEVAL auto operator"" _colalias() {
+            // numeric identifiers are used for automatically assigning implicit aliases to unaliased column expressions,
+            // which start at "1".
+            static_assert(std::array{Chars...}[0] > '0');
+            return internal::column_alias<Chars...>{};
+        }
     }
 #endif
 }

--- a/tests/static_tests/operators_adl.cpp
+++ b/tests/static_tests/operators_adl.cpp
@@ -1,7 +1,7 @@
 #include <sqlite_orm/sqlite_orm.h>
 #include <catch2/catch_all.hpp>
 
-#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+#if defined(SQLITE_ORM_WITH_CPP20_ALIASES) || defined(SQLITE_ORM_WITH_CTE)
 using namespace sqlite_orm::literals;
 #endif
 using sqlite_orm::alias_a;
@@ -108,15 +108,22 @@ void runTests(E expression) {
     STATIC_REQUIRE(is_specialization_of_v<decltype(!expression || (expression && 42)), or_condition_t>);
 }
 
-#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
 TEST_CASE("inline namespace literals expressions") {
+#ifdef SQLITE_ORM_WITH_CTE
+    constexpr auto col1 = 1_colalias;
+    constexpr auto cte1 = 1_ctealias;
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+    constexpr auto cte_mnkr = "1"_cte;
+#endif
+#endif
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
     constexpr auto u_alias_builder = "u"_alias;
-    constexpr auto c_alias = "c"_col;
+    constexpr auto c_col = "c"_col;
     constexpr auto f_scalar_builder = "f"_scalar;
-    constexpr auto numeric_cte_alias_builder = 1_ctealias;
-    constexpr auto cte_alias_builder = "1"_cte;
+#endif
 }
 
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
 TEST_CASE("ADL and pointer-to-member expressions") {
     struct User {
         int id;


### PR DESCRIPTION
The `_colalias` literal operator should be in the inline namespace `sqlite_orm::literals`.