### PR TITLE
Threadsafe connection

### DIFF
--- a/dev/connection_holder.h
+++ b/dev/connection_holder.h
@@ -2,20 +2,114 @@
 
 #include <sqlite3.h>
 #include <atomic>
+#ifdef SQLITE_ORM_CPP20_SEMAPHORE_SUPPORTED
+#include <semaphore>
+#endif
 #include <string>  //  std::string
 
 #include "error_code.h"
 
 namespace sqlite_orm {
-
     namespace internal {
 
-        struct connection_holder {
+#ifdef SQLITE_ORM_CPP20_SEMAPHORE_SUPPORTED
+        /** 
+         *  The connection holder should be performant in all variants:
+            1. single-threaded use
+            2. opened once (open forever)
+            3. concurrent open/close
 
-            connection_holder(std::string filename_) : filename(std::move(filename_)) {}
+            Hence, a light-weight binary semaphore is used to synchronize opening and closing a database connection.
+        */
+        struct connection_holder {
+            struct maybe_lock {
+                maybe_lock(std::binary_semaphore& sync, bool shouldLock) noexcept(noexcept(sync.acquire())) :
+                    isSynced{shouldLock}, sync{sync} {
+                    if (shouldLock) {
+                        sync.acquire();
+                    }
+                }
+
+                ~maybe_lock() {
+                    if (isSynced) {
+                        sync.release();
+                    }
+                }
+
+                const bool isSynced;
+                std::binary_semaphore& sync;
+            };
+
+            explicit connection_holder(std::string filename) : filename(std::move(filename)) {}
 
             void retain() {
-                if (1 == ++this->_retain_count) {
+                const maybe_lock maybeLock{this->_sync, !this->_openedForeverHint};
+
+                // `maybeLock.isSynced`: the lock above already synchronized everything, so we can just atomically increment the counter
+                // `!maybeLock.isSynced`: we presume that this the connection is opened once in a single-threaded context [open forever].
+                //                        so we can just use an atomic operation but don't need sequencing due to `prevCount > 0`.
+                const int prevCount = this->_retain_count.fetch_add(1, std::memory_order_relaxed);
+
+                if (prevCount == 0 || (maybeLock.isSynced && !this->db)) {
+                    if (int rc = sqlite3_open(this->filename.c_str(), &this->db); rc != SQLITE_OK)
+                        [[unlikely]] /*unexpected*/ {
+                        throw_translated_sqlite_error(this->db);
+                    }
+                }
+            }
+
+            void release() {
+                const maybe_lock maybeLock{this->_sync, !this->_openedForeverHint};
+
+                if (int prevCount = this->_retain_count.fetch_sub(
+                        1,
+                        maybeLock.isSynced
+                            // the lock above already synchronized everything, so we can just atomically decrement the counter
+                            ? std::memory_order_relaxed
+                            // the counter must serve as a synchronization point
+                            : std::memory_order_acq_rel);
+                    prevCount > 1) {
+                    return;
+                }
+
+                if (int rc = sqlite3_close(this->db); rc != SQLITE_OK) [[unlikely]] {
+                    throw_translated_sqlite_error(this->db);
+                } else {
+                    this->db = nullptr;
+                }
+            }
+
+            sqlite3* get() const {
+                // note: ensuring a valid DB handle was already memory ordered with `retain()`
+                return this->db;
+            }
+
+            /** 
+             *  @attention While retrieving the reference count value is well-defined it makes only sense at single-threaded points in code
+             */
+            int retain_count() const {
+                return this->_retain_count.load(std::memory_order_relaxed);
+            }
+
+            const std::string filename;
+
+          protected:
+            sqlite3* db = nullptr;
+
+          private:
+            std::binary_semaphore _sync{1};
+            const bool _openedForeverHint = false;
+            std::atomic_int _retain_count{};
+        };
+#else
+        struct connection_holder {
+            explicit connection_holder(std::string filename) : filename(std::move(filename)) {}
+
+            void retain() {
+                // first one opens the connection.
+                // we presume that this the connection is opened once in a single-threaded context [also open forever].
+                // so we can just use an atomic read but don't need sequencing due to `prevCount > 0`.
+                if (this->_retain_count.fetch_add(1, std::memory_order_relaxed) == 0) {
                     auto rc = sqlite3_open(this->filename.c_str(), &this->db);
                     if (rc != SQLITE_OK) {
                         throw_translated_sqlite_error(rc);
@@ -24,28 +118,36 @@ namespace sqlite_orm {
             }
 
             void release() {
-                if (0 == --this->_retain_count) {
+                // last one closes the connection.
+                // we assume that this might happen by any thread.
+                if (this->_retain_count.fetch_sub(1, std::memory_order_acq_rel) == 1) {
                     auto rc = sqlite3_close(this->db);
                     if (rc != SQLITE_OK) {
-                        throw_translated_sqlite_error(db);
+                        throw_translated_sqlite_error(this->db);
+                    } else {
+                        this->db = nullptr;
                     }
                 }
             }
 
             sqlite3* get() const {
+                // note: ensuring a valid DB handle was already memory ordered with `retain()`
                 return this->db;
             }
 
             int retain_count() const {
-                return this->_retain_count;
+                return this->_retain_count.load(std::memory_order_relaxed);
             }
 
             const std::string filename;
 
           protected:
             sqlite3* db = nullptr;
+
+          private:
             std::atomic_int _retain_count{};
         };
+#endif
 
         struct connection_ref {
             connection_ref(connection_holder& holder) : holder(&holder) {

--- a/dev/connection_holder.h
+++ b/dev/connection_holder.h
@@ -18,7 +18,7 @@ namespace sqlite_orm {
                 if (1 == ++this->_retain_count) {
                     auto rc = sqlite3_open(this->filename.c_str(), &this->db);
                     if (rc != SQLITE_OK) {
-                        throw_translated_sqlite_error(db);
+                        throw_translated_sqlite_error(rc);
                     }
                 }
             }

--- a/dev/functional/config.h
+++ b/dev/functional/config.h
@@ -58,6 +58,10 @@
 #define SQLITE_ORM_CPP20_RANGES_SUPPORTED
 #endif
 
+#if __cpp_lib_semaphore >= 201907L
+#define SQLITE_ORM_CPP20_SEMAPHORE_SUPPORTED
+#endif
+
 // C++20 or later (unfortunately there's no feature test macro).
 // Stupidly, clang says C++20, but `std::default_sentinel_t` was only implemented in libc++ 13 and libstd++-v3 10
 // (the latter is used on Linux).

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -257,6 +257,10 @@ using std::nullptr_t;
 #define SQLITE_ORM_CPP20_RANGES_SUPPORTED
 #endif
 
+#if __cpp_lib_semaphore >= 201907L
+#define SQLITE_ORM_CPP20_SEMAPHORE_SUPPORTED
+#endif
+
 // C++20 or later (unfortunately there's no feature test macro).
 // Stupidly, clang says C++20, but `std::default_sentinel_t` was only implemented in libc++ 13 and libstd++-v3 10
 // (the latter is used on Linux).
@@ -13644,20 +13648,114 @@ namespace sqlite_orm {
 
 #include <sqlite3.h>
 #include <atomic>
+#ifdef SQLITE_ORM_CPP20_SEMAPHORE_SUPPORTED
+#include <semaphore>
+#endif
 #include <string>  //  std::string
 
 // #include "error_code.h"
 
 namespace sqlite_orm {
-
     namespace internal {
 
-        struct connection_holder {
+#ifdef SQLITE_ORM_CPP20_SEMAPHORE_SUPPORTED
+        /** 
+         *  The connection holder should be performant in all variants:
+            1. single-threaded use
+            2. opened once (open forever)
+            3. concurrent open/close
 
-            connection_holder(std::string filename_) : filename(std::move(filename_)) {}
+            Hence, a light-weight binary semaphore is used to synchronize opening and closing a database connection.
+        */
+        struct connection_holder {
+            struct maybe_lock {
+                maybe_lock(std::binary_semaphore& sync, bool shouldLock) noexcept(noexcept(sync.acquire())) :
+                    isSynced{shouldLock}, sync{sync} {
+                    if (shouldLock) {
+                        sync.acquire();
+                    }
+                }
+
+                ~maybe_lock() {
+                    if (isSynced) {
+                        sync.release();
+                    }
+                }
+
+                const bool isSynced;
+                std::binary_semaphore& sync;
+            };
+
+            explicit connection_holder(std::string filename) : filename(std::move(filename)) {}
 
             void retain() {
-                if (1 == ++this->_retain_count) {
+                const maybe_lock maybeLock{this->_sync, !this->_openedForeverHint};
+
+                // `maybeLock.isSynced`: the lock above already synchronized everything, so we can just atomically increment the counter
+                // `!maybeLock.isSynced`: we presume that this the connection is opened once in a single-threaded context [open forever].
+                //                        so we can just use an atomic operation but don't need sequencing due to `prevCount > 0`.
+                const int prevCount = this->_retain_count.fetch_add(1, std::memory_order_relaxed);
+
+                if (prevCount == 0 || (maybeLock.isSynced && !this->db)) {
+                    if (int rc = sqlite3_open(this->filename.c_str(), &this->db); rc != SQLITE_OK)
+                        [[unlikely]] /*unexpected*/ {
+                        throw_translated_sqlite_error(this->db);
+                    }
+                }
+            }
+
+            void release() {
+                const maybe_lock maybeLock{this->_sync, !this->_openedForeverHint};
+
+                if (int prevCount = this->_retain_count.fetch_sub(
+                        1,
+                        maybeLock.isSynced
+                            // the lock above already synchronized everything, so we can just atomically decrement the counter
+                            ? std::memory_order_relaxed
+                            // the counter must serve as a synchronization point
+                            : std::memory_order_acq_rel);
+                    prevCount > 1) {
+                    return;
+                }
+
+                if (int rc = sqlite3_close(this->db); rc != SQLITE_OK) [[unlikely]] {
+                    throw_translated_sqlite_error(this->db);
+                } else {
+                    this->db = nullptr;
+                }
+            }
+
+            sqlite3* get() const {
+                // note: ensuring a valid DB handle was already memory ordered with `retain()`
+                return this->db;
+            }
+
+            /** 
+             *  @attention While retrieving the reference count value is well-defined it makes only sense at single-threaded points in code
+             */
+            int retain_count() const {
+                return this->_retain_count.load(std::memory_order_relaxed);
+            }
+
+            const std::string filename;
+
+          protected:
+            sqlite3* db = nullptr;
+
+          private:
+            std::binary_semaphore _sync{1};
+            const bool _openedForeverHint = false;
+            std::atomic_int _retain_count{};
+        };
+#else
+        struct connection_holder {
+            explicit connection_holder(std::string filename) : filename(std::move(filename)) {}
+
+            void retain() {
+                // first one opens the connection.
+                // we presume that this the connection is opened once in a single-threaded context [also open forever].
+                // so we can just use an atomic read but don't need sequencing due to `prevCount > 0`.
+                if (this->_retain_count.fetch_add(1, std::memory_order_relaxed) == 0) {
                     auto rc = sqlite3_open(this->filename.c_str(), &this->db);
                     if (rc != SQLITE_OK) {
                         throw_translated_sqlite_error(rc);
@@ -13666,28 +13764,36 @@ namespace sqlite_orm {
             }
 
             void release() {
-                if (0 == --this->_retain_count) {
+                // last one closes the connection.
+                // we assume that this might happen by any thread.
+                if (this->_retain_count.fetch_sub(1, std::memory_order_acq_rel) == 1) {
                     auto rc = sqlite3_close(this->db);
                     if (rc != SQLITE_OK) {
-                        throw_translated_sqlite_error(db);
+                        throw_translated_sqlite_error(this->db);
+                    } else {
+                        this->db = nullptr;
                     }
                 }
             }
 
             sqlite3* get() const {
+                // note: ensuring a valid DB handle was already memory ordered with `retain()`
                 return this->db;
             }
 
             int retain_count() const {
-                return this->_retain_count;
+                return this->_retain_count.load(std::memory_order_relaxed);
             }
 
             const std::string filename;
 
           protected:
             sqlite3* db = nullptr;
+
+          private:
             std::atomic_int _retain_count{};
         };
+#endif
 
         struct connection_ref {
             connection_ref(connection_holder& holder) : holder(&holder) {

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -13660,7 +13660,7 @@ namespace sqlite_orm {
                 if (1 == ++this->_retain_count) {
                     auto rc = sqlite3_open(this->filename.c_str(), &this->db);
                     if (rc != SQLITE_OK) {
-                        throw_translated_sqlite_error(db);
+                        throw_translated_sqlite_error(rc);
                     }
                 }
             }


### PR DESCRIPTION
With C++20 a more light-weight binary semaphore can be conditionally used to synchronize opening and closing a database connection.

Therefore, the connection holder should be performant in all variants:
1. single-threaded use
2. opened once (open forever)
3. concurrent open/close
