### PR TITLE
Correctly guard all features with `SQLITE_VERSION_NUMBER`

### DIFF
--- a/dev/alias.h
+++ b/dev/alias.h
@@ -4,7 +4,7 @@
 #include <utility>  //  std::make_index_sequence, std::move
 #include <string>  //  std::string
 #include <sstream>  //  std::stringstream
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
 #include <array>
 #endif
 
@@ -101,7 +101,7 @@ namespace sqlite_orm {
                 return alias_extractor::extract();
             }
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
             // for CTE monikers -> empty
             template<class T = A, satisfies<std::is_same, polyfill::detected_t<type_t, T>, A> = true>
             static std::string as_alias() {
@@ -168,7 +168,7 @@ namespace sqlite_orm {
         };
 #endif
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
         template<size_t n, char... C>
         SQLITE_ORM_CONSTEVAL auto n_to_colalias() {
             constexpr column_alias<'1' + n % 10, C...> colalias{};
@@ -281,7 +281,7 @@ namespace sqlite_orm {
     }
 #endif
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
     /**
      *  Create a column reference to an aliased CTE column.
      */
@@ -474,7 +474,7 @@ namespace sqlite_orm {
     }
 #endif
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
     inline namespace literals {
         /**
          *  column_alias<'1'[, ...]> from a numeric literal.

--- a/dev/alias_traits.h
+++ b/dev/alias_traits.h
@@ -56,7 +56,7 @@ namespace sqlite_orm {
          */
         template<class A>
         SQLITE_ORM_INLINE_VAR constexpr bool is_cte_moniker_v =
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
             polyfill::conjunction_v<is_recordset_alias<A>,
                                     std::is_same<polyfill::detected_t<type_t, A>, std::remove_const_t<A>>>;
 #else

--- a/dev/ast_iterator.h
+++ b/dev/ast_iterator.h
@@ -226,7 +226,7 @@ namespace sqlite_orm {
             }
         };
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
         template<class CTE>
         struct ast_iterator<CTE, match_specialization_of<CTE, common_table_expression>> {
             using node_type = CTE;

--- a/dev/carray.h
+++ b/dev/carray.h
@@ -6,15 +6,18 @@
  *  Hence we make it only available for compilers supporting inline variables.
  */
 
+#if SQLITE_VERSION_NUMBER >= 3020000
 #ifdef SQLITE_ORM_INLINE_VARIABLES_SUPPORTED
 #include <utility>  //  std::move
 #ifndef SQLITE_ORM_WITH_CPP20_ALIASES
 #include <type_traits>  //  std::integral_constant
 #endif
 #endif
+#endif
 
 #include "pointer_value.h"
 
+#if SQLITE_VERSION_NUMBER >= 3020000
 #ifdef SQLITE_ORM_INLINE_VARIABLES_SUPPORTED
 namespace sqlite_orm {
 
@@ -143,4 +146,5 @@ namespace sqlite_orm {
         }
     };
 }
+#endif
 #endif

--- a/dev/column_pointer.h
+++ b/dev/column_pointer.h
@@ -35,7 +35,7 @@ namespace sqlite_orm {
         SQLITE_ORM_INLINE_VAR constexpr bool is_operator_argument_v<T, std::enable_if_t<is_column_pointer<T>::value>> =
             true;
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
         template<class A>
         struct alias_holder;
 #endif
@@ -96,7 +96,7 @@ namespace sqlite_orm {
     }
 #endif
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
     /**
      *  Explicitly refer to a column alias mapped into a CTE or subquery.
      *

--- a/dev/column_result.h
+++ b/dev/column_result.h
@@ -236,7 +236,7 @@ namespace sqlite_orm {
         template<class DBOs, class T, class F>
         struct column_result_t<DBOs, column_pointer<T, F>, void> : column_result_t<DBOs, F> {};
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
         template<class DBOs, class Moniker, class ColAlias>
         struct column_result_t<DBOs, column_pointer<Moniker, alias_holder<ColAlias>>, void> {
             using table_type = storage_pick_table_t<Moniker, DBOs>;

--- a/dev/constraints.h
+++ b/dev/constraints.h
@@ -184,7 +184,6 @@ namespace sqlite_orm {
         };
 
 #if SQLITE_VERSION_NUMBER >= 3006019
-
         /**
          *  FOREIGN KEY constraint class.
          *  Cs are columns which has foreign key

--- a/dev/constraints.h
+++ b/dev/constraints.h
@@ -410,7 +410,6 @@ namespace sqlite_orm {
             expression_type expression;
         };
 
-#if SQLITE_VERSION_NUMBER >= 3031000
         struct basic_generated_always {
             enum class storage_type {
                 not_specified,
@@ -418,14 +417,17 @@ namespace sqlite_orm {
                 stored,
             };
 
+#if SQLITE_VERSION_NUMBER >= 3031000
             bool full = true;
             storage_type storage = storage_type::not_specified;
+#endif
 
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
             basic_generated_always(bool full, storage_type storage) : full{full}, storage{storage} {}
 #endif
         };
 
+#if SQLITE_VERSION_NUMBER >= 3031000
         template<class T>
         struct generated_always_t : basic_generated_always {
             using expression_type = T;

--- a/dev/constraints.h
+++ b/dev/constraints.h
@@ -548,6 +548,7 @@ namespace sqlite_orm {
         return {{}};
     }
 
+#if SQLITE_VERSION_NUMBER >= 3009000
     /**
      *  UNINDEXED column constraint builder function. Used in FTS virtual tables.
      * 
@@ -596,6 +597,7 @@ namespace sqlite_orm {
     internal::table_content_t<T> content() {
         return {};
     }
+#endif
 
     /**
      *  PRIMARY KEY table constraint builder function.

--- a/dev/core_functions.h
+++ b/dev/core_functions.h
@@ -1650,7 +1650,6 @@ namespace sqlite_orm {
     }
 
 #if SQLITE_VERSION_NUMBER >= 3007016
-
     /**
      *  CHAR(X1,X2,...,XN) function https://sqlite.org/lang_corefunc.html#char
      */
@@ -1665,7 +1664,6 @@ namespace sqlite_orm {
     inline internal::built_in_function_t<int, internal::random_string> random() {
         return {{}};
     }
-
 #endif
 
     /**

--- a/dev/cte_column_names_collector.h
+++ b/dev/cte_column_names_collector.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
 #include <string>
 #include <vector>
 #include <functional>  //  std::reference_wrapper
@@ -16,7 +16,7 @@
 #include "select_constraints.h"
 #include "serializer_context.h"
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
 namespace sqlite_orm {
     namespace internal {
         // collecting column names utilizes the statement serializer

--- a/dev/cte_moniker.h
+++ b/dev/cte_moniker.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
 #include <concepts>
 #include <utility>  //  std::make_index_sequence
@@ -14,7 +14,7 @@
 #include "functional/cstring_literal.h"
 #include "alias.h"
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
 namespace sqlite_orm {
 
     namespace internal {
@@ -74,6 +74,7 @@ namespace sqlite_orm {
         [[nodiscard]] SQLITE_ORM_CONSTEVAL auto operator"" _ctealias() {
             return internal::cte_moniker<Chars...>{};
         }
+
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
         /**
          *  cte_moniker<'1'[, ...]> from a string literal.

--- a/dev/cte_storage.h
+++ b/dev/cte_storage.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
 #include <type_traits>
 #include <tuple>
 #include <string>
@@ -22,7 +22,7 @@
 namespace sqlite_orm {
     namespace internal {
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
         // F = field_type
         template<typename Moniker,
                  typename ExplicitColRefs,

--- a/dev/cte_types.h
+++ b/dev/cte_types.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
 #include <type_traits>
 #include <tuple>
 #endif
@@ -9,7 +9,7 @@
 #include "functional/cxx_type_traits_polyfill.h"
 #include "tuple_helper/tuple_fy.h"
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
 namespace sqlite_orm {
 
     namespace internal {

--- a/dev/function.h
+++ b/dev/function.h
@@ -19,8 +19,10 @@ namespace sqlite_orm {
 
     struct arg_values;
 
+    // note (internal): forward declare even if `SQLITE_VERSION_NUMBER < 3020000` in order to simplify coding below
     template<class P, class T>
     struct pointer_arg;
+    // note (internal): forward declare even if `SQLITE_VERSION_NUMBER < 3020000` in order to simplify coding below
     template<class P, class T, class D>
     class pointer_binding;
 

--- a/dev/functional/config.h
+++ b/dev/functional/config.h
@@ -79,3 +79,8 @@
 #if defined(SQLITE_ORM_FOLD_EXPRESSIONS_SUPPORTED) && defined(SQLITE_ORM_IF_CONSTEXPR_SUPPORTED)
 #define SQLITE_ORM_WITH_CTE
 #endif
+
+// define the inline namespace "literals" so that it is available even if it was not introduced by a feature
+namespace sqlite_orm {
+    inline namespace literals {}
+}

--- a/dev/node_tuple.h
+++ b/dev/node_tuple.h
@@ -127,7 +127,7 @@ namespace sqlite_orm {
         template<class T>
         struct node_tuple<T, match_if<is_compound_operator, T>> : node_tuple<typename T::expressions_tuple> {};
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
         template<class CTE>
         struct node_tuple<CTE, match_specialization_of<CTE, common_table_expression>>
             : node_tuple<typename CTE::expression_type> {};

--- a/dev/pointer_value.h
+++ b/dev/pointer_value.h
@@ -1,15 +1,18 @@
 #pragma once
 
+#if SQLITE_VERSION_NUMBER >= 3020000
 #include <type_traits>
 #include <memory>
 #include <utility>
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
 #include <concepts>
 #endif
+#endif
 
 #include "functional/cstring_literal.h"
 #include "xdestroy_handling.h"
 
+#if SQLITE_VERSION_NUMBER >= 3020000
 namespace sqlite_orm {
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
     namespace internal {
@@ -290,3 +293,4 @@ namespace sqlite_orm {
         return bind_pointer_statically<T>(pv.ptr());
     }
 }
+#endif

--- a/dev/row_extractor.h
+++ b/dev/row_extractor.h
@@ -127,6 +127,7 @@ namespace sqlite_orm {
         return 0;
     }
 
+#if SQLITE_VERSION_NUMBER >= 3020000
     /**
      *  Specialization for the 'pointer-passing interface'.
      * 
@@ -151,6 +152,7 @@ namespace sqlite_orm {
      */
     template<class P, class T, class D>
     struct row_extractor<pointer_binding<P, T, D>, void>;
+#endif
 
     /**
      *  Specialization for arithmetic types.

--- a/dev/schema/table.h
+++ b/dev/schema/table.h
@@ -41,7 +41,7 @@ namespace sqlite_orm {
                                                                               check_if_is_template<table_content_t>>,
                                                              T>;
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
         /**
          *  A subselect mapper's CTE moniker, void otherwise.
          */
@@ -69,7 +69,7 @@ namespace sqlite_orm {
          */
         template<class O, bool WithoutRowId, class... Cs>
         struct table_t : basic_table {
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
             // this typename is used in contexts where it is known that the 'table' holds a subselect_mapper
             // instead of a regular object type
             using cte_mapper_type = O;

--- a/dev/schema/table.h
+++ b/dev/schema/table.h
@@ -349,6 +349,7 @@ namespace sqlite_orm {
         template<class M>
         struct is_virtual_table<virtual_table_t<M>> : std::true_type {};
 
+#if SQLITE_VERSION_NUMBER >= 3009000
         template<class T, class... Cs>
         struct using_fts5_t {
             using object_type = T;
@@ -386,6 +387,7 @@ namespace sqlite_orm {
                 iterate_tuple(this->columns, col_index_sequence{}, lambda);
             }
         };
+#endif
 
         template<class O, bool WithoutRowId, class... Cs, class G, class S>
         bool exists_in_composite_primary_key(const table_t<O, WithoutRowId, Cs...>& table,
@@ -413,6 +415,7 @@ namespace sqlite_orm {
         }
     }
 
+#if SQLITE_VERSION_NUMBER >= 3009000
     template<class... Cs, class T = typename std::tuple_element_t<0, std::tuple<Cs...>>::object_type>
     internal::using_fts5_t<T, Cs...> using_fts5(Cs... columns) {
         static_assert(polyfill::conjunction_v<internal::is_table_element_or_constraint<Cs>...>,
@@ -428,6 +431,7 @@ namespace sqlite_orm {
 
         SQLITE_ORM_CLANG_SUPPRESS_MISSING_BRACES(return {std::make_tuple(std::forward<Cs>(columns)...)});
     }
+#endif
 
     /**
      *  Factory function for a table definition.

--- a/dev/select_constraints.h
+++ b/dev/select_constraints.h
@@ -529,6 +529,7 @@ namespace sqlite_orm {
     }
 
 #ifdef SQLITE_ORM_WITH_CTE
+#if SQLITE_VERSION_NUMBER >= 3035003
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
     /*
      *  Materialization hint to instruct SQLite to materialize the select statement of a CTE into an ephemeral table as an "optimization fence".
@@ -549,6 +550,7 @@ namespace sqlite_orm {
     inline consteval internal::not_materialized_t not_materialized() {
         return {};
     }
+#endif
 #endif
 
     /**

--- a/dev/select_constraints.h
+++ b/dev/select_constraints.h
@@ -217,7 +217,7 @@ namespace sqlite_orm {
             using super::super;
         };
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
         /*
          *  Turn explicit columns for a CTE into types that the CTE backend understands
          */
@@ -528,7 +528,7 @@ namespace sqlite_orm {
         return {{std::forward<E>(expressions)...}};
     }
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
 #if SQLITE_VERSION_NUMBER >= 3035003
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
     /*

--- a/dev/statement_binder.h
+++ b/dev/statement_binder.h
@@ -49,6 +49,7 @@ namespace sqlite_orm {
         struct is_bindable : polyfill::bool_constant<is_bindable_v<T>> {};
     }
 
+#if SQLITE_VERSION_NUMBER >= 3020000
     /**
      *  Specialization for pointer bindings (part of the 'pointer-passing interface').
      */
@@ -69,6 +70,7 @@ namespace sqlite_orm {
             sqlite3_result_pointer(context, (void*)value.take_ptr(), T::value, value.get_xdestroy());
         }
     };
+#endif
 
     /**
      *  Specialization for arithmetic types.

--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -132,11 +132,13 @@ namespace sqlite_orm {
                 return quote_blob_literal(field_printer<std::vector<char>>{}(t));
             }
 
+#if SQLITE_VERSION_NUMBER >= 3020000
             template<class P, class PT, class D>
             std::string do_serialize(const pointer_binding<P, PT, D>&) const {
                 // always serialize null (security reasons)
                 return field_printer<nullptr_t>{}(nullptr);
             }
+#endif
         };
 
         template<class O, bool WithoutRowId, class... Cs>

--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -586,7 +586,7 @@ namespace sqlite_orm {
             }
         };
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
 #if SQLITE_VERSION_NUMBER >= 3035003
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
         template<>

--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -1133,6 +1133,7 @@ namespace sqlite_orm {
             }
         };
 
+#if SQLITE_VERSION_NUMBER >= 3006019
         template<class... Cs, class... Rs>
         struct statement_serializer<foreign_key_t<std::tuple<Cs...>, std::tuple<Rs...>>, void> {
             using statement_type = foreign_key_t<std::tuple<Cs...>, std::tuple<Rs...>>;
@@ -1158,6 +1159,7 @@ namespace sqlite_orm {
                 return ss.str();
             }
         };
+#endif
 
         template<class T>
         struct statement_serializer<check_t<T>, void> {

--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -1049,6 +1049,7 @@ namespace sqlite_orm {
             }
         };
 
+#if SQLITE_VERSION_NUMBER >= 3009000
         template<>
         struct statement_serializer<unindexed_t, void> {
             using statement_type = unindexed_t;
@@ -1110,6 +1111,7 @@ namespace sqlite_orm {
                 return ss.str();
             }
         };
+#endif
 
         template<>
         struct statement_serializer<collate_constraint_t, void> {
@@ -1813,6 +1815,7 @@ namespace sqlite_orm {
             }
         };
 
+#if SQLITE_VERSION_NUMBER >= 3009000
         template<class... Cs>
         struct statement_serializer<using_fts5_t<Cs...>, void> {
             using statement_type = using_fts5_t<Cs...>;
@@ -1827,6 +1830,7 @@ namespace sqlite_orm {
                 return ss.str();
             }
         };
+#endif
 
         template<class M>
         struct statement_serializer<virtual_table_t<M>, void> {

--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -587,6 +587,7 @@ namespace sqlite_orm {
         };
 
 #ifdef SQLITE_ORM_WITH_CTE
+#if SQLITE_VERSION_NUMBER >= 3035003
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
         template<>
         struct statement_serializer<materialized_t, void> {
@@ -607,6 +608,7 @@ namespace sqlite_orm {
                 return "NOT MATERIALIZED";
             }
         };
+#endif
 #endif
 
         template<class CTE>

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -267,7 +267,7 @@ namespace sqlite_orm {
                 return {this->db_objects, std::move(con), std::move(expression)};
             }
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
             template<class... CTEs, class E>
                 requires(is_select_v<E>)
             result_set_view<with_t<E, CTEs...>, db_objects_type> iterate(with_t<E, CTEs...> expression) {
@@ -682,7 +682,7 @@ namespace sqlite_orm {
                 return this->execute(statement);
             }
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
             /**
              *  Using a CTE, select a single column into std::vector<T> or multiple columns into std::vector<std::tuple<...>>.
              */
@@ -1201,7 +1201,7 @@ namespace sqlite_orm {
 
             using storage_base::table_exists;  // now that it is in storage_base make it into overload set
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
             template<class... CTEs,
                      class E,
                      std::enable_if_t<polyfill::disjunction_v<is_select<E>, is_insert_raw<E>>, bool> = true>
@@ -1330,7 +1330,7 @@ namespace sqlite_orm {
                 perform_step(stmt);
             }
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
             template<class... CTEs, class E, satisfies<is_insert_raw, E> = true>
             void execute(const prepared_statement_t<with_t<E, CTEs...>>& statement) {
                 sqlite3_stmt* stmt = reset_stmt(statement.stmt);
@@ -1560,7 +1560,7 @@ namespace sqlite_orm {
                 perform_step(stmt);
             }
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
             template<class... CTEs, class T, class... Args>
             auto execute(const prepared_statement_t<with_t<select_t<T, Args...>, CTEs...>>& statement) {
                 using ExprDBOs = decltype(db_objects_for_expression(this->db_objects, statement.expression));

--- a/dev/storage_impl.h
+++ b/dev/storage_impl.h
@@ -56,7 +56,7 @@ namespace sqlite_orm {
             return cp.field;
         }
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
         /**
          *  Materialize column pointer:
          *  3. by moniker and alias_holder<>.
@@ -92,7 +92,7 @@ namespace sqlite_orm {
             return pick_table<O>(dbObjects).find_column_name(field);
         }
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
         /**
          *  Find column name by:
          *  3. by moniker and alias_holder<>.

--- a/dev/type_traits.h
+++ b/dev/type_traits.h
@@ -116,7 +116,7 @@ namespace sqlite_orm {
         using auto_udf_type_t = typename decltype(a)::udf_type;
 #endif
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
         template<typename T>
         using cte_moniker_type_t = typename T::cte_moniker_type;
 

--- a/examples/common_table_expressions.cpp
+++ b/examples/common_table_expressions.cpp
@@ -758,6 +758,7 @@ void sudoku() {
 }
 
 void show_optimization_fence() {
+#if SQLITE_VERSION_NUMBER >= 3035003
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
     auto storage = make_storage("");
 
@@ -784,6 +785,7 @@ void show_optimization_fence() {
 
         [[maybe_unused]] auto stmt = storage.prepare(ast);
     }
+#endif
 #endif
 }
 

--- a/examples/common_table_expressions.cpp
+++ b/examples/common_table_expressions.cpp
@@ -3,7 +3,7 @@
  */
 
 #include <sqlite_orm/sqlite_orm.h>
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
 #define ENABLE_THIS_EXAMPLE
 #endif
 

--- a/examples/composite_key.cpp
+++ b/examples/composite_key.cpp
@@ -10,6 +10,11 @@
 
 #include <sqlite_orm/sqlite_orm.h>
 
+#if SQLITE_VERSION_NUMBER >= 3006019
+#define ENABLE_THIS_EXAMPLE
+#endif
+
+#ifdef ENABLE_THIS_EXAMPLE
 using std::cout;
 using std::endl;
 
@@ -24,8 +29,10 @@ struct UserVisit {
     std::string userFirstName;
     time_t time;
 };
+#endif
 
 int main() {
+#ifdef ENABLE_THIS_EXAMPLE
     using namespace sqlite_orm;
 
     auto storage = make_storage(
@@ -59,5 +66,7 @@ int main() {
     storage.replace(User{2, "The Weeknd", "Singer"});
     auto weeknd = storage.get<User>(2, "The Weeknd");
     cout << "weeknd = " << storage.dump(weeknd) << endl;
+#endif
+
     return 0;
 }

--- a/examples/core_functions.cpp
+++ b/examples/core_functions.cpp
@@ -1029,6 +1029,7 @@ int main(int, char** argv) {
     //  SELECT TRIM('42totn6372', '0123456789')
     cout << "TRIM('42totn6372', '0123456789') = " << storage.select(trim("42totn6372", "0123456789")).front() << endl;
 
+#if SQLITE_VERSION_NUMBER >= 3007016
     //  SELECT RANDOM()
     for(auto i = 0; i < 10; ++i) {
         cout << "RANDOM() = " << storage.select(sqlite_orm::random()).front() << endl;
@@ -1038,6 +1039,7 @@ int main(int, char** argv) {
     for(auto& hero: storage.iterate<MarvelHero>(order_by(sqlite_orm::random()))) {
         cout << "hero = " << storage.dump(hero) << endl;
     }
+#endif
 
     //  https://www.techonthenet.com/sqlite/functions/ltrim.php
 

--- a/examples/exists.cpp
+++ b/examples/exists.cpp
@@ -518,7 +518,9 @@ int main(int, char**) {
                                    order_by(alias_column<als>(&Customer::paymentAmt))));
 #endif
 
+#if SQLITE_VERSION_NUMBER >= 3014000
         auto sql = statement.expanded_sql();
+#endif
         auto rows = storage.execute(statement);
         cout << endl;
         for(auto& row: rows) {

--- a/examples/foreign_key.cpp
+++ b/examples/foreign_key.cpp
@@ -9,6 +9,11 @@
 #include <cassert>
 #include <memory>
 
+#if SQLITE_VERSION_NUMBER >= 3006019
+#define ENABLE_THIS_EXAMPLE
+#endif
+
+#ifdef ENABLE_THIS_EXAMPLE
 using std::cout;
 using std::endl;
 
@@ -22,10 +27,10 @@ struct Track {
     std::string trackName;
     std::unique_ptr<int> trackArtist;  //  must map to &Artist::artistId
 };
+#endif
 
-int main(int, char** argv) {
-    cout << "path = " << argv[0] << endl;
-
+int main() {
+#ifdef ENABLE_THIS_EXAMPLE
     using namespace sqlite_orm;
     {  //  simple case with foreign key to a single column without actions
         auto storage = make_storage("foreign_key.sqlite",
@@ -228,6 +233,7 @@ int main(int, char** argv) {
         }
         cout << endl;
     }
+#endif
 
     return 0;
 }

--- a/examples/pointer_passing_interface.cpp
+++ b/examples/pointer_passing_interface.cpp
@@ -17,8 +17,10 @@
  *  Note: pointers are only accessible within application code, and therefore unleakable.
  */
 #include <sqlite_orm/sqlite_orm.h>
+#if SQLITE_VERSION_NUMBER >= 3020000
 #ifdef SQLITE_ORM_INLINE_VARIABLES_SUPPORTED
 #define ENABLE_THIS_EXAMPLE
+#endif
 #endif
 
 #ifdef ENABLE_THIS_EXAMPLE

--- a/examples/select.cpp
+++ b/examples/select.cpp
@@ -6,6 +6,11 @@
 
 #include <iostream>
 
+#if SQLITE_VERSION_NUMBER >= 3006019
+#define ENABLE_THIS_EXAMPLE
+#endif
+
+#ifdef ENABLE_THIS_EXAMPLE
 using namespace sqlite_orm;
 using std::cout;
 using std::endl;
@@ -203,9 +208,10 @@ void named_adhoc_structs() {
     }
     cout << endl;
 }
+#endif
 
 int main() {
-
+#ifdef ENABLE_THIS_EXAMPLE
     try {
         all_employees();
         all_artists();
@@ -213,6 +219,7 @@ int main() {
     } catch(const std::system_error& e) {
         cout << "[" << e.code() << "] " << e.what();
     }
+#endif
 
     return 0;
 }

--- a/examples/self_join.cpp
+++ b/examples/self_join.cpp
@@ -6,6 +6,11 @@
 #include <iostream>
 #include <cassert>
 
+#if SQLITE_VERSION_NUMBER >= 3006019
+#define ENABLE_THIS_EXAMPLE
+#endif
+
+#ifdef ENABLE_THIS_EXAMPLE
 using std::cout;
 using std::endl;
 
@@ -41,8 +46,10 @@ struct custom_alias : sqlite_orm::alias_tag {
         return res;
     }
 };
+#endif
 
 int main() {
+#ifdef ENABLE_THIS_EXAMPLE
     using namespace sqlite_orm;
     auto storage =
         make_storage("self_join.sqlite",
@@ -252,6 +259,7 @@ int main() {
         }
 #endif
     }
+#endif
 
     return 0;
 }

--- a/examples/union.cpp
+++ b/examples/union.cpp
@@ -8,11 +8,17 @@
 #include <algorithm>
 #include <iostream>
 
+#if SQLITE_VERSION_NUMBER >= 3006019
+#define ENABLE_THIS_EXAMPLE
+#endif
+
+#ifdef ENABLE_THIS_EXAMPLE
 using std::cout;
 using std::endl;
+#endif
 
 int main() {
-
+#ifdef ENABLE_THIS_EXAMPLE
     struct Employee {
         int id;
         std::string name;
@@ -108,6 +114,7 @@ int main() {
         }
         cout << endl;
     }
+#endif
 
     return 0;
 }

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -9498,11 +9498,13 @@ namespace sqlite_orm {
 }
 #pragma once
 
+#if SQLITE_VERSION_NUMBER >= 3020000
 #include <type_traits>
 #include <memory>
 #include <utility>
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
 #include <concepts>
+#endif
 #endif
 
 // #include "functional/cstring_literal.h"
@@ -9759,6 +9761,7 @@ namespace sqlite_orm {
 #endif
 }
 
+#if SQLITE_VERSION_NUMBER >= 3020000
 namespace sqlite_orm {
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
     namespace internal {
@@ -10039,6 +10042,7 @@ namespace sqlite_orm {
         return bind_pointer_statically<T>(pv.ptr());
     }
 }
+#endif
 #pragma once
 
 #include <sqlite3.h>
@@ -10100,6 +10104,7 @@ namespace sqlite_orm {
         struct is_bindable : polyfill::bool_constant<is_bindable_v<T>> {};
     }
 
+#if SQLITE_VERSION_NUMBER >= 3020000
     /**
      *  Specialization for pointer bindings (part of the 'pointer-passing interface').
      */
@@ -10120,6 +10125,7 @@ namespace sqlite_orm {
             sqlite3_result_pointer(context, (void*)value.take_ptr(), T::value, value.get_xdestroy());
         }
     };
+#endif
 
     /**
      *  Specialization for arithmetic types.
@@ -10743,6 +10749,7 @@ namespace sqlite_orm {
         return 0;
     }
 
+#if SQLITE_VERSION_NUMBER >= 3020000
     /**
      *  Specialization for the 'pointer-passing interface'.
      * 
@@ -10767,6 +10774,7 @@ namespace sqlite_orm {
      */
     template<class P, class T, class D>
     struct row_extractor<pointer_binding<P, T, D>, void>;
+#endif
 
     /**
      *  Specialization for arithmetic types.
@@ -12763,8 +12771,10 @@ namespace sqlite_orm {
 
     struct arg_values;
 
+    // note (internal): forward declare even if `SQLITE_VERSION_NUMBER < 3020000` in order to simplify coding below
     template<class P, class T>
     struct pointer_arg;
+    // note (internal): forward declare even if `SQLITE_VERSION_NUMBER < 3020000` in order to simplify coding below
     template<class P, class T, class D>
     class pointer_binding;
 
@@ -19138,11 +19148,13 @@ namespace sqlite_orm {
                 return quote_blob_literal(field_printer<std::vector<char>>{}(t));
             }
 
+#if SQLITE_VERSION_NUMBER >= 3020000
             template<class P, class PT, class D>
             std::string do_serialize(const pointer_binding<P, PT, D>&) const {
                 // always serialize null (security reasons)
                 return field_printer<nullptr_t>{}(nullptr);
             }
+#endif
         };
 
         template<class O, bool WithoutRowId, class... Cs>
@@ -23831,15 +23843,18 @@ namespace sqlite_orm {
  *  Hence we make it only available for compilers supporting inline variables.
  */
 
+#if SQLITE_VERSION_NUMBER >= 3020000
 #ifdef SQLITE_ORM_INLINE_VARIABLES_SUPPORTED
 #include <utility>  //  std::move
 #ifndef SQLITE_ORM_WITH_CPP20_ALIASES
 #include <type_traits>  //  std::integral_constant
 #endif
 #endif
+#endif
 
 // #include "pointer_value.h"
 
+#if SQLITE_VERSION_NUMBER >= 3020000
 #ifdef SQLITE_ORM_INLINE_VARIABLES_SUPPORTED
 namespace sqlite_orm {
 
@@ -23968,6 +23983,7 @@ namespace sqlite_orm {
         }
     };
 }
+#endif
 #endif
 #pragma once
 

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -268,6 +268,11 @@ using std::nullptr_t;
 #if defined(SQLITE_ORM_FOLD_EXPRESSIONS_SUPPORTED) && defined(SQLITE_ORM_IF_CONSTEXPR_SUPPORTED)
 #define SQLITE_ORM_WITH_CTE
 #endif
+
+// define the inline namespace "literals" so that it is available even if it was not introduced by a feature
+namespace sqlite_orm {
+    inline namespace literals {}
+}
 #pragma once
 
 #include <type_traits>  //  std::enable_if, std::is_same, std::is_empty, std::is_aggregate
@@ -574,7 +579,7 @@ namespace sqlite_orm {
         using auto_udf_type_t = typename decltype(a)::udf_type;
 #endif
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
         template<typename T>
         using cte_moniker_type_t = typename T::cte_moniker_type;
 
@@ -3613,7 +3618,7 @@ namespace sqlite_orm {
          */
         template<class A>
         SQLITE_ORM_INLINE_VAR constexpr bool is_cte_moniker_v =
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
             polyfill::conjunction_v<is_recordset_alias<A>,
                                     std::is_same<polyfill::detected_t<type_t, A>, std::remove_const_t<A>>>;
 #else
@@ -3818,7 +3823,7 @@ namespace sqlite_orm {
         SQLITE_ORM_INLINE_VAR constexpr bool is_operator_argument_v<T, std::enable_if_t<is_column_pointer<T>::value>> =
             true;
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
         template<class A>
         struct alias_holder;
 #endif
@@ -3879,7 +3884,7 @@ namespace sqlite_orm {
     }
 #endif
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
     /**
      *  Explicitly refer to a column alias mapped into a CTE or subquery.
      *
@@ -5231,7 +5236,7 @@ namespace sqlite_orm {
 #include <utility>  //  std::make_index_sequence, std::move
 #include <string>  //  std::string
 #include <sstream>  //  std::stringstream
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
 #include <array>
 #endif
 
@@ -5369,7 +5374,7 @@ namespace sqlite_orm {
                 return alias_extractor::extract();
             }
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
             // for CTE monikers -> empty
             template<class T = A, satisfies<std::is_same, polyfill::detected_t<type_t, T>, A> = true>
             static std::string as_alias() {
@@ -5436,7 +5441,7 @@ namespace sqlite_orm {
         };
 #endif
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
         template<size_t n, char... C>
         SQLITE_ORM_CONSTEVAL auto n_to_colalias() {
             constexpr column_alias<'1' + n % 10, C...> colalias{};
@@ -5549,7 +5554,7 @@ namespace sqlite_orm {
     }
 #endif
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
     /**
      *  Create a column reference to an aliased CTE column.
      */
@@ -5742,7 +5747,7 @@ namespace sqlite_orm {
     }
 #endif
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
     inline namespace literals {
         /**
          *  column_alias<'1'[, ...]> from a numeric literal.
@@ -8251,7 +8256,7 @@ namespace sqlite_orm {
 
 // #include "cte_moniker.h"
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
 #include <concepts>
 #include <utility>  //  std::make_index_sequence
@@ -8267,7 +8272,7 @@ namespace sqlite_orm {
 
 // #include "alias.h"
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
 namespace sqlite_orm {
 
     namespace internal {
@@ -8327,6 +8332,7 @@ namespace sqlite_orm {
         [[nodiscard]] SQLITE_ORM_CONSTEVAL auto operator"" _ctealias() {
             return internal::cte_moniker<Chars...>{};
         }
+
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
         /**
          *  cte_moniker<'1'[, ...]> from a string literal.
@@ -8536,7 +8542,7 @@ namespace sqlite_orm {
             using super::super;
         };
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
         /*
          *  Turn explicit columns for a CTE into types that the CTE backend understands
          */
@@ -8847,7 +8853,7 @@ namespace sqlite_orm {
         return {{std::forward<E>(expressions)...}};
     }
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
 #if SQLITE_VERSION_NUMBER >= 3035003
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
     /*
@@ -11640,7 +11646,7 @@ namespace sqlite_orm {
                                                                               check_if_is_template<table_content_t>>,
                                                              T>;
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
         /**
          *  A subselect mapper's CTE moniker, void otherwise.
          */
@@ -11668,7 +11674,7 @@ namespace sqlite_orm {
          */
         template<class O, bool WithoutRowId, class... Cs>
         struct table_t : basic_table {
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
             // this typename is used in contexts where it is known that the 'table' holds a subselect_mapper
             // instead of a regular object type
             using cte_mapper_type = O;
@@ -12099,7 +12105,7 @@ namespace sqlite_orm {
 
 // #include "cte_types.h"
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
 #include <type_traits>
 #include <tuple>
 #endif
@@ -12130,7 +12136,7 @@ namespace sqlite_orm {
     }
 }
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
 namespace sqlite_orm {
 
     namespace internal {
@@ -12381,7 +12387,7 @@ namespace sqlite_orm {
             return cp.field;
         }
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
         /**
          *  Materialize column pointer:
          *  3. by moniker and alias_holder<>.
@@ -12417,7 +12423,7 @@ namespace sqlite_orm {
             return pick_table<O>(dbObjects).find_column_name(field);
         }
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
         /**
          *  Find column name by:
          *  3. by moniker and alias_holder<>.
@@ -13525,7 +13531,7 @@ namespace sqlite_orm {
         template<class DBOs, class T, class F>
         struct column_result_t<DBOs, column_pointer<T, F>, void> : column_result_t<DBOs, F> {};
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
         template<class DBOs, class Moniker, class ColAlias>
         struct column_result_t<DBOs, column_pointer<Moniker, alias_holder<ColAlias>>, void> {
             using table_type = storage_pick_table_t<Moniker, DBOs>;
@@ -15341,7 +15347,7 @@ namespace sqlite_orm {
             }
         };
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
         template<class CTE>
         struct ast_iterator<CTE, match_specialization_of<CTE, common_table_expression>> {
             using node_type = CTE;
@@ -18762,7 +18768,7 @@ namespace sqlite_orm {
 
 // #include "cte_column_names_collector.h"
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
 #include <string>
 #include <vector>
 #include <functional>  //  std::reference_wrapper
@@ -18785,7 +18791,7 @@ namespace sqlite_orm {
 
 // #include "serializer_context.h"
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
 namespace sqlite_orm {
     namespace internal {
         // collecting column names utilizes the statement serializer
@@ -19610,7 +19616,7 @@ namespace sqlite_orm {
             }
         };
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
 #if SQLITE_VERSION_NUMBER >= 3035003
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
         template<>
@@ -21347,7 +21353,7 @@ namespace sqlite_orm {
 
 // #include "cte_storage.h"
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
 #include <type_traits>
 #include <tuple>
 #include <string>
@@ -21491,7 +21497,7 @@ namespace sqlite_orm {
 namespace sqlite_orm {
     namespace internal {
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
         // F = field_type
         template<typename Moniker,
                  typename ExplicitColRefs,
@@ -22007,7 +22013,7 @@ namespace sqlite_orm {
                 return {this->db_objects, std::move(con), std::move(expression)};
             }
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
             template<class... CTEs, class E>
                 requires(is_select_v<E>)
             result_set_view<with_t<E, CTEs...>, db_objects_type> iterate(with_t<E, CTEs...> expression) {
@@ -22422,7 +22428,7 @@ namespace sqlite_orm {
                 return this->execute(statement);
             }
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
             /**
              *  Using a CTE, select a single column into std::vector<T> or multiple columns into std::vector<std::tuple<...>>.
              */
@@ -22941,7 +22947,7 @@ namespace sqlite_orm {
 
             using storage_base::table_exists;  // now that it is in storage_base make it into overload set
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
             template<class... CTEs,
                      class E,
                      std::enable_if_t<polyfill::disjunction_v<is_select<E>, is_insert_raw<E>>, bool> = true>
@@ -23070,7 +23076,7 @@ namespace sqlite_orm {
                 perform_step(stmt);
             }
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
             template<class... CTEs, class E, satisfies<is_insert_raw, E> = true>
             void execute(const prepared_statement_t<with_t<E, CTEs...>>& statement) {
                 sqlite3_stmt* stmt = reset_stmt(statement.stmt);
@@ -23300,7 +23306,7 @@ namespace sqlite_orm {
                 perform_step(stmt);
             }
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
             template<class... CTEs, class T, class... Args>
             auto execute(const prepared_statement_t<with_t<select_t<T, Args...>, CTEs...>>& statement) {
                 using ExprDBOs = decltype(db_objects_for_expression(this->db_objects, statement.expression));
@@ -23560,7 +23566,7 @@ namespace sqlite_orm {
         template<class T>
         struct node_tuple<T, match_if<is_compound_operator, T>> : node_tuple<typename T::expressions_tuple> {};
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
         template<class CTE>
         struct node_tuple<CTE, match_specialization_of<CTE, common_table_expression>>
             : node_tuple<typename CTE::expression_type> {};

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -2348,6 +2348,7 @@ namespace sqlite_orm {
         return {{}};
     }
 
+#if SQLITE_VERSION_NUMBER >= 3009000
     /**
      *  UNINDEXED column constraint builder function. Used in FTS virtual tables.
      * 
@@ -2396,6 +2397,7 @@ namespace sqlite_orm {
     internal::table_content_t<T> content() {
         return {};
     }
+#endif
 
     /**
      *  PRIMARY KEY table constraint builder function.
@@ -11946,6 +11948,7 @@ namespace sqlite_orm {
         template<class M>
         struct is_virtual_table<virtual_table_t<M>> : std::true_type {};
 
+#if SQLITE_VERSION_NUMBER >= 3009000
         template<class T, class... Cs>
         struct using_fts5_t {
             using object_type = T;
@@ -11983,6 +11986,7 @@ namespace sqlite_orm {
                 iterate_tuple(this->columns, col_index_sequence{}, lambda);
             }
         };
+#endif
 
         template<class O, bool WithoutRowId, class... Cs, class G, class S>
         bool exists_in_composite_primary_key(const table_t<O, WithoutRowId, Cs...>& table,
@@ -12010,6 +12014,7 @@ namespace sqlite_orm {
         }
     }
 
+#if SQLITE_VERSION_NUMBER >= 3009000
     template<class... Cs, class T = typename std::tuple_element_t<0, std::tuple<Cs...>>::object_type>
     internal::using_fts5_t<T, Cs...> using_fts5(Cs... columns) {
         static_assert(polyfill::conjunction_v<internal::is_table_element_or_constraint<Cs>...>,
@@ -12025,6 +12030,7 @@ namespace sqlite_orm {
 
         SQLITE_ORM_CLANG_SUPPRESS_MISSING_BRACES(return {std::make_tuple(std::forward<Cs>(columns)...)});
     }
+#endif
 
     /**
      *  Factory function for a table definition.
@@ -20067,6 +20073,7 @@ namespace sqlite_orm {
             }
         };
 
+#if SQLITE_VERSION_NUMBER >= 3009000
         template<>
         struct statement_serializer<unindexed_t, void> {
             using statement_type = unindexed_t;
@@ -20128,6 +20135,7 @@ namespace sqlite_orm {
                 return ss.str();
             }
         };
+#endif
 
         template<>
         struct statement_serializer<collate_constraint_t, void> {
@@ -20831,6 +20839,7 @@ namespace sqlite_orm {
             }
         };
 
+#if SQLITE_VERSION_NUMBER >= 3009000
         template<class... Cs>
         struct statement_serializer<using_fts5_t<Cs...>, void> {
             using statement_type = using_fts5_t<Cs...>;
@@ -20845,6 +20854,7 @@ namespace sqlite_orm {
                 return ss.str();
             }
         };
+#endif
 
         template<class M>
         struct statement_serializer<virtual_table_t<M>, void> {

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -1989,7 +1989,6 @@ namespace sqlite_orm {
         };
 
 #if SQLITE_VERSION_NUMBER >= 3006019
-
         /**
          *  FOREIGN KEY constraint class.
          *  Cs are columns which has foreign key
@@ -20163,6 +20162,7 @@ namespace sqlite_orm {
             }
         };
 
+#if SQLITE_VERSION_NUMBER >= 3006019
         template<class... Cs, class... Rs>
         struct statement_serializer<foreign_key_t<std::tuple<Cs...>, std::tuple<Rs...>>, void> {
             using statement_type = foreign_key_t<std::tuple<Cs...>, std::tuple<Rs...>>;
@@ -20188,6 +20188,7 @@ namespace sqlite_orm {
                 return ss.str();
             }
         };
+#endif
 
         template<class T>
         struct statement_serializer<check_t<T>, void> {

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -7437,7 +7437,6 @@ namespace sqlite_orm {
     }
 
 #if SQLITE_VERSION_NUMBER >= 3007016
-
     /**
      *  CHAR(X1,X2,...,XN) function https://sqlite.org/lang_corefunc.html#char
      */
@@ -7452,7 +7451,6 @@ namespace sqlite_orm {
     inline internal::built_in_function_t<int, internal::random_string> random() {
         return {{}};
     }
-
 #endif
 
     /**

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -2210,7 +2210,6 @@ namespace sqlite_orm {
             expression_type expression;
         };
 
-#if SQLITE_VERSION_NUMBER >= 3031000
         struct basic_generated_always {
             enum class storage_type {
                 not_specified,
@@ -2218,14 +2217,17 @@ namespace sqlite_orm {
                 stored,
             };
 
+#if SQLITE_VERSION_NUMBER >= 3031000
             bool full = true;
             storage_type storage = storage_type::not_specified;
+#endif
 
 #ifndef SQLITE_ORM_AGGREGATE_NSDMI_SUPPORTED
             basic_generated_always(bool full, storage_type storage) : full{full}, storage{storage} {}
 #endif
         };
 
+#if SQLITE_VERSION_NUMBER >= 3031000
         template<class T>
         struct generated_always_t : basic_generated_always {
             using expression_type = T;

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -8848,6 +8848,7 @@ namespace sqlite_orm {
     }
 
 #ifdef SQLITE_ORM_WITH_CTE
+#if SQLITE_VERSION_NUMBER >= 3035003
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
     /*
      *  Materialization hint to instruct SQLite to materialize the select statement of a CTE into an ephemeral table as an "optimization fence".
@@ -8868,6 +8869,7 @@ namespace sqlite_orm {
     inline consteval internal::not_materialized_t not_materialized() {
         return {};
     }
+#endif
 #endif
 
     /**
@@ -19605,6 +19607,7 @@ namespace sqlite_orm {
         };
 
 #ifdef SQLITE_ORM_WITH_CTE
+#if SQLITE_VERSION_NUMBER >= 3035003
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
         template<>
         struct statement_serializer<materialized_t, void> {
@@ -19625,6 +19628,7 @@ namespace sqlite_orm {
                 return "NOT MATERIALIZED";
             }
         };
+#endif
 #endif
 
         template<class CTE>

--- a/tests/ast_iterator_tests.cpp
+++ b/tests/ast_iterator_tests.cpp
@@ -330,7 +330,7 @@ TEST_CASE("ast_iterator") {
         iterate_ast(expression, lambda);
     }
 #endif
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
     SECTION("with ordinary") {
         using cte_1 = decltype(1_ctealias);
         auto expression = with(cte<cte_1>().as(select(1)), select(column<cte_1>(1_colalias)));

--- a/tests/constraints/foreign_key.cpp
+++ b/tests/constraints/foreign_key.cpp
@@ -5,6 +5,7 @@
 
 #include "../static_tests/static_tests_storage_traits.h"
 
+#if SQLITE_VERSION_NUMBER >= 3006019
 using namespace sqlite_orm;
 
 TEST_CASE("Foreign key") {
@@ -127,3 +128,4 @@ TEST_CASE("Foreign key 2") {
 
     storage.update(t2);
 }
+#endif

--- a/tests/iterate.cpp
+++ b/tests/iterate.cpp
@@ -97,7 +97,7 @@ TEST_CASE("Iterate select statement") {
     }
 #endif
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
     constexpr auto x = "x"_cte;
     std::input_iterator auto begin =

--- a/tests/pointer_passing_interface.cpp
+++ b/tests/pointer_passing_interface.cpp
@@ -1,10 +1,11 @@
 #include <sqlite_orm/sqlite_orm.h>
 #include <catch2/catch_all.hpp>
 
+#if SQLITE_VERSION_NUMBER >= 3020000
+#ifdef SQLITE_ORM_INLINE_VARIABLES_SUPPORTED
 using namespace sqlite_orm;
 using std::unique_ptr;
 
-#ifdef SQLITE_ORM_INLINE_VARIABLES_SUPPORTED
 namespace {
     struct delete_int64 {
         static int64 lastSelectedId;
@@ -175,13 +176,6 @@ TEST_CASE("pointer-passing") {
             REQUIRE(v.back() == delete_int64::lastSelectedId);
         }
     }
-
-    SECTION("dump prepared") {
-        int64 lastSelectedId;
-        auto stmt = storage.prepare(
-            select(func<note_value_fn<int64>>(select(&Object::id), bind_carray_pointer_statically(&lastSelectedId))));
-        std::string sql = storage.dump(stmt);
-        (void)sql;
-    }
 }
+#endif
 #endif

--- a/tests/prepared_statement_tests/get.cpp
+++ b/tests/prepared_statement_tests/get.cpp
@@ -3,6 +3,7 @@
 
 #include "prepared_common.h"
 
+#if SQLITE_VERSION_NUMBER >= 3006019
 using namespace sqlite_orm;
 
 TEST_CASE("Prepared get") {
@@ -136,3 +137,4 @@ TEST_CASE("Prepared get") {
         }
     }
 }
+#endif

--- a/tests/prepared_statement_tests/get_all.cpp
+++ b/tests/prepared_statement_tests/get_all.cpp
@@ -3,6 +3,7 @@
 
 #include "prepared_common.h"
 
+#if SQLITE_VERSION_NUMBER >= 3006019
 using namespace sqlite_orm;
 
 TEST_CASE("Prepared get all") {
@@ -229,3 +230,4 @@ TEST_CASE("Prepared get all") {
     }
 #endif
 }
+#endif

--- a/tests/prepared_statement_tests/get_all_optional.cpp
+++ b/tests/prepared_statement_tests/get_all_optional.cpp
@@ -3,6 +3,7 @@
 
 #include "prepared_common.h"
 
+#if SQLITE_VERSION_NUMBER >= 3006019
 using namespace sqlite_orm;
 
 #ifdef SQLITE_ORM_OPTIONAL_SUPPORTED
@@ -133,3 +134,4 @@ TEST_CASE("Prepared get all optional") {
     }
 }
 #endif  // SQLITE_ORM_OPTIONAL_SUPPORTED
+#endif

--- a/tests/prepared_statement_tests/get_all_pointer.cpp
+++ b/tests/prepared_statement_tests/get_all_pointer.cpp
@@ -3,6 +3,7 @@
 
 #include "prepared_common.h"
 
+#if SQLITE_VERSION_NUMBER >= 3006019
 using namespace sqlite_orm;
 
 TEST_CASE("Prepared get all pointer") {
@@ -138,3 +139,4 @@ TEST_CASE("Prepared get all pointer") {
         }
     }
 }
+#endif

--- a/tests/prepared_statement_tests/get_optional.cpp
+++ b/tests/prepared_statement_tests/get_optional.cpp
@@ -5,6 +5,7 @@
 
 using namespace sqlite_orm;
 
+#if SQLITE_VERSION_NUMBER >= 3006019
 #ifdef SQLITE_ORM_OPTIONAL_SUPPORTED
 TEST_CASE("Prepared get optional") {
     using namespace PreparedStatementTests;
@@ -147,3 +148,4 @@ TEST_CASE("Prepared get optional") {
     }
 }
 #endif  // SQLITE_ORM_OPTIONAL_SUPPORTED
+#endif

--- a/tests/prepared_statement_tests/get_pointer.cpp
+++ b/tests/prepared_statement_tests/get_pointer.cpp
@@ -3,6 +3,7 @@
 
 #include "prepared_common.h"
 
+#if SQLITE_VERSION_NUMBER >= 3006019
 using namespace sqlite_orm;
 
 TEST_CASE("Prepared get pointer") {
@@ -139,3 +140,4 @@ TEST_CASE("Prepared get pointer") {
         }
     }
 }
+#endif

--- a/tests/prepared_statement_tests/insert.cpp
+++ b/tests/prepared_statement_tests/insert.cpp
@@ -3,6 +3,7 @@
 
 #include "prepared_common.h"
 
+#if SQLITE_VERSION_NUMBER >= 3006019
 using namespace sqlite_orm;
 
 TEST_CASE("Prepared insert") {
@@ -238,3 +239,4 @@ TEST_CASE("Prepared insert") {
         }
     }
 }
+#endif

--- a/tests/prepared_statement_tests/insert_explicit.cpp
+++ b/tests/prepared_statement_tests/insert_explicit.cpp
@@ -3,6 +3,7 @@
 
 #include "prepared_common.h"
 
+#if SQLITE_VERSION_NUMBER >= 3006019
 using namespace sqlite_orm;
 
 TEST_CASE("Prepared insert explicit") {
@@ -112,3 +113,4 @@ TEST_CASE("Prepared insert explicit") {
         }
     }
 }
+#endif

--- a/tests/prepared_statement_tests/insert_range.cpp
+++ b/tests/prepared_statement_tests/insert_range.cpp
@@ -4,6 +4,7 @@
 
 #include "prepared_common.h"
 
+#if SQLITE_VERSION_NUMBER >= 3006019
 using namespace sqlite_orm;
 
 TEST_CASE("Prepared insert range") {
@@ -138,3 +139,4 @@ TEST_CASE("Prepared insert range") {
     auto rows = storage.get_all<User>();
     REQUIRE_THAT(rows, UnorderedEquals(expected));
 }
+#endif

--- a/tests/prepared_statement_tests/remove.cpp
+++ b/tests/prepared_statement_tests/remove.cpp
@@ -3,6 +3,7 @@
 
 #include "prepared_common.h"
 
+#if SQLITE_VERSION_NUMBER >= 3006019
 using namespace sqlite_orm;
 
 TEST_CASE("Prepared remove") {
@@ -97,3 +98,4 @@ TEST_CASE("Prepared remove") {
         REQUIRE(storage.count<User>() == 0);
     }
 }
+#endif

--- a/tests/prepared_statement_tests/remove_all.cpp
+++ b/tests/prepared_statement_tests/remove_all.cpp
@@ -3,6 +3,7 @@
 
 #include "prepared_common.h"
 
+#if SQLITE_VERSION_NUMBER >= 3006019
 using namespace sqlite_orm;
 
 TEST_CASE("Prepared remove all") {
@@ -181,3 +182,4 @@ TEST_CASE("Prepared remove all") {
         }
     }
 }
+#endif

--- a/tests/prepared_statement_tests/replace.cpp
+++ b/tests/prepared_statement_tests/replace.cpp
@@ -3,6 +3,7 @@
 
 #include "prepared_common.h"
 
+#if SQLITE_VERSION_NUMBER >= 3006019
 using namespace sqlite_orm;
 
 TEST_CASE("Prepared replace") {
@@ -159,3 +160,4 @@ TEST_CASE("Prepared replace") {
     auto rows = storage.get_all<User>();
     REQUIRE_THAT(rows, UnorderedEquals(expected));
 }
+#endif

--- a/tests/prepared_statement_tests/replace_range.cpp
+++ b/tests/prepared_statement_tests/replace_range.cpp
@@ -3,6 +3,7 @@
 
 #include "prepared_common.h"
 
+#if SQLITE_VERSION_NUMBER >= 3006019
 using namespace sqlite_orm;
 
 TEST_CASE("Prepared replace range") {
@@ -129,3 +130,4 @@ TEST_CASE("Prepared replace range") {
     auto rows = storage.get_all<User>();
     REQUIRE_THAT(rows, UnorderedEquals(expected));
 }
+#endif

--- a/tests/prepared_statement_tests/select.cpp
+++ b/tests/prepared_statement_tests/select.cpp
@@ -439,5 +439,25 @@ TEST_CASE("dumping") {
             expected = "SELECT 1";
         }
     }
+#if SQLITE_VERSION_NUMBER >= 3020000
+#ifdef SQLITE_ORM_INLINE_VARIABLES_SUPPORTED
+    SECTION("with bound pointer") {
+        int64 lastSelectedId;
+        auto statement = storage.prepare(select(bind_carray_pointer_statically(&lastSelectedId)));
+        SECTION("default") {
+            value = storage.dump(statement);
+            expected = "SELECT ?";
+        }
+        SECTION("parametrized") {
+            value = storage.dump(statement, true);
+            expected = "SELECT ?";
+        }
+        SECTION("dump") {
+            value = storage.dump(statement, false);
+            expected = "SELECT NULL";
+        }
+    }
+#endif
+#endif
     REQUIRE(value == expected);
 }

--- a/tests/prepared_statement_tests/select.cpp
+++ b/tests/prepared_statement_tests/select.cpp
@@ -5,6 +5,7 @@
 
 using namespace sqlite_orm;
 
+#if SQLITE_VERSION_NUMBER >= 3006019
 TEST_CASE("Prepared select") {
     using namespace PreparedStatementTests;
     using Catch::Matchers::UnorderedEquals;
@@ -403,6 +404,7 @@ TEST_CASE("Prepared select") {
         }
     }
 }
+#endif
 
 TEST_CASE("dumping") {
     auto storage = make_storage("");

--- a/tests/prepared_statement_tests/update.cpp
+++ b/tests/prepared_statement_tests/update.cpp
@@ -3,6 +3,7 @@
 
 #include "prepared_common.h"
 
+#if SQLITE_VERSION_NUMBER >= 3006019
 using namespace sqlite_orm;
 
 TEST_CASE("Prepared update") {
@@ -100,3 +101,4 @@ TEST_CASE("Prepared update") {
         }
     }
 }
+#endif

--- a/tests/prepared_statement_tests/update_all.cpp
+++ b/tests/prepared_statement_tests/update_all.cpp
@@ -3,6 +3,7 @@
 
 #include "prepared_common.h"
 
+#if SQLITE_VERSION_NUMBER >= 3006019
 using namespace sqlite_orm;
 
 TEST_CASE("Prepared update all") {
@@ -157,3 +158,4 @@ TEST_CASE("Prepared update all") {
         }
     }
 }
+#endif

--- a/tests/schema/explicit_columns.cpp
+++ b/tests/schema/explicit_columns.cpp
@@ -1,6 +1,7 @@
 #include <sqlite_orm/sqlite_orm.h>
 #include <catch2/catch_all.hpp>
 
+#if SQLITE_VERSION_NUMBER >= 3006019
 using namespace sqlite_orm;
 
 TEST_CASE("Explicit columns") {
@@ -93,3 +94,4 @@ TEST_CASE("Explicit columns") {
         REQUIRE(std::get<1>(joinedRows.front()) == "abc");
     }
 }
+#endif

--- a/tests/schema/table_tests.cpp
+++ b/tests/schema/table_tests.cpp
@@ -168,6 +168,7 @@ TEST_CASE("Composite key column names") {
     }
 }
 
+#if SQLITE_VERSION_NUMBER >= 3006019
 TEST_CASE("for_each_foreign_key") {
     struct Location {
         int id;
@@ -207,3 +208,4 @@ TEST_CASE("for_each_foreign_key") {
     });
     REQUIRE(visitCallsCount == 1);
 }
+#endif

--- a/tests/schema/virtual_table.cpp
+++ b/tests/schema/virtual_table.cpp
@@ -1,6 +1,7 @@
 #include <sqlite_orm/sqlite_orm.h>
 #include <catch2/catch_all.hpp>
 
+#if SQLITE_VERSION_NUMBER >= 3009000
 using namespace sqlite_orm;
 
 TEST_CASE("virtual table") {
@@ -75,3 +76,4 @@ TEST_CASE("virtual table") {
                        where(match<Post>("SQLite")),
                        order_by(rank()));
 }
+#endif

--- a/tests/select_constraints_tests.cpp
+++ b/tests/select_constraints_tests.cpp
@@ -139,6 +139,7 @@ TEST_CASE("select constraints") {
             expected.push_back("James");
             REQUIRE_THAT(rows, UnorderedEquals(expected));
         }
+#if SQLITE_VERSION_NUMBER >= 3006019
         SECTION("left join") {
             struct Author {
                 int id = 0;
@@ -208,6 +209,7 @@ TEST_CASE("select constraints") {
                 REQUIRE_THAT(rows, UnorderedEquals(expected));
             }
         }
+#endif
     }
 #endif  //  SQLITE_ORM_OPTIONAL_SUPPORTED
 }
@@ -234,6 +236,7 @@ namespace {
 #endif
     };
 }
+#if SQLITE_VERSION_NUMBER >= 3006019
 TEST_CASE("Exists") {
     auto storage = make_storage(
         "",
@@ -259,6 +262,7 @@ TEST_CASE("Exists") {
         where(exists(select(&Visit1::id, where(c(&Visit1::time) == 200000 and eq(&Visit1::userId, &User1::id))))));
     REQUIRE(rows.empty() == false);
 }
+#endif
 
 namespace {
     struct User2 {

--- a/tests/statement_serializer_tests/aggregate_functions.cpp
+++ b/tests/statement_serializer_tests/aggregate_functions.cpp
@@ -94,7 +94,7 @@ TEST_CASE("statement_serializer aggregate functions") {
                 expected = R"(COUNT(*))";
             }
 #endif
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
             SECTION("with CTE") {
                 auto expression = count<1_ctealias>();

--- a/tests/statement_serializer_tests/alias_extractor.cpp
+++ b/tests/statement_serializer_tests/alias_extractor.cpp
@@ -19,7 +19,7 @@ TEST_CASE("alias extractor") {
         REQUIRE(alias_extractor<alias_a<User>>::extract() == "a");
         REQUIRE(alias_extractor<alias_a<User>>::as_alias() == "a");
     }
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
     SECTION("cte moniker") {
         using cte_1 = decltype(1_ctealias);
         REQUIRE(alias_extractor<cte_1>::extract() == "1");

--- a/tests/statement_serializer_tests/ast/match.cpp
+++ b/tests/statement_serializer_tests/ast/match.cpp
@@ -1,6 +1,7 @@
 #include <sqlite_orm/sqlite_orm.h>
 #include <catch2/catch_all.hpp>
 
+#if SQLITE_VERSION_NUMBER >= 3009000
 using namespace sqlite_orm;
 
 TEST_CASE("statement_serializer match") {
@@ -16,5 +17,6 @@ TEST_CASE("statement_serializer match") {
     context_t context{dbObjects};
     auto node = match<User>("Claude");
     auto value = serialize(node, context);
-    REQUIRE(value == "\"users\" MATCH 'Claude'");
+    REQUIRE(value == R"("users" MATCH 'Claude')");
 }
+#endif

--- a/tests/statement_serializer_tests/bindables.cpp
+++ b/tests/statement_serializer_tests/bindables.cpp
@@ -259,6 +259,7 @@ TEST_CASE("bindables") {
         }
     }
 
+#if SQLITE_VERSION_NUMBER >= 3020000
 #ifdef SQLITE_ORM_INLINE_VARIABLES_SUPPORTED
     SECTION("bindable_pointer") {
         string value, expected;
@@ -309,5 +310,6 @@ TEST_CASE("bindables") {
 
         REQUIRE(value == expected);
     }
+#endif
 #endif
 }

--- a/tests/statement_serializer_tests/column_constraints/unindexed.cpp
+++ b/tests/statement_serializer_tests/column_constraints/unindexed.cpp
@@ -1,6 +1,7 @@
 #include <sqlite_orm/sqlite_orm.h>
 #include <catch2/catch_all.hpp>
 
+#if SQLITE_VERSION_NUMBER >= 3009000
 using namespace sqlite_orm;
 
 TEST_CASE("statement_serializer unindexed") {
@@ -10,3 +11,4 @@ TEST_CASE("statement_serializer unindexed") {
     auto value = serialize(node, context);
     REQUIRE(value == "UNINDEXED");
 }
+#endif

--- a/tests/statement_serializer_tests/column_names.cpp
+++ b/tests/statement_serializer_tests/column_names.cpp
@@ -164,7 +164,7 @@ TEST_CASE("statement_serializer column names") {
             auto value = serialize(alias_column<als>(&Object::id), context);
             REQUIRE(value == R"("a"."id")");
         }
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
         SECTION("cte") {
             auto dbObjects2 =

--- a/tests/statement_serializer_tests/schema/using_fts5.cpp
+++ b/tests/statement_serializer_tests/schema/using_fts5.cpp
@@ -1,6 +1,7 @@
 #include <sqlite_orm/sqlite_orm.h>
 #include <catch2/catch_all.hpp>
 
+#if SQLITE_VERSION_NUMBER >= 3009000
 using namespace sqlite_orm;
 
 TEST_CASE("statement_serializer using_fts5") {
@@ -62,3 +63,4 @@ TEST_CASE("statement_serializer using_fts5") {
     }
     REQUIRE(value == expected);
 }
+#endif

--- a/tests/statement_serializer_tests/schema/virtual_table.cpp
+++ b/tests/statement_serializer_tests/schema/virtual_table.cpp
@@ -1,6 +1,7 @@
 #include <sqlite_orm/sqlite_orm.h>
 #include <catch2/catch_all.hpp>
 
+#if SQLITE_VERSION_NUMBER >= 3009000
 using namespace sqlite_orm;
 
 TEST_CASE("statement_serializer FTS5") {
@@ -13,5 +14,6 @@ TEST_CASE("statement_serializer FTS5") {
     auto node =
         make_virtual_table("posts", using_fts5(make_column("title", &Post::title), make_column("body", &Post::body)));
     auto value = serialize(node, context);
-    REQUIRE(value == "CREATE VIRTUAL TABLE IF NOT EXISTS \"posts\" USING FTS5(\"title\", \"body\")");
+    REQUIRE(value == R"(CREATE VIRTUAL TABLE IF NOT EXISTS "posts" USING FTS5("title", "body"))");
 }
+#endif

--- a/tests/statement_serializer_tests/select_constraints.cpp
+++ b/tests/statement_serializer_tests/select_constraints.cpp
@@ -126,6 +126,7 @@ TEST_CASE("statement_serializer select constraints") {
             value = serialize(expression, context);
             expected = R"("1"("1") AS (SELECT 1))";
         }
+#if SQLITE_VERSION_NUMBER >= 3035000
         SECTION("as materialized") {
             auto expression = cte<cte_1>().as<materialized()>(select(1));
             value = serialize(expression, context);
@@ -136,6 +137,7 @@ TEST_CASE("statement_serializer select constraints") {
             value = serialize(expression, context);
             expected = R"("1"("1") AS NOT MATERIALIZED (SELECT 1))";
         }
+#endif
 #endif
         SECTION("with ordinary") {
             auto expression = with(cte<cte_1>().as(select(1)), select(column<cte_1>(1_colalias)));

--- a/tests/statement_serializer_tests/select_constraints.cpp
+++ b/tests/statement_serializer_tests/select_constraints.cpp
@@ -92,7 +92,7 @@ TEST_CASE("statement_serializer select constraints") {
         }
 #endif
     }
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
     SECTION("from CTE") {
         using cte_1 = decltype(1_ctealias);
         auto dbObjects2 =

--- a/tests/statement_serializer_tests/statements/select.cpp
+++ b/tests/statement_serializer_tests/statements/select.cpp
@@ -197,6 +197,7 @@ TEST_CASE("statement_serializer select_t") {
                 stringValue = serialize(expression, context);
                 expected = R"("users".*, "users"."id", "users"."name")";
             }
+#if SQLITE_VERSION_NUMBER >= 3006019
             SECTION("issue #945") {
                 struct Employee {
                     int m_empno;
@@ -232,6 +233,7 @@ TEST_CASE("statement_serializer select_t") {
                 expected =
                     R"(SELECT "d".* FROM "Dept" "d" LEFT JOIN "Emp" "e" ON "d"."deptno" = "e"."deptno"  WHERE ("e"."deptno" IS NULL))";
             }
+#endif
         }
     }
     REQUIRE(stringValue == expected);

--- a/tests/statement_serializer_tests/table_constraints/prefix.cpp
+++ b/tests/statement_serializer_tests/table_constraints/prefix.cpp
@@ -1,6 +1,7 @@
 #include <sqlite_orm/sqlite_orm.h>
 #include <catch2/catch_all.hpp>
 
+#if SQLITE_VERSION_NUMBER >= 3009000
 using namespace sqlite_orm;
 
 TEST_CASE("statement_serializer prefix") {
@@ -25,3 +26,4 @@ TEST_CASE("statement_serializer prefix") {
     }
     REQUIRE(value == expected);
 }
+#endif

--- a/tests/static_tests/alias.cpp
+++ b/tests/static_tests/alias.cpp
@@ -69,7 +69,7 @@ TEST_CASE("aliases") {
             alias_column<d_alias>(&User::id));
         runTest<alias_column_t<alias_d<DerivedUser>, column_pointer<DerivedUser, int User::*>>>(d_alias->*&User::id);
 #endif
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
         runTest<column_alias<'1'>>(1_colalias);
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
         using cte_1 = decltype(1_ctealias);

--- a/tests/static_tests/bindable_filter.cpp
+++ b/tests/static_tests/bindable_filter.cpp
@@ -65,11 +65,13 @@ TEST_CASE("bindable_filter") {
 #endif
                                  std::unique_ptr<int>,
                                  std::shared_ptr<int>,
+#if SQLITE_VERSION_NUMBER >= 3020000
 #ifdef SQLITE_ORM_INLINE_VARIABLES_SUPPORTED
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
                                  static_pointer_binding_t<std::nullptr_t, carray_pointer_tag>,
 #else
                                  static_pointer_binding<std::nullptr_t, carray_pointer_type>,
+#endif
 #endif
 #endif
                                  Custom,

--- a/tests/static_tests/column_expression_type.cpp
+++ b/tests/static_tests/column_expression_type.cpp
@@ -54,7 +54,7 @@ TEST_CASE("column_expression_of_t") {
     runTest<db_objects_t, column_pointer<Derived, int64 Org::*>>(moniker->*&Org::id);
     runTest<db_objects_t, std::tuple<int64 Org::*, int64 Org::*>>(asterisk<moniker>());
 #endif
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
     using cte_1 = decltype(1_ctealias);
     auto dbObjects2 =
         internal::db_objects_cat(dbObjects,

--- a/tests/static_tests/column_result_t.cpp
+++ b/tests/static_tests/column_result_t.cpp
@@ -130,7 +130,7 @@ TEST_CASE("column_result_of_t") {
         columns(struct_<User>(asterisk<User>()), struct_<User>(asterisk<User>())));
     runTest<db_objects_t, int>(union_all(select(1), select(2)));
     runTest<db_objects_t, int64>(union_all(select(1ll), select(2)));
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
     using cte_1 = decltype(1_ctealias);
     // note: even though used with the CTE, &User::id doesn't need to be mapped into the CTE to make column results work;
     //       this is because the result type is taken from the member pointer just because we can't look it up in the storage definition

--- a/tests/static_tests/cte.cpp
+++ b/tests/static_tests/cte.cpp
@@ -1,5 +1,5 @@
 #include <sqlite_orm/sqlite_orm.h>
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
 #include <type_traits>  //  std::is_same, std::is_constructible
 #include <tuple>  //  std::ignore
 #include <string>  //  std::string

--- a/tests/static_tests/foreign_key.cpp
+++ b/tests/static_tests/foreign_key.cpp
@@ -7,6 +7,7 @@
 
 #include "static_tests_storage_traits.h"
 
+#if SQLITE_VERSION_NUMBER >= 3006019
 using namespace sqlite_orm;
 
 TEST_CASE("foreign key static") {
@@ -135,3 +136,4 @@ TEST_CASE("foreign key static") {
         STATIC_REQUIRE(std::is_same<FkTuple, Expected>::value);
     }
 }
+#endif

--- a/tests/static_tests/is_bindable.cpp
+++ b/tests/static_tests/is_bindable.cpp
@@ -67,11 +67,13 @@ TEST_CASE("is_bindable") {
     STATIC_REQUIRE(is_bindable_v<std::optional<Custom>>);
     STATIC_REQUIRE_FALSE(is_bindable_v<std::optional<User>>);
 #endif  // SQLITE_ORM_OPTIONAL_SUPPORTED
+#if SQLITE_VERSION_NUMBER >= 3020000
 #ifdef SQLITE_ORM_INLINE_VARIABLES_SUPPORTED
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
     STATIC_REQUIRE(is_bindable_v<static_pointer_binding_t<std::nullptr_t, carray_pointer_tag>>);
 #else
     STATIC_REQUIRE(is_bindable_v<static_pointer_binding<std::nullptr_t, carray_pointer_type>>);
+#endif
 #endif
 #endif
 

--- a/tests/static_tests/is_printable.cpp
+++ b/tests/static_tests/is_printable.cpp
@@ -63,11 +63,13 @@ TEST_CASE("is_printable") {
     STATIC_REQUIRE(is_printable_v<std::optional<Custom>>);
     STATIC_REQUIRE_FALSE(is_printable_v<std::optional<User>>);
 #endif  // SQLITE_ORM_OPTIONAL_SUPPORTED
+#if SQLITE_VERSION_NUMBER >= 3020000
 #ifdef SQLITE_ORM_INLINE_VARIABLES_SUPPORTED
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
     STATIC_REQUIRE_FALSE(is_printable_v<static_pointer_binding_t<std::nullptr_t, carray_pointer_tag>>);
 #else
     STATIC_REQUIRE_FALSE(is_printable_v<static_pointer_binding<std::nullptr_t, carray_pointer_type>>);
+#endif
 #endif
 #endif
 

--- a/tests/static_tests/iterator_t.cpp
+++ b/tests/static_tests/iterator_t.cpp
@@ -184,7 +184,7 @@ TEST_CASE("can view and iterate result set") {
         storage_iterate_result_set<storage_type, decltype(select(object<Object>())), table_reference<Object>>);
 #endif
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
     constexpr orm_cte_moniker auto x = "x"_cte;
     constexpr orm_column_alias auto i = "i"_col;

--- a/tests/static_tests/node_tuple.cpp
+++ b/tests/static_tests/node_tuple.cpp
@@ -250,7 +250,7 @@ TEST_CASE("Node tuple") {
             using Expected = tuple<decltype(node)>;
             static_assert(is_same<Tuple, Expected>::value, "count(*)");
         }
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
         SECTION("count(*) cte") {
             auto node = count<decltype(1_ctealias)>();
             using Node = decltype(node);
@@ -976,7 +976,7 @@ TEST_CASE("Node tuple") {
         using ExpectedTuple = tuple<decltype(&User::name), decltype(&User::name), const char*>;
         STATIC_REQUIRE(std::is_same<Tuple, ExpectedTuple>::value);
     }
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
     SECTION("with ordinary") {
         using cte_1 = decltype(1_ctealias);
         auto expression = with(1_ctealias().as(select(1)), select(column<cte_1>(1_colalias)));

--- a/tests/static_tests/operators_adl.cpp
+++ b/tests/static_tests/operators_adl.cpp
@@ -109,7 +109,7 @@ void runTests(E expression) {
 }
 
 TEST_CASE("inline namespace literals expressions") {
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
     constexpr auto col1 = 1_colalias;
     constexpr auto cte1 = 1_ctealias;
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
@@ -133,11 +133,15 @@ TEST_CASE("ADL and pointer-to-member expressions") {
     };
     constexpr auto user_table = c<User>();
     constexpr auto u_alias = "u"_alias.for_<User>();
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
     constexpr auto cte = "1"_cte;
+#endif
 
     user_table->*&User::id;
     u_alias->*&User::id;
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
     cte->*&User::id;
+#endif
 }
 #endif
 

--- a/tests/static_tests/operators_adl.cpp
+++ b/tests/static_tests/operators_adl.cpp
@@ -120,7 +120,9 @@ TEST_CASE("inline namespace literals expressions") {
     constexpr auto u_alias_builder = "u"_alias;
     constexpr auto c_col = "c"_col;
     constexpr auto f_scalar_builder = "f"_scalar;
+#if SQLITE_VERSION_NUMBER >= 3020000
     constexpr auto domain_ptr_tag = "domain"_pointer_type;
+#endif
 #endif
 }
 

--- a/tests/static_tests/row_extractor.cpp
+++ b/tests/static_tests/row_extractor.cpp
@@ -92,6 +92,7 @@ TEST_CASE("is_extractable") {
     check_extractable<std::optional<custom_enum>>();
     check_not_extractable<std::optional<User>>();
 #endif  // SQLITE_ORM_OPTIONAL_SUPPORTED
+#if SQLITE_VERSION_NUMBER >= 3020000
 #ifdef SQLITE_ORM_INLINE_VARIABLES_SUPPORTED
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
     check_not_extractable<static_pointer_binding_t<std::nullptr_t, carray_pointer_tag>>();
@@ -105,6 +106,7 @@ TEST_CASE("is_extractable") {
         STATIC_CHECK_FALSE(orm_row_value_extractable<int64_pointer_arg>);
         STATIC_CHECK(orm_boxed_value_extractable<int64_pointer_arg>);
     }
+#endif
 #endif
 
     check_extractable<custom_enum>();

--- a/tests/storage_tests.cpp
+++ b/tests/storage_tests.cpp
@@ -203,6 +203,7 @@ TEST_CASE("Storage copy") {
     storageCopy.remove_all<User>();
 }
 
+#if SQLITE_VERSION_NUMBER >= 3006019
 TEST_CASE("column_name") {
     struct User {
         int id = 0;
@@ -230,6 +231,7 @@ TEST_CASE("column_name") {
     REQUIRE(*storage.find_column_name(&Visit::date) == "date");
     REQUIRE(storage.find_column_name(&Visit::notUsed) == nullptr);
 }
+#endif
 
 namespace {
     class Record final {

--- a/tests/table_name_collector.cpp
+++ b/tests/table_name_collector.cpp
@@ -49,7 +49,7 @@ TEST_CASE("table name collector") {
         REQUIRE(collector.table_names == expected);
     }
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
     SECTION("from CTE") {
         auto dbObjects2 =
             internal::db_objects_cat(dbObjects, internal::make_cte_table(dbObjects, 1_ctealias().as(select(1))));

--- a/tests/tests3.cpp
+++ b/tests/tests3.cpp
@@ -386,7 +386,7 @@ TEST_CASE("Escape chars") {
     storage.remove<Employee>(10);
 }
 
-#ifdef SQLITE_ORM_WITH_CTE
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
 TEST_CASE("With select") {
     using Catch::Matchers::Equals;
 

--- a/tests/tests4.cpp
+++ b/tests/tests4.cpp
@@ -144,6 +144,7 @@ TEST_CASE("join") {
     }
 }
 
+#if SQLITE_VERSION_NUMBER >= 3006019
 TEST_CASE("two joins") {
     struct Statement {
         int id_statement;
@@ -288,3 +289,4 @@ TEST_CASE("two joins") {
                                  inner_join<als_b>(on(alias_column<als_t>(&Transaccion::fkey_account_own) ==
                                                       alias_column<als_b>(&Account::id_account))));
 }
+#endif

--- a/tests/unique_cases/index_named_table_with_fk.cpp
+++ b/tests/unique_cases/index_named_table_with_fk.cpp
@@ -1,6 +1,7 @@
 #include <sqlite_orm/sqlite_orm.h>
 #include <catch2/catch_all.hpp>
 
+#if SQLITE_VERSION_NUMBER >= 3006019
 using namespace sqlite_orm;
 
 TEST_CASE("index named table") {
@@ -77,3 +78,4 @@ TEST_CASE("index named table") {
                                 foreign_key(&pay_info::order_number).references(&OrderTable::order_number)));
     storage.sync_schema();
 }
+#endif

--- a/tests/unique_cases/issue937.cpp
+++ b/tests/unique_cases/issue937.cpp
@@ -65,7 +65,9 @@ TEST_CASE("issue937") {
         select(columns(as<NamesAlias>(&Department::m_deptname), as_optional(&Department::m_deptno))),
         select(union_all(select(columns(quote("--------------------"), std::optional<int>())),
                          select(columns(as<NamesAlias>(&Employee::m_ename), as_optional(&Employee::m_depno))))))));
+#if SQLITE_VERSION_NUMBER >= 3014000
     auto sql = statement.expanded_sql();
+#endif
     auto rows = storage.execute(statement);
     {  //  issue953
         auto expression = select(

--- a/tests/unique_cases/issue937.cpp
+++ b/tests/unique_cases/issue937.cpp
@@ -1,7 +1,9 @@
 #include <sqlite_orm/sqlite_orm.h>
 #include <catch2/catch_all.hpp>
 
+#if SQLITE_VERSION_NUMBER >= 3006019
 using namespace sqlite_orm;
+
 #ifdef SQLITE_ORM_OPTIONAL_SUPPORTED
 TEST_CASE("issue937") {
     struct Employee {
@@ -87,4 +89,5 @@ TEST_CASE("issue937") {
         REQUIRE_NOTHROW(storage.prepare(expression));
     }
 }
+#endif
 #endif


### PR DESCRIPTION
Several features were not properly guarded or not at all using SQLite's version number macro `SQLITE_VERSION_NUMBER`, either in code, tests, and/or examples:
* Foreign keys (3.6.19)
* RANDOM (3.7.16)
* Common Table Expressions (3.8.3)
* FTS5 (3.9.0 [amalgamated])
* Retrieving the "expanded" SQL string of a prepared statement (3.14.0)
* Pointer-passing interface (3.20.0)
* Generated columns (3.31.0)
* CTE materialization hints (3.35.0)
