### PR TITLE
CTEs for the rest of CRUD statements

### DIFF
--- a/dev/ast/set.h
+++ b/dev/ast/set.h
@@ -50,7 +50,8 @@ namespace sqlite_orm {
             void push_back(assign_t<L, R> assign) {
                 auto newContext = this->context;
                 newContext.skip_table_name = true;
-                iterate_ast(assign, this->collector);
+                // note: we are only interested in the table name on the left-hand side of the assignment operator expression
+                iterate_ast(assign.lhs, this->collector);
                 std::stringstream ss;
                 ss << serialize(assign.lhs, newContext) << ' ' << assign.serialize() << ' '
                    << serialize(assign.rhs, context);

--- a/dev/ast/where.h
+++ b/dev/ast/where.h
@@ -26,7 +26,7 @@ namespace sqlite_orm {
 
             expression_type expression;
 
-            where_t(expression_type expression_) : expression(std::move(expression_)) {}
+            constexpr where_t(expression_type expression_) : expression(std::move(expression_)) {}
         };
 
         template<class T>
@@ -46,7 +46,7 @@ namespace sqlite_orm {
      *  auto rows = storage.select(&Letter::name, where(greater_than(&Letter::id, 3)));
      */
     template<class C>
-    internal::where_t<C> where(C expression) {
+    constexpr internal::where_t<C> where(C expression) {
         return {std::move(expression)};
     }
 }

--- a/dev/conditions.h
+++ b/dev/conditions.h
@@ -113,7 +113,7 @@ namespace sqlite_orm {
         struct negated_condition_t : condition_t, negated_condition_string {
             C c;
 
-            negated_condition_t(C c_) : c(std::move(c_)) {}
+            constexpr negated_condition_t(C c_) : c(std::move(c_)) {}
         };
 
         /**
@@ -132,9 +132,9 @@ namespace sqlite_orm {
             left_type lhs;
             right_type rhs;
 
-            binary_condition() = default;
+            constexpr binary_condition() = default;
 
-            binary_condition(left_type l_, right_type r_) : lhs(std::move(l_)), rhs(std::move(r_)) {}
+            constexpr binary_condition(left_type l_, right_type r_) : lhs(std::move(l_)), rhs(std::move(r_)) {}
         };
 
         template<class T>
@@ -849,7 +849,7 @@ namespace sqlite_orm {
             class T,
             std::enable_if_t<polyfill::disjunction<std::is_base_of<negatable_t, T>, is_operator_argument<T>>::value,
                              bool> = true>
-        negated_condition_t<T> operator!(T arg) {
+        constexpr negated_condition_t<T> operator!(T arg) {
             return {std::move(arg)};
         }
 
@@ -860,7 +860,7 @@ namespace sqlite_orm {
                                                         is_operator_argument<L>,
                                                         is_operator_argument<R>>::value,
                                   bool> = true>
-        less_than_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator<(L l, R r) {
+        constexpr less_than_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator<(L l, R r) {
             return {get_from_expression(std::forward<L>(l)), get_from_expression(std::forward<R>(r))};
         }
 
@@ -871,7 +871,7 @@ namespace sqlite_orm {
                                                         is_operator_argument<L>,
                                                         is_operator_argument<R>>::value,
                                   bool> = true>
-        less_or_equal_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator<=(L l, R r) {
+        constexpr less_or_equal_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator<=(L l, R r) {
             return {get_from_expression(std::forward<L>(l)), get_from_expression(std::forward<R>(r))};
         }
 
@@ -882,7 +882,7 @@ namespace sqlite_orm {
                                                         is_operator_argument<L>,
                                                         is_operator_argument<R>>::value,
                                   bool> = true>
-        greater_than_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator>(L l, R r) {
+        constexpr greater_than_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator>(L l, R r) {
             return {get_from_expression(std::forward<L>(l)), get_from_expression(std::forward<R>(r))};
         }
 
@@ -893,20 +893,7 @@ namespace sqlite_orm {
                                                         is_operator_argument<L>,
                                                         is_operator_argument<R>>::value,
                                   bool> = true>
-        greater_or_equal_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator>=(L l, R r) {
-            return {get_from_expression(std::forward<L>(l)), get_from_expression(std::forward<R>(r))};
-        }
-
-        template<class L,
-                 class R,
-                 std::enable_if_t<polyfill::disjunction<std::is_base_of<arithmetic_t, L>,
-                                                        std::is_base_of<arithmetic_t, R>,
-                                                        std::is_base_of<condition_t, L>,
-                                                        std::is_base_of<condition_t, R>,
-                                                        is_operator_argument<L>,
-                                                        is_operator_argument<R>>::value,
-                                  bool> = true>
-        is_equal_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator==(L l, R r) {
+        constexpr greater_or_equal_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator>=(L l, R r) {
             return {get_from_expression(std::forward<L>(l)), get_from_expression(std::forward<R>(r))};
         }
 
@@ -919,7 +906,20 @@ namespace sqlite_orm {
                                                         is_operator_argument<L>,
                                                         is_operator_argument<R>>::value,
                                   bool> = true>
-        is_not_equal_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator!=(L l, R r) {
+        constexpr is_equal_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator==(L l, R r) {
+            return {get_from_expression(std::forward<L>(l)), get_from_expression(std::forward<R>(r))};
+        }
+
+        template<class L,
+                 class R,
+                 std::enable_if_t<polyfill::disjunction<std::is_base_of<arithmetic_t, L>,
+                                                        std::is_base_of<arithmetic_t, R>,
+                                                        std::is_base_of<condition_t, L>,
+                                                        std::is_base_of<condition_t, R>,
+                                                        is_operator_argument<L>,
+                                                        is_operator_argument<R>>::value,
+                                  bool> = true>
+        constexpr is_not_equal_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator!=(L l, R r) {
             return {get_from_expression(std::forward<L>(l)), get_from_expression(std::forward<R>(r))};
         }
 
@@ -930,7 +930,7 @@ namespace sqlite_orm {
                                                         is_operator_argument<L>,
                                                         is_operator_argument<R>>::value,
                                   bool> = true>
-        and_condition_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator&&(L l, R r) {
+        constexpr and_condition_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator&&(L l, R r) {
             return {get_from_expression(std::forward<L>(l)), get_from_expression(std::forward<R>(r))};
         }
 
@@ -939,7 +939,7 @@ namespace sqlite_orm {
                  std::enable_if_t<
                      polyfill::disjunction<std::is_base_of<condition_t, L>, std::is_base_of<condition_t, R>>::value,
                      bool> = true>
-        or_condition_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator||(L l, R r) {
+        constexpr or_condition_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator||(L l, R r) {
             return {get_from_expression(std::forward<L>(l)), get_from_expression(std::forward<R>(r))};
         }
 
@@ -955,7 +955,7 @@ namespace sqlite_orm {
                                  polyfill::negation<polyfill::disjunction<std::is_base_of<condition_t, L>,
                                                                           std::is_base_of<condition_t, R>>>>::value,
                              bool> = true>
-        conc_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator||(L l, R r) {
+        constexpr conc_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator||(L l, R r) {
             return {get_from_expression(std::forward<L>(l)), get_from_expression(std::forward<R>(r))};
         }
     }
@@ -1053,14 +1053,14 @@ namespace sqlite_orm {
     }
 
     template<class L, class R>
-    auto and_(L l, R r) {
+    constexpr auto and_(L l, R r) {
         using namespace ::sqlite_orm::internal;
         return and_condition_t<unwrap_expression_t<L>, unwrap_expression_t<R>>{get_from_expression(std::forward<L>(l)),
                                                                                get_from_expression(std::forward<R>(r))};
     }
 
     template<class L, class R>
-    auto or_(L l, R r) {
+    constexpr auto or_(L l, R r) {
         using namespace ::sqlite_orm::internal;
         return or_condition_t<unwrap_expression_t<L>, unwrap_expression_t<R>>{get_from_expression(std::forward<L>(l)),
                                                                               get_from_expression(std::forward<R>(r))};
@@ -1107,52 +1107,52 @@ namespace sqlite_orm {
     }
 
     template<class L, class R>
-    internal::is_equal_t<L, R> is_equal(L l, R r) {
+    constexpr internal::is_equal_t<L, R> is_equal(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
-    internal::is_equal_t<L, R> eq(L l, R r) {
+    constexpr internal::is_equal_t<L, R> eq(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
-    internal::is_equal_with_table_t<L, R> is_equal(R rhs) {
+    constexpr internal::is_equal_with_table_t<L, R> is_equal(R rhs) {
         return {std::move(rhs)};
     }
 
     template<class L, class R>
-    internal::is_not_equal_t<L, R> is_not_equal(L l, R r) {
+    constexpr internal::is_not_equal_t<L, R> is_not_equal(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
-    internal::is_not_equal_t<L, R> ne(L l, R r) {
+    constexpr internal::is_not_equal_t<L, R> ne(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
-    internal::greater_than_t<L, R> greater_than(L l, R r) {
+    constexpr internal::greater_than_t<L, R> greater_than(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
-    internal::greater_than_t<L, R> gt(L l, R r) {
+    constexpr internal::greater_than_t<L, R> gt(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
-    internal::greater_or_equal_t<L, R> greater_or_equal(L l, R r) {
+    constexpr internal::greater_or_equal_t<L, R> greater_or_equal(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
-    internal::greater_or_equal_t<L, R> ge(L l, R r) {
+    constexpr internal::greater_or_equal_t<L, R> ge(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
-    internal::less_than_t<L, R> less_than(L l, R r) {
+    constexpr internal::less_than_t<L, R> less_than(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
@@ -1166,12 +1166,12 @@ namespace sqlite_orm {
     }
 
     template<class L, class R>
-    internal::less_than_t<L, R> lt(L l, R r) {
+    constexpr internal::less_than_t<L, R> lt(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
-    internal::less_or_equal_t<L, R> less_or_equal(L l, R r) {
+    constexpr internal::less_or_equal_t<L, R> less_or_equal(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
@@ -1185,7 +1185,7 @@ namespace sqlite_orm {
     }
 
     template<class L, class R>
-    internal::less_or_equal_t<L, R> le(L l, R r) {
+    constexpr internal::less_or_equal_t<L, R> le(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 

--- a/dev/core_functions.h
+++ b/dev/core_functions.h
@@ -2048,7 +2048,7 @@ namespace sqlite_orm {
                                                         is_operator_argument<L>,
                                                         is_operator_argument<R>>::value,
                                   bool> = true>
-        add_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator+(L l, R r) {
+        constexpr add_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator+(L l, R r) {
             return {get_from_expression(std::forward<L>(l)), get_from_expression(std::forward<R>(r))};
         }
 
@@ -2059,7 +2059,7 @@ namespace sqlite_orm {
                                                         is_operator_argument<L>,
                                                         is_operator_argument<R>>::value,
                                   bool> = true>
-        sub_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator-(L l, R r) {
+        constexpr sub_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator-(L l, R r) {
             return {get_from_expression(std::forward<L>(l)), get_from_expression(std::forward<R>(r))};
         }
 
@@ -2070,7 +2070,7 @@ namespace sqlite_orm {
                                                         is_operator_argument<L>,
                                                         is_operator_argument<R>>::value,
                                   bool> = true>
-        mul_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator*(L l, R r) {
+        constexpr mul_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator*(L l, R r) {
             return {get_from_expression(std::forward<L>(l)), get_from_expression(std::forward<R>(r))};
         }
 
@@ -2081,7 +2081,7 @@ namespace sqlite_orm {
                                                         is_operator_argument<L>,
                                                         is_operator_argument<R>>::value,
                                   bool> = true>
-        div_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator/(L l, R r) {
+        constexpr div_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator/(L l, R r) {
             return {get_from_expression(std::forward<L>(l)), get_from_expression(std::forward<R>(r))};
         }
 
@@ -2092,7 +2092,7 @@ namespace sqlite_orm {
                                                         is_operator_argument<L>,
                                                         is_operator_argument<R>>::value,
                                   bool> = true>
-        mod_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator%(L l, R r) {
+        constexpr mod_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator%(L l, R r) {
             return {get_from_expression(std::forward<L>(l)), get_from_expression(std::forward<R>(r))};
         }
     }

--- a/dev/cte_moniker.h
+++ b/dev/cte_moniker.h
@@ -50,7 +50,7 @@ namespace sqlite_orm {
                           std::same_as<ExplicitCols, std::remove_cvref_t<decltype(std::ignore)>> ||
                           std::convertible_to<ExplicitCols, std::string>) &&
                          ...)
-            auto operator()(ExplicitCols... explicitColumns) const;
+            constexpr auto operator()(ExplicitCols... explicitColumns) const;
 #else
             template<class... ExplicitCols,
                      std::enable_if_t<polyfill::conjunction_v<polyfill::disjunction<
@@ -59,7 +59,7 @@ namespace sqlite_orm {
                                           std::is_same<ExplicitCols, polyfill::remove_cvref_t<decltype(std::ignore)>>,
                                           std::is_convertible<ExplicitCols, std::string>>...>,
                                       bool> = true>
-            auto operator()(ExplicitCols... explicitColumns) const;
+            constexpr auto operator()(ExplicitCols... explicitColumns) const;
 #endif
         };
     }

--- a/dev/expression.h
+++ b/dev/expression.h
@@ -68,12 +68,12 @@ namespace sqlite_orm {
             is_operator_argument_v<T, std::enable_if_t<polyfill::is_specialization_of<T, expression_t>::value>> = true;
 
         template<class T>
-        T get_from_expression(T value) {
+        constexpr T get_from_expression(T value) {
             return std::move(value);
         }
 
         template<class T>
-        T get_from_expression(expression_t<T> expression) {
+        constexpr T get_from_expression(expression_t<T> expression) {
             return std::move(expression.value);
         }
 
@@ -86,7 +86,7 @@ namespace sqlite_orm {
      * `storage.update(set(c(&User::name) = "Dua Lipa"));
      */
     template<class T>
-    internal::expression_t<T> c(T value) {
+    constexpr internal::expression_t<T> c(T value) {
         return {std::move(value)};
     }
 }

--- a/dev/operators.h
+++ b/dev/operators.h
@@ -20,7 +20,7 @@ namespace sqlite_orm {
             left_type lhs;
             right_type rhs;
 
-            binary_operator(left_type lhs_, right_type rhs_) : lhs(std::move(lhs_)), rhs(std::move(rhs_)) {}
+            constexpr binary_operator(left_type lhs_, right_type rhs_) : lhs(std::move(lhs_)), rhs(std::move(rhs_)) {}
         };
 
         template<class T>
@@ -197,7 +197,7 @@ namespace sqlite_orm {
      * name || '@gmail.com' FROM users
      */
     template<class L, class R>
-    internal::conc_t<L, R> conc(L l, R r) {
+    constexpr internal::conc_t<L, R> conc(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
@@ -205,7 +205,7 @@ namespace sqlite_orm {
      *  Public interface for + operator. Example: `select(add(&User::age, 100));` => SELECT age + 100 FROM users
      */
     template<class L, class R>
-    internal::add_t<L, R> add(L l, R r) {
+    constexpr internal::add_t<L, R> add(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
@@ -213,7 +213,7 @@ namespace sqlite_orm {
      *  Public interface for - operator. Example: `select(sub(&User::age, 1));` => SELECT age - 1 FROM users
      */
     template<class L, class R>
-    internal::sub_t<L, R> sub(L l, R r) {
+    constexpr internal::sub_t<L, R> sub(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
@@ -221,7 +221,7 @@ namespace sqlite_orm {
      *  Public interface for * operator. Example: `select(mul(&User::salary, 2));` => SELECT salary * 2 FROM users
      */
     template<class L, class R>
-    internal::mul_t<L, R> mul(L l, R r) {
+    constexpr internal::mul_t<L, R> mul(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
@@ -231,7 +231,7 @@ namespace sqlite_orm {
      *  If you use `using namespace sqlite_orm` directive you an specify which `div` you call explicitly using  `::div` or `sqlite_orm::div` statements.
      */
     template<class L, class R>
-    internal::div_t<L, R> div(L l, R r) {
+    constexpr internal::div_t<L, R> div(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
@@ -239,32 +239,32 @@ namespace sqlite_orm {
      *  Public interface for % operator. Example: `select(mod(&User::age, 5));` => SELECT age % 5 FROM users
      */
     template<class L, class R>
-    internal::mod_t<L, R> mod(L l, R r) {
+    constexpr internal::mod_t<L, R> mod(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
-    internal::bitwise_shift_left_t<L, R> bitwise_shift_left(L l, R r) {
+    constexpr internal::bitwise_shift_left_t<L, R> bitwise_shift_left(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
-    internal::bitwise_shift_right_t<L, R> bitwise_shift_right(L l, R r) {
+    constexpr internal::bitwise_shift_right_t<L, R> bitwise_shift_right(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
-    internal::bitwise_and_t<L, R> bitwise_and(L l, R r) {
+    constexpr internal::bitwise_and_t<L, R> bitwise_and(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
-    internal::bitwise_or_t<L, R> bitwise_or(L l, R r) {
+    constexpr internal::bitwise_or_t<L, R> bitwise_or(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
     template<class T>
-    internal::bitwise_not_t<T> bitwise_not(T t) {
+    constexpr internal::bitwise_not_t<T> bitwise_not(T t) {
         return {std::move(t)};
     }
 

--- a/dev/prepared_statement.h
+++ b/dev/prepared_statement.h
@@ -142,6 +142,12 @@ namespace sqlite_orm {
             conditions_type conditions;
         };
 
+        template<class T>
+        SQLITE_ORM_INLINE_VAR constexpr bool is_update_all_v = polyfill::is_specialization_of<T, update_all_t>::value;
+
+        template<class T>
+        using is_update_all = polyfill::bool_constant<is_update_all_v<T>>;
+
         template<class T, class... Args>
         struct remove_all_t {
             using type = T;
@@ -149,6 +155,12 @@ namespace sqlite_orm {
 
             conditions_type conditions;
         };
+
+        template<class T>
+        SQLITE_ORM_INLINE_VAR constexpr bool is_remove_all_v = polyfill::is_specialization_of<T, remove_all_t>::value;
+
+        template<class T>
+        using is_remove_all = polyfill::bool_constant<is_remove_all_v<T>>;
 
         template<class T, class... Ids>
         struct get_t {

--- a/dev/select_constraints.h
+++ b/dev/select_constraints.h
@@ -146,7 +146,7 @@ namespace sqlite_orm {
 
             expressions_tuple compound;
 
-            compound_operator(expressions_tuple compound) : compound{std::move(compound)} {
+            constexpr compound_operator(expressions_tuple compound) : compound{std::move(compound)} {
                 iterate_tuple(this->compound, [](auto& expression) {
                     expression.highest_level = true;
                 });
@@ -182,7 +182,7 @@ namespace sqlite_orm {
         struct union_t : public compound_operator<E...>, union_base {
             using typename compound_operator<E...>::expressions_tuple;
 
-            union_t(expressions_tuple compound, bool all) :
+            constexpr union_t(expressions_tuple compound, bool all) :
                 compound_operator<E...>{std::move(compound)}, union_base{all} {}
         };
 
@@ -263,7 +263,7 @@ namespace sqlite_orm {
             explicit_colrefs_tuple explicitColumns;
             expression_type subselect;
 
-            common_table_expression(explicit_colrefs_tuple explicitColumns, expression_type subselect) :
+            constexpr common_table_expression(explicit_colrefs_tuple explicitColumns, expression_type subselect) :
                 explicitColumns{std::move(explicitColumns)}, subselect{std::move(subselect)} {
                 this->subselect.highest_level = true;
             }
@@ -278,23 +278,25 @@ namespace sqlite_orm {
 
 #if SQLITE_VERSION_NUMBER >= 3035000 && defined(SQLITE_ORM_WITH_CPP20_ALIASES)
             template<auto... hints, class Select, satisfies<is_select, Select> = true>
-            common_table_expression<Moniker, ExplicitCols, std::tuple<decltype(hints)...>, Select> as(Select sel) && {
+            constexpr common_table_expression<Moniker, ExplicitCols, std::tuple<decltype(hints)...>, Select>
+            as(Select sel) && {
                 return {std::move(this->explicitColumns), std::move(sel)};
             }
 
             template<auto... hints, class Compound, satisfies<is_compound_operator, Compound> = true>
-            common_table_expression<Moniker, ExplicitCols, std::tuple<decltype(hints)...>, select_t<Compound>>
+            constexpr common_table_expression<Moniker, ExplicitCols, std::tuple<decltype(hints)...>, select_t<Compound>>
             as(Compound sel) && {
                 return {std::move(this->explicitColumns), {std::move(sel)}};
             }
 #else
             template<class Select, satisfies<is_select, Select> = true>
-            common_table_expression<Moniker, ExplicitCols, std::tuple<>, Select> as(Select sel) && {
+            constexpr common_table_expression<Moniker, ExplicitCols, std::tuple<>, Select> as(Select sel) && {
                 return {std::move(this->explicitColumns), std::move(sel)};
             }
 
             template<class Compound, satisfies<is_compound_operator, Compound> = true>
-            common_table_expression<Moniker, ExplicitCols, std::tuple<>, select_t<Compound>> as(Compound sel) && {
+            constexpr common_table_expression<Moniker, ExplicitCols, std::tuple<>, select_t<Compound>>
+            as(Compound sel) && {
                 return {std::move(this->explicitColumns), {std::move(sel)}};
             }
 #endif
@@ -416,7 +418,7 @@ namespace sqlite_orm {
         };
 
         template<class T>
-        void validate_conditions() {
+        constexpr void validate_conditions() {
             static_assert(count_tuple<T, is_where>::value <= 1, "a single query cannot contain > 1 WHERE blocks");
             static_assert(count_tuple<T, is_group_by>::value <= 1, "a single query cannot contain > 1 GROUP BY blocks");
             static_assert(count_tuple<T, is_order_by>::value <= 1, "a single query cannot contain > 1 ORDER BY blocks");
@@ -483,7 +485,7 @@ namespace sqlite_orm {
      *  Public function for subselect query. Is useful in UNION queries.
      */
     template<class T, class... Args>
-    internal::select_t<T, Args...> select(T t, Args... args) {
+    constexpr internal::select_t<T, Args...> select(T t, Args... args) {
         using args_tuple = std::tuple<Args...>;
         internal::validate_conditions<args_tuple>();
         return {std::move(t), {std::forward<Args>(args)...}};
@@ -495,7 +497,7 @@ namespace sqlite_orm {
      *  Look through example in examples/union.cpp
      */
     template<class... E>
-    internal::union_t<E...> union_(E... expressions) {
+    constexpr internal::union_t<E...> union_(E... expressions) {
         static_assert(sizeof...(E) >= 2, "Compound operators must have at least 2 select statements");
         return {{std::forward<E>(expressions)...}, false};
     }
@@ -506,7 +508,7 @@ namespace sqlite_orm {
      *  Look through example in examples/union.cpp
      */
     template<class... E>
-    internal::union_t<E...> union_all(E... expressions) {
+    constexpr internal::union_t<E...> union_all(E... expressions) {
         static_assert(sizeof...(E) >= 2, "Compound operators must have at least 2 select statements");
         return {{std::forward<E>(expressions)...}, true};
     }
@@ -517,13 +519,13 @@ namespace sqlite_orm {
      *  Look through example in examples/except.cpp
      */
     template<class... E>
-    internal::except_t<E...> except(E... expressions) {
+    constexpr internal::except_t<E...> except(E... expressions) {
         static_assert(sizeof...(E) >= 2, "Compound operators must have at least 2 select statements");
         return {{std::forward<E>(expressions)...}};
     }
 
     template<class... E>
-    internal::intersect_t<E...> intersect(E... expressions) {
+    constexpr internal::intersect_t<E...> intersect(E... expressions) {
         static_assert(sizeof...(E) >= 2, "Compound operators must have at least 2 select statements");
         return {{std::forward<E>(expressions)...}};
     }
@@ -577,7 +579,7 @@ namespace sqlite_orm {
                                   std::is_same<ExplicitCols, polyfill::remove_cvref_t<decltype(std::ignore)>>,
                                   std::is_convertible<ExplicitCols, std::string>>...>,
                               bool> = true>
-    auto cte(ExplicitCols... explicitColumns) {
+    constexpr auto cte(ExplicitCols... explicitColumns) {
         using namespace ::sqlite_orm::internal;
         static_assert(is_cte_moniker_v<Moniker>, "Moniker must be a CTE moniker");
         static_assert((!is_builtin_numeric_column_alias_v<ExplicitCols> && ...),
@@ -595,7 +597,7 @@ namespace sqlite_orm {
                   std::same_as<ExplicitCols, std::remove_cvref_t<decltype(std::ignore)>> ||
                   std::convertible_to<ExplicitCols, std::string>) &&
                  ...)
-    auto cte(ExplicitCols... explicitColumns) {
+    constexpr auto cte(ExplicitCols... explicitColumns) {
         using namespace ::sqlite_orm::internal;
         static_assert((!is_builtin_numeric_column_alias_v<ExplicitCols> && ...),
                       "Numeric column aliases are reserved for referencing columns locally within a single CTE.");
@@ -614,7 +616,7 @@ namespace sqlite_orm {
                       std::same_as<ExplicitCols, std::remove_cvref_t<decltype(std::ignore)>> ||
                       std::convertible_to<ExplicitCols, std::string>) &&
                      ...)
-        auto cte_moniker<A, X...>::operator()(ExplicitCols... explicitColumns) const {
+        constexpr auto cte_moniker<A, X...>::operator()(ExplicitCols... explicitColumns) const {
             return cte<cte_moniker<A, X...>>(std::forward<ExplicitCols>(explicitColumns)...);
         }
 #else
@@ -626,7 +628,7 @@ namespace sqlite_orm {
                                       std::is_same<ExplicitCols, polyfill::remove_cvref_t<decltype(std::ignore)>>,
                                       std::is_convertible<ExplicitCols, std::string>>...>,
                                   bool>>
-        auto cte_moniker<A, X...>::operator()(ExplicitCols... explicitColumns) const {
+        constexpr auto cte_moniker<A, X...>::operator()(ExplicitCols... explicitColumns) const {
             return cte<cte_moniker<A, X...>>(std::forward<ExplicitCols>(explicitColumns)...);
         }
 #endif
@@ -763,7 +765,7 @@ namespace sqlite_orm {
      *   If you need to fetch results as objects instead of tuples please use `object<T>()`.
      */
     template<class T>
-    internal::asterisk_t<T> asterisk(bool definedOrder = false) {
+    constexpr internal::asterisk_t<T> asterisk(bool definedOrder = false) {
         return {definedOrder};
     }
 
@@ -775,7 +777,7 @@ namespace sqlite_orm {
      *      storage.select(asterisk<m>(), inner_join<m>(on(m->*&Employee::reportsTo == &Employee::employeeId)));
      */
     template<orm_refers_to_recordset auto recordset>
-    auto asterisk(bool definedOrder = false) {
+    constexpr auto asterisk(bool definedOrder = false) {
         return asterisk<internal::auto_decay_table_ref_t<recordset>>(definedOrder);
     }
 #endif
@@ -792,13 +794,13 @@ namespace sqlite_orm {
      *   If you need to fetch results as tuples instead of objects please use `asterisk<T>()`.
      */
     template<class T>
-    internal::object_t<T> object(bool definedOrder = false) {
+    constexpr internal::object_t<T> object(bool definedOrder = false) {
         return {definedOrder};
     }
 
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
     template<orm_refers_to_table auto als>
-    auto object(bool definedOrder = false) {
+    constexpr auto object(bool definedOrder = false) {
         return object<internal::auto_decay_table_ref_t<als>>(definedOrder);
     }
 #endif

--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -1362,7 +1362,10 @@ namespace sqlite_orm {
         template<class Ctx, class... Args>
         std::set<std::pair<std::string, std::string>> collect_table_names(const set_t<Args...>& set, const Ctx& ctx) {
             auto collector = make_table_name_collector(ctx.db_objects);
-            iterate_ast(set, collector);
+            // note: we are only interested in the table name on the left-hand side of the assignment operator expression
+            iterate_tuple(set.assigns, [&collector](const auto& assignmentOperator) {
+                iterate_ast(assignmentOperator.lhs, collector);
+            });
             return std::move(collector.table_names);
         }
 
@@ -1375,8 +1378,7 @@ namespace sqlite_orm {
         template<class Ctx, class T, satisfies<is_select, T> = true>
         std::set<std::pair<std::string, std::string>> collect_table_names(const T& sel, const Ctx& ctx) {
             auto collector = make_table_name_collector(ctx.db_objects);
-            iterate_ast(sel.col, collector);
-            iterate_ast(sel.conditions, collector);
+            iterate_ast(sel, collector);
             return std::move(collector.table_names);
         }
 

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -1253,7 +1253,8 @@ namespace sqlite_orm {
 #if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
             template<class... CTEs,
                      class E,
-                     std::enable_if_t<polyfill::disjunction_v<is_select<E>, is_insert_raw<E>>, bool> = true>
+                     std::enable_if_t<polyfill::disjunction_v<is_select<E>, is_insert_raw<E>, is_replace_raw<E>>,
+                                      bool> = true>
             prepared_statement_t<with_t<E, CTEs...>> prepare(with_t<E, CTEs...> sel) {
                 return this->prepare_impl<with_t<E, CTEs...>>(std::move(sel));
             }
@@ -1380,7 +1381,9 @@ namespace sqlite_orm {
             }
 
 #if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
-            template<class... CTEs, class E, satisfies<is_insert_raw, E> = true>
+            template<class... CTEs,
+                     class E,
+                     std::enable_if_t<polyfill::disjunction_v<is_insert_raw<E>, is_replace_raw<E>>, bool> = true>
             void execute(const prepared_statement_t<with_t<E, CTEs...>>& statement) {
                 sqlite3_stmt* stmt = reset_stmt(statement.stmt);
                 iterate_ast(statement.expression, conditional_binder{stmt});

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -1253,7 +1253,11 @@ namespace sqlite_orm {
 #if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
             template<class... CTEs,
                      class E,
-                     std::enable_if_t<polyfill::disjunction_v<is_select<E>, is_insert_raw<E>, is_replace_raw<E>>,
+                     std::enable_if_t<polyfill::disjunction_v<is_select<E>,
+                                                              is_insert_raw<E>,
+                                                              is_replace_raw<E>,
+                                                              is_update_all<E>,
+                                                              is_remove_all<E>>,
                                       bool> = true>
             prepared_statement_t<with_t<E, CTEs...>> prepare(with_t<E, CTEs...> sel) {
                 return this->prepare_impl<with_t<E, CTEs...>>(std::move(sel));
@@ -1381,9 +1385,12 @@ namespace sqlite_orm {
             }
 
 #if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
-            template<class... CTEs,
-                     class E,
-                     std::enable_if_t<polyfill::disjunction_v<is_insert_raw<E>, is_replace_raw<E>>, bool> = true>
+            template<
+                class... CTEs,
+                class E,
+                std::enable_if_t<
+                    polyfill::disjunction_v<is_insert_raw<E>, is_replace_raw<E>, is_update_all<E>, is_remove_all<E>>,
+                    bool> = true>
             void execute(const prepared_statement_t<with_t<E, CTEs...>>& statement) {
                 sqlite3_stmt* stmt = reset_stmt(statement.stmt);
                 iterate_ast(statement.expression, conditional_binder{stmt});

--- a/dev/tuple_helper/tuple_iteration.h
+++ b/dev/tuple_helper/tuple_iteration.h
@@ -8,7 +8,7 @@ namespace sqlite_orm {
     namespace internal {
 #if defined(SQLITE_ORM_FOLD_EXPRESSIONS_SUPPORTED) && defined(SQLITE_ORM_IF_CONSTEXPR_SUPPORTED)
         template<bool reversed = false, class Tpl, size_t... Idx, class L>
-        void iterate_tuple(Tpl& tpl, std::index_sequence<Idx...>, L&& lambda) {
+        constexpr void iterate_tuple(Tpl& tpl, std::index_sequence<Idx...>, L&& lambda) {
             if constexpr(reversed) {
                 // nifty fold expression trick: make use of guaranteed right-to-left evaluation order when folding over operator=
                 int sink;
@@ -34,7 +34,7 @@ namespace sqlite_orm {
         }
 #endif
         template<bool reversed = false, class Tpl, class L>
-        void iterate_tuple(Tpl&& tpl, L&& lambda) {
+        constexpr void iterate_tuple(Tpl&& tpl, L&& lambda) {
             iterate_tuple<reversed>(tpl,
                                     std::make_index_sequence<std::tuple_size<std::remove_reference_t<Tpl>>::value>{},
                                     std::forward<L>(lambda));

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -1639,7 +1639,7 @@ namespace sqlite_orm {
     namespace internal {
 #if defined(SQLITE_ORM_FOLD_EXPRESSIONS_SUPPORTED) && defined(SQLITE_ORM_IF_CONSTEXPR_SUPPORTED)
         template<bool reversed = false, class Tpl, size_t... Idx, class L>
-        void iterate_tuple(Tpl& tpl, std::index_sequence<Idx...>, L&& lambda) {
+        constexpr void iterate_tuple(Tpl& tpl, std::index_sequence<Idx...>, L&& lambda) {
             if constexpr(reversed) {
                 // nifty fold expression trick: make use of guaranteed right-to-left evaluation order when folding over operator=
                 int sink;
@@ -1665,7 +1665,7 @@ namespace sqlite_orm {
         }
 #endif
         template<bool reversed = false, class Tpl, class L>
-        void iterate_tuple(Tpl&& tpl, L&& lambda) {
+        constexpr void iterate_tuple(Tpl&& tpl, L&& lambda) {
             iterate_tuple<reversed>(tpl,
                                     std::make_index_sequence<std::tuple_size<std::remove_reference_t<Tpl>>::value>{},
                                     std::forward<L>(lambda));
@@ -4147,7 +4147,7 @@ namespace sqlite_orm {
             left_type lhs;
             right_type rhs;
 
-            binary_operator(left_type lhs_, right_type rhs_) : lhs(std::move(lhs_)), rhs(std::move(rhs_)) {}
+            constexpr binary_operator(left_type lhs_, right_type rhs_) : lhs(std::move(lhs_)), rhs(std::move(rhs_)) {}
         };
 
         template<class T>
@@ -4324,7 +4324,7 @@ namespace sqlite_orm {
      * name || '@gmail.com' FROM users
      */
     template<class L, class R>
-    internal::conc_t<L, R> conc(L l, R r) {
+    constexpr internal::conc_t<L, R> conc(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
@@ -4332,7 +4332,7 @@ namespace sqlite_orm {
      *  Public interface for + operator. Example: `select(add(&User::age, 100));` => SELECT age + 100 FROM users
      */
     template<class L, class R>
-    internal::add_t<L, R> add(L l, R r) {
+    constexpr internal::add_t<L, R> add(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
@@ -4340,7 +4340,7 @@ namespace sqlite_orm {
      *  Public interface for - operator. Example: `select(sub(&User::age, 1));` => SELECT age - 1 FROM users
      */
     template<class L, class R>
-    internal::sub_t<L, R> sub(L l, R r) {
+    constexpr internal::sub_t<L, R> sub(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
@@ -4348,7 +4348,7 @@ namespace sqlite_orm {
      *  Public interface for * operator. Example: `select(mul(&User::salary, 2));` => SELECT salary * 2 FROM users
      */
     template<class L, class R>
-    internal::mul_t<L, R> mul(L l, R r) {
+    constexpr internal::mul_t<L, R> mul(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
@@ -4358,7 +4358,7 @@ namespace sqlite_orm {
      *  If you use `using namespace sqlite_orm` directive you an specify which `div` you call explicitly using  `::div` or `sqlite_orm::div` statements.
      */
     template<class L, class R>
-    internal::div_t<L, R> div(L l, R r) {
+    constexpr internal::div_t<L, R> div(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
@@ -4366,32 +4366,32 @@ namespace sqlite_orm {
      *  Public interface for % operator. Example: `select(mod(&User::age, 5));` => SELECT age % 5 FROM users
      */
     template<class L, class R>
-    internal::mod_t<L, R> mod(L l, R r) {
+    constexpr internal::mod_t<L, R> mod(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
-    internal::bitwise_shift_left_t<L, R> bitwise_shift_left(L l, R r) {
+    constexpr internal::bitwise_shift_left_t<L, R> bitwise_shift_left(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
-    internal::bitwise_shift_right_t<L, R> bitwise_shift_right(L l, R r) {
+    constexpr internal::bitwise_shift_right_t<L, R> bitwise_shift_right(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
-    internal::bitwise_and_t<L, R> bitwise_and(L l, R r) {
+    constexpr internal::bitwise_and_t<L, R> bitwise_and(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
-    internal::bitwise_or_t<L, R> bitwise_or(L l, R r) {
+    constexpr internal::bitwise_or_t<L, R> bitwise_or(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
     template<class T>
-    internal::bitwise_not_t<T> bitwise_not(T t) {
+    constexpr internal::bitwise_not_t<T> bitwise_not(T t) {
         return {std::move(t)};
     }
 
@@ -4485,7 +4485,7 @@ namespace sqlite_orm {
 
             expression_type expression;
 
-            where_t(expression_type expression_) : expression(std::move(expression_)) {}
+            constexpr where_t(expression_type expression_) : expression(std::move(expression_)) {}
         };
 
         template<class T>
@@ -4505,7 +4505,7 @@ namespace sqlite_orm {
      *  auto rows = storage.select(&Letter::name, where(greater_than(&Letter::id, 3)));
      */
     template<class C>
-    internal::where_t<C> where(C expression) {
+    constexpr internal::where_t<C> where(C expression) {
         return {std::move(expression)};
     }
 }
@@ -4717,12 +4717,12 @@ namespace sqlite_orm {
             is_operator_argument_v<T, std::enable_if_t<polyfill::is_specialization_of<T, expression_t>::value>> = true;
 
         template<class T>
-        T get_from_expression(T value) {
+        constexpr T get_from_expression(T value) {
             return std::move(value);
         }
 
         template<class T>
-        T get_from_expression(expression_t<T> expression) {
+        constexpr T get_from_expression(expression_t<T> expression) {
             return std::move(expression.value);
         }
 
@@ -4735,7 +4735,7 @@ namespace sqlite_orm {
      * `storage.update(set(c(&User::name) = "Dua Lipa"));
      */
     template<class T>
-    internal::expression_t<T> c(T value) {
+    constexpr internal::expression_t<T> c(T value) {
         return {std::move(value)};
     }
 }
@@ -4852,7 +4852,7 @@ namespace sqlite_orm {
         struct negated_condition_t : condition_t, negated_condition_string {
             C c;
 
-            negated_condition_t(C c_) : c(std::move(c_)) {}
+            constexpr negated_condition_t(C c_) : c(std::move(c_)) {}
         };
 
         /**
@@ -4871,9 +4871,9 @@ namespace sqlite_orm {
             left_type lhs;
             right_type rhs;
 
-            binary_condition() = default;
+            constexpr binary_condition() = default;
 
-            binary_condition(left_type l_, right_type r_) : lhs(std::move(l_)), rhs(std::move(r_)) {}
+            constexpr binary_condition(left_type l_, right_type r_) : lhs(std::move(l_)), rhs(std::move(r_)) {}
         };
 
         template<class T>
@@ -5588,7 +5588,7 @@ namespace sqlite_orm {
             class T,
             std::enable_if_t<polyfill::disjunction<std::is_base_of<negatable_t, T>, is_operator_argument<T>>::value,
                              bool> = true>
-        negated_condition_t<T> operator!(T arg) {
+        constexpr negated_condition_t<T> operator!(T arg) {
             return {std::move(arg)};
         }
 
@@ -5599,7 +5599,7 @@ namespace sqlite_orm {
                                                         is_operator_argument<L>,
                                                         is_operator_argument<R>>::value,
                                   bool> = true>
-        less_than_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator<(L l, R r) {
+        constexpr less_than_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator<(L l, R r) {
             return {get_from_expression(std::forward<L>(l)), get_from_expression(std::forward<R>(r))};
         }
 
@@ -5610,7 +5610,7 @@ namespace sqlite_orm {
                                                         is_operator_argument<L>,
                                                         is_operator_argument<R>>::value,
                                   bool> = true>
-        less_or_equal_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator<=(L l, R r) {
+        constexpr less_or_equal_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator<=(L l, R r) {
             return {get_from_expression(std::forward<L>(l)), get_from_expression(std::forward<R>(r))};
         }
 
@@ -5621,7 +5621,7 @@ namespace sqlite_orm {
                                                         is_operator_argument<L>,
                                                         is_operator_argument<R>>::value,
                                   bool> = true>
-        greater_than_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator>(L l, R r) {
+        constexpr greater_than_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator>(L l, R r) {
             return {get_from_expression(std::forward<L>(l)), get_from_expression(std::forward<R>(r))};
         }
 
@@ -5632,20 +5632,7 @@ namespace sqlite_orm {
                                                         is_operator_argument<L>,
                                                         is_operator_argument<R>>::value,
                                   bool> = true>
-        greater_or_equal_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator>=(L l, R r) {
-            return {get_from_expression(std::forward<L>(l)), get_from_expression(std::forward<R>(r))};
-        }
-
-        template<class L,
-                 class R,
-                 std::enable_if_t<polyfill::disjunction<std::is_base_of<arithmetic_t, L>,
-                                                        std::is_base_of<arithmetic_t, R>,
-                                                        std::is_base_of<condition_t, L>,
-                                                        std::is_base_of<condition_t, R>,
-                                                        is_operator_argument<L>,
-                                                        is_operator_argument<R>>::value,
-                                  bool> = true>
-        is_equal_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator==(L l, R r) {
+        constexpr greater_or_equal_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator>=(L l, R r) {
             return {get_from_expression(std::forward<L>(l)), get_from_expression(std::forward<R>(r))};
         }
 
@@ -5658,7 +5645,20 @@ namespace sqlite_orm {
                                                         is_operator_argument<L>,
                                                         is_operator_argument<R>>::value,
                                   bool> = true>
-        is_not_equal_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator!=(L l, R r) {
+        constexpr is_equal_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator==(L l, R r) {
+            return {get_from_expression(std::forward<L>(l)), get_from_expression(std::forward<R>(r))};
+        }
+
+        template<class L,
+                 class R,
+                 std::enable_if_t<polyfill::disjunction<std::is_base_of<arithmetic_t, L>,
+                                                        std::is_base_of<arithmetic_t, R>,
+                                                        std::is_base_of<condition_t, L>,
+                                                        std::is_base_of<condition_t, R>,
+                                                        is_operator_argument<L>,
+                                                        is_operator_argument<R>>::value,
+                                  bool> = true>
+        constexpr is_not_equal_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator!=(L l, R r) {
             return {get_from_expression(std::forward<L>(l)), get_from_expression(std::forward<R>(r))};
         }
 
@@ -5669,7 +5669,7 @@ namespace sqlite_orm {
                                                         is_operator_argument<L>,
                                                         is_operator_argument<R>>::value,
                                   bool> = true>
-        and_condition_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator&&(L l, R r) {
+        constexpr and_condition_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator&&(L l, R r) {
             return {get_from_expression(std::forward<L>(l)), get_from_expression(std::forward<R>(r))};
         }
 
@@ -5678,7 +5678,7 @@ namespace sqlite_orm {
                  std::enable_if_t<
                      polyfill::disjunction<std::is_base_of<condition_t, L>, std::is_base_of<condition_t, R>>::value,
                      bool> = true>
-        or_condition_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator||(L l, R r) {
+        constexpr or_condition_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator||(L l, R r) {
             return {get_from_expression(std::forward<L>(l)), get_from_expression(std::forward<R>(r))};
         }
 
@@ -5694,7 +5694,7 @@ namespace sqlite_orm {
                                  polyfill::negation<polyfill::disjunction<std::is_base_of<condition_t, L>,
                                                                           std::is_base_of<condition_t, R>>>>::value,
                              bool> = true>
-        conc_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator||(L l, R r) {
+        constexpr conc_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator||(L l, R r) {
             return {get_from_expression(std::forward<L>(l)), get_from_expression(std::forward<R>(r))};
         }
     }
@@ -5792,14 +5792,14 @@ namespace sqlite_orm {
     }
 
     template<class L, class R>
-    auto and_(L l, R r) {
+    constexpr auto and_(L l, R r) {
         using namespace ::sqlite_orm::internal;
         return and_condition_t<unwrap_expression_t<L>, unwrap_expression_t<R>>{get_from_expression(std::forward<L>(l)),
                                                                                get_from_expression(std::forward<R>(r))};
     }
 
     template<class L, class R>
-    auto or_(L l, R r) {
+    constexpr auto or_(L l, R r) {
         using namespace ::sqlite_orm::internal;
         return or_condition_t<unwrap_expression_t<L>, unwrap_expression_t<R>>{get_from_expression(std::forward<L>(l)),
                                                                               get_from_expression(std::forward<R>(r))};
@@ -5846,52 +5846,52 @@ namespace sqlite_orm {
     }
 
     template<class L, class R>
-    internal::is_equal_t<L, R> is_equal(L l, R r) {
+    constexpr internal::is_equal_t<L, R> is_equal(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
-    internal::is_equal_t<L, R> eq(L l, R r) {
+    constexpr internal::is_equal_t<L, R> eq(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
-    internal::is_equal_with_table_t<L, R> is_equal(R rhs) {
+    constexpr internal::is_equal_with_table_t<L, R> is_equal(R rhs) {
         return {std::move(rhs)};
     }
 
     template<class L, class R>
-    internal::is_not_equal_t<L, R> is_not_equal(L l, R r) {
+    constexpr internal::is_not_equal_t<L, R> is_not_equal(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
-    internal::is_not_equal_t<L, R> ne(L l, R r) {
+    constexpr internal::is_not_equal_t<L, R> ne(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
-    internal::greater_than_t<L, R> greater_than(L l, R r) {
+    constexpr internal::greater_than_t<L, R> greater_than(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
-    internal::greater_than_t<L, R> gt(L l, R r) {
+    constexpr internal::greater_than_t<L, R> gt(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
-    internal::greater_or_equal_t<L, R> greater_or_equal(L l, R r) {
+    constexpr internal::greater_or_equal_t<L, R> greater_or_equal(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
-    internal::greater_or_equal_t<L, R> ge(L l, R r) {
+    constexpr internal::greater_or_equal_t<L, R> ge(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
-    internal::less_than_t<L, R> less_than(L l, R r) {
+    constexpr internal::less_than_t<L, R> less_than(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
@@ -5905,12 +5905,12 @@ namespace sqlite_orm {
     }
 
     template<class L, class R>
-    internal::less_than_t<L, R> lt(L l, R r) {
+    constexpr internal::less_than_t<L, R> lt(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
-    internal::less_or_equal_t<L, R> less_or_equal(L l, R r) {
+    constexpr internal::less_or_equal_t<L, R> less_or_equal(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
@@ -5924,7 +5924,7 @@ namespace sqlite_orm {
     }
 
     template<class L, class R>
-    internal::less_or_equal_t<L, R> le(L l, R r) {
+    constexpr internal::less_or_equal_t<L, R> le(L l, R r) {
         return {std::move(l), std::move(r)};
     }
 
@@ -8086,7 +8086,7 @@ namespace sqlite_orm {
                                                         is_operator_argument<L>,
                                                         is_operator_argument<R>>::value,
                                   bool> = true>
-        add_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator+(L l, R r) {
+        constexpr add_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator+(L l, R r) {
             return {get_from_expression(std::forward<L>(l)), get_from_expression(std::forward<R>(r))};
         }
 
@@ -8097,7 +8097,7 @@ namespace sqlite_orm {
                                                         is_operator_argument<L>,
                                                         is_operator_argument<R>>::value,
                                   bool> = true>
-        sub_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator-(L l, R r) {
+        constexpr sub_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator-(L l, R r) {
             return {get_from_expression(std::forward<L>(l)), get_from_expression(std::forward<R>(r))};
         }
 
@@ -8108,7 +8108,7 @@ namespace sqlite_orm {
                                                         is_operator_argument<L>,
                                                         is_operator_argument<R>>::value,
                                   bool> = true>
-        mul_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator*(L l, R r) {
+        constexpr mul_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator*(L l, R r) {
             return {get_from_expression(std::forward<L>(l)), get_from_expression(std::forward<R>(r))};
         }
 
@@ -8119,7 +8119,7 @@ namespace sqlite_orm {
                                                         is_operator_argument<L>,
                                                         is_operator_argument<R>>::value,
                                   bool> = true>
-        div_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator/(L l, R r) {
+        constexpr div_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator/(L l, R r) {
             return {get_from_expression(std::forward<L>(l)), get_from_expression(std::forward<R>(r))};
         }
 
@@ -8130,7 +8130,7 @@ namespace sqlite_orm {
                                                         is_operator_argument<L>,
                                                         is_operator_argument<R>>::value,
                                   bool> = true>
-        mod_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator%(L l, R r) {
+        constexpr mod_t<unwrap_expression_t<L>, unwrap_expression_t<R>> operator%(L l, R r) {
             return {get_from_expression(std::forward<L>(l)), get_from_expression(std::forward<R>(r))};
         }
     }
@@ -8196,7 +8196,7 @@ namespace sqlite_orm {
                           std::same_as<ExplicitCols, std::remove_cvref_t<decltype(std::ignore)>> ||
                           std::convertible_to<ExplicitCols, std::string>) &&
                          ...)
-            auto operator()(ExplicitCols... explicitColumns) const;
+            constexpr auto operator()(ExplicitCols... explicitColumns) const;
 #else
             template<class... ExplicitCols,
                      std::enable_if_t<polyfill::conjunction_v<polyfill::disjunction<
@@ -8205,7 +8205,7 @@ namespace sqlite_orm {
                                           std::is_same<ExplicitCols, polyfill::remove_cvref_t<decltype(std::ignore)>>,
                                           std::is_convertible<ExplicitCols, std::string>>...>,
                                       bool> = true>
-            auto operator()(ExplicitCols... explicitColumns) const;
+            constexpr auto operator()(ExplicitCols... explicitColumns) const;
 #endif
         };
     }
@@ -8600,7 +8600,7 @@ namespace sqlite_orm {
 
             expressions_tuple compound;
 
-            compound_operator(expressions_tuple compound) : compound{std::move(compound)} {
+            constexpr compound_operator(expressions_tuple compound) : compound{std::move(compound)} {
                 iterate_tuple(this->compound, [](auto& expression) {
                     expression.highest_level = true;
                 });
@@ -8636,7 +8636,7 @@ namespace sqlite_orm {
         struct union_t : public compound_operator<E...>, union_base {
             using typename compound_operator<E...>::expressions_tuple;
 
-            union_t(expressions_tuple compound, bool all) :
+            constexpr union_t(expressions_tuple compound, bool all) :
                 compound_operator<E...>{std::move(compound)}, union_base{all} {}
         };
 
@@ -8717,7 +8717,7 @@ namespace sqlite_orm {
             explicit_colrefs_tuple explicitColumns;
             expression_type subselect;
 
-            common_table_expression(explicit_colrefs_tuple explicitColumns, expression_type subselect) :
+            constexpr common_table_expression(explicit_colrefs_tuple explicitColumns, expression_type subselect) :
                 explicitColumns{std::move(explicitColumns)}, subselect{std::move(subselect)} {
                 this->subselect.highest_level = true;
             }
@@ -8732,23 +8732,25 @@ namespace sqlite_orm {
 
 #if SQLITE_VERSION_NUMBER >= 3035000 && defined(SQLITE_ORM_WITH_CPP20_ALIASES)
             template<auto... hints, class Select, satisfies<is_select, Select> = true>
-            common_table_expression<Moniker, ExplicitCols, std::tuple<decltype(hints)...>, Select> as(Select sel) && {
+            constexpr common_table_expression<Moniker, ExplicitCols, std::tuple<decltype(hints)...>, Select>
+            as(Select sel) && {
                 return {std::move(this->explicitColumns), std::move(sel)};
             }
 
             template<auto... hints, class Compound, satisfies<is_compound_operator, Compound> = true>
-            common_table_expression<Moniker, ExplicitCols, std::tuple<decltype(hints)...>, select_t<Compound>>
+            constexpr common_table_expression<Moniker, ExplicitCols, std::tuple<decltype(hints)...>, select_t<Compound>>
             as(Compound sel) && {
                 return {std::move(this->explicitColumns), {std::move(sel)}};
             }
 #else
             template<class Select, satisfies<is_select, Select> = true>
-            common_table_expression<Moniker, ExplicitCols, std::tuple<>, Select> as(Select sel) && {
+            constexpr common_table_expression<Moniker, ExplicitCols, std::tuple<>, Select> as(Select sel) && {
                 return {std::move(this->explicitColumns), std::move(sel)};
             }
 
             template<class Compound, satisfies<is_compound_operator, Compound> = true>
-            common_table_expression<Moniker, ExplicitCols, std::tuple<>, select_t<Compound>> as(Compound sel) && {
+            constexpr common_table_expression<Moniker, ExplicitCols, std::tuple<>, select_t<Compound>>
+            as(Compound sel) && {
                 return {std::move(this->explicitColumns), {std::move(sel)}};
             }
 #endif
@@ -8870,7 +8872,7 @@ namespace sqlite_orm {
         };
 
         template<class T>
-        void validate_conditions() {
+        constexpr void validate_conditions() {
             static_assert(count_tuple<T, is_where>::value <= 1, "a single query cannot contain > 1 WHERE blocks");
             static_assert(count_tuple<T, is_group_by>::value <= 1, "a single query cannot contain > 1 GROUP BY blocks");
             static_assert(count_tuple<T, is_order_by>::value <= 1, "a single query cannot contain > 1 ORDER BY blocks");
@@ -8937,7 +8939,7 @@ namespace sqlite_orm {
      *  Public function for subselect query. Is useful in UNION queries.
      */
     template<class T, class... Args>
-    internal::select_t<T, Args...> select(T t, Args... args) {
+    constexpr internal::select_t<T, Args...> select(T t, Args... args) {
         using args_tuple = std::tuple<Args...>;
         internal::validate_conditions<args_tuple>();
         return {std::move(t), {std::forward<Args>(args)...}};
@@ -8949,7 +8951,7 @@ namespace sqlite_orm {
      *  Look through example in examples/union.cpp
      */
     template<class... E>
-    internal::union_t<E...> union_(E... expressions) {
+    constexpr internal::union_t<E...> union_(E... expressions) {
         static_assert(sizeof...(E) >= 2, "Compound operators must have at least 2 select statements");
         return {{std::forward<E>(expressions)...}, false};
     }
@@ -8960,7 +8962,7 @@ namespace sqlite_orm {
      *  Look through example in examples/union.cpp
      */
     template<class... E>
-    internal::union_t<E...> union_all(E... expressions) {
+    constexpr internal::union_t<E...> union_all(E... expressions) {
         static_assert(sizeof...(E) >= 2, "Compound operators must have at least 2 select statements");
         return {{std::forward<E>(expressions)...}, true};
     }
@@ -8971,13 +8973,13 @@ namespace sqlite_orm {
      *  Look through example in examples/except.cpp
      */
     template<class... E>
-    internal::except_t<E...> except(E... expressions) {
+    constexpr internal::except_t<E...> except(E... expressions) {
         static_assert(sizeof...(E) >= 2, "Compound operators must have at least 2 select statements");
         return {{std::forward<E>(expressions)...}};
     }
 
     template<class... E>
-    internal::intersect_t<E...> intersect(E... expressions) {
+    constexpr internal::intersect_t<E...> intersect(E... expressions) {
         static_assert(sizeof...(E) >= 2, "Compound operators must have at least 2 select statements");
         return {{std::forward<E>(expressions)...}};
     }
@@ -9031,7 +9033,7 @@ namespace sqlite_orm {
                                   std::is_same<ExplicitCols, polyfill::remove_cvref_t<decltype(std::ignore)>>,
                                   std::is_convertible<ExplicitCols, std::string>>...>,
                               bool> = true>
-    auto cte(ExplicitCols... explicitColumns) {
+    constexpr auto cte(ExplicitCols... explicitColumns) {
         using namespace ::sqlite_orm::internal;
         static_assert(is_cte_moniker_v<Moniker>, "Moniker must be a CTE moniker");
         static_assert((!is_builtin_numeric_column_alias_v<ExplicitCols> && ...),
@@ -9049,7 +9051,7 @@ namespace sqlite_orm {
                   std::same_as<ExplicitCols, std::remove_cvref_t<decltype(std::ignore)>> ||
                   std::convertible_to<ExplicitCols, std::string>) &&
                  ...)
-    auto cte(ExplicitCols... explicitColumns) {
+    constexpr auto cte(ExplicitCols... explicitColumns) {
         using namespace ::sqlite_orm::internal;
         static_assert((!is_builtin_numeric_column_alias_v<ExplicitCols> && ...),
                       "Numeric column aliases are reserved for referencing columns locally within a single CTE.");
@@ -9068,7 +9070,7 @@ namespace sqlite_orm {
                       std::same_as<ExplicitCols, std::remove_cvref_t<decltype(std::ignore)>> ||
                       std::convertible_to<ExplicitCols, std::string>) &&
                      ...)
-        auto cte_moniker<A, X...>::operator()(ExplicitCols... explicitColumns) const {
+        constexpr auto cte_moniker<A, X...>::operator()(ExplicitCols... explicitColumns) const {
             return cte<cte_moniker<A, X...>>(std::forward<ExplicitCols>(explicitColumns)...);
         }
 #else
@@ -9080,7 +9082,7 @@ namespace sqlite_orm {
                                       std::is_same<ExplicitCols, polyfill::remove_cvref_t<decltype(std::ignore)>>,
                                       std::is_convertible<ExplicitCols, std::string>>...>,
                                   bool>>
-        auto cte_moniker<A, X...>::operator()(ExplicitCols... explicitColumns) const {
+        constexpr auto cte_moniker<A, X...>::operator()(ExplicitCols... explicitColumns) const {
             return cte<cte_moniker<A, X...>>(std::forward<ExplicitCols>(explicitColumns)...);
         }
 #endif
@@ -9217,7 +9219,7 @@ namespace sqlite_orm {
      *   If you need to fetch results as objects instead of tuples please use `object<T>()`.
      */
     template<class T>
-    internal::asterisk_t<T> asterisk(bool definedOrder = false) {
+    constexpr internal::asterisk_t<T> asterisk(bool definedOrder = false) {
         return {definedOrder};
     }
 
@@ -9229,7 +9231,7 @@ namespace sqlite_orm {
      *      storage.select(asterisk<m>(), inner_join<m>(on(m->*&Employee::reportsTo == &Employee::employeeId)));
      */
     template<orm_refers_to_recordset auto recordset>
-    auto asterisk(bool definedOrder = false) {
+    constexpr auto asterisk(bool definedOrder = false) {
         return asterisk<internal::auto_decay_table_ref_t<recordset>>(definedOrder);
     }
 #endif
@@ -9246,13 +9248,13 @@ namespace sqlite_orm {
      *   If you need to fetch results as tuples instead of objects please use `asterisk<T>()`.
      */
     template<class T>
-    internal::object_t<T> object(bool definedOrder = false) {
+    constexpr internal::object_t<T> object(bool definedOrder = false) {
         return {definedOrder};
     }
 
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
     template<orm_refers_to_table auto als>
-    auto object(bool definedOrder = false) {
+    constexpr auto object(bool definedOrder = false) {
         return object<internal::auto_decay_table_ref_t<als>>(definedOrder);
     }
 #endif

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -23112,7 +23112,8 @@ namespace sqlite_orm {
 #if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
             template<class... CTEs,
                      class E,
-                     std::enable_if_t<polyfill::disjunction_v<is_select<E>, is_insert_raw<E>>, bool> = true>
+                     std::enable_if_t<polyfill::disjunction_v<is_select<E>, is_insert_raw<E>, is_replace_raw<E>>,
+                                      bool> = true>
             prepared_statement_t<with_t<E, CTEs...>> prepare(with_t<E, CTEs...> sel) {
                 return this->prepare_impl<with_t<E, CTEs...>>(std::move(sel));
             }
@@ -23239,7 +23240,9 @@ namespace sqlite_orm {
             }
 
 #if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
-            template<class... CTEs, class E, satisfies<is_insert_raw, E> = true>
+            template<class... CTEs,
+                     class E,
+                     std::enable_if_t<polyfill::disjunction_v<is_insert_raw<E>, is_replace_raw<E>>, bool> = true>
             void execute(const prepared_statement_t<with_t<E, CTEs...>>& statement) {
                 sqlite3_stmt* stmt = reset_stmt(statement.stmt);
                 iterate_ast(statement.expression, conditional_binder{stmt});

--- a/tests/statement_serializer_tests/statements/insert_replace.cpp
+++ b/tests/statement_serializer_tests/statements/insert_replace.cpp
@@ -80,6 +80,23 @@ TEST_CASE("statement_serializer insert/replace") {
                 expected =
                     R"(REPLACE INTO "users" SELECT "users_backup"."id", "users_backup"."name" FROM "users_backup")";
             }
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+            SECTION("With clause") {
+                constexpr orm_cte_moniker auto data = "data"_cte;
+                constexpr auto cteExpression = cte<data>().as(select(asterisk<UserBackup>()));
+                auto dbObjects2 =
+                    internal::db_objects_cat(dbObjects, internal::make_cte_table(dbObjects, cteExpression));
+                using context_t = internal::serializer_context<decltype(dbObjects2)>;
+                context_t context2{dbObjects2};
+
+                auto expression = with(cteExpression, replace(into<User>(), select(asterisk<data>())));
+                value = serialize(expression, context2);
+                expected =
+                    R"(WITH "data"("id", "name") AS (SELECT "users_backup".* FROM "users_backup") REPLACE INTO "users" SELECT "data".* FROM "data")";
+            }
+#endif
+#endif
         }
         SECTION("range") {
             context.replace_bindable_with_question = false;
@@ -355,6 +372,23 @@ TEST_CASE("statement_serializer insert/replace") {
                     expected =
                         R"(INSERT OR ROLLBACK INTO "users" SELECT "users_backup"."id", "users_backup"."name" FROM "users_backup")";
                 }
+            }
+            SECTION("With clause") {
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+                constexpr orm_cte_moniker auto data = "data"_cte;
+                constexpr auto cteExpression = cte<data>().as(select(asterisk<UserBackup>()));
+                auto dbObjects2 =
+                    internal::db_objects_cat(dbObjects, internal::make_cte_table(dbObjects, cteExpression));
+                using context_t = internal::serializer_context<decltype(dbObjects2)>;
+                context_t context2{dbObjects2};
+
+                auto expression = with(cteExpression, insert(into<User>(), select(asterisk<data>())));
+                value = serialize(expression, context2);
+                expected =
+                    R"(WITH "data"("id", "name") AS (SELECT "users_backup".* FROM "users_backup") INSERT INTO "users" SELECT "data".* FROM "data")";
+#endif
+#endif
             }
         }
         SECTION("range") {

--- a/tests/statement_serializer_tests/statements/remove_all.cpp
+++ b/tests/statement_serializer_tests/statements/remove_all.cpp
@@ -19,19 +19,35 @@ TEST_CASE("statement_serializer remove_all") {
     std::string expected;
 
     SECTION("all") {
-        auto statement = remove_all<User>();
-        value = serialize(statement, context);
+        auto expression = remove_all<User>();
+        value = serialize(expression, context);
         expected = R"(DELETE FROM "users")";
     }
     SECTION("where") {
-        auto statement = remove_all<User>(where(&User::id == c(1)));
-        value = serialize(statement, context);
+        auto expression = remove_all<User>(where(&User::id == c(1)));
+        value = serialize(expression, context);
         expected = R"(DELETE FROM "users" WHERE ("id" = 1))";
     }
     SECTION("conditions") {
-        auto statement = remove_all<User>(where(&User::id == c(1)), limit(1));
-        value = serialize(statement, context);
+        auto expression = remove_all<User>(where(&User::id == c(1)), limit(1));
+        value = serialize(expression, context);
         expected = R"(DELETE FROM "users" WHERE ("id" = 1) LIMIT 1)";
     }
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+    SECTION("With clause") {
+        constexpr orm_cte_moniker auto data = "data"_cte;
+        constexpr auto cteExpression = cte<data>().as(select(1));
+        auto dbObjects2 = internal::db_objects_cat(dbObjects, internal::make_cte_table(dbObjects, cteExpression));
+        using context_t = internal::serializer_context<decltype(dbObjects2)>;
+        context_t context2{dbObjects2};
+
+        auto expression = with(cteExpression, remove_all<User>(where(c(&User::id).in(select(data->*1_colalias)))));
+        value = serialize(expression, context2);
+        expected =
+            R"(WITH "data"("1") AS (SELECT 1) DELETE FROM "users" WHERE ("id" IN (SELECT "data"."1" FROM "data")))";
+    }
+#endif
+#endif
     REQUIRE(value == expected);
 }

--- a/tests/statement_serializer_tests/statements/update_all.cpp
+++ b/tests/statement_serializer_tests/statements/update_all.cpp
@@ -51,10 +51,33 @@ TEST_CASE("statement_serializer update_all") {
     using context_t = internal::serializer_context<db_objects_t>;
     context_t context{dbObjects};
 
-    auto statement =
-        update_all(set(c(&Contact::phone) = select(&Customer::phone, from<Customer>(), where(c(&Customer::id) == 1))));
-    auto value = serialize(statement, context);
-    decltype(value) expected =
-        R"(UPDATE "contacts" SET "phone" = (SELECT "customers"."Phone" FROM "customers" WHERE ("customers"."CustomerId" = 1)))";
+    std::string value;
+    std::string expected;
+    SECTION("select") {
+        auto expression = update_all(set(c(&Contact::phone) = select(&Customer::phone, where(c(&Customer::id) == 1))),
+                                     where(c(&Contact::id) == 1));
+        value = serialize(expression, context);
+        expected =
+            R"(UPDATE "contacts" SET "phone" = (SELECT "customers"."Phone" FROM "customers" WHERE ("customers"."CustomerId" = 1)) WHERE ("contact_id" = 1))";
+    }
+#if(SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+    SECTION("With clause") {
+        constexpr orm_cte_moniker auto data = "data"_cte;
+        constexpr auto cteExpression = cte<data>().as(select(&Customer::phone, where(c(&Customer::id) == 1)));
+        auto dbObjects2 = internal::db_objects_cat(dbObjects, internal::make_cte_table(dbObjects, cteExpression));
+        using context_t = internal::serializer_context<decltype(dbObjects2)>;
+        context_t context2{dbObjects2};
+
+        auto expression =
+            with(cteExpression,
+                 update_all(set(c(&Contact::phone) = select(data->*&Customer::phone)), where(c(&Contact::id) == 1)));
+
+        value = serialize(expression, context2);
+        expected =
+            R"(WITH "data"("Phone") AS (SELECT "customers"."Phone" FROM "customers" WHERE ("customers"."CustomerId" = 1)) UPDATE "contacts" SET "phone" = (SELECT "data"."Phone" FROM "data") WHERE ("contact_id" = 1))";
+    }
+#endif
+#endif
     REQUIRE(value == expected);
 }

--- a/tests/storage_tests.cpp
+++ b/tests/storage_tests.cpp
@@ -583,7 +583,7 @@ TEST_CASE("With clause") {
     }
 
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
-    SECTION("insert") {
+    SECTION("crud") {
         struct Object {
             int id;
         };
@@ -596,6 +596,10 @@ TEST_CASE("With clause") {
         storage.with(cte<data>().as(select(2)),
                      insert(into<Object>(), columns(&Object::id), select(data->*1_colalias)));
         REQUIRE(2 == storage.last_insert_rowid());
+
+        storage.with(cte<data>().as(select(2)),
+                     replace(into<Object>(), columns(&Object::id), select(data->*1_colalias)));
+        REQUIRE(storage.changes() == 1);
     }
 #endif
 }

--- a/tests/storage_tests.cpp
+++ b/tests/storage_tests.cpp
@@ -593,23 +593,22 @@ TEST_CASE("With clause") {
         storage.sync_schema();
 
         constexpr orm_cte_moniker auto data = "data"_cte;
-        storage.with(cte<data>().as(union_all(select(2), select(3))),
-                     insert(into<Object>(), columns(&Object::id), select(data->*1_colalias)));
+        constexpr auto cteExpression = cte<data>().as(union_all(select(2), select(3)));
+
+        storage.with(cteExpression, insert(into<Object>(), columns(&Object::id), select(data->*1_colalias)));
         REQUIRE(3 == storage.last_insert_rowid());
 
-        storage.with(cte<data>().as(union_all(select(2), select(3))),
-                     replace(into<Object>(), columns(&Object::id), select(data->*1_colalias)));
+        storage.with(cteExpression, replace(into<Object>(), columns(&Object::id), select(data->*1_colalias)));
         REQUIRE(storage.changes() == 2);
 
         storage.with(
-            cte<data>().as(union_all(select(2), select(3))),
+            cteExpression,
             update_all(
                 set(c(&Object::id) = select(data->*1_colalias, from<data>(), where(data->*1_colalias == &Object::id))),
                 where(c(&Object::id).in(select(data->*1_colalias)))));
         REQUIRE(storage.changes() == 2);
 
-        storage.with(cte<data>().as(union_all(select(2), select(3))),
-                     remove_all<Object>(where(c(&Object::id).in(select(data->*1_colalias)))));
+        storage.with(cteExpression, remove_all<Object>(where(c(&Object::id).in(select(data->*1_colalias)))));
         REQUIRE(storage.changes() == 2);
     }
 #endif


### PR DESCRIPTION
This PR adds the ability to use common table expressions for the rest of CRUD statements, in addition to "raw" insert statements: "raw" replace, update all, remove all.

In addition, this PR contains:
* More expression factory functions are now marked `constexpr`: operators, asterisk, object, where, select, compound, cte.
