### PR TITLE
Fixed binding values in several 'order by' clauses

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -113,7 +113,7 @@ for:
   install:
     - |-
       cd C:\Tools\vcpkg
-      git fetch --tags && git checkout 2025.01.13
+      git fetch --tags && git checkout 2025.02.14
       cd %APPVEYOR_BUILD_FOLDER%
       C:\Tools\vcpkg\bootstrap-vcpkg.bat -disableMetrics
       C:\Tools\vcpkg\vcpkg integrate install
@@ -146,7 +146,7 @@ for:
   install:
     - |-
       pushd $HOME/vcpkg
-      git fetch --tags && git checkout 2025.01.13
+      git fetch --tags && git checkout 2025.02.14
       popd
       $HOME/vcpkg/bootstrap-vcpkg.sh -disableMetrics
       $HOME/vcpkg/vcpkg integrate install --overlay-triplets=vcpkg/triplets
@@ -174,7 +174,7 @@ for:
   # using custom vcpkg triplets for building and linking dynamic dependent libraries
   install:
     - |-
-      git clone --depth 1 --branch 2025.01.13 https://github.com/microsoft/vcpkg.git $HOME/vcpkg
+      git clone --depth 1 --branch 2025.02.14 https://github.com/microsoft/vcpkg.git $HOME/vcpkg
       $HOME/vcpkg/bootstrap-vcpkg.sh -disableMetrics
       $HOME/vcpkg/vcpkg integrate install --overlay-triplets=vcpkg/triplets
       vcpkg install sqlite3[core,dbstat,math,json1,fts5,soundex] catch2 --overlay-triplets=vcpkg/triplets

--- a/dev/ast_iterator.h
+++ b/dev/ast_iterator.h
@@ -707,6 +707,16 @@ namespace sqlite_orm {
             }
         };
 
+        template<class... Args>
+        struct ast_iterator<multi_order_by_t<Args...>, void> {
+            using node_type = multi_order_by_t<Args...>;
+
+            template<class L>
+            void operator()(const node_type& node, L& lambda) const {
+                iterate_ast(node.args, lambda);
+            }
+        };
+
         template<class T>
         struct ast_iterator<collate_t<T>, void> {
             using node_type = collate_t<T>;

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -16052,6 +16052,16 @@ namespace sqlite_orm {
             }
         };
 
+        template<class... Args>
+        struct ast_iterator<multi_order_by_t<Args...>, void> {
+            using node_type = multi_order_by_t<Args...>;
+
+            template<class L>
+            void operator()(const node_type& node, L& lambda) const {
+                iterate_ast(node.args, lambda);
+            }
+        };
+
         template<class T>
         struct ast_iterator<collate_t<T>, void> {
             using node_type = collate_t<T>;

--- a/tests/ast_iterator_tests.cpp
+++ b/tests/ast_iterator_tests.cpp
@@ -183,6 +183,22 @@ TEST_CASE("ast_iterator") {
             auto node = order_by(1);
             iterate_ast(node, lambda);
         }
+        SECTION("normal") {
+            auto node = order_by(&User::id);
+            expected.push_back(typeid(&User::id));
+            iterate_ast(node, lambda);
+        }
+        SECTION("multi, single") {
+            auto node = multi_order_by(order_by(&User::id));
+            expected.push_back(typeid(&User::id));
+            iterate_ast(node, lambda);
+        }
+        SECTION("multi, several") {
+            auto node = multi_order_by(order_by(&User::id), order_by(&User::name));
+            expected.push_back(typeid(&User::id));
+            expected.push_back(typeid(&User::name));
+            iterate_ast(node, lambda);
+        }
         SECTION("sole column alias") {
             auto node = order_by(get<colalias_a>());
             iterate_ast(node, lambda);

--- a/tests/statement_serializer_tests/conditions.cpp
+++ b/tests/statement_serializer_tests/conditions.cpp
@@ -6,17 +6,18 @@ using namespace sqlite_orm;
 TEST_CASE("statement_serializer conditions") {
     std::string value, expected;
 
+    struct User {
+        int64 id;
+        std::string name;
+    };
+
+    auto t1 = make_table("user", make_column("id", &User::id), make_column("name", &User::name));
+    auto storage = internal::db_objects_tuple<decltype(t1)>{t1};
+    using db_objects_tuple = decltype(storage);
+
+    internal::serializer_context<db_objects_tuple> ctx{storage};
+
     SECTION("using") {
-        struct User {
-            int64 id;
-        };
-
-        auto t1 = make_table("user", make_column("id", &User::id));
-        auto storage = internal::db_objects_tuple<decltype(t1)>{t1};
-        using db_objects_tuple = decltype(storage);
-
-        internal::serializer_context<db_objects_tuple> ctx{storage};
-
         SECTION("using column") {
             auto expression = using_(&User::id);
             value = serialize(expression, ctx);
@@ -29,15 +30,55 @@ TEST_CASE("statement_serializer conditions") {
         }
     }
     SECTION("order by") {
-        auto storage = internal::db_objects_tuple<>{};
-        using db_objects_tuple = decltype(storage);
-
-        internal::serializer_context<db_objects_tuple> ctx{storage};
-
         SECTION("positional ordinal") {
             auto expression = order_by(1);
             value = serialize(expression, ctx);
             expected = "ORDER BY 1";
+        }
+        SECTION("normal") {
+            auto expression = order_by(&User::id);
+            value = serialize(expression, ctx);
+            expected = R"(ORDER BY "user"."id")";
+        }
+        SECTION("asc") {
+            auto expression = order_by(&User::id).asc();
+            value = serialize(expression, ctx);
+            expected = R"(ORDER BY "user"."id" ASC)";
+        }
+        SECTION("desc") {
+            auto expression = order_by(&User::id).desc();
+            value = serialize(expression, ctx);
+            expected = R"(ORDER BY "user"."id" DESC)";
+        }
+        SECTION("multi, single") {
+            auto expression = multi_order_by(order_by(&User::id));
+            value = serialize(expression, ctx);
+            expected = R"(ORDER BY "user"."id")";
+        }
+        SECTION("multi, single, asc") {
+            auto expression = multi_order_by(order_by(&User::id).asc());
+            value = serialize(expression, ctx);
+            expected = R"(ORDER BY "user"."id" ASC)";
+        }
+        SECTION("multi, single, desc") {
+            auto expression = multi_order_by(order_by(&User::id).desc());
+            value = serialize(expression, ctx);
+            expected = R"(ORDER BY "user"."id" DESC)";
+        }
+        SECTION("multi, several") {
+            auto expression = multi_order_by(order_by(&User::id), order_by(&User::name));
+            value = serialize(expression, ctx);
+            expected = R"(ORDER BY "user"."id", "user"."name")";
+        }
+        SECTION("multi, several, asc") {
+            auto expression = multi_order_by(order_by(&User::id).asc(), order_by(&User::name).asc());
+            value = serialize(expression, ctx);
+            expected = R"(ORDER BY "user"."id" ASC, "user"."name" ASC)";
+        }
+        SECTION("multi, several, desc") {
+            auto expression = multi_order_by(order_by(&User::id).desc(), order_by(&User::name).desc());
+            value = serialize(expression, ctx);
+            expected = R"(ORDER BY "user"."id" DESC, "user"."name" DESC)";
         }
     }
 


### PR DESCRIPTION
Bindable values contained in several 'order by' clauses (with 'multi_order_by' expressions) were left unbound, which resulted in wrong query results or non-executable SQL queries.