### PR TITLE
 C++20 defaulted comparisons

### DIFF
--- a/dev/arg_values.h
+++ b/dev/arg_values.h
@@ -98,9 +98,11 @@ namespace sqlite_orm {
                 return &other.container == &this->container && other.index == this->index;
             }
 
+#ifndef SQLITE_ORM_DEFAULT_COMPARISONS_SUPPORTED
             bool operator!=(const iterator& other) const {
                 return !(*this == other);
             }
+#endif
 
           private:
             const arg_values& container;

--- a/dev/udf_proxy.h
+++ b/dev/udf_proxy.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <sqlite3.h>
-#include <cassert>  //  assert macro
+#include <assert.h>  //  assert macro
 #include <type_traits>  //  std::true_type, std::false_type
 #include <new>  //  std::bad_alloc
 #include <memory>  //  std::allocator, std::allocator_traits, std::unique_ptr

--- a/examples/any.cpp
+++ b/examples/any.cpp
@@ -16,7 +16,7 @@
 #include <sqlite_orm/sqlite_orm.h>
 #include <any>
 #include <iostream>
-#include <cstdio>
+#include <cstdio>  //  std::remove
 
 using namespace sqlite_orm;
 using std::cout;
@@ -135,7 +135,7 @@ int main() {
         std::any value;
     };
     auto filename = "any.sqlite";
-    ::remove(filename);
+    std::remove(filename);
     auto storage = make_storage(
         filename,
         make_table("test", make_column("id", &Value::id, primary_key()), make_column("value", &Value::value)));

--- a/examples/any.cpp
+++ b/examples/any.cpp
@@ -14,7 +14,17 @@
  *  BLOB is mapped to std::vector<char>.
 */
 #include <sqlite_orm/sqlite_orm.h>
+#ifdef __has_include
+#if __has_include(<any>)
 #include <any>
+#endif
+#endif
+
+#if __cpp_lib_any >= 201606L
+#define ENABLE_THIS_EXAMPLE
+#endif
+
+#ifdef ENABLE_THIS_EXAMPLE
 #include <iostream>
 #include <cstdio>  //  std::remove
 
@@ -128,8 +138,10 @@ namespace sqlite_orm {
         }
     };
 }
+#endif
 
 int main() {
+#ifdef ENABLE_THIS_EXAMPLE
     struct Value {
         int id = 0;
         std::any value;
@@ -151,5 +163,6 @@ int main() {
         cout << storage.dump(test) << endl;
     }
     cout << endl;
+#endif
     return 0;
 }

--- a/examples/blob.cpp
+++ b/examples/blob.cpp
@@ -3,7 +3,7 @@
 #include <string>
 #include <vector>
 #include <iostream>
-#include <cassert>
+#include <assert.h>
 
 using std::cout;
 using std::endl;

--- a/examples/chrono_binding.cpp
+++ b/examples/chrono_binding.cpp
@@ -11,6 +11,7 @@
 
 #ifdef ENABLE_THIS_EXAMPLE
 #include <cassert>
+#include <cstdio>  //  std::remove
 #include <string>
 #include <iostream>
 #include <chrono>
@@ -30,8 +31,7 @@
 
 //  also we need transform functions to make string from enum..
 static std::string sysDaysToString(std::chrono::sys_days pt) {
-    auto r = std::format("{:%F}", pt);
-    return r;
+    return std::format("{:%F}", pt);
 }
 
 /**
@@ -149,7 +149,7 @@ struct Person {
 int main(int, char**) {
 #ifdef ENABLE_THIS_EXAMPLE
     const std::string db_name = "sys_days.sqlite";
-    ::remove(db_name.c_str());
+    std::remove(db_name.c_str());
 
     auto storage = make_storage(db_name,
                                 make_table("Persons",

--- a/examples/chrono_binding.cpp
+++ b/examples/chrono_binding.cpp
@@ -10,7 +10,7 @@
 #endif
 
 #ifdef ENABLE_THIS_EXAMPLE
-#include <cassert>
+#include <assert.h>
 #include <cstdio>  //  std::remove
 #include <string>
 #include <iostream>

--- a/examples/column_aliases.cpp
+++ b/examples/column_aliases.cpp
@@ -1,6 +1,5 @@
 #include <sqlite_orm/sqlite_orm.h>
 #include <iostream>
-#include <cassert>
 
 using std::cout;
 using std::endl;

--- a/examples/core_functions.cpp
+++ b/examples/core_functions.cpp
@@ -1,6 +1,6 @@
 #include <sqlite_orm/sqlite_orm.h>
 #include <iostream>
-#include <cassert>
+#include <assert.h>
 
 using std::cout;
 using std::endl;

--- a/examples/custom_aliases.cpp
+++ b/examples/custom_aliases.cpp
@@ -4,7 +4,7 @@
 
 #include <sqlite_orm/sqlite_orm.h>
 
-#include <cassert>
+#include <assert.h>
 #include <string>
 #include <iostream>
 

--- a/examples/enum_binding.cpp
+++ b/examples/enum_binding.cpp
@@ -3,7 +3,7 @@
 
 #include <iostream>
 #include <memory>
-#include <cassert>
+#include <assert.h>
 
 using std::cout;
 using std::endl;

--- a/examples/foreign_key.cpp
+++ b/examples/foreign_key.cpp
@@ -6,7 +6,7 @@
 
 #include <string>
 #include <iostream>
-#include <cassert>
+#include <assert.h>
 #include <memory>
 
 #if SQLITE_VERSION_NUMBER >= 3006019

--- a/examples/in_memory.cpp
+++ b/examples/in_memory.cpp
@@ -2,7 +2,7 @@
 
 #include <string>
 #include <iostream>
-#include <cassert>
+#include <assert.h>
 
 using namespace sqlite_orm;
 

--- a/examples/private_class_members.cpp
+++ b/examples/private_class_members.cpp
@@ -10,7 +10,7 @@
 
 #include <sqlite_orm/sqlite_orm.h>
 #include <iostream>
-#include <cassert>
+#include <assert.h>
 
 using std::cout;
 using std::endl;

--- a/examples/self_join.cpp
+++ b/examples/self_join.cpp
@@ -4,7 +4,7 @@
 
 #include <sqlite_orm/sqlite_orm.h>
 #include <iostream>
-#include <cassert>
+#include <assert.h>
 
 #if SQLITE_VERSION_NUMBER >= 3006019
 #define ENABLE_THIS_EXAMPLE

--- a/examples/union.cpp
+++ b/examples/union.cpp
@@ -4,7 +4,7 @@
 
 #include <sqlite_orm/sqlite_orm.h>
 #include <string>
-#include <cassert>
+#include <assert.h>
 #include <algorithm>
 #include <iostream>
 

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -17278,7 +17278,7 @@ namespace sqlite_orm {
 // #include "udf_proxy.h"
 
 #include <sqlite3.h>
-#include <cassert>  //  assert macro
+#include <assert.h>  //  assert macro
 #include <type_traits>  //  std::true_type, std::false_type
 #include <new>  //  std::bad_alloc
 #include <memory>  //  std::allocator, std::allocator_traits, std::unique_ptr

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -17189,9 +17189,11 @@ namespace sqlite_orm {
                 return &other.container == &this->container && other.index == this->index;
             }
 
+#ifndef SQLITE_ORM_DEFAULT_COMPARISONS_SUPPORTED
             bool operator!=(const iterator& other) const {
                 return !(*this == other);
             }
+#endif
 
           private:
             const arg_values& container;

--- a/tests/backup_tests.cpp
+++ b/tests/backup_tests.cpp
@@ -87,7 +87,7 @@ TEST_CASE("backup") {
         REQUIRE_THAT(rowsFromBackup, UnorderedEquals(expectedRows));
     }
     SECTION("from") {
-        ::remove(backupFilename.c_str());
+        std::remove(backupFilename.c_str());
         auto storage = makeStorage(backupFilename);
         storage.sync_schema();
         storage.replace(User{1, "Sharon"});

--- a/tests/backup_tests.cpp
+++ b/tests/backup_tests.cpp
@@ -13,11 +13,15 @@ namespace {
         User() = default;
         User(int id, std::string name) : id{id}, name{std::move(name)} {}
 #endif
-    };
 
-    bool operator==(const User& lhs, const User& rhs) {
-        return lhs.id == rhs.id && lhs.name == rhs.name;
-    }
+#ifdef SQLITE_ORM_DEFAULT_COMPARISONS_SUPPORTED
+        friend bool operator==(const User&, const User&) = default;
+#else
+        friend bool operator==(const User& lhs, const User& rhs) {
+            return lhs.id == rhs.id && lhs.name == rhs.name;
+        }
+#endif
+    };
 
     struct MarvelHero {
         int id;

--- a/tests/constraints/default.cpp
+++ b/tests/constraints/default.cpp
@@ -1,5 +1,6 @@
 #include <sqlite_orm/sqlite_orm.h>
 #include <catch2/catch_all.hpp>
+#include <cstdio>  //  std::remove
 
 using namespace sqlite_orm;
 
@@ -14,7 +15,7 @@ TEST_CASE("Default value") {
 
     auto filename = "test_db.sqlite";
 
-    ::remove(filename);
+    std::remove(filename);
 
     auto storage1 = make_storage(filename,
                                  make_table("User",

--- a/tests/iterate.cpp
+++ b/tests/iterate.cpp
@@ -9,9 +9,13 @@ TEST_CASE("Iterate mapped") {
         int64_t id;
         std::vector<char> key;
 
+#ifdef SQLITE_ORM_DEFAULT_COMPARISONS_SUPPORTED
+        bool operator==(const Test&) const = default;
+#else
         bool operator==(const Test& rhs) const {
             return this->id == rhs.id && this->key == rhs.key;
         }
+#endif
     };
 
     auto db =

--- a/tests/operators/in.cpp
+++ b/tests/operators/in.cpp
@@ -14,9 +14,13 @@ TEST_CASE("In") {
             User(int id) : id{id} {}
 #endif
 
+#ifdef SQLITE_ORM_DEFAULT_COMPARISONS_SUPPORTED
+            bool operator==(const User& other) const = default;
+#else
             bool operator==(const User& other) const {
                 return this->id == other.id;
             }
+#endif
 
             std::ostream& operator<<(std::ostream& os) const {
                 return os << this->id;

--- a/tests/prepared_statement_tests/prepared_common.h
+++ b/tests/prepared_statement_tests/prepared_common.h
@@ -14,6 +14,18 @@ namespace PreparedStatementTests {
         User() = default;
         User(int id, std::string name) : id{id}, name{std::move(name)} {}
 #endif
+
+#ifdef SQLITE_ORM_DEFAULT_COMPARISONS_SUPPORTED
+        friend bool operator==(const User&, const User&) = default;
+#else
+        friend bool operator==(const User& lhs, const User& rhs) {
+            return lhs.id == rhs.id && lhs.name == rhs.name;
+        }
+
+        friend bool operator!=(const User& lhs, const User& rhs) {
+            return !(lhs == rhs);
+        }
+#endif
     };
 
     struct Visit {
@@ -39,14 +51,6 @@ namespace PreparedStatementTests {
                      std::string description) : userId{userId}, visitId{visitId}, description{std::move(description)} {}
 #endif
     };
-
-    inline bool operator==(const User& lhs, const User& rhs) {
-        return lhs.id == rhs.id && lhs.name == rhs.name;
-    }
-
-    inline bool operator!=(const User& lhs, const User& rhs) {
-        return !(lhs == rhs);
-    }
 
     inline void testSerializing(const sqlite_orm::internal::prepared_statement_base& statement) {
         auto sql = statement.sql();

--- a/tests/prepared_statement_tests/select.cpp
+++ b/tests/prepared_statement_tests/select.cpp
@@ -373,11 +373,17 @@ TEST_CASE("Prepared select") {
             decltype(User::id) id = 0;
             decltype(User::name) name;
 
+#ifndef SQLITE_ORM_AGGREGATE_PAREN_INIT_SUPPORTED
             Z(decltype(id) id, decltype(name) name) : id{id}, name{std::move(name)} {}
+#endif
 
+#ifdef SQLITE_ORM_DEFAULT_COMPARISONS_SUPPORTED
+            bool operator==(const Z&) const = default;
+#else
             bool operator==(const Z& z) const {
                 return this->id == z.id && this->name == z.name;
             }
+#endif
         };
         constexpr auto z_struct = struct_<Z>(&User::id, &User::name);
         auto statement = storage.prepare(select(z_struct));

--- a/tests/schema/virtual_table.cpp
+++ b/tests/schema/virtual_table.cpp
@@ -11,9 +11,13 @@ TEST_CASE("virtual table") {
         std::string title;
         std::string body;
 
+#ifdef SQLITE_ORM_DEFAULT_COMPARISONS_SUPPORTED
+        bool operator==(const Post&) const = default;
+#else
         bool operator==(const Post& other) const {
             return this->title == other.title && this->body == other.body;
         }
+#endif
     };
 
     /// CREATE VIRTUAL TABLE posts

--- a/tests/select_constraints_tests.cpp
+++ b/tests/select_constraints_tests.cpp
@@ -11,10 +11,14 @@ namespace {
         std::string address;  //  optional
         double salary;  //  optional
 
+#ifdef SQLITE_ORM_DEFAULT_COMPARISONS_SUPPORTED
+        bool operator==(const Employee&) const = default;
+#else
         bool operator==(const Employee& other) const {
             return this->id == other.id && this->name == other.name && this->age == other.age &&
                    this->address == other.address && this->salary == other.salary;
         }
+#endif
     };
 }
 TEST_CASE("select constraints") {
@@ -428,9 +432,13 @@ namespace {
         User4(int id, std::string firstName) : id{id}, firstName{std::move(firstName)} {}
 #endif
 
+#ifdef SQLITE_ORM_DEFAULT_COMPARISONS_SUPPORTED
+        bool operator==(const User4&) const = default;
+#else
         bool operator==(const User4& user) const {
             return this->id == user.id && this->firstName == user.firstName;
         }
+#endif
     };
 }
 TEST_CASE("collate") {

--- a/tests/storage_tests.cpp
+++ b/tests/storage_tests.cpp
@@ -460,10 +460,14 @@ TEST_CASE("insert with generated column") {
             name{std::move(name)}, price{price}, discount{discount}, tax{tax}, netPrice{netPrice} {}
 #endif
 
+#ifdef SQLITE_ORM_DEFAULT_COMPARISONS_SUPPORTED
+        bool operator==(const Product&) const = default;
+#else
         bool operator==(const Product& other) const {
             return this->name == other.name && this->price == other.price && this->discount == other.discount &&
                    this->tax == other.tax && this->netPrice == other.netPrice;
         }
+#endif
     };
     auto storage =
         make_storage({},

--- a/tests/sync_schema_tests.cpp
+++ b/tests/sync_schema_tests.cpp
@@ -1,4 +1,5 @@
 #include <cstdint>
+#include <cstdio>  //  std::remove
 #include <sqlite_orm/sqlite_orm.h>
 #include <catch2/catch_all.hpp>
 
@@ -34,7 +35,7 @@ TEST_CASE("Sync schema") {
 
     //  create an old storage
     auto filename = "sync_schema_text.sqlite";
-    ::remove(filename);
+    std::remove(filename);
     auto storage = make_storage(filename,
                                 make_table("users",
                                            make_column("id", &UserBefore::id, primary_key()),
@@ -150,7 +151,7 @@ TEST_CASE("issue521") {
     };
     std::vector<MockDatabasePoco> pocosToInsert;
 
-    ::remove(storagePath);
+    std::remove(storagePath);
     {
         // --- Create the initial database
         auto storage = sqlite_orm::make_storage(
@@ -310,7 +311,7 @@ TEST_CASE("sync_schema") {
         const std::string name = "name";
         const std::string age = "age";
     } columnNames;
-    ::remove(storagePath);
+    std::remove(storagePath);
     {
         auto storage = make_storage(storagePath,
                                     make_table(tableName,
@@ -501,7 +502,7 @@ TEST_CASE("sync_schema with generated columns") {
         }
     };
     auto storagePath = "sync_schema_with_generated.sqlite";
-    ::remove(storagePath);
+    std::remove(storagePath);
     auto storage1 = make_storage(storagePath, make_table("users", make_column("id", &User::id)));
     storage1.sync_schema();
     storage1.insert(User{5});

--- a/tests/sync_schema_tests.cpp
+++ b/tests/sync_schema_tests.cpp
@@ -28,8 +28,8 @@ TEST_CASE("Sync schema") {
         int id;
         std::string name;
 
-        bool operator==(const UserBefore& userBefore) const {
-            return this->id == userBefore.id && this->name == userBefore.name;
+        bool operator==(const UserBefore& before) const {
+            return this->id == before.id && this->name == before.name;
         }
     };
 
@@ -497,9 +497,13 @@ TEST_CASE("sync_schema with generated columns") {
         User(int id, int hash = 0) : id{id}, hash{hash} {}
 #endif
 
+#ifdef SQLITE_ORM_DEFAULT_COMPARISONS_SUPPORTED
+        bool operator==(const User& other) const = default;
+#else
         bool operator==(const User& other) const {
             return this->id == other.id && this->hash == other.hash;
         }
+#endif
     };
     auto storagePath = "sync_schema_with_generated.sqlite";
     std::remove(storagePath);

--- a/tests/transaction_tests.cpp
+++ b/tests/transaction_tests.cpp
@@ -15,9 +15,13 @@ namespace {
         Object(int id, std::string name) : id{id}, name{std::move(name)} {}
 #endif
 
+#ifdef SQLITE_ORM_DEFAULT_COMPARISONS_SUPPORTED
+        bool operator==(const Object&) const = default;
+#else
         bool operator==(const Object& other) const {
             return this->id == other.id && this->name == other.name;
         }
+#endif
     };
 }
 

--- a/tests/transaction_tests.cpp
+++ b/tests/transaction_tests.cpp
@@ -1,5 +1,6 @@
 #include <sqlite_orm/sqlite_orm.h>
 #include <catch2/catch_all.hpp>
+#include <cstdio>  //  std::remove
 #include "catch_matchers.h"
 
 using namespace sqlite_orm;
@@ -22,7 +23,7 @@ namespace {
 
 TEST_CASE("transaction") {
     auto filename = "transaction_test.sqlite";
-    ::remove(filename);
+    std::remove(filename);
     auto storage = make_storage(
         "test_transaction_guard.sqlite",
         make_table("objects", make_column("id", &Object::id, primary_key()), make_column("name", &Object::name)));
@@ -64,7 +65,7 @@ TEST_CASE("begin_transaction") {
 }
 
 TEST_CASE("Transaction guard") {
-    ::remove("guard.sqlite");
+    std::remove("guard.sqlite");
     auto table =
         make_table("objects", make_column("id", &Object::id, primary_key()), make_column("name", &Object::name));
     auto storage = make_storage("guard.sqlite", table);
@@ -342,5 +343,5 @@ TEST_CASE("Transaction guard") {
         guard->commit_on_destroy = true;
         REQUIRE_THROWS_WITH(guard->~transaction_guard_t(), ContainsSubstring("database is locked"));
     }
-    ::remove("guard.sqlite");
+    std::remove("guard.sqlite");
 }

--- a/tests/unique_cases/get_all_with_two_tables.cpp
+++ b/tests/unique_cases/get_all_with_two_tables.cpp
@@ -20,11 +20,15 @@ namespace {
         Item() = default;
         Item(int id, std::string attributes) : id{id}, attributes{std::move(attributes)} {}
 #endif
-    };
 
-    inline bool operator==(const Item& lhs, const Item& rhs) {
-        return lhs.id == rhs.id && lhs.attributes == rhs.attributes;
-    }
+#ifdef SQLITE_ORM_DEFAULT_COMPARISONS_SUPPORTED
+        friend bool operator==(const Item&, const Item&) = default;
+#else
+        friend bool operator==(const Item& lhs, const Item& rhs) {
+            return lhs.id == rhs.id && lhs.attributes == rhs.attributes;
+        }
+#endif
+    };
 }
 
 TEST_CASE("get_all with two tables") {

--- a/tests/unique_cases/issue663.cpp
+++ b/tests/unique_cases/issue663.cpp
@@ -65,16 +65,18 @@ namespace {
 
 namespace {
     struct User1 {
-        bool operator==(const User1& rhs) const {
-            return std::tie(id, name, age, email) == std::tie(rhs.id, rhs.name, rhs.age, rhs.email);
-        }
-        bool operator!=(const User1& rhs) const {
-            return !(rhs == *this);
-        }
         int id;
         std::string name;
         int age;
         std::string email;
+
+#ifdef SQLITE_ORM_DEFAULT_COMPARISONS_SUPPORTED
+        bool operator==(const User1&) const = default;
+#else
+        bool operator==(const User1& rhs) const {
+            return std::tie(id, name, age, email) == std::tie(rhs.id, rhs.name, rhs.age, rhs.email);
+        }
+#endif
     };
 }
 

--- a/tests/unique_cases/issue937.cpp
+++ b/tests/unique_cases/issue937.cpp
@@ -1,5 +1,6 @@
 #include <sqlite_orm/sqlite_orm.h>
 #include <catch2/catch_all.hpp>
+#include <cstdio>  //  std::remove
 
 #if SQLITE_VERSION_NUMBER >= 3006019
 using namespace sqlite_orm;
@@ -32,7 +33,7 @@ TEST_CASE("issue937") {
 
     using namespace sqlite_orm;
 
-    ::remove("SQLCookbook.sqlite");
+    std::remove("SQLCookbook.sqlite");
     auto storage = make_storage("SQLCookbook.sqlite",
                                 make_table("Emp",
                                            make_column("empno", &Employee::m_empno, primary_key().autoincrement()),

--- a/tests/user_defined_functions.cpp
+++ b/tests/user_defined_functions.cpp
@@ -1,5 +1,6 @@
 #include <sqlite_orm/sqlite_orm.h>
 #include <catch2/catch_all.hpp>
+#include <cstdio>  //  std::remove
 #include "catch_matchers.h"
 
 using namespace sqlite_orm;
@@ -291,7 +292,7 @@ TEST_CASE("custom functions") {
     }
     SECTION("file") {
         path = "custom_function.sqlite";
-        ::remove(path.c_str());
+        std::remove(path.c_str());
     }
     struct User {
         int id = 0;


### PR DESCRIPTION
Use C++20's feature of defaulted comparisons where possible.

Additionally:
* Runner-up: Qualified all calls to `std::remove()` with `std`.
* Included the C header `assert.h` instead of the C++ header `cassert`. This will be important when importing the Standard Library as a named module.