### PR TITLE
Provide a table reference for the "dbstat" eponymous virtual table

### DIFF
--- a/dev/eponymous_vtabs/dbstat.h
+++ b/dev/eponymous_vtabs/dbstat.h
@@ -6,6 +6,7 @@
 
 #include "../schema/column.h"
 #include "../schema/table.h"
+#include "../column_pointer.h"
 
 namespace sqlite_orm {
 #ifdef SQLITE_ENABLE_DBSTAT_VTAB
@@ -35,5 +36,9 @@ namespace sqlite_orm {
                           make_column("pgoffset", &dbstat::pgoffset),
                           make_column("pgsize", &dbstat::pgsize));
     }
+
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+    inline constexpr orm_table_reference auto dbstat_table = c<dbstat>();
+#endif
 #endif  //  SQLITE_ENABLE_DBSTAT_VTAB
 }

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -23768,6 +23768,8 @@ namespace sqlite_orm {
 
 // #include "../schema/table.h"
 
+// #include "../column_pointer.h"
+
 namespace sqlite_orm {
 #ifdef SQLITE_ENABLE_DBSTAT_VTAB
     struct dbstat {
@@ -23796,6 +23798,10 @@ namespace sqlite_orm {
                           make_column("pgoffset", &dbstat::pgoffset),
                           make_column("pgsize", &dbstat::pgsize));
     }
+
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+    inline constexpr orm_table_reference auto dbstat_table = c<dbstat>();
+#endif
 #endif  //  SQLITE_ENABLE_DBSTAT_VTAB
 }
 

--- a/tests/builtin_tables.cpp
+++ b/tests/builtin_tables.cpp
@@ -50,6 +50,10 @@ TEST_CASE("builtin tables") {
 
         auto dbstatRows = storage.get_all<dbstat>();
         std::ignore = dbstatRows;
+
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+        dbstatRows = storage.get_all<dbstat_table>();
+#endif
     }
 #endif  //  SQLITE_ENABLE_DBSTAT_VTAB
 }

--- a/tests/prepared_statement_tests/get_all.cpp
+++ b/tests/prepared_statement_tests/get_all.cpp
@@ -217,8 +217,8 @@ TEST_CASE("Prepared get all") {
     }
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
     SECTION("from table reference") {
-        constexpr auto schema = c<sqlite_master>();
-        auto statement = storage.prepare(get_all<schema>(where(schema->*&sqlite_master::type == "table")));
+        auto statement =
+            storage.prepare(get_all<sqlite_master_table>(where(sqlite_master_table->*&sqlite_master::type == "table")));
         auto str = storage.dump(statement);
         testSerializing(statement);
     }


### PR DESCRIPTION
Just as sqlite_orm provides a “table reference” for the built-in sqlite “master” schema table, a table reference should also be provided for the built-in “dbstat” table.