### PR TITLE
#1390 : Fix clang v19.1.5 compile errors

### DIFF
--- a/dev/functional/cxx_core_features.h
+++ b/dev/functional/cxx_core_features.h
@@ -82,7 +82,7 @@
 #define SQLITE_ORM_CLASSTYPE_TEMPLATE_ARGS_SUPPORTED
 #endif
 
-#if __cpp_pack_indexing >= 202311L
+#if __cpp_pack_indexing >= 202311L && __cplusplus > 202302L
 #define SQLITE_ORM_PACK_INDEXING_SUPPORTED
 #endif
 

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -127,7 +127,7 @@ using std::nullptr_t;
 #define SQLITE_ORM_CLASSTYPE_TEMPLATE_ARGS_SUPPORTED
 #endif
 
-#if __cpp_pack_indexing >= 202311L
+#if __cpp_pack_indexing >= 202311L && __cplusplus > 202302L
 #define SQLITE_ORM_PACK_INDEXING_SUPPORTED
 #endif
 


### PR DESCRIPTION
Fixes #1390

## Changelog
- Adds check to `__cplusplus` while checking for the enablement of C++26 pack indexing to prevent the feature from being enabled when it is included as a non-standard extension by the compiler
- Ran code generator and `clang-format`