### PR TITLE
Fix for race condition in relation to error handling for query errors

### DIFF
--- a/dev/ast_iterator.h
+++ b/dev/ast_iterator.h
@@ -6,7 +6,9 @@
 #include <functional>  //  std::reference_wrapper
 #endif
 
+#include "functional/cxx_functional_polyfill.h"  //  std::is_invocable
 #include "tuple_helper/tuple_iteration.h"
+#include "functional/static_magic.h"
 #include "type_traits.h"
 #include "conditions.h"
 #include "alias.h"
@@ -68,12 +70,11 @@ namespace sqlite_orm {
         void iterate_ast(const T& t, L&& lambda) {
             ast_iterator<T> iterator;
 
-#if defined(SQLITE_ORM_IF_CONSTEXPR_SUPPORTED) && __cpp_lib_is_invocable >= 201703L
             // possibly invoke lambda with node itself
-            if constexpr (std::is_invocable<L, polyfill::bool_constant<true>, const T&>::value) {
-                lambda(polyfill::bool_constant<true>{}, t);
-            }
-#endif
+            call_if_constexpr<polyfill::is_invocable<L, polyfill::bool_constant<true>, const T&>::value>(
+                lambda,
+                polyfill::bool_constant<true>{},
+                t);
 
             iterator(t, lambda);
         }
@@ -126,7 +127,6 @@ namespace sqlite_orm {
 
             template<class L>
             void operator()(const node_type& expression, L& lambda) const {
-                lambda(expression);
                 iterate_ast(expression.argument0, lambda);
                 iterate_ast(expression.argument1, lambda);
                 iterate_ast(expression.argument2, lambda);

--- a/dev/ast_iterator.h
+++ b/dev/ast_iterator.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #ifndef SQLITE_ORM_IMPORT_STD_MODULE
+#include <type_traits>  //  std::is_invocable
 #include <vector>  //  std::vector
 #include <functional>  //  std::reference_wrapper
 #endif
@@ -36,7 +37,7 @@ namespace sqlite_orm {
          *  ast_iterator is used in finding literals to be bound to
          *  a statement, and to collect table names.
          *  
-         *  Note that not all leaves of the expression tree are always visited:
+         *  Note that not all leaves of the expression tree are visited:
          *  Column expressions can be more complex, but are passed as a whole to the callable.
          *  Examples are `column_pointer<>` and `alias_column_t<>`.
          *  
@@ -52,17 +53,28 @@ namespace sqlite_orm {
              *  L is a callable type. Mostly is a templated lambda
              */
             template<class L>
-            void operator()(const T& t, L& lambda) const {
-                lambda(t);
+            void operator()(const node_type& leaf, L& lambda) const {
+                lambda(leaf);
             }
         };
 
         /**
-         *  Simplified API
+         *  Simplified API.
+         *  
+         *  @param lambda Callable invoked with each leaf expression.
+         *  The callable can opt in to be invoked for a node expression.
          */
         template<class T, class L>
         void iterate_ast(const T& t, L&& lambda) {
             ast_iterator<T> iterator;
+
+#if defined(SQLITE_ORM_IF_CONSTEXPR_SUPPORTED) && __cpp_lib_is_invocable >= 201703L
+            // possibly invoke lambda with node itself
+            if constexpr (std::is_invocable<L, polyfill::bool_constant<true>, const T&>::value) {
+                lambda(polyfill::bool_constant<true>{}, t);
+            }
+#endif
+
             iterator(t, lambda);
         }
 

--- a/dev/connection_holder.h
+++ b/dev/connection_holder.h
@@ -28,7 +28,12 @@ namespace sqlite_orm {
                 if (_retainCount.fetch_add(1, std::memory_order_relaxed) == 0) {
                     int rc = sqlite3_open_v2(this->filename.c_str(),
                                              &this->db,
-                                             SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE,
+                                             SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE
+#if SQLITE_VERSION_NUMBER >= 3008008
+                                                 | SQLITE_OPEN_EXRESCODE,
+#else
+                                                 | 0,
+#endif
                                              nullptr);
                     if (rc != SQLITE_OK) SQLITE_ORM_CPP_UNLIKELY /*possible, but unexpected*/ {
                         throw_translated_sqlite_error(this->db);

--- a/dev/connection_holder.h
+++ b/dev/connection_holder.h
@@ -36,7 +36,7 @@ namespace sqlite_orm {
 #endif
                                              nullptr);
                     if (rc != SQLITE_OK) SQLITE_ORM_CPP_UNLIKELY /*possible, but unexpected*/ {
-                        throw_translated_sqlite_error(this->db);
+                        throw_translated_sqlite_error(rc);
                     }
 
                     if (_didOpenDb) {

--- a/dev/core_functions.h
+++ b/dev/core_functions.h
@@ -620,12 +620,9 @@ namespace sqlite_orm {
             using argument1_type = Y;
             using argument2_type = Z;
 
-            argument0_type argument0;
-            argument1_type argument1;
-            argument2_type argument2;
-
-            highlight_t(argument0_type argument0, argument1_type argument1, argument2_type argument2) :
-                argument0(std::move(argument0)), argument1(std::move(argument1)), argument2(std::move(argument2)) {}
+            argument0_type argument0{};
+            argument1_type argument1{};
+            argument2_type argument2{};
         };
     }
 }

--- a/dev/error_code.h
+++ b/dev/error_code.h
@@ -112,8 +112,8 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
             return "SQLite error";
         }
 
-        std::string message(int c) const override final {
-            return sqlite3_errstr(c);
+        std::string message(int ev) const override final {
+            return sqlite3_errstr(ev);
         }
     };
 

--- a/dev/error_code.h
+++ b/dev/error_code.h
@@ -41,6 +41,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
         index_is_out_of_bounds,
         value_is_null,
         no_tables_specified,
+        empty_range,
     };
 }
 

--- a/dev/functional/cxx_functional_polyfill.h
+++ b/dev/functional/cxx_functional_polyfill.h
@@ -85,12 +85,21 @@ namespace sqlite_orm {
             template<class Void, class... X>
             struct is_invocable_impl : std::false_type {};
 
+#if __cplusplus >= 201703
             template<class... Ts>
             struct is_invocable_impl<polyfill::void_t<decltype(polyfill::invoke(std::declval<Ts>()...))>, Ts...>
                 : std::true_type {};
+#else
+            template<class Callable, class... Args>
+            struct is_invocable_impl<
+                polyfill::void_t<decltype(std::declval<std::reference_wrapper<std::remove_reference_t<Callable>>>()(
+                    std::declval<Args>()...))>,
+                Callable,
+                Args...> : std::true_type {};
+#endif
 
             template<class Callable, class... Args>
-            struct is_invocable : is_invocable_impl<void, Callable && (Args && ...)>::type {};
+            struct is_invocable : is_invocable_impl<void, Callable, Args...>::type {};
 #endif
         }
     }

--- a/dev/functional/cxx_functional_polyfill.h
+++ b/dev/functional/cxx_functional_polyfill.h
@@ -78,6 +78,22 @@ namespace sqlite_orm {
                 return std::forward<Callable>(callable)(std::forward<Args>(args)...);
             }
 #endif
+
+#if __cpp_lib_is_invocable >= 201703L
+            using std::is_invocable;
+#else
+            template<class T, class SFINAE = void>
+            struct is_invocable_impl : std::false_type {};
+
+            template<class F, class... Ts>
+            struct is_invocable_impl<
+                F(Ts...),
+                polyfill::void_t<decltype(polyfill::invoke(std::declval<F>(), std::declval<Ts>()...))>>
+                : std::true_type {};
+
+            template<class Callable, class... Args>
+            struct is_invocable : is_invocable_impl<Callable && (Args && ...)>::type {};
+#endif
         }
     }
 

--- a/dev/functional/cxx_functional_polyfill.h
+++ b/dev/functional/cxx_functional_polyfill.h
@@ -82,17 +82,15 @@ namespace sqlite_orm {
 #if __cpp_lib_is_invocable >= 201703L
             using std::is_invocable;
 #else
-            template<class T, class SFINAE = void>
+            template<class Void, class... X>
             struct is_invocable_impl : std::false_type {};
 
-            template<class F, class... Ts>
-            struct is_invocable_impl<
-                F(Ts...),
-                polyfill::void_t<decltype(polyfill::invoke(std::declval<F>(), std::declval<Ts>()...))>>
+            template<class... Ts>
+            struct is_invocable_impl<polyfill::void_t<decltype(polyfill::invoke(std::declval<Ts>()...))>, Ts...>
                 : std::true_type {};
 
             template<class Callable, class... Args>
-            struct is_invocable : is_invocable_impl<Callable && (Args && ...)>::type {};
+            struct is_invocable : is_invocable_impl<void, Callable && (Args && ...)>::type {};
 #endif
         }
     }

--- a/dev/statement_binder.h
+++ b/dev/statement_binder.h
@@ -300,7 +300,7 @@ namespace sqlite_orm {
             void operator()(const T& t) {
                 int rc = statement_binder<T>{}.bind(this->stmt, this->index++, t);
                 if (SQLITE_OK != rc) {
-                    throw_translated_sqlite_error(this->stmt);
+                    throw_translated_sqlite_error(rc);
                 }
             }
 
@@ -354,7 +354,7 @@ namespace sqlite_orm {
             void bind(const T& t, size_t idx) const {
                 int rc = statement_binder<T>{}.bind(this->stmt, int(idx + 1), t);
                 if (SQLITE_OK != rc) {
-                    throw_translated_sqlite_error(this->stmt);
+                    throw_translated_sqlite_error(rc);
                 }
             }
 

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -94,6 +94,42 @@ namespace sqlite_orm {
 #endif
         }
 
+#if defined(SQLITE_ORM_IF_CONSTEXPR_SUPPORTED) && __cpp_lib_is_invocable >= 201703L
+        /*
+         *  AST iteration callable that matches function call node expressions and throws a `orm_error_code::function_not_found` exception
+         *  if an application-defined function is not found among the registered application-defined scalar or aggregate functions.
+         */
+        struct udf_presence_checker {
+            const std::list<udf_proxy>& _scalarFunctions;
+            const std::list<udf_proxy>& _aggregateFunctions;
+
+            // examine `function_call` node expressions
+            template<class UDF, class... CallArgs>
+            void operator()(polyfill::bool_constant<true>, const function_call<UDF, CallArgs...>& udfCall) const {
+                auto&& name = udfCall.name();
+                if (!_contains(_scalarFunctions, name) && !_contains(_aggregateFunctions, name))
+                    SQLITE_ORM_CPP_UNLIKELY {
+                    throw std::system_error{orm_error_code::function_not_found, std::string(name)};
+                }
+            }
+
+            // swallow leaf expressions
+            template<class T>
+            void operator()(const T&) const {}
+
+            static bool _contains(const std::list<udf_proxy>& functions, const std::string_view& name) {
+#ifdef SQLITE_ORM_CPP20_RANGES_SUPPORTED
+                auto it = std::ranges::find(functions, name, &udf_proxy::name);
+#else
+                auto it = std::find_if(functions.begin(), functions.end(), [&name](const udf_proxy& udfProxy) {
+                    return udfProxy.name == name;
+                });
+#endif
+                return it != functions.end();
+            }
+        };
+#endif
+
         /**
          *  Storage class itself. Create an instanse to use it as an interfacto to sqlite db by calling `make_storage`
          *  function.
@@ -1202,6 +1238,10 @@ namespace sqlite_orm {
 
             template<typename S>
             prepared_statement_t<S> prepare_impl(S statement) {
+#if defined(SQLITE_ORM_IF_CONSTEXPR_SUPPORTED) && __cpp_lib_is_invocable >= 201703L
+                iterate_ast(statement, udf_presence_checker{this->scalarFunctions, this->aggregateFunctions});
+#endif
+
                 const auto& exprDBOs = db_objects_for_expression(this->db_objects, statement);
                 using context_t = serializer_context<polyfill::remove_cvref_t<decltype(exprDBOs)>>;
                 context_t context{exprDBOs};
@@ -1211,7 +1251,7 @@ namespace sqlite_orm {
                 auto con = this->get_connection();
                 std::string sql = serialize(statement, context);
                 sqlite3_stmt* stmt = prepare_stmt(con.get(), std::move(sql));
-                return prepared_statement_t<S>{std::forward<S>(statement), stmt, con};
+                return prepared_statement_t<S>{std::forward<S>(statement), stmt, std::move(con)};
             }
 
           public:
@@ -1379,6 +1419,9 @@ namespace sqlite_orm {
                 using object_type = expression_object_type_t<decltype(statement)>;
                 this->assert_mapped_type<object_type>();
                 this->assert_insertable_type<object_type>();
+                if (statement.range.first == statement.range.second) {
+                    throw std::system_error{orm_error_code::empty_range};
+                }
                 return this->prepare_impl(std::move(statement));
             }
 
@@ -1386,6 +1429,9 @@ namespace sqlite_orm {
             prepared_statement_t<E> prepare(E statement) {
                 using object_type = expression_object_type_t<decltype(statement)>;
                 this->assert_mapped_type<object_type>();
+                if (statement.range.first == statement.range.second) {
+                    throw std::system_error{orm_error_code::empty_range};
+                }
                 return this->prepare_impl(std::move(statement));
             }
 

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -1486,6 +1486,10 @@ namespace sqlite_orm {
                 perform_step(stmt);
             }
 
+            /** 
+             *  @return The rowid of the last inserted row.
+             *  @note The returned rowid is only meaningful in single-thread contexts.
+             */
             template<class T, class... Cols>
             int64 execute(const prepared_statement_t<insert_explicit<T, Cols...>>& statement) {
                 using object_type = statement_object_type_t<decltype(statement)>;
@@ -1541,6 +1545,10 @@ namespace sqlite_orm {
                 perform_step(stmt);
             }
 
+            /** 
+             *  @return The rowid of the last inserted row.
+             *  @note The returned rowid is only meaningful in single-thread contexts.
+             */
             template<class T,
                      std::enable_if_t<polyfill::disjunction<is_insert<T>, is_insert_range<T>>::value, bool> = true>
             int64 execute(const prepared_statement_t<T>& statement) {

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -94,14 +94,17 @@ namespace sqlite_orm {
 #endif
         }
 
-#if defined(SQLITE_ORM_IF_CONSTEXPR_SUPPORTED) && __cpp_lib_is_invocable >= 201703L
+#ifdef SQLITE_ORM_STRING_VIEW_SUPPORTED
         /*
-         *  AST iteration callable that matches function call node expressions and throws a `orm_error_code::function_not_found` exception
-         *  if an application-defined function is not found among the registered application-defined scalar or aggregate functions.
+         *  AST iteration callable that matches function call node expressions.
+         *  * Throws a `orm_error_code::function_not_found` exception
+         *    if an application-defined scalar or aggregate function was not registered.
+         *  * Throws a `sqlite_errc(SQLITE_ERROR_MISSING_COLLSEQ)` if a named collation function was not registered.
          */
         struct udf_presence_checker {
             const std::list<udf_proxy>& _scalarFunctions;
             const std::list<udf_proxy>& _aggregateFunctions;
+            const std::map<std::string, storage_base::collating_function>& _collatingFunctions;
 
             // examine `function_call` node expressions
             template<class UDF, class... CallArgs>
@@ -110,6 +113,17 @@ namespace sqlite_orm {
                 if (!_contains(_scalarFunctions, name) && !_contains(_aggregateFunctions, name))
                     SQLITE_ORM_CPP_UNLIKELY {
                     throw std::system_error{orm_error_code::function_not_found, std::string(name)};
+                }
+            }
+
+            // examine `named_collate` node expressions
+            void operator()(polyfill::bool_constant<true>, const named_collate_base& collateCall) const {
+                if (_collatingFunctions.find(collateCall.name) == _collatingFunctions.end()) SQLITE_ORM_CPP_UNLIKELY {
+#if SQLITE_VERSION_NUMBER >= 3008008
+                    throw std::system_error{sqlite_errc(SQLITE_ERROR_MISSING_COLLSEQ), std::string(collateCall.name)};
+#else
+                    throw std::system_error{sqlite_errc(SQLITE_ERROR), std::string(collateCall.name)};
+#endif
                 }
             }
 
@@ -1238,8 +1252,10 @@ namespace sqlite_orm {
 
             template<typename S>
             prepared_statement_t<S> prepare_impl(S statement) {
-#if defined(SQLITE_ORM_IF_CONSTEXPR_SUPPORTED) && __cpp_lib_is_invocable >= 201703L
-                iterate_ast(statement, udf_presence_checker{this->scalarFunctions, this->aggregateFunctions});
+#ifdef SQLITE_ORM_STRING_VIEW_SUPPORTED
+                iterate_ast(
+                    statement,
+                    udf_presence_checker{this->scalarFunctions, this->aggregateFunctions, this->collatingFunctions});
 #endif
 
                 const auto& exprDBOs = db_objects_for_expression(this->db_objects, statement);

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -1604,8 +1604,8 @@ namespace sqlite_orm {
                 return std::move(res).value();
 #else
                 auto& table = this->get_table<T>();
-                auto stepRes = sqlite3_step(stmt);
-                switch (stepRes) {
+                int rc = sqlite3_step(stmt);
+                switch (rc) {
                     case SQLITE_ROW: {
                         T res;
                         object_from_column_builder<T> builder{res, stmt};

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -1650,8 +1650,7 @@ namespace sqlite_orm {
                 return std::move(res).value();
 #else
                 auto& table = this->get_table<T>();
-                int rc = sqlite3_step(stmt);
-                switch (rc) {
+                switch (int rc = sqlite3_step(stmt)) {
                     case SQLITE_ROW: {
                         T res;
                         object_from_column_builder<T> builder{res, stmt};
@@ -1662,7 +1661,7 @@ namespace sqlite_orm {
                         throw std::system_error{orm_error_code::not_found};
                     } break;
                     default: {
-                        throw_translated_sqlite_error(stmt);
+                        throw_translated_sqlite_error(rc);
                     }
                 }
 #endif

--- a/dev/storage_base.h
+++ b/dev/storage_base.h
@@ -538,7 +538,7 @@ namespace sqlite_orm {
                                                       function,
                                                       functionExists ? collate_callback : nullptr);
                     if (rc != SQLITE_OK) {
-                        throw_translated_sqlite_error(db);
+                        throw_translated_sqlite_error(rc);
                     }
                 }
 
@@ -751,7 +751,7 @@ namespace sqlite_orm {
                 for (auto& p: this->collatingFunctions) {
                     int rc = sqlite3_create_collation(db, p.first.c_str(), SQLITE_UTF8, &p.second, collate_callback);
                     if (rc != SQLITE_OK) {
-                        throw_translated_sqlite_error(db);
+                        throw_translated_sqlite_error(rc);
                     }
                 }
 
@@ -878,7 +878,7 @@ namespace sqlite_orm {
                                                             nullptr,
                                                             nullptr);
                         if (rc != SQLITE_OK) {
-                            throw_translated_sqlite_error(db);
+                            throw_translated_sqlite_error(rc);
                         }
                     }
                     it = functions.erase(it);
@@ -898,7 +898,7 @@ namespace sqlite_orm {
                                                     nullptr,
                                                     nullptr);
                 if (rc != SQLITE_OK) {
-                    throw_translated_sqlite_error(db);
+                    throw_translated_sqlite_error(rc);
                 }
             }
 

--- a/dev/storage_base.h
+++ b/dev/storage_base.h
@@ -861,7 +861,7 @@ namespace sqlite_orm {
 #ifdef SQLITE_ORM_CPP20_RANGES_SUPPORTED
                 auto it = std::ranges::find(functions, name, &udf_proxy::name);
 #else
-                auto it = std::find_if(functions.begin(), functions.end(), [&name](auto& udfProxy) {
+                auto it = std::find_if(functions.begin(), functions.end(), [&name](const udf_proxy& udfProxy) {
                     return udfProxy.name == name;
                 });
 #endif

--- a/dev/table_name_collector.h
+++ b/dev/table_name_collector.h
@@ -30,8 +30,6 @@ namespace sqlite_orm {
 
             const db_objects_type& db_objects;
 
-            table_name_collector() = default;
-
             table_name_collector(const db_objects_type& dbObjects) : db_objects{dbObjects} {}
 
             template<class T>
@@ -90,7 +88,7 @@ namespace sqlite_orm {
             }
 
             template<class T, class X, class Y, class Z>
-            void operator()(const highlight_t<T, X, Y, Z>&) {
+            void operator()(polyfill::bool_constant<true>, const highlight_t<T, X, Y, Z>&) {
                 this->table_names.emplace(lookup_table_name<T>(this->db_objects), "");
             }
         };

--- a/dev/util.h
+++ b/dev/util.h
@@ -38,7 +38,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     inline std::string quote_blob_literal(std::string v) {
         constexpr char quoteChar = '\'';
-        return std::string{char('x'), quoteChar} + std::move(v) + quoteChar;
+        return std::string{'x', quoteChar} + std::move(v) + quoteChar;
     }
 
     /** 

--- a/dev/util.h
+++ b/dev/util.h
@@ -107,7 +107,7 @@ namespace sqlite_orm {
                     lambda(stmt);
                 } break;
                 case SQLITE_DONE:
-                    break;
+                    return;
                 default: {
                     throw_translated_sqlite_error(stmt);
                 }
@@ -116,19 +116,18 @@ namespace sqlite_orm {
 
         template<class L>
         void perform_steps(sqlite3_stmt* stmt, L&& lambda) {
-            int rc;
-            do {
-                switch (rc = sqlite3_step(stmt)) {
+            for (;;) {
+                switch (int rc = sqlite3_step(stmt)) {
                     case SQLITE_ROW: {
                         lambda(stmt);
                     } break;
                     case SQLITE_DONE:
-                        break;
+                        return;
                     default: {
                         throw_translated_sqlite_error(stmt);
                     }
                 }
-            } while (rc != SQLITE_DONE);
+            }
         }
     }
 }

--- a/dev/util.h
+++ b/dev/util.h
@@ -62,8 +62,9 @@ namespace sqlite_orm {
         // note: query is deliberately taken by value, such that it is thrown away early
         inline sqlite3_stmt* prepare_stmt(sqlite3* db, std::string query) {
             sqlite3_stmt* stmt;
-            if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) != SQLITE_OK) {
-                throw_translated_sqlite_error(db);
+            int rc = sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr);
+            if (rc != SQLITE_OK) SQLITE_ORM_CPP_UNLIKELY /*possible but unexpected*/ {
+                throw_translated_sqlite_error(rc);
             }
             return stmt;
         }
@@ -71,7 +72,7 @@ namespace sqlite_orm {
         inline void perform_void_exec(sqlite3* db, const std::string& query) {
             int rc = sqlite3_exec(db, query.c_str(), nullptr, nullptr, nullptr);
             if (rc != SQLITE_OK) {
-                throw_translated_sqlite_error(db);
+                throw_translated_sqlite_error(rc);
             }
         }
 
@@ -81,7 +82,7 @@ namespace sqlite_orm {
                                  void* user_data) {
             int rc = sqlite3_exec(db, query, callback, user_data, nullptr);
             if (rc != SQLITE_OK) {
-                throw_translated_sqlite_error(db);
+                throw_translated_sqlite_error(rc);
             }
         }
 
@@ -96,7 +97,7 @@ namespace sqlite_orm {
         void perform_step(sqlite3_stmt* stmt) {
             int rc = sqlite3_step(stmt);
             if (rc != expected) {
-                throw_translated_sqlite_error(stmt);
+                throw_translated_sqlite_error(rc);
             }
         }
 
@@ -109,7 +110,7 @@ namespace sqlite_orm {
                 case SQLITE_DONE:
                     return;
                 default: {
-                    throw_translated_sqlite_error(stmt);
+                    throw_translated_sqlite_error(rc);
                 }
             }
         }
@@ -124,7 +125,7 @@ namespace sqlite_orm {
                     case SQLITE_DONE:
                         return;
                     default: {
-                        throw_translated_sqlite_error(stmt);
+                        throw_translated_sqlite_error(rc);
                     }
                 }
             }

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -3070,8 +3070,8 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
             return "SQLite error";
         }
 
-        std::string message(int c) const override final {
-            return sqlite3_errstr(c);
+        std::string message(int ev) const override final {
+            return sqlite3_errstr(ev);
         }
     };
 
@@ -14023,7 +14023,12 @@ namespace sqlite_orm {
                 if (_retainCount.fetch_add(1, std::memory_order_relaxed) == 0) {
                     int rc = sqlite3_open_v2(this->filename.c_str(),
                                              &this->db,
-                                             SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE,
+                                             SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE
+#if SQLITE_VERSION_NUMBER >= 3008008
+                                                 | SQLITE_OPEN_EXRESCODE,
+#else
+                                                 | 0,
+#endif
                                              nullptr);
                     if (rc != SQLITE_OK) SQLITE_ORM_CPP_UNLIKELY /*possible, but unexpected*/ {
                         throw_translated_sqlite_error(this->db);
@@ -24167,8 +24172,8 @@ namespace sqlite_orm {
                 return std::move(res).value();
 #else
                 auto& table = this->get_table<T>();
-                auto stepRes = sqlite3_step(stmt);
-                switch (stepRes) {
+                int rc = sqlite3_step(stmt);
+                switch (rc) {
                     case SQLITE_ROW: {
                         T res;
                         object_from_column_builder<T> builder{res, stmt};

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -13825,7 +13825,7 @@ namespace sqlite_orm {
                     lambda(stmt);
                 } break;
                 case SQLITE_DONE:
-                    break;
+                    return;
                 default: {
                     throw_translated_sqlite_error(stmt);
                 }
@@ -13834,19 +13834,18 @@ namespace sqlite_orm {
 
         template<class L>
         void perform_steps(sqlite3_stmt* stmt, L&& lambda) {
-            int rc;
-            do {
-                switch (rc = sqlite3_step(stmt)) {
+            for (;;) {
+                switch (int rc = sqlite3_step(stmt)) {
                     case SQLITE_ROW: {
                         lambda(stmt);
                     } break;
                     case SQLITE_DONE:
-                        break;
+                        return;
                     default: {
                         throw_translated_sqlite_error(stmt);
                     }
                 }
-            } while (rc != SQLITE_DONE);
+            }
         }
     }
 }

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -13756,7 +13756,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     inline std::string quote_blob_literal(std::string v) {
         constexpr char quoteChar = '\'';
-        return std::string{char('x'), quoteChar} + std::move(v) + quoteChar;
+        return std::string{'x', quoteChar} + std::move(v) + quoteChar;
     }
 
     /** 

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -717,12 +717,21 @@ namespace sqlite_orm {
             template<class Void, class... X>
             struct is_invocable_impl : std::false_type {};
 
+#if __cplusplus >= 201703
             template<class... Ts>
             struct is_invocable_impl<polyfill::void_t<decltype(polyfill::invoke(std::declval<Ts>()...))>, Ts...>
                 : std::true_type {};
+#else
+            template<class Callable, class... Args>
+            struct is_invocable_impl<
+                polyfill::void_t<decltype(std::declval<std::reference_wrapper<std::remove_reference_t<Callable>>>()(
+                    std::declval<Args>()...))>,
+                Callable,
+                Args...> : std::true_type {};
+#endif
 
             template<class Callable, class... Args>
-            struct is_invocable : is_invocable_impl<void, Callable && (Args && ...)>::type {};
+            struct is_invocable : is_invocable_impl<void, Callable, Args...>::type {};
 #endif
         }
     }

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -710,6 +710,22 @@ namespace sqlite_orm {
                 return std::forward<Callable>(callable)(std::forward<Args>(args)...);
             }
 #endif
+
+#if __cpp_lib_is_invocable >= 201703L
+            using std::is_invocable;
+#else
+            template<class T, class SFINAE = void>
+            struct is_invocable_impl : std::false_type {};
+
+            template<class F, class... Ts>
+            struct is_invocable_impl<
+                F(Ts...),
+                polyfill::void_t<decltype(polyfill::invoke(std::declval<F>(), std::declval<Ts>()...))>>
+                : std::true_type {};
+
+            template<class Callable, class... Args>
+            struct is_invocable : is_invocable_impl<Callable && (Args && ...)>::type {};
+#endif
         }
     }
 
@@ -6928,12 +6944,9 @@ namespace sqlite_orm {
             using argument1_type = Y;
             using argument2_type = Z;
 
-            argument0_type argument0;
-            argument1_type argument1;
-            argument2_type argument2;
-
-            highlight_t(argument0_type argument0, argument1_type argument1, argument2_type argument2) :
-                argument0(std::move(argument0)), argument1(std::move(argument1)), argument2(std::move(argument2)) {}
+            argument0_type argument0{};
+            argument1_type argument1{};
+            argument2_type argument2{};
         };
     }
 }
@@ -13964,7 +13977,11 @@ namespace sqlite_orm {
 #include <functional>  //  std::reference_wrapper
 #endif
 
+// #include "functional/cxx_functional_polyfill.h"
+//  std::is_invocable
 // #include "tuple_helper/tuple_iteration.h"
+
+// #include "functional/static_magic.h"
 
 // #include "type_traits.h"
 
@@ -14296,8 +14313,6 @@ namespace sqlite_orm {
 
             const db_objects_type& db_objects;
 
-            table_name_collector() = default;
-
             table_name_collector(const db_objects_type& dbObjects) : db_objects{dbObjects} {}
 
             template<class T>
@@ -14356,7 +14371,7 @@ namespace sqlite_orm {
             }
 
             template<class T, class X, class Y, class Z>
-            void operator()(const highlight_t<T, X, Y, Z>&) {
+            void operator()(polyfill::bool_constant<true>, const highlight_t<T, X, Y, Z>&) {
                 this->table_names.emplace(lookup_table_name<T>(this->db_objects), "");
             }
         };
@@ -15419,12 +15434,11 @@ namespace sqlite_orm {
         void iterate_ast(const T& t, L&& lambda) {
             ast_iterator<T> iterator;
 
-#if defined(SQLITE_ORM_IF_CONSTEXPR_SUPPORTED) && __cpp_lib_is_invocable >= 201703L
             // possibly invoke lambda with node itself
-            if constexpr (std::is_invocable<L, polyfill::bool_constant<true>, const T&>::value) {
-                lambda(polyfill::bool_constant<true>{}, t);
-            }
-#endif
+            call_if_constexpr<polyfill::is_invocable<L, polyfill::bool_constant<true>, const T&>::value>(
+                lambda,
+                polyfill::bool_constant<true>{},
+                t);
 
             iterator(t, lambda);
         }
@@ -15477,7 +15491,6 @@ namespace sqlite_orm {
 
             template<class L>
             void operator()(const node_type& expression, L& lambda) const {
-                lambda(expression);
                 iterate_ast(expression.argument0, lambda);
                 iterate_ast(expression.argument1, lambda);
                 iterate_ast(expression.argument2, lambda);
@@ -22676,14 +22689,17 @@ namespace sqlite_orm {
 #endif
         }
 
-#if defined(SQLITE_ORM_IF_CONSTEXPR_SUPPORTED) && __cpp_lib_is_invocable >= 201703L
+#ifdef SQLITE_ORM_STRING_VIEW_SUPPORTED
         /*
-         *  AST iteration callable that matches function call node expressions and throws a `orm_error_code::function_not_found` exception
-         *  if an application-defined function is not found among the registered application-defined scalar or aggregate functions.
+         *  AST iteration callable that matches function call node expressions.
+         *  * Throws a `orm_error_code::function_not_found` exception
+         *    if an application-defined scalar or aggregate function was not registered.
+         *  * Throws a `sqlite_errc(SQLITE_ERROR_MISSING_COLLSEQ)` if a named collation function was not registered.
          */
         struct udf_presence_checker {
             const std::list<udf_proxy>& _scalarFunctions;
             const std::list<udf_proxy>& _aggregateFunctions;
+            const std::map<std::string, storage_base::collating_function>& _collatingFunctions;
 
             // examine `function_call` node expressions
             template<class UDF, class... CallArgs>
@@ -22692,6 +22708,17 @@ namespace sqlite_orm {
                 if (!_contains(_scalarFunctions, name) && !_contains(_aggregateFunctions, name))
                     SQLITE_ORM_CPP_UNLIKELY {
                     throw std::system_error{orm_error_code::function_not_found, std::string(name)};
+                }
+            }
+
+            // examine `named_collate` node expressions
+            void operator()(polyfill::bool_constant<true>, const named_collate_base& collateCall) const {
+                if (_collatingFunctions.find(collateCall.name) == _collatingFunctions.end()) SQLITE_ORM_CPP_UNLIKELY {
+#if SQLITE_VERSION_NUMBER >= 3008008
+                    throw std::system_error{sqlite_errc(SQLITE_ERROR_MISSING_COLLSEQ), std::string(collateCall.name)};
+#else
+                    throw std::system_error{sqlite_errc(SQLITE_ERROR), std::string(collateCall.name)};
+#endif
                 }
             }
 
@@ -23820,8 +23847,10 @@ namespace sqlite_orm {
 
             template<typename S>
             prepared_statement_t<S> prepare_impl(S statement) {
-#if defined(SQLITE_ORM_IF_CONSTEXPR_SUPPORTED) && __cpp_lib_is_invocable >= 201703L
-                iterate_ast(statement, udf_presence_checker{this->scalarFunctions, this->aggregateFunctions});
+#ifdef SQLITE_ORM_STRING_VIEW_SUPPORTED
+                iterate_ast(
+                    statement,
+                    udf_presence_checker{this->scalarFunctions, this->aggregateFunctions, this->collatingFunctions});
 #endif
 
                 const auto& exprDBOs = db_objects_for_expression(this->db_objects, statement);

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -24110,6 +24110,10 @@ namespace sqlite_orm {
                 perform_step(stmt);
             }
 
+            /** 
+             *  @return The rowid of the last inserted row.
+             *  @note The returned rowid is only meaningful in single-thread contexts.
+             */
             template<class T, class... Cols>
             int64 execute(const prepared_statement_t<insert_explicit<T, Cols...>>& statement) {
                 using object_type = statement_object_type_t<decltype(statement)>;
@@ -24165,6 +24169,10 @@ namespace sqlite_orm {
                 perform_step(stmt);
             }
 
+            /** 
+             *  @return The rowid of the last inserted row.
+             *  @note The returned rowid is only meaningful in single-thread contexts.
+             */
             template<class T,
                      std::enable_if_t<polyfill::disjunction<is_insert<T>, is_insert_range<T>>::value, bool> = true>
             int64 execute(const prepared_statement_t<T>& statement) {

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -10474,7 +10474,7 @@ namespace sqlite_orm {
             void operator()(const T& t) {
                 int rc = statement_binder<T>{}.bind(this->stmt, this->index++, t);
                 if (SQLITE_OK != rc) {
-                    throw_translated_sqlite_error(this->stmt);
+                    throw_translated_sqlite_error(rc);
                 }
             }
 
@@ -10528,7 +10528,7 @@ namespace sqlite_orm {
             void bind(const T& t, size_t idx) const {
                 int rc = statement_binder<T>{}.bind(this->stmt, int(idx + 1), t);
                 if (SQLITE_OK != rc) {
-                    throw_translated_sqlite_error(this->stmt);
+                    throw_translated_sqlite_error(rc);
                 }
             }
 
@@ -13781,8 +13781,9 @@ namespace sqlite_orm {
         // note: query is deliberately taken by value, such that it is thrown away early
         inline sqlite3_stmt* prepare_stmt(sqlite3* db, std::string query) {
             sqlite3_stmt* stmt;
-            if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) != SQLITE_OK) {
-                throw_translated_sqlite_error(db);
+            int rc = sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr);
+            if (rc != SQLITE_OK) SQLITE_ORM_CPP_UNLIKELY /*possible but unexpected*/ {
+                throw_translated_sqlite_error(rc);
             }
             return stmt;
         }
@@ -13790,7 +13791,7 @@ namespace sqlite_orm {
         inline void perform_void_exec(sqlite3* db, const std::string& query) {
             int rc = sqlite3_exec(db, query.c_str(), nullptr, nullptr, nullptr);
             if (rc != SQLITE_OK) {
-                throw_translated_sqlite_error(db);
+                throw_translated_sqlite_error(rc);
             }
         }
 
@@ -13800,7 +13801,7 @@ namespace sqlite_orm {
                                  void* user_data) {
             int rc = sqlite3_exec(db, query, callback, user_data, nullptr);
             if (rc != SQLITE_OK) {
-                throw_translated_sqlite_error(db);
+                throw_translated_sqlite_error(rc);
             }
         }
 
@@ -13815,7 +13816,7 @@ namespace sqlite_orm {
         void perform_step(sqlite3_stmt* stmt) {
             int rc = sqlite3_step(stmt);
             if (rc != expected) {
-                throw_translated_sqlite_error(stmt);
+                throw_translated_sqlite_error(rc);
             }
         }
 
@@ -13828,7 +13829,7 @@ namespace sqlite_orm {
                 case SQLITE_DONE:
                     return;
                 default: {
-                    throw_translated_sqlite_error(stmt);
+                    throw_translated_sqlite_error(rc);
                 }
             }
         }
@@ -13843,7 +13844,7 @@ namespace sqlite_orm {
                     case SQLITE_DONE:
                         return;
                     default: {
-                        throw_translated_sqlite_error(stmt);
+                        throw_translated_sqlite_error(rc);
                     }
                 }
             }
@@ -14033,7 +14034,7 @@ namespace sqlite_orm {
 #endif
                                              nullptr);
                     if (rc != SQLITE_OK) SQLITE_ORM_CPP_UNLIKELY /*possible, but unexpected*/ {
-                        throw_translated_sqlite_error(this->db);
+                        throw_translated_sqlite_error(rc);
                     }
 
                     if (_didOpenDb) {
@@ -18429,7 +18430,7 @@ namespace sqlite_orm {
                                                       function,
                                                       functionExists ? collate_callback : nullptr);
                     if (rc != SQLITE_OK) {
-                        throw_translated_sqlite_error(db);
+                        throw_translated_sqlite_error(rc);
                     }
                 }
 
@@ -18642,7 +18643,7 @@ namespace sqlite_orm {
                 for (auto& p: this->collatingFunctions) {
                     int rc = sqlite3_create_collation(db, p.first.c_str(), SQLITE_UTF8, &p.second, collate_callback);
                     if (rc != SQLITE_OK) {
-                        throw_translated_sqlite_error(db);
+                        throw_translated_sqlite_error(rc);
                     }
                 }
 
@@ -18769,7 +18770,7 @@ namespace sqlite_orm {
                                                             nullptr,
                                                             nullptr);
                         if (rc != SQLITE_OK) {
-                            throw_translated_sqlite_error(db);
+                            throw_translated_sqlite_error(rc);
                         }
                     }
                     it = functions.erase(it);
@@ -18789,7 +18790,7 @@ namespace sqlite_orm {
                                                     nullptr,
                                                     nullptr);
                 if (rc != SQLITE_OK) {
-                    throw_translated_sqlite_error(db);
+                    throw_translated_sqlite_error(rc);
                 }
             }
 
@@ -24231,8 +24232,7 @@ namespace sqlite_orm {
                 return std::move(res).value();
 #else
                 auto& table = this->get_table<T>();
-                int rc = sqlite3_step(stmt);
-                switch (rc) {
+                switch (int rc = sqlite3_step(stmt)) {
                     case SQLITE_ROW: {
                         T res;
                         object_from_column_builder<T> builder{res, stmt};
@@ -24243,7 +24243,7 @@ namespace sqlite_orm {
                         throw std::system_error{orm_error_code::not_found};
                     } break;
                     default: {
-                        throw_translated_sqlite_error(stmt);
+                        throw_translated_sqlite_error(rc);
                     }
                 }
 #endif

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -714,17 +714,15 @@ namespace sqlite_orm {
 #if __cpp_lib_is_invocable >= 201703L
             using std::is_invocable;
 #else
-            template<class T, class SFINAE = void>
+            template<class Void, class... X>
             struct is_invocable_impl : std::false_type {};
 
-            template<class F, class... Ts>
-            struct is_invocable_impl<
-                F(Ts...),
-                polyfill::void_t<decltype(polyfill::invoke(std::declval<F>(), std::declval<Ts>()...))>>
+            template<class... Ts>
+            struct is_invocable_impl<polyfill::void_t<decltype(polyfill::invoke(std::declval<Ts>()...))>, Ts...>
                 : std::true_type {};
 
             template<class Callable, class... Args>
-            struct is_invocable : is_invocable_impl<Callable && (Args && ...)>::type {};
+            struct is_invocable : is_invocable_impl<void, Callable && (Args && ...)>::type {};
 #endif
         }
     }

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -2999,6 +2999,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
         index_is_out_of_bounds,
         value_is_null,
         no_tables_specified,
+        empty_range,
     };
 }
 
@@ -13957,6 +13958,7 @@ namespace sqlite_orm {
 // #include "ast_iterator.h"
 
 #ifndef SQLITE_ORM_IMPORT_STD_MODULE
+#include <type_traits>  //  std::is_invocable
 #include <vector>  //  std::vector
 #include <functional>  //  std::reference_wrapper
 #endif
@@ -15385,7 +15387,7 @@ namespace sqlite_orm {
          *  ast_iterator is used in finding literals to be bound to
          *  a statement, and to collect table names.
          *  
-         *  Note that not all leaves of the expression tree are always visited:
+         *  Note that not all leaves of the expression tree are visited:
          *  Column expressions can be more complex, but are passed as a whole to the callable.
          *  Examples are `column_pointer<>` and `alias_column_t<>`.
          *  
@@ -15401,17 +15403,28 @@ namespace sqlite_orm {
              *  L is a callable type. Mostly is a templated lambda
              */
             template<class L>
-            void operator()(const T& t, L& lambda) const {
-                lambda(t);
+            void operator()(const node_type& leaf, L& lambda) const {
+                lambda(leaf);
             }
         };
 
         /**
-         *  Simplified API
+         *  Simplified API.
+         *  
+         *  @param lambda Callable invoked with each leaf expression.
+         *  The callable can opt in to be invoked for a node expression.
          */
         template<class T, class L>
         void iterate_ast(const T& t, L&& lambda) {
             ast_iterator<T> iterator;
+
+#if defined(SQLITE_ORM_IF_CONSTEXPR_SUPPORTED) && __cpp_lib_is_invocable >= 201703L
+            // possibly invoke lambda with node itself
+            if constexpr (std::is_invocable<L, polyfill::bool_constant<true>, const T&>::value) {
+                lambda(polyfill::bool_constant<true>{}, t);
+            }
+#endif
+
             iterator(t, lambda);
         }
 
@@ -18739,7 +18752,7 @@ namespace sqlite_orm {
 #ifdef SQLITE_ORM_CPP20_RANGES_SUPPORTED
                 auto it = std::ranges::find(functions, name, &udf_proxy::name);
 #else
-                auto it = std::find_if(functions.begin(), functions.end(), [&name](auto& udfProxy) {
+                auto it = std::find_if(functions.begin(), functions.end(), [&name](const udf_proxy& udfProxy) {
                     return udfProxy.name == name;
                 });
 #endif
@@ -22662,6 +22675,42 @@ namespace sqlite_orm {
 #endif
         }
 
+#if defined(SQLITE_ORM_IF_CONSTEXPR_SUPPORTED) && __cpp_lib_is_invocable >= 201703L
+        /*
+         *  AST iteration callable that matches function call node expressions and throws a `orm_error_code::function_not_found` exception
+         *  if an application-defined function is not found among the registered application-defined scalar or aggregate functions.
+         */
+        struct udf_presence_checker {
+            const std::list<udf_proxy>& _scalarFunctions;
+            const std::list<udf_proxy>& _aggregateFunctions;
+
+            // examine `function_call` node expressions
+            template<class UDF, class... CallArgs>
+            void operator()(polyfill::bool_constant<true>, const function_call<UDF, CallArgs...>& udfCall) const {
+                auto&& name = udfCall.name();
+                if (!_contains(_scalarFunctions, name) && !_contains(_aggregateFunctions, name))
+                    SQLITE_ORM_CPP_UNLIKELY {
+                    throw std::system_error{orm_error_code::function_not_found, std::string(name)};
+                }
+            }
+
+            // swallow leaf expressions
+            template<class T>
+            void operator()(const T&) const {}
+
+            static bool _contains(const std::list<udf_proxy>& functions, const std::string_view& name) {
+#ifdef SQLITE_ORM_CPP20_RANGES_SUPPORTED
+                auto it = std::ranges::find(functions, name, &udf_proxy::name);
+#else
+                auto it = std::find_if(functions.begin(), functions.end(), [&name](const udf_proxy& udfProxy) {
+                    return udfProxy.name == name;
+                });
+#endif
+                return it != functions.end();
+            }
+        };
+#endif
+
         /**
          *  Storage class itself. Create an instanse to use it as an interfacto to sqlite db by calling `make_storage`
          *  function.
@@ -23770,6 +23819,10 @@ namespace sqlite_orm {
 
             template<typename S>
             prepared_statement_t<S> prepare_impl(S statement) {
+#if defined(SQLITE_ORM_IF_CONSTEXPR_SUPPORTED) && __cpp_lib_is_invocable >= 201703L
+                iterate_ast(statement, udf_presence_checker{this->scalarFunctions, this->aggregateFunctions});
+#endif
+
                 const auto& exprDBOs = db_objects_for_expression(this->db_objects, statement);
                 using context_t = serializer_context<polyfill::remove_cvref_t<decltype(exprDBOs)>>;
                 context_t context{exprDBOs};
@@ -23779,7 +23832,7 @@ namespace sqlite_orm {
                 auto con = this->get_connection();
                 std::string sql = serialize(statement, context);
                 sqlite3_stmt* stmt = prepare_stmt(con.get(), std::move(sql));
-                return prepared_statement_t<S>{std::forward<S>(statement), stmt, con};
+                return prepared_statement_t<S>{std::forward<S>(statement), stmt, std::move(con)};
             }
 
           public:
@@ -23947,6 +24000,9 @@ namespace sqlite_orm {
                 using object_type = expression_object_type_t<decltype(statement)>;
                 this->assert_mapped_type<object_type>();
                 this->assert_insertable_type<object_type>();
+                if (statement.range.first == statement.range.second) {
+                    throw std::system_error{orm_error_code::empty_range};
+                }
                 return this->prepare_impl(std::move(statement));
             }
 
@@ -23954,6 +24010,9 @@ namespace sqlite_orm {
             prepared_statement_t<E> prepare(E statement) {
                 using object_type = expression_object_type_t<decltype(statement)>;
                 this->assert_mapped_type<object_type>();
+                if (statement.range.first == statement.range.second) {
+                    throw std::system_error{orm_error_code::empty_range};
+                }
                 return this->prepare_impl(std::move(statement));
             }
 

--- a/tests/ast_iterator_tests.cpp
+++ b/tests/ast_iterator_tests.cpp
@@ -10,16 +10,41 @@ using internal::column_alias;
 using internal::column_pointer;
 using internal::iterate_ast;
 
+#if __cpp_generic_lambdas >= 201707L
+template<class... L>
+struct overload : L... {
+    using L::operator()...;
+};
+#endif
+
 TEST_CASE("ast_iterator") {
     struct User {
         int id = 0;
         std::string name;
     };
+
     std::vector<std::type_index> typeIndexes;
     decltype(typeIndexes) expected;
-    auto lambda = [&typeIndexes](auto& value) {
+    const auto lambda = [&typeIndexes](auto& value) {
         typeIndexes.push_back(typeid(value));
     };
+#if __cpp_generic_lambdas >= 201707L
+    const auto nodeLambda = overload(
+        [&typeIndexes]<class UDF, class... CallArgs>(polyfill::bool_constant<true>,
+                                                     const internal::function_call<UDF, CallArgs...>& udfCall) {
+            typeIndexes.push_back(typeid(udfCall.name));
+        },
+        [&typeIndexes](polyfill::bool_constant<true>, const internal::named_collate_base& collateCall) {
+            typeIndexes.push_back(typeid(collateCall));
+        },
+        [&typeIndexes]<class T, class X, class Y, class Z>(polyfill::bool_constant<true>,
+                                                           const internal::highlight_t<T, X, Y, Z>&) {
+            typeIndexes.push_back(typeid(T));
+        },
+        // swallow leaf expressions
+        [](auto&) {});
+#endif
+
     SECTION("bindables") {
         auto node = select(1);
         expected.push_back(typeid(int));
@@ -411,11 +436,25 @@ TEST_CASE("ast_iterator") {
 #endif
     SECTION("highlight") {
         auto expression = highlight<User>(0, std::string("<b>"), std::string("</b>"));
-        expected.push_back(typeid(expression));
         expected.push_back(typeid(int));
         expected.push_back(typeid(std::string));
         expected.push_back(typeid(std::string));
         iterate_ast(expression, lambda);
     }
+#if __cpp_generic_lambdas >= 201707L
+    SECTION("node expressions") {
+        struct Func {
+            static const char* name();
+            const std::string& operator()(const std::string& value) const;
+        };
+        auto expression1 = func<Func>(&User::name);
+        auto expression2 = is_equal("", "").collate("");
+        auto expression3 = highlight<User>(0, std::string("<b>"), std::string("</b>"));
+        expected.assign({typeid(internal::udf_holder<Func>), typeid(internal::named_collate_base), typeid(User)});
+        iterate_ast(expression1, nodeLambda);
+        iterate_ast(expression2, nodeLambda);
+        iterate_ast(expression3, nodeLambda);
+    }
+#endif
     REQUIRE(typeIndexes == expected);
 }

--- a/tests/ast_iterator_tests.cpp
+++ b/tests/ast_iterator_tests.cpp
@@ -10,11 +10,15 @@ using internal::column_alias;
 using internal::column_pointer;
 using internal::iterate_ast;
 
-#if __cpp_generic_lambdas >= 201707L
+#ifdef SQLITE_ORM_EXPLICIT_GENERIC_LAMBDA_SUPPORTED
 template<class... L>
-struct overload : L... {
+struct overloaded : L... {
     using L::operator()...;
 };
+#if __cpp_deduction_guides < 201907L
+template<class... L>
+overloaded(L...) -> overloaded<L...>;
+#endif
 #endif
 
 TEST_CASE("ast_iterator") {
@@ -28,8 +32,8 @@ TEST_CASE("ast_iterator") {
     const auto lambda = [&typeIndexes](auto& value) {
         typeIndexes.push_back(typeid(value));
     };
-#if __cpp_generic_lambdas >= 201707L
-    const auto nodeLambda = overload(
+#ifdef SQLITE_ORM_EXPLICIT_GENERIC_LAMBDA_SUPPORTED
+    const auto nodeLambda = overloaded(
         [&typeIndexes]<class UDF, class... CallArgs>(polyfill::bool_constant<true>,
                                                      const internal::function_call<UDF, CallArgs...>& udfCall) {
             typeIndexes.push_back(typeid(udfCall.name));
@@ -441,7 +445,7 @@ TEST_CASE("ast_iterator") {
         expected.push_back(typeid(std::string));
         iterate_ast(expression, lambda);
     }
-#if __cpp_generic_lambdas >= 201707L
+#ifdef SQLITE_ORM_EXPLICIT_GENERIC_LAMBDA_SUPPORTED
     SECTION("node expressions") {
         struct Func {
             static const char* name();

--- a/tests/ast_iterator_tests.cpp
+++ b/tests/ast_iterator_tests.cpp
@@ -33,7 +33,7 @@ TEST_CASE("ast_iterator") {
         typeIndexes.push_back(typeid(value));
     };
 #ifdef SQLITE_ORM_EXPLICIT_GENERIC_LAMBDA_SUPPORTED
-    const auto nodeLambda = overloaded(
+    const auto nodeLambda = overloaded{
         [&typeIndexes]<class UDF, class... CallArgs>(polyfill::bool_constant<true>,
                                                      const internal::function_call<UDF, CallArgs...>& udfCall) {
             typeIndexes.push_back(typeid(udfCall.name));
@@ -46,7 +46,7 @@ TEST_CASE("ast_iterator") {
             typeIndexes.push_back(typeid(T));
         },
         // swallow leaf expressions
-        [](auto&) {});
+        [](auto&) {}};
 #endif
 
     SECTION("bindables") {

--- a/tests/constraints/unique.cpp
+++ b/tests/constraints/unique.cpp
@@ -1,10 +1,15 @@
 #include <sqlite_orm/sqlite_orm.h>
 #include <catch2/catch_all.hpp>
+#include "../catch_matchers.h"
 
 using namespace sqlite_orm;
 
 TEST_CASE("Unique") {
-    using Catch::Matchers::ContainsSubstring;
+#if SQLITE_VERSION_NUMBER >= 3008008
+    const ErrorCodeExceptionMatcher uniqueExceptionMatcher(sqlite_errc(SQLITE_CONSTRAINT_UNIQUE));
+#else
+    const ErrorCodeExceptionMatcher uniqueExceptionMatcher(sqlite_errc(SQLITE_CONSTRAINT));
+#endif
 
     struct Contact {
         int id = 0;
@@ -39,12 +44,13 @@ TEST_CASE("Unique") {
 
     storage.insert(Contact{0, "John", "Doe", "john.doe@gmail.com"});
 
-    REQUIRE_THROWS_WITH(storage.insert(Contact{0, "Johnny", "Doe", "john.doe@gmail.com"}),
-                        ContainsSubstring("constraint failed"));
+    REQUIRE_THROWS_MATCHES(storage.insert(Contact{0, "Johnny", "Doe", "john.doe@gmail.com"}),
+                           std::system_error,
+                           uniqueExceptionMatcher);
 
     storage.insert(Shape{0, "red", "green"});
     storage.insert(Shape{0, "red", "blue"});
-    REQUIRE_THROWS_WITH(storage.insert(Shape{0, "red", "green"}), ContainsSubstring("constraint failed"));
+    REQUIRE_THROWS_MATCHES(storage.insert(Shape{0, "red", "green"}), std::system_error, uniqueExceptionMatcher);
 
     std::vector<List> lists(2);
     REQUIRE_NOTHROW(storage.insert_range(lists.begin(), lists.end()));

--- a/tests/prepared_statement_tests/get.cpp
+++ b/tests/prepared_statement_tests/get.cpp
@@ -1,5 +1,6 @@
 #include <sqlite_orm/sqlite_orm.h>
 #include <catch2/catch_all.hpp>
+#include "../catch_matchers.h"
 
 #include "prepared_common.h"
 
@@ -8,8 +9,8 @@ using namespace sqlite_orm;
 
 TEST_CASE("Prepared get") {
     using namespace PreparedStatementTests;
-    using Catch::Matchers::ContainsSubstring;
     using Catch::Matchers::UnorderedEquals;
+    const ErrorCodeExceptionMatcher notFoundExceptionMatcher(orm_error_code::not_found);
 
     const int defaultVisitTime = 50;
 
@@ -73,7 +74,7 @@ TEST_CASE("Prepared get") {
             }
             {
                 get<0>(statement) = 4;
-                REQUIRE_THROWS_WITH(storage.execute(statement), ContainsSubstring("Not found"));
+                REQUIRE_THROWS_MATCHES(storage.execute(statement), std::system_error, notFoundExceptionMatcher);
             }
         }
     }
@@ -95,7 +96,7 @@ TEST_CASE("Prepared get") {
             //..
         }
         SECTION("execute") {
-            REQUIRE_THROWS_WITH(storage.execute(statement), ContainsSubstring("Not found"));
+            REQUIRE_THROWS_MATCHES(storage.execute(statement), std::system_error, notFoundExceptionMatcher);
         }
     }
     {

--- a/tests/prepared_statement_tests/insert.cpp
+++ b/tests/prepared_statement_tests/insert.cpp
@@ -1,5 +1,6 @@
 #include <sqlite_orm/sqlite_orm.h>
 #include <catch2/catch_all.hpp>
+#include <cstring>  //  std::strcmp
 
 #include "prepared_common.h"
 
@@ -76,7 +77,7 @@ TEST_CASE("Prepared insert") {
                         insert(into<User>(), columns(&User::id, &User::name), values(std::make_tuple(1, "Ellie"))));
                     storage.execute(statement);
                     REQUIRE(get<0>(statement) == 1);
-                    REQUIRE(::strcmp(get<1>(statement), "Ellie") == 0);
+                    REQUIRE(std::strcmp(get<1>(statement), "Ellie") == 0);
                 }
                 SECTION("no statement") {
                     storage.insert(into<User>(), columns(&User::id, &User::name), values(std::make_tuple(1, "Ellie")));
@@ -93,9 +94,9 @@ TEST_CASE("Prepared insert") {
                                                values(std::make_tuple(1, "Ellie"), std::make_tuple(5, "Calvin"))));
                     storage.execute(statement);
                     REQUIRE(get<0>(statement) == 1);
-                    REQUIRE(::strcmp(get<1>(statement), "Ellie") == 0);
+                    REQUIRE(std::strcmp(get<1>(statement), "Ellie") == 0);
                     REQUIRE(get<2>(statement) == 5);
-                    REQUIRE(::strcmp(get<3>(statement), "Calvin") == 0);
+                    REQUIRE(std::strcmp(get<3>(statement), "Calvin") == 0);
                 }
                 SECTION("no statement") {
                     storage.insert(into<User>(),

--- a/tests/prepared_statement_tests/insert_explicit.cpp
+++ b/tests/prepared_statement_tests/insert_explicit.cpp
@@ -1,5 +1,6 @@
 #include <sqlite_orm/sqlite_orm.h>
 #include <catch2/catch_all.hpp>
+#include "../catch_matchers.h"
 
 #include "prepared_common.h"
 
@@ -8,8 +9,12 @@ using namespace sqlite_orm;
 
 TEST_CASE("Prepared insert explicit") {
     using namespace PreparedStatementTests;
-    using Catch::Matchers::ContainsSubstring;
     using Catch::Matchers::UnorderedEquals;
+#if SQLITE_VERSION_NUMBER >= 3008008
+    const ErrorCodeExceptionMatcher primaryKeyExceptionMatcher(sqlite_errc(SQLITE_CONSTRAINT_PRIMARYKEY));
+#else
+    const ErrorCodeExceptionMatcher primaryKeyExceptionMatcher(sqlite_errc(SQLITE_CONSTRAINT));
+#endif
 
     const int defaultVisitTime = 50;
 
@@ -68,7 +73,7 @@ TEST_CASE("Prepared insert explicit") {
             {
                 user.id = 6;
                 user.name = "Nate Dogg";
-                REQUIRE_THROWS_WITH(storage.execute(statement), ContainsSubstring("constraint failed"));
+                REQUIRE_THROWS_MATCHES(storage.execute(statement), std::system_error, primaryKeyExceptionMatcher);
 
                 get<0>(statement) = user;
                 auto insertedId = storage.execute(statement);

--- a/tests/prepared_statement_tests/insert_range.cpp
+++ b/tests/prepared_statement_tests/insert_range.cpp
@@ -1,6 +1,7 @@
 #include <sqlite_orm/sqlite_orm.h>
 #include <catch2/catch_all.hpp>
 #include <algorithm>
+#include "../catch_matchers.h"
 
 #include "prepared_common.h"
 
@@ -9,8 +10,8 @@ using namespace sqlite_orm;
 
 TEST_CASE("Prepared insert range") {
     using namespace PreparedStatementTests;
-    using Catch::Matchers::ContainsSubstring;
     using Catch::Matchers::UnorderedEquals;
+    const ErrorCodeExceptionMatcher emptyRangeExceptionMatcher(orm_error_code::empty_range);
 
     const int defaultVisitTime = 50;
 
@@ -41,22 +42,21 @@ TEST_CASE("Prepared insert range") {
     storage.replace(UserAndVisit{3, 1, "Shine on"});
 
     std::vector<User> users;
-    std::vector<User> expected;
-    expected.push_back(User{1, "Team BS"});
-    expected.push_back(User{2, "Shy'm"});
-    expected.push_back(User{3, "Maître Gims"});
+    std::vector<User> expected{{1, "Team BS"}, {2, "Shy'm"}, {3, "Maître Gims"}};
 
     SECTION("empty") {
         SECTION("strict") {
-            REQUIRE_THROWS_WITH(storage.prepare(insert_range(users.begin(), users.end())),
-                                ContainsSubstring("incomplete input"));
+            REQUIRE_THROWS_MATCHES(storage.prepare(insert_range(users.begin(), users.end())),
+                                   std::system_error,
+                                   emptyRangeExceptionMatcher);
         }
         SECTION("container with pointers") {
             std::vector<std::unique_ptr<User>> usersPointers;
-            REQUIRE_THROWS_WITH(
+            REQUIRE_THROWS_MATCHES(
                 storage.prepare(
                     insert_range(usersPointers.begin(), usersPointers.end(), &std::unique_ptr<User>::operator*)),
-                ContainsSubstring("incomplete input"));
+                std::system_error,
+                emptyRangeExceptionMatcher);
         }
     }
     SECTION("one") {

--- a/tests/prepared_statement_tests/replace.cpp
+++ b/tests/prepared_statement_tests/replace.cpp
@@ -1,5 +1,6 @@
 #include <sqlite_orm/sqlite_orm.h>
 #include <catch2/catch_all.hpp>
+#include <cstring>  //  std::strcmp
 
 #include "prepared_common.h"
 
@@ -41,7 +42,7 @@ TEST_CASE("Prepared replace") {
                         replace(into<User>(), columns(&User::id, &User::name), values(std::make_tuple(1, "Ellie"))));
                     storage.execute(statement);
                     REQUIRE(get<0>(statement) == 1);
-                    REQUIRE(::strcmp(get<1>(statement), "Ellie") == 0);
+                    REQUIRE(std::strcmp(get<1>(statement), "Ellie") == 0);
                 }
                 SECTION("no statement") {
                     storage.replace(into<User>(), columns(&User::id, &User::name), values(std::make_tuple(1, "Ellie")));
@@ -56,9 +57,9 @@ TEST_CASE("Prepared replace") {
                                                 values(std::make_tuple(1, "Ellie"), std::make_tuple(5, "Calvin"))));
                     storage.execute(statement);
                     REQUIRE(get<0>(statement) == 1);
-                    REQUIRE(::strcmp(get<1>(statement), "Ellie") == 0);
+                    REQUIRE(std::strcmp(get<1>(statement), "Ellie") == 0);
                     REQUIRE(get<2>(statement) == 5);
-                    REQUIRE(::strcmp(get<3>(statement), "Calvin") == 0);
+                    REQUIRE(std::strcmp(get<3>(statement), "Calvin") == 0);
                 }
                 SECTION("no statement") {
                     storage.replace(into<User>(),

--- a/tests/prepared_statement_tests/replace_range.cpp
+++ b/tests/prepared_statement_tests/replace_range.cpp
@@ -41,9 +41,6 @@ TEST_CASE("Prepared replace range") {
     std::vector<User> users;
     std::vector<std::unique_ptr<User>> userPointers;
     std::vector<User> expected;
-    auto lambda = [](const std::unique_ptr<User>& pointer) -> const User& {
-        return *pointer;
-    };
     SECTION("empty") {
         using Catch::Matchers::ContainsSubstring;
 
@@ -55,8 +52,10 @@ TEST_CASE("Prepared replace range") {
                                 ContainsSubstring("incomplete input"));
         }
         SECTION("pointers") {
-            REQUIRE_THROWS_WITH(storage.prepare(replace_range<User>(userPointers.begin(), userPointers.end(), lambda)),
-                                ContainsSubstring("incomplete input"));
+            REQUIRE_THROWS_WITH(
+                storage.prepare(
+                    replace_range<User>(userPointers.begin(), userPointers.end(), &std::unique_ptr<User>::operator*)),
+                ContainsSubstring("incomplete input"));
         }
     }
     SECTION("one existing") {
@@ -73,7 +72,8 @@ TEST_CASE("Prepared replace range") {
         }
         SECTION("pointers") {
             userPointers.push_back(std::make_unique<User>(user));
-            auto statement = storage.prepare(replace_range<User>(userPointers.begin(), userPointers.end(), lambda));
+            auto statement = storage.prepare(
+                replace_range<User>(userPointers.begin(), userPointers.end(), &std::unique_ptr<User>::operator*));
             REQUIRE(get<0>(statement) == userPointers.begin());
             REQUIRE(get<1>(statement) == userPointers.end());
             storage.execute(statement);
@@ -97,7 +97,8 @@ TEST_CASE("Prepared replace range") {
         SECTION("pointers") {
             userPointers.push_back(std::make_unique<User>(user));
             userPointers.push_back(std::make_unique<User>(user2));
-            auto statement = storage.prepare(replace_range<User>(userPointers.begin(), userPointers.end(), lambda));
+            auto statement = storage.prepare(
+                replace_range<User>(userPointers.begin(), userPointers.end(), &std::unique_ptr<User>::operator*));
             REQUIRE(get<0>(statement) == userPointers.begin());
             REQUIRE(get<1>(statement) == userPointers.end());
             storage.execute(statement);
@@ -121,7 +122,8 @@ TEST_CASE("Prepared replace range") {
             userPointers.push_back(std::make_unique<User>(user));
             userPointers.push_back(std::make_unique<User>(user2));
             userPointers.push_back(std::make_unique<User>(user3));
-            auto statement = storage.prepare(replace_range<User>(userPointers.begin(), userPointers.end(), lambda));
+            auto statement = storage.prepare(
+                replace_range<User>(userPointers.begin(), userPointers.end(), &std::unique_ptr<User>::operator*));
             REQUIRE(get<0>(statement) == userPointers.begin());
             REQUIRE(get<1>(statement) == userPointers.end());
             storage.execute(statement);

--- a/tests/prepared_statement_tests/replace_range.cpp
+++ b/tests/prepared_statement_tests/replace_range.cpp
@@ -1,5 +1,6 @@
 #include <sqlite_orm/sqlite_orm.h>
 #include <catch2/catch_all.hpp>
+#include "../catch_matchers.h"
 
 #include "prepared_common.h"
 
@@ -9,6 +10,7 @@ using namespace sqlite_orm;
 TEST_CASE("Prepared replace range") {
     using namespace PreparedStatementTests;
     using Catch::Matchers::UnorderedEquals;
+    const ErrorCodeExceptionMatcher emptyRangeExceptionMatcher(orm_error_code::empty_range);
 
     const int defaultVisitTime = 50;
 
@@ -42,20 +44,20 @@ TEST_CASE("Prepared replace range") {
     std::vector<std::unique_ptr<User>> userPointers;
     std::vector<User> expected;
     SECTION("empty") {
-        using Catch::Matchers::ContainsSubstring;
-
         expected.push_back(User{1, "Team BS"});
         expected.push_back(User{2, "Shy'm"});
         expected.push_back(User{3, "Maître Gims"});
         SECTION("straight") {
-            REQUIRE_THROWS_WITH(storage.prepare(replace_range(users.begin(), users.end())),
-                                ContainsSubstring("incomplete input"));
+            REQUIRE_THROWS_MATCHES(storage.prepare(replace_range(users.begin(), users.end())),
+                                   std::system_error,
+                                   emptyRangeExceptionMatcher);
         }
         SECTION("pointers") {
-            REQUIRE_THROWS_WITH(
+            REQUIRE_THROWS_MATCHES(
                 storage.prepare(
                     replace_range<User>(userPointers.begin(), userPointers.end(), &std::unique_ptr<User>::operator*)),
-                ContainsSubstring("incomplete input"));
+                std::system_error,
+                emptyRangeExceptionMatcher);
         }
     }
     SECTION("one existing") {

--- a/tests/schema/index_tests.cpp
+++ b/tests/schema/index_tests.cpp
@@ -1,5 +1,6 @@
 #include <sqlite_orm/sqlite_orm.h>
 #include <catch2/catch_all.hpp>
+#include "../catch_matchers.h"
 
 using namespace sqlite_orm;
 
@@ -66,7 +67,11 @@ TEST_CASE("index") {
 
 #ifdef SQLITE_ORM_OPTIONAL_SUPPORTED
 TEST_CASE("filtered index") {
-    using Catch::Matchers::ContainsSubstring;
+#if SQLITE_VERSION_NUMBER >= 3008008
+    const ErrorCodeExceptionMatcher uniqueExceptionMatcher(sqlite_errc(SQLITE_CONSTRAINT_UNIQUE));
+#else
+    const ErrorCodeExceptionMatcher uniqueExceptionMatcher(sqlite_errc(SQLITE_CONSTRAINT));
+#endif
 
     struct Test {
         std::optional<int> field1 = 0;
@@ -80,7 +85,7 @@ TEST_CASE("filtered index") {
         REQUIRE_NOTHROW(storage.sync_schema());
 
         storage.insert(Test{1, std::nullopt});
-        REQUIRE_THROWS_WITH(storage.insert(Test{1, std::nullopt}), ContainsSubstring("constraint failed"));
+        REQUIRE_THROWS_MATCHES(storage.insert(Test{1, std::nullopt}), std::system_error, uniqueExceptionMatcher);
     }
     SECTION("2") {
         auto storage = make_storage(

--- a/tests/storage_non_crud_tests.cpp
+++ b/tests/storage_non_crud_tests.cpp
@@ -2,6 +2,7 @@
 #include <sqlite_orm/sqlite_orm.h>
 #include <catch2/catch_all.hpp>
 #include <cstring>  //  std::strcmp
+#include "catch_matchers.h"
 
 using namespace sqlite_orm;
 
@@ -504,7 +505,11 @@ TEST_CASE("Remove all") {
 }
 
 TEST_CASE("Explicit insert") {
-    using Catch::Matchers::ContainsSubstring;
+#if SQLITE_VERSION_NUMBER >= 3008008
+    const ErrorCodeExceptionMatcher notNullExceptionMatcher(sqlite_errc(SQLITE_CONSTRAINT_NOTNULL));
+#else
+    const ErrorCodeExceptionMatcher notNullExceptionMatcher(sqlite_errc(SQLITE_CONSTRAINT));
+#endif
 
     struct User {
         int id;
@@ -593,8 +598,9 @@ TEST_CASE("Explicit insert") {
         SECTION("one column") {
             User user4;
             user4.name = "Egor";
-            REQUIRE_THROWS_WITH(storage.insert(user4, columns(&User::name)),
-                                ContainsSubstring("NOT NULL constraint failed"));
+            REQUIRE_THROWS_MATCHES(storage.insert(user4, columns(&User::name)),
+                                   std::system_error,
+                                   notNullExceptionMatcher);
         }
     }
     SECTION("visit") {
@@ -626,8 +632,9 @@ TEST_CASE("Explicit insert") {
             Visit visit3;
             visit3.setId(10);
             SECTION("getter") {
-                REQUIRE_THROWS_WITH(storage.insert(visit3, columns(&Visit::id)),
-                                    ContainsSubstring("NOT NULL constraint failed"));
+                REQUIRE_THROWS_MATCHES(storage.insert(visit3, columns(&Visit::id)),
+                                       std::system_error,
+                                       notNullExceptionMatcher);
             }
         }
     }

--- a/tests/storage_non_crud_tests.cpp
+++ b/tests/storage_non_crud_tests.cpp
@@ -1,6 +1,7 @@
 #include <sqlite3.h>
 #include <sqlite_orm/sqlite_orm.h>
 #include <catch2/catch_all.hpp>
+#include <cstring>  //  std::strcmp
 
 using namespace sqlite_orm;
 
@@ -268,9 +269,9 @@ TEST_CASE("Select") {
             throw std::runtime_error(sqlite3_errmsg(db));
         }
         REQUIRE(sqlite3_column_int(stmt, 0) == firstId);
-        REQUIRE(::strcmp((const char*)sqlite3_column_text(stmt, 1), "best") == 0);
-        REQUIRE(::strcmp((const char*)sqlite3_column_text(stmt, 2), "behaviour") == 0);
-        REQUIRE(::strcmp((const char*)sqlite3_column_text(stmt, 3), "hey") == 0);
+        REQUIRE(std::strcmp((const char*)sqlite3_column_text(stmt, 1), "best") == 0);
+        REQUIRE(std::strcmp((const char*)sqlite3_column_text(stmt, 2), "behaviour") == 0);
+        REQUIRE(std::strcmp((const char*)sqlite3_column_text(stmt, 3), "hey") == 0);
         REQUIRE(sqlite3_column_int(stmt, 4) == 5);
         sqlite3_finalize(stmt);
     }

--- a/tests/table_name_collector.cpp
+++ b/tests/table_name_collector.cpp
@@ -18,6 +18,11 @@ TEST_CASE("table name collector") {
     internal::serializer_context<db_objects_t> context{dbObjects};
     auto collector = internal::make_table_name_collector(context.db_objects);
 
+    SECTION("static tests") {
+        STATIC_REQUIRE(polyfill::is_invocable<internal::table_name_collector<std::tuple<>>,
+                                              polyfill::bool_constant<true>,
+                                              internal::highlight_t<User, int, int, int>>::value);
+    }
     SECTION("from table") {
         SECTION("regular column") {
             auto expression = &User::id;

--- a/tests/table_name_collector.cpp
+++ b/tests/table_name_collector.cpp
@@ -21,7 +21,7 @@ TEST_CASE("table name collector") {
     SECTION("static tests") {
         STATIC_REQUIRE(polyfill::is_invocable<internal::table_name_collector<std::tuple<>>,
                                               polyfill::bool_constant<true>,
-                                              internal::highlight_t<User, int, int, int>>::value);
+                                              const internal::highlight_t<User, int, int, int>&>::value);
     }
     SECTION("from table") {
         SECTION("regular column") {

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -1,5 +1,6 @@
 #include <sqlite_orm/sqlite_orm.h>
 #include <catch2/catch_all.hpp>
+#include "catch_matchers.h"
 
 #include <vector>  //  std::vector
 #include <string>  //  std::string
@@ -102,7 +103,11 @@ TEST_CASE("Limits") {
 }
 
 TEST_CASE("Custom collate") {
-    using Catch::Matchers::ContainsSubstring;
+#if SQLITE_VERSION_NUMBER >= 3008008
+    const ErrorCodeExceptionMatcher collSequExceptionMatcher(sqlite_errc(SQLITE_ERROR_MISSING_COLLSEQ));
+#else
+    const ErrorCodeExceptionMatcher collSequExceptionMatcher(sqlite_errc(SQLITE_ERROR));
+#endif
 
     struct Item {
         int id;
@@ -187,12 +192,16 @@ TEST_CASE("Custom collate") {
     } else {
         storage.delete_collation<OtotoCollation>();
     }
-    REQUIRE_THROWS_WITH(storage.select(&Item::name, where(is_equal(&Item::name, "Mercury").collate("ototo"))),
-                        ContainsSubstring("no such collation sequence"));
-    REQUIRE_THROWS_WITH(storage.select(&Item::name, where(is_equal(&Item::name, "Mercury").collate<OtotoCollation>())),
-                        ContainsSubstring("no such collation sequence"));
-    REQUIRE_THROWS_WITH(storage.select(&Item::name, where(is_equal(&Item::name, "Mercury").collate("ototo2"))),
-                        ContainsSubstring("no such collation sequence"));
+    REQUIRE_THROWS_MATCHES(storage.select(&Item::name, where(is_equal(&Item::name, "Mercury").collate("ototo"))),
+                           std::system_error,
+                           collSequExceptionMatcher);
+    REQUIRE_THROWS_MATCHES(
+        storage.select(&Item::name, where(is_equal(&Item::name, "Mercury").collate<OtotoCollation>())),
+        std::system_error,
+        collSequExceptionMatcher);
+    REQUIRE_THROWS_MATCHES(storage.select(&Item::name, where(is_equal(&Item::name, "Mercury").collate("ototo2"))),
+                           std::system_error,
+                           collSequExceptionMatcher);
 
     rows = storage.select(&Item::name,
                           where(is_equal(&Item::name, "Mercury").collate("alwaysequal")),

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -4,6 +4,7 @@
 #include <vector>  //  std::vector
 #include <string>  //  std::string
 #include <cstdio>  //  std::remove
+#include <cstring>  //  std::strncmp
 
 using namespace sqlite_orm;
 
@@ -111,7 +112,7 @@ TEST_CASE("Custom collate") {
     struct OtotoCollation {
         int operator()(int leftLength, const void* lhs, int rightLength, const void* rhs) const {
             if (leftLength == rightLength) {
-                return ::strncmp((const char*)lhs, (const char*)rhs, leftLength);
+                return std::strncmp((const char*)lhs, (const char*)rhs, leftLength);
             } else {
                 return 1;
             }
@@ -153,7 +154,7 @@ TEST_CASE("Custom collate") {
     if (useLegacyScript) {
         storage.create_collation("ototo", [](int leftLength, const void* lhs, int rightLength, const void* rhs) {
             if (leftLength == rightLength) {
-                return ::strncmp((const char*)lhs, (const char*)rhs, leftLength);
+                return std::strncmp((const char*)lhs, (const char*)rhs, leftLength);
             } else {
                 return 1;
             }

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -103,7 +103,7 @@ TEST_CASE("Limits") {
 }
 
 TEST_CASE("Custom collate") {
-#if defined(SQLITE_ORM_STRING_VIEW_SUPPORTED) && SQLITE_VERSION_NUMBER >= 3008008
+#if defined(SQLITE_ORM_STRING_VIEW_SUPPORTED) || SQLITE_VERSION_NUMBER >= 3008008
     const ErrorCodeExceptionMatcher collSequExceptionMatcher(sqlite_errc(SQLITE_ERROR_MISSING_COLLSEQ));
 #else
     const ErrorCodeExceptionMatcher collSequExceptionMatcher(sqlite_errc(SQLITE_ERROR));

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -103,7 +103,7 @@ TEST_CASE("Limits") {
 }
 
 TEST_CASE("Custom collate") {
-#if SQLITE_VERSION_NUMBER >= 3008008
+#if defined(SQLITE_ORM_STRING_VIEW_SUPPORTED) && SQLITE_VERSION_NUMBER >= 3008008
     const ErrorCodeExceptionMatcher collSequExceptionMatcher(sqlite_errc(SQLITE_ERROR_MISSING_COLLSEQ));
 #else
     const ErrorCodeExceptionMatcher collSequExceptionMatcher(sqlite_errc(SQLITE_ERROR));

--- a/tests/transaction_tests.cpp
+++ b/tests/transaction_tests.cpp
@@ -64,6 +64,9 @@ TEST_CASE("begin_transaction") {
 }
 
 TEST_CASE("Transaction guard") {
+    const ErrorCodeExceptionMatcher notFoundExceptionMatcher(orm_error_code::not_found);
+    const ErrorCodeExceptionMatcher busyExceptionMatcher(sqlite_errc(SQLITE_BUSY));
+
     std::remove("guard.sqlite");
     auto table =
         make_table("objects", make_column("id", &Object::id, primary_key()), make_column("name", &Object::name));
@@ -74,7 +77,6 @@ TEST_CASE("Transaction guard") {
 
     storage.insert(Object{0, "Jack"});
 
-    const ErrorCodeExceptionMatcher notFoundExceptionMatcher(orm_error_code::not_found);
     SECTION("insert, call make a storage to call an exception and check that rollback was fired") {
         auto countBefore = storage.count<Object>();
         SECTION("transaction_guard") {
@@ -329,8 +331,6 @@ TEST_CASE("Transaction guard") {
         REQUIRE(storage.count<Object>() == countBefore);
     }
     SECTION("exception propagated from dtor") {
-        using Catch::Matchers::ContainsSubstring;
-
         // create a second database connection
         auto storage2 = make_storage("guard.sqlite", table);
         auto guard2 = storage2.transaction_guard();
@@ -340,7 +340,7 @@ TEST_CASE("Transaction guard") {
         auto guard = new (&buffer) internal::transaction_guard_t{storage.transaction_guard()};
         storage.insert<Object>({});
         guard->commit_on_destroy = true;
-        REQUIRE_THROWS_WITH(guard->~transaction_guard_t(), ContainsSubstring("database is locked"));
+        REQUIRE_THROWS_MATCHES(guard->~transaction_guard_t(), std::system_error, busyExceptionMatcher);
     }
     std::remove("guard.sqlite");
 }

--- a/tests/user_defined_functions.cpp
+++ b/tests/user_defined_functions.cpp
@@ -280,7 +280,7 @@ struct NonDefaultCtorAggregateFunction {
 
 TEST_CASE("custom functions") {
     const ErrorCodeExceptionMatcher noMemExceptionMatcher(sqlite_errc(SQLITE_NOMEM));
-#if defined(SQLITE_ORM_IF_CONSTEXPR_SUPPORTED) && __cpp_lib_is_invocable >= 201703L
+#ifdef SQLITE_ORM_STRING_VIEW_SUPPORTED
     const ErrorCodeExceptionMatcher notFoundExceptionMatcher(orm_error_code::function_not_found);
 #else
     const ErrorCodeExceptionMatcher notFoundExceptionMatcher(sqlite_errc(SQLITE_ERROR));

--- a/tests/user_defined_functions.cpp
+++ b/tests/user_defined_functions.cpp
@@ -279,8 +279,12 @@ struct NonDefaultCtorAggregateFunction {
 };
 
 TEST_CASE("custom functions") {
-    using Catch::Matchers::ContainsSubstring;
     const ErrorCodeExceptionMatcher noMemExceptionMatcher(sqlite_errc(SQLITE_NOMEM));
+#if defined(SQLITE_ORM_IF_CONSTEXPR_SUPPORTED) && __cpp_lib_is_invocable >= 201703L
+    const ErrorCodeExceptionMatcher notFoundExceptionMatcher(orm_error_code::function_not_found);
+#else
+    const ErrorCodeExceptionMatcher notFoundExceptionMatcher(sqlite_errc(SQLITE_ERROR));
+#endif
 
     SqrtFunction::callsCount = 0;
     StatelessHasPrefixFunction::callsCount = 0;
@@ -314,7 +318,7 @@ TEST_CASE("custom functions") {
     storage.delete_aggregate_function<NonAllocatableAggregateFunction>();
 
     //   call before creation
-    REQUIRE_THROWS_WITH(storage.select(func<SqrtFunction>(4)), ContainsSubstring("no such function"));
+    REQUIRE_THROWS_MATCHES(storage.select(func<SqrtFunction>(4)), std::system_error, notFoundExceptionMatcher);
 
     //  create function
     REQUIRE(SqrtFunction::callsCount == 0);

--- a/tests/user_defined_functions.cpp
+++ b/tests/user_defined_functions.cpp
@@ -280,6 +280,7 @@ struct NonDefaultCtorAggregateFunction {
 
 TEST_CASE("custom functions") {
     using Catch::Matchers::ContainsSubstring;
+    const ErrorCodeExceptionMatcher noMemExceptionMatcher(sqlite_errc(SQLITE_NOMEM));
 
     SqrtFunction::callsCount = 0;
     StatelessHasPrefixFunction::callsCount = 0;
@@ -309,7 +310,7 @@ TEST_CASE("custom functions") {
     // test w/o a result set, i.e when the final aggregate call is the first to require the aggregate function
     REQUIRE_THROWS_MATCHES(storage.select(func<NonAllocatableAggregateFunction>(&User::id)),
                            std::system_error,
-                           ErrorCodeExceptionMatcher(sqlite_errc(SQLITE_NOMEM)));
+                           noMemExceptionMatcher);
     storage.delete_aggregate_function<NonAllocatableAggregateFunction>();
 
     //   call before creation
@@ -425,7 +426,7 @@ TEST_CASE("custom functions") {
     storage.create_aggregate_function<NonAllocatableAggregateFunction>();
     REQUIRE_THROWS_MATCHES(storage.select(func<NonAllocatableAggregateFunction>(&User::id)),
                            std::system_error,
-                           ErrorCodeExceptionMatcher(sqlite_errc(SQLITE_NOMEM)));
+                           noMemExceptionMatcher);
     storage.delete_aggregate_function<NonAllocatableAggregateFunction>();
 
     storage.create_scalar_function<FirstFunction>();


### PR DESCRIPTION
This PR addresses a [comment by @jagerman](https://github.com/fnc12/sqlite_orm/issues/707#issuecomment-859649406).

The problem solved is the race condition between executing a statement and retrieving the last error from SQLite.
There are two ways to fix this: Either handle errors solely based on the return code of an API call. Or serialize access to the DB handle.

This PR implements handling errors based on the return code.

When handling errors solely based on the return code, SQLite obviously cannot provide as much information as to why (or where) a statement failed. I consider this as a flaw in SQLite as it would be easily solvable with storing the last error per thread in the SQLite3 library.

Important things to know:
* The library can handle empty ranges of insert/replace statements and unregistered function errors up-front. SQLite would only return a generic `SQLITE_ERROR` error value.
* Checking missing application-defined collation sequences wasn't pursued because SQLite will at least return a dedicated `SQLITE_ERROR_MISSING_COLLSEQ` extended error value. It would be easily implementable.
* Detailed information of constraint errors [`SQLITE_CONSTRAINT_*`], e.g. about the specific column violating a constraint (e.g. primary key, foreign key, not null) is lost; only the type of constraint violation is known.

Additional improvements:
* Enabled SQLite extended error codes
* Maximum efficient result row stepping loop. Returning instead of looping on a condition saves a couple of instructions.