### PR TITLE
Circumvented Clang's buggy pack indexing expression evaluation

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -108,7 +108,7 @@ for:
   install:
     - |-
       cd C:\Tools\vcpkg
-      git fetch --tags && git checkout 2024.07.12
+      git fetch --tags && git checkout 2025.01.13
       cd %APPVEYOR_BUILD_FOLDER%
       C:\Tools\vcpkg\bootstrap-vcpkg.bat -disableMetrics
       C:\Tools\vcpkg\vcpkg integrate install
@@ -141,7 +141,7 @@ for:
   install:
     - |-
       pushd $HOME/vcpkg
-      git fetch --tags && git checkout 2024.07.12
+      git fetch --tags && git checkout 2025.01.13
       popd
       $HOME/vcpkg/bootstrap-vcpkg.sh -disableMetrics
       $HOME/vcpkg/vcpkg integrate install --overlay-triplets=vcpkg/triplets
@@ -169,7 +169,7 @@ for:
   # using custom vcpkg triplets for building and linking dynamic dependent libraries
   install:
     - |-
-      git clone --depth 1 --branch 2024.07.12 https://github.com/microsoft/vcpkg.git $HOME/vcpkg
+      git clone --depth 1 --branch 2025.01.13 https://github.com/microsoft/vcpkg.git $HOME/vcpkg
       $HOME/vcpkg/bootstrap-vcpkg.sh -disableMetrics
       $HOME/vcpkg/vcpkg integrate install --overlay-triplets=vcpkg/triplets
       vcpkg install sqlite3[core,dbstat,math,json1,fts5,soundex] catch2 --overlay-triplets=vcpkg/triplets

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ environment:
       CC: clang
       CXX: clang++
       SQLITE_ORM_CXX_STANDARD: "-DSQLITE_ORM_ENABLE_CXX_14=ON"
-      cmake_build_parallel: --parallel
+      cmake_build_parallel: ""
 
     - job_name: gcc, C++14
       appveyor_build_worker_image: Ubuntu

--- a/dev/functional/index_sequence_util.h
+++ b/dev/functional/index_sequence_util.h
@@ -9,7 +9,7 @@ namespace sqlite_orm {
          *  Get the index value of an `index_sequence` at a specific position.
          */
         template<size_t Pos, size_t... Idx>
-        SQLITE_ORM_CONSTEVAL size_t index_sequence_value_at(std::index_sequence<Idx...>) {
+        SQLITE_ORM_CONSTEVAL auto index_sequence_value_at(std::index_sequence<Idx...>) {
             return Idx...[Pos];
         }
 #elif defined(SQLITE_ORM_FOLD_EXPRESSIONS_SUPPORTED)

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -1371,7 +1371,7 @@ namespace sqlite_orm {
          *  Get the index value of an `index_sequence` at a specific position.
          */
         template<size_t Pos, size_t... Idx>
-        SQLITE_ORM_CONSTEVAL size_t index_sequence_value_at(std::index_sequence<Idx...>) {
+        SQLITE_ORM_CONSTEVAL auto index_sequence_value_at(std::index_sequence<Idx...>) {
             return Idx...[Pos];
         }
 #elif defined(SQLITE_ORM_FOLD_EXPRESSIONS_SUPPORTED)


### PR DESCRIPTION
This PR fixes build errors with clang 19.1.0 in all C++ language modes.

Clang 19.1.0 enables pack indexing [in all language modes](https://github.com/llvm/llvm-project/pull/101956), but has issues returning a value of explicit type `size_t` from a pack index subscript expression.

Additionally:
* Disabled parallel build for appveyor environment "clang, C++14". Parallel builds cause appveyor VMs to get stuck.
* Updated vcpkg environment to "2025.01.13".