### PR TITLE
Updates discovered by testing the pointer passing feature

### DIFF
--- a/dev/field_printer.h
+++ b/dev/field_printer.h
@@ -121,14 +121,14 @@ namespace sqlite_orm {
     template<>
     struct field_printer<nullptr_t, void> {
         std::string operator()(const nullptr_t&) const {
-            return "null";
+            return "NULL";
         }
     };
 #ifdef SQLITE_ORM_OPTIONAL_SUPPORTED
     template<>
     struct field_printer<std::nullopt_t, void> {
         std::string operator()(const std::nullopt_t&) const {
-            return "null";
+            return "NULL";
         }
     };
 #endif  //  SQLITE_ORM_OPTIONAL_SUPPORTED

--- a/dev/pointer_value.h
+++ b/dev/pointer_value.h
@@ -43,7 +43,7 @@ namespace sqlite_orm {
      * 
      *  Template parameters:
      *    - P: The value type, possibly const-qualified.
-     *    - T: An integral constant string denoting the pointer type, e.g. `carray_pointer_type`.
+     *    - T: An integral constant string denoting the pointer type, e.g. `"carray"_pointer_type`.
      *
      */
     template<typename P, typename T>
@@ -52,7 +52,7 @@ namespace sqlite_orm {
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
         // note (internal): this is currently a static assertion instead of a type constraint because
         // of forward declarations in other places (e.g. function.h)
-        static_assert(orm_pointer_type<T>, "The pointer type (tag) must be convertible to `const char*`");
+        static_assert(orm_pointer_type<T>, "T must be a pointer type (tag)");
 #else
         static_assert(std::is_convertible<typename T::value_type, const char*>::value,
                       "The pointer type (tag) must be convertible to `const char*`");

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -702,7 +702,7 @@ namespace sqlite_orm {
 
             template<class T, satisfies<is_prepared_statement, T> = true>
             std::string dump(const T& preparedStatement, bool parametrized = true) const {
-                return this->dump(preparedStatement.expression, parametrized);
+                return this->dump_highest_level(preparedStatement.expression, parametrized);
             }
 
             template<class E,
@@ -720,13 +720,7 @@ namespace sqlite_orm {
                     [](const auto& expression) -> decltype(auto) {
                         return (expression);
                     })(std::forward<E>(expression));
-                const auto& exprDBOs = db_objects_for_expression(this->db_objects, expression);
-                using context_t = serializer_context<polyfill::remove_cvref_t<decltype(exprDBOs)>>;
-                context_t context{exprDBOs};
-                context.replace_bindable_with_question = parametrized;
-                // just like prepare_impl()
-                context.skip_table_name = false;
-                return serialize(e2, context);
+                return this->dump_highest_level(e2, parametrized);
             }
 
             /**
@@ -1090,6 +1084,34 @@ namespace sqlite_orm {
                 perform_void_exec(db, ss.str());
             }
 
+            template<class ColResult, class S>
+            auto execute_select(const S& statement) {
+                sqlite3_stmt* stmt = reset_stmt(statement.stmt);
+
+                iterate_ast(statement.expression, conditional_binder{stmt});
+
+                using R = decltype(make_row_extractor<ColResult>(this->db_objects).extract(nullptr, 0));
+                std::vector<R> res;
+                perform_steps(
+                    stmt,
+                    [rowExtractor = make_row_extractor<ColResult>(this->db_objects), &res](sqlite3_stmt* stmt) {
+                        res.push_back(rowExtractor.extract(stmt, 0));
+                    });
+                res.shrink_to_fit();
+                return res;
+            }
+
+            template<class E>
+            std::string dump_highest_level(E&& expression, bool parametrized) const {
+                const auto& exprDBOs = db_objects_for_expression(this->db_objects, expression);
+                using context_t = serializer_context<polyfill::remove_cvref_t<decltype(exprDBOs)>>;
+                context_t context{exprDBOs};
+                context.replace_bindable_with_question = parametrized;
+                // just like prepare_impl()
+                context.skip_table_name = false;
+                return serialize(expression, context);
+            }
+
             template<typename S>
             prepared_statement_t<S> prepare_impl(S statement) {
                 const auto& exprDBOs = db_objects_for_expression(this->db_objects, statement);
@@ -1164,7 +1186,7 @@ namespace sqlite_orm {
                      class E,
                      std::enable_if_t<polyfill::disjunction_v<is_select<E>, is_insert_raw<E>>, bool> = true>
             prepared_statement_t<with_t<E, CTEs...>> prepare(with_t<E, CTEs...> sel) {
-                return prepare_impl<with_t<E, CTEs...>>(std::move(sel));
+                return this->prepare_impl<with_t<E, CTEs...>>(std::move(sel));
             }
 #endif
 
@@ -1518,23 +1540,6 @@ namespace sqlite_orm {
                 perform_step(stmt);
             }
 
-            template<class ColResult, class S>
-            auto _execute_select(const S& statement) {
-                sqlite3_stmt* stmt = reset_stmt(statement.stmt);
-
-                iterate_ast(statement.expression, conditional_binder{stmt});
-
-                using R = decltype(make_row_extractor<ColResult>(this->db_objects).extract(nullptr, 0));
-                std::vector<R> res;
-                perform_steps(
-                    stmt,
-                    [rowExtractor = make_row_extractor<ColResult>(this->db_objects), &res](sqlite3_stmt* stmt) {
-                        res.push_back(rowExtractor.extract(stmt, 0));
-                    });
-                res.shrink_to_fit();
-                return res;
-            }
-
 #ifdef SQLITE_ORM_WITH_CTE
             template<class... CTEs, class T, class... Args>
             auto execute(const prepared_statement_t<with_t<select_t<T, Args...>, CTEs...>>& statement) {
@@ -1542,14 +1547,14 @@ namespace sqlite_orm {
                 // note: it is enough to only use the 'expression DBOs' at compile-time to determine the column results;
                 // because we cannot select objects/structs from a CTE, the permanently defined DBOs are enough.
                 using ColResult = column_result_of_t<ExprDBOs, T>;
-                return _execute_select<ColResult>(statement);
+                return this->execute_select<ColResult>(statement);
             }
 #endif
 
             template<class T, class... Args>
             auto execute(const prepared_statement_t<select_t<T, Args...>>& statement) {
                 using ColResult = column_result_of_t<db_objects_type, T>;
-                return _execute_select<ColResult>(statement);
+                return this->execute_select<ColResult>(statement);
             }
 
             template<class T, class R, class... Args, class O = mapped_type_proxy_t<T>>

--- a/examples/pointer_passing_interface.cpp
+++ b/examples/pointer_passing_interface.cpp
@@ -112,9 +112,9 @@ int main() {
             size_t idx = min<size_t>(errorCategory, ecat_map.size());
             const error_category* ecat = idx != ecat_map.size() ? &get<const error_category&>(ecat_map[idx]) : nullptr;
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-            return statically_bindable_pointer<ecat_pointer_tag>(ecat);
+            return bind_pointer_statically<ecat_pointer_tag>(ecat);
 #else
-            return statically_bindable_pointer<ecat_pointer_type>(ecat);
+            return bind_pointer_statically<ecat_pointer_type>(ecat);
 #endif
         }
 
@@ -168,7 +168,7 @@ int main() {
             error_code* ec = idx != ecat_map.size()
                                  ? new error_code{errorValue, get<const error_category&>(ecat_map[idx])}
                                  : nullptr;
-            return bindable_pointer<ecode_binding>(ec, default_delete<error_code>{});
+            return bind_pointer<ecode_binding>(ec, default_delete<error_code>{});
         }
 
         static constexpr const char* name() {
@@ -232,9 +232,9 @@ int main() {
                                    as<str_alias<'e', 'q'>>(func<equal_error_code_fn>(
                                        func<make_error_code_fn>(&Result::errorValue, &Result::errorCategory),
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-                                       bindable_pointer<ecode_pointer_tag>(make_unique<error_code>()))),
+                                       bind_pointer<ecode_pointer_tag>(make_unique<error_code>()))),
 #else
-                                       bindable_pointer<ecode_pointer_type>(make_unique<error_code>()))),
+                                       bind_pointer<ecode_pointer_type>(make_unique<error_code>()))),
 #endif
                                    func<error_category_name_fn>(func<get_error_category_fn>(&Result::errorCategory)),
                                    func<error_category_message_fn>(func<get_error_category_fn>(&Result::errorCategory),

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -3339,14 +3339,14 @@ namespace sqlite_orm {
     template<>
     struct field_printer<nullptr_t, void> {
         std::string operator()(const nullptr_t&) const {
-            return "null";
+            return "NULL";
         }
     };
 #ifdef SQLITE_ORM_OPTIONAL_SUPPORTED
     template<>
     struct field_printer<std::nullopt_t, void> {
         std::string operator()(const std::nullopt_t&) const {
-            return "null";
+            return "NULL";
         }
     };
 #endif  //  SQLITE_ORM_OPTIONAL_SUPPORTED

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -22206,7 +22206,7 @@ namespace sqlite_orm {
 
             template<class T, satisfies<is_prepared_statement, T> = true>
             std::string dump(const T& preparedStatement, bool parametrized = true) const {
-                return this->dump(preparedStatement.expression, parametrized);
+                return this->dump_highest_level(preparedStatement.expression, parametrized);
             }
 
             template<class E,
@@ -22224,13 +22224,7 @@ namespace sqlite_orm {
                     [](const auto& expression) -> decltype(auto) {
                         return (expression);
                     })(std::forward<E>(expression));
-                const auto& exprDBOs = db_objects_for_expression(this->db_objects, expression);
-                using context_t = serializer_context<polyfill::remove_cvref_t<decltype(exprDBOs)>>;
-                context_t context{exprDBOs};
-                context.replace_bindable_with_question = parametrized;
-                // just like prepare_impl()
-                context.skip_table_name = false;
-                return serialize(e2, context);
+                return this->dump_highest_level(e2, parametrized);
             }
 
             /**
@@ -22594,6 +22588,34 @@ namespace sqlite_orm {
                 perform_void_exec(db, ss.str());
             }
 
+            template<class ColResult, class S>
+            auto execute_select(const S& statement) {
+                sqlite3_stmt* stmt = reset_stmt(statement.stmt);
+
+                iterate_ast(statement.expression, conditional_binder{stmt});
+
+                using R = decltype(make_row_extractor<ColResult>(this->db_objects).extract(nullptr, 0));
+                std::vector<R> res;
+                perform_steps(
+                    stmt,
+                    [rowExtractor = make_row_extractor<ColResult>(this->db_objects), &res](sqlite3_stmt* stmt) {
+                        res.push_back(rowExtractor.extract(stmt, 0));
+                    });
+                res.shrink_to_fit();
+                return res;
+            }
+
+            template<class E>
+            std::string dump_highest_level(E&& expression, bool parametrized) const {
+                const auto& exprDBOs = db_objects_for_expression(this->db_objects, expression);
+                using context_t = serializer_context<polyfill::remove_cvref_t<decltype(exprDBOs)>>;
+                context_t context{exprDBOs};
+                context.replace_bindable_with_question = parametrized;
+                // just like prepare_impl()
+                context.skip_table_name = false;
+                return serialize(expression, context);
+            }
+
             template<typename S>
             prepared_statement_t<S> prepare_impl(S statement) {
                 const auto& exprDBOs = db_objects_for_expression(this->db_objects, statement);
@@ -22668,7 +22690,7 @@ namespace sqlite_orm {
                      class E,
                      std::enable_if_t<polyfill::disjunction_v<is_select<E>, is_insert_raw<E>>, bool> = true>
             prepared_statement_t<with_t<E, CTEs...>> prepare(with_t<E, CTEs...> sel) {
-                return prepare_impl<with_t<E, CTEs...>>(std::move(sel));
+                return this->prepare_impl<with_t<E, CTEs...>>(std::move(sel));
             }
 #endif
 
@@ -23022,23 +23044,6 @@ namespace sqlite_orm {
                 perform_step(stmt);
             }
 
-            template<class ColResult, class S>
-            auto _execute_select(const S& statement) {
-                sqlite3_stmt* stmt = reset_stmt(statement.stmt);
-
-                iterate_ast(statement.expression, conditional_binder{stmt});
-
-                using R = decltype(make_row_extractor<ColResult>(this->db_objects).extract(nullptr, 0));
-                std::vector<R> res;
-                perform_steps(
-                    stmt,
-                    [rowExtractor = make_row_extractor<ColResult>(this->db_objects), &res](sqlite3_stmt* stmt) {
-                        res.push_back(rowExtractor.extract(stmt, 0));
-                    });
-                res.shrink_to_fit();
-                return res;
-            }
-
 #ifdef SQLITE_ORM_WITH_CTE
             template<class... CTEs, class T, class... Args>
             auto execute(const prepared_statement_t<with_t<select_t<T, Args...>, CTEs...>>& statement) {
@@ -23046,14 +23051,14 @@ namespace sqlite_orm {
                 // note: it is enough to only use the 'expression DBOs' at compile-time to determine the column results;
                 // because we cannot select objects/structs from a CTE, the permanently defined DBOs are enough.
                 using ColResult = column_result_of_t<ExprDBOs, T>;
-                return _execute_select<ColResult>(statement);
+                return this->execute_select<ColResult>(statement);
             }
 #endif
 
             template<class T, class... Args>
             auto execute(const prepared_statement_t<select_t<T, Args...>>& statement) {
                 using ColResult = column_result_of_t<db_objects_type, T>;
-                return _execute_select<ColResult>(statement);
+                return this->execute_select<ColResult>(statement);
             }
 
             template<class T, class R, class... Args, class O = mapped_type_proxy_t<T>>

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -9790,7 +9790,7 @@ namespace sqlite_orm {
      * 
      *  Template parameters:
      *    - P: The value type, possibly const-qualified.
-     *    - T: An integral constant string denoting the pointer type, e.g. `carray_pointer_type`.
+     *    - T: An integral constant string denoting the pointer type, e.g. `"carray"_pointer_type`.
      *
      */
     template<typename P, typename T>
@@ -9799,7 +9799,7 @@ namespace sqlite_orm {
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
         // note (internal): this is currently a static assertion instead of a type constraint because
         // of forward declarations in other places (e.g. function.h)
-        static_assert(orm_pointer_type<T>, "The pointer type (tag) must be convertible to `const char*`");
+        static_assert(orm_pointer_type<T>, "T must be a pointer type (tag)");
 #else
         static_assert(std::is_convertible<typename T::value_type, const char*>::value,
                       "The pointer type (tag) must be convertible to `const char*`");

--- a/tests/pointer_passing_interface.cpp
+++ b/tests/pointer_passing_interface.cpp
@@ -175,5 +175,13 @@ TEST_CASE("pointer-passing") {
             REQUIRE(v.back() == delete_int64::lastSelectedId);
         }
     }
+
+    SECTION("dump prepared") {
+        int64 lastSelectedId;
+        auto stmt = storage.prepare(
+            select(func<note_value_fn<int64>>(select(&Object::id), bind_carray_pointer_statically(&lastSelectedId))));
+        std::string sql = storage.dump(stmt);
+        (void)sql;
+    }
 }
 #endif

--- a/tests/statement_serializer_tests/bindables.cpp
+++ b/tests/statement_serializer_tests/bindables.cpp
@@ -171,14 +171,14 @@ TEST_CASE("bindables") {
                                                   "0",
                                                   "0",
                                                   "''",
-                                                  "null"
+                                                  "NULL"
 #ifndef SQLITE_ORM_OMITS_CODECVT
                                                   ,
                                                   "''"
 #endif
 #ifdef SQLITE_ORM_OPTIONAL_SUPPORTED
                                                   ,
-                                                  "null"
+                                                  "NULL"
 #endif
         };
 
@@ -227,12 +227,12 @@ TEST_CASE("bindables") {
                                                   "''",
                                                   "''",
 #endif
-                                                  "null",
-                                                  "null",
+                                                  "NULL",
+                                                  "NULL",
                                                   "x''",
 #ifdef SQLITE_ORM_OPTIONAL_SUPPORTED
-                                                  "null",
-                                                  "null",
+                                                  "NULL",
+                                                  "NULL",
 #endif
 #ifdef SQLITE_ORM_STRING_VIEW_SUPPORTED
                                                   "''",
@@ -242,7 +242,7 @@ TEST_CASE("bindables") {
 #endif
                                                   "''",
                                                   "custom",
-                                                  "null"};
+                                                  "NULL"};
 
         SECTION("dump") {
             context.replace_bindable_with_question = false;
@@ -271,7 +271,7 @@ TEST_CASE("bindables") {
             auto v = bind_pointer_statically<carray_pointer_type, nullptr_t>(nullptr);
 #endif
             value = serialize(v, context);
-            expected = "null";
+            expected = "NULL";
         }
         SECTION("null by itself 2") {
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
@@ -280,7 +280,7 @@ TEST_CASE("bindables") {
             auto v = bind_pointer_statically<carray_pointer_type>(&value);
 #endif
             value = serialize(v, context);
-            expected = "null";
+            expected = "NULL";
         }
         SECTION("null in select") {
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
@@ -290,7 +290,7 @@ TEST_CASE("bindables") {
 #endif
             ast.highest_level = true;
             value = serialize(ast, context);
-            expected = "SELECT null";
+            expected = "SELECT NULL";
         }
         SECTION("null as function argument") {
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
@@ -299,12 +299,12 @@ TEST_CASE("bindables") {
             auto ast = func<remember_fn>(1, bind_pointer_statically<carray_pointer_type, nullptr_t>(nullptr));
 #endif
             value = serialize(ast, context);
-            expected = R"("remember"(1, null))";
+            expected = R"("remember"(1, NULL))";
         }
         SECTION("null as function argument 2") {
             auto ast = func<remember_fn>(1, nullptr);
             value = serialize(ast, context);
-            expected = R"("remember"(1, null))";
+            expected = R"("remember"(1, NULL))";
         }
 
         REQUIRE(value == expected);

--- a/tests/statement_serializer_tests/statements/select.cpp
+++ b/tests/statement_serializer_tests/statements/select.cpp
@@ -34,12 +34,12 @@ TEST_CASE("statement_serializer select_t") {
             SECTION("!highest_level") {
                 statement.highest_level = false;
                 stringValue = serialize(statement, context);
-                expected = "(SELECT null)";
+                expected = "(SELECT NULL)";
             }
             SECTION("highest_level") {
                 statement.highest_level = true;
                 stringValue = serialize(statement, context);
-                expected = "SELECT null";
+                expected = "SELECT NULL";
             }
         }
     }
@@ -110,12 +110,12 @@ TEST_CASE("statement_serializer select_t") {
             SECTION("!highest_level") {
                 statement.highest_level = false;
                 stringValue = serialize(statement, context);
-                expected = "(SELECT null)";
+                expected = "(SELECT NULL)";
             }
             SECTION("highest_level") {
                 statement.highest_level = true;
                 stringValue = serialize(statement, context);
-                expected = "SELECT null";
+                expected = "SELECT NULL";
             }
         }
         SECTION("asterisk") {

--- a/tests/static_tests/operators_adl.cpp
+++ b/tests/static_tests/operators_adl.cpp
@@ -108,15 +108,21 @@ void runTests(E expression) {
     STATIC_REQUIRE(is_specialization_of_v<decltype(!expression || (expression && 42)), or_condition_t>);
 }
 
-#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
 TEST_CASE("inline namespace literals expressions") {
+#ifdef SQLITE_ORM_WITH_CTE
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+    constexpr auto cte_mnkr = "1"_cte;
+#endif
+#endif
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
     constexpr auto u_alias_builder = "u"_alias;
-    constexpr auto c_alias = "c"_col;
+    constexpr auto c_col = "c"_col;
     constexpr auto f_scalar_builder = "f"_scalar;
-    constexpr auto numeric_cte_alias_builder = 1_ctealias;
-    constexpr auto cte_alias_builder = "1"_cte;
+    constexpr auto domain_ptr_tag = "domain"_pointer_type;
+#endif
 }
 
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
 TEST_CASE("ADL and pointer-to-member expressions") {
     struct User {
         int id;

--- a/tests/static_tests/operators_adl.cpp
+++ b/tests/static_tests/operators_adl.cpp
@@ -110,6 +110,8 @@ void runTests(E expression) {
 
 TEST_CASE("inline namespace literals expressions") {
 #ifdef SQLITE_ORM_WITH_CTE
+    constexpr auto col1 = 1_colalias;
+    constexpr auto cte1 = 1_ctealias;
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
     constexpr auto cte_mnkr = "1"_cte;
 #endif

--- a/tests/tests5.cpp
+++ b/tests/tests5.cpp
@@ -231,7 +231,7 @@ TEST_CASE("Dump") {
     REQUIRE(allUsers.size() == 2);
 
     const std::string dumpUser1 = storage.dump(allUsers[0]);
-    REQUIRE(dumpUser1 == std::string{"{ id : '1', car_year : 'null' }"});
+    REQUIRE(dumpUser1 == std::string{"{ id : '1', car_year : 'NULL' }"});
 
     const std::string dumpUser2 = storage.dump(allUsers[1]);
     REQUIRE(dumpUser2 == std::string{"{ id : '2', car_year : '2006' }"});


### PR DESCRIPTION
* Field printer for `std::nullptr_t` and `std::nullopt_t` returns upper-case `NULL` as a literal SQLite value.
* Updated pointer passing example.
* Tested namespace of `_pointer_value` literal operator.
* Prepared statements containing bound pointers couldn't be dumped with `storage_t<>::dump`, but can now.