### PR TITLE
moved cast_t to ast folder, added unit tests artifacts to gitignore a…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ cmake-build-debug/
 /compile
 build/
 build-xcode/
+*.sqlite
+*.db

--- a/dev/ast/cast.h
+++ b/dev/ast/cast.h
@@ -5,6 +5,7 @@
 #include <utility>  // std::move
 #endif  //  SQLITE_ORM_IMPORT_STD_MODULE
 namespace sqlite_orm {
+
     namespace internal {
 
         /**
@@ -19,8 +20,6 @@ namespace sqlite_orm {
             using expression_type = E;
 
             expression_type expression;
-
-            cast_t(expression_type expression_) : expression(std::move(expression_)) {}
         };
     }
 }

--- a/dev/ast/cast.h
+++ b/dev/ast/cast.h
@@ -2,7 +2,6 @@
 
 #ifndef SQLITE_ORM_IMPORT_STD_MODULE
 #include <string>  // std::string
-#include <utility>  // std::move
 #endif  //  SQLITE_ORM_IMPORT_STD_MODULE
 namespace sqlite_orm {
 

--- a/dev/ast/cast.h
+++ b/dev/ast/cast.h
@@ -1,8 +1,9 @@
 #pragma once
 
+#ifndef SQLITE_ORM_IMPORT_STD_MODULE
 #include <string>  // std::string
 #include <utility>  // std::move
-
+#endif  //  SQLITE_ORM_IMPORT_STD_MODULE
 namespace sqlite_orm {
     namespace internal {
 

--- a/dev/ast/cast.h
+++ b/dev/ast/cast.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <string>  // std::string
+#include <utility>  // std::move
+
+namespace sqlite_orm {
+    namespace internal {
+
+        /**
+         *  CAST holder.
+         *  T is a type to cast to
+         *  E is an expression type
+         *  Example: cast<std::string>(&User::id)
+         */
+        template<class T, class E>
+        struct cast_t {
+            using to_type = T;
+            using expression_type = E;
+
+            expression_type expression;
+
+            cast_t(expression_type expression_) : expression(std::move(expression_)) {}
+        };
+    }
+}
+
+SQLITE_ORM_EXPORT namespace sqlite_orm {
+    /**
+     *  CAST(X AS type).
+     *  Example: cast<std::string>(&User::id)
+     */
+    template<class T, class E>
+    internal::cast_t<T, E> cast(E e) {
+        return {std::move(e)};
+    }
+}

--- a/dev/ast/cast.h
+++ b/dev/ast/cast.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #ifndef SQLITE_ORM_IMPORT_STD_MODULE
-#include <string>  // std::string
+#include <utility>  // std::move
 #endif  //  SQLITE_ORM_IMPORT_STD_MODULE
 namespace sqlite_orm {
 

--- a/dev/ast_iterator.h
+++ b/dev/ast_iterator.h
@@ -25,6 +25,7 @@
 #include "ast/exists.h"
 #include "ast/set.h"
 #include "ast/match.h"
+#include "ast/cast.h"
 
 namespace sqlite_orm {
 

--- a/dev/column_result.h
+++ b/dev/column_result.h
@@ -25,6 +25,7 @@
 #include "storage_traits.h"
 #include "function.h"
 #include "ast/special_keywords.h"
+#include "ast/cast.h"
 
 namespace sqlite_orm {
 

--- a/dev/conditions.h
+++ b/dev/conditions.h
@@ -778,28 +778,6 @@ namespace sqlite_orm {
             inner_join_t(on_type constraint_) : constraint(std::move(constraint_)) {}
         };
 
-        struct cast_string {
-            operator std::string() const {
-                return "CAST";
-            }
-        };
-
-        /**
-         *  CAST holder.
-         *  T is a type to cast to
-         *  E is an expression type
-         *  Example: cast<std::string>(&User::id)
-         */
-        template<class T, class E>
-        struct cast_t : cast_string {
-            using to_type = T;
-            using expression_type = E;
-
-            expression_type expression;
-
-            cast_t(expression_type expression_) : expression(std::move(expression_)) {}
-        };
-
         template<class... Args>
         struct from_t {
             using tuple_type = std::tuple<Args...>;
@@ -1267,14 +1245,5 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     template<class A, class T, class E>
     internal::like_t<A, T, E> like(A a, T t, E e) {
         return {std::move(a), std::move(t), {std::move(e)}};
-    }
-
-    /**
-     *  CAST(X AS type).
-     *  Example: cast<std::string>(&User::id)
-     */
-    template<class T, class E>
-    internal::cast_t<T, E> cast(E e) {
-        return {std::move(e)};
     }
 }

--- a/dev/node_tuple.h
+++ b/dev/node_tuple.h
@@ -24,6 +24,7 @@
 #include "ast/into.h"
 #include "ast/group_by.h"
 #include "ast/match.h"
+#include "ast/cast.h"
 
 namespace sqlite_orm {
     namespace internal {

--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -578,7 +578,7 @@ namespace sqlite_orm {
             template<class Ctx>
             std::string operator()(const statement_type& c, const Ctx& context) const {
                 std::stringstream ss;
-                ss << static_cast<std::string>(c) << " (";
+                ss << "CAST (";
                 ss << serialize(c.expression, context) << " AS " << type_printer<T>().print() << ")";
                 return ss.str();
             }

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -11477,9 +11477,10 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 }
 // #include "ast/cast.h"
 
+#ifndef SQLITE_ORM_IMPORT_STD_MODULE
 #include <string>  // std::string
 #include <utility>  // std::move
-
+#endif  //  SQLITE_ORM_IMPORT_STD_MODULE
 namespace sqlite_orm {
     namespace internal {
 

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -11479,7 +11479,6 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 
 #ifndef SQLITE_ORM_IMPORT_STD_MODULE
 #include <string>  // std::string
-#include <utility>  // std::move
 #endif  //  SQLITE_ORM_IMPORT_STD_MODULE
 namespace sqlite_orm {
 

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -5697,28 +5697,6 @@ namespace sqlite_orm {
             inner_join_t(on_type constraint_) : constraint(std::move(constraint_)) {}
         };
 
-        struct cast_string {
-            operator std::string() const {
-                return "CAST";
-            }
-        };
-
-        /**
-         *  CAST holder.
-         *  T is a type to cast to
-         *  E is an expression type
-         *  Example: cast<std::string>(&User::id)
-         */
-        template<class T, class E>
-        struct cast_t : cast_string {
-            using to_type = T;
-            using expression_type = E;
-
-            expression_type expression;
-
-            cast_t(expression_type expression_) : expression(std::move(expression_)) {}
-        };
-
         template<class... Args>
         struct from_t {
             using tuple_type = std::tuple<Args...>;
@@ -6186,15 +6164,6 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     template<class A, class T, class E>
     internal::like_t<A, T, E> like(A a, T t, E e) {
         return {std::move(a), std::move(t), {std::move(e)}};
-    }
-
-    /**
-     *  CAST(X AS type).
-     *  Example: cast<std::string>(&User::id)
-     */
-    template<class T, class E>
-    internal::cast_t<T, E> cast(E e) {
-        return {std::move(e)};
     }
 }
 
@@ -11506,6 +11475,42 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
         return {};
     }
 }
+// #include "ast/cast.h"
+
+#include <string>  // std::string
+#include <utility>  // std::move
+
+namespace sqlite_orm {
+    namespace internal {
+
+        /**
+         *  CAST holder.
+         *  T is a type to cast to
+         *  E is an expression type
+         *  Example: cast<std::string>(&User::id)
+         */
+        template<class T, class E>
+        struct cast_t {
+            using to_type = T;
+            using expression_type = E;
+
+            expression_type expression;
+
+            cast_t(expression_type expression_) : expression(std::move(expression_)) {}
+        };
+    }
+}
+
+SQLITE_ORM_EXPORT namespace sqlite_orm {
+    /**
+     *  CAST(X AS type).
+     *  Example: cast<std::string>(&User::id)
+     */
+    template<class T, class E>
+    internal::cast_t<T, E> cast(E e) {
+        return {std::move(e)};
+    }
+}
 
 namespace sqlite_orm {
 
@@ -15383,6 +15388,8 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
         return {std::move(argument)};
     }
 }
+
+// #include "ast/cast.h"
 
 namespace sqlite_orm {
 
@@ -20456,7 +20463,7 @@ namespace sqlite_orm {
             template<class Ctx>
             std::string operator()(const statement_type& c, const Ctx& context) const {
                 std::stringstream ss;
-                ss << static_cast<std::string>(c) << " (";
+                ss << "CAST (";
                 ss << serialize(c.expression, context) << " AS " << type_printer<T>().print() << ")";
                 return ss.str();
             }
@@ -25098,6 +25105,8 @@ namespace sqlite_orm {
 // #include "ast/group_by.h"
 
 // #include "ast/match.h"
+
+// #include "ast/cast.h"
 
 namespace sqlite_orm {
     namespace internal {

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -11478,7 +11478,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 // #include "ast/cast.h"
 
 #ifndef SQLITE_ORM_IMPORT_STD_MODULE
-#include <string>  // std::string
+#include <utility>  // std::move
 #endif  //  SQLITE_ORM_IMPORT_STD_MODULE
 namespace sqlite_orm {
 

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -11482,6 +11482,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 #include <utility>  // std::move
 #endif  //  SQLITE_ORM_IMPORT_STD_MODULE
 namespace sqlite_orm {
+
     namespace internal {
 
         /**
@@ -11496,8 +11497,6 @@ namespace sqlite_orm {
             using expression_type = E;
 
             expression_type expression;
-
-            cast_t(expression_type expression_) : expression(std::move(expression_)) {}
         };
     }
 }

--- a/tests/backup_tests.cpp
+++ b/tests/backup_tests.cpp
@@ -123,6 +123,7 @@ TEST_CASE("backup") {
         auto rowsFromBackup = storage2.get_all<User>();
         REQUIRE_THAT(rowsFromBackup, UnorderedEquals(storage.get_all<User>()));
     }
+    std::remove(backupFilename.c_str());
 }
 
 TEST_CASE("Backup crash") {
@@ -155,4 +156,6 @@ TEST_CASE("Backup crash") {
     // --- Backup the current storage to the file
     auto backup = storage.make_backup_to(backupFilename);
     backup.step(-1);
+
+    std::remove(backupFilename.c_str());
 }

--- a/tests/pragma_tests.cpp
+++ b/tests/pragma_tests.cpp
@@ -130,6 +130,8 @@ TEST_CASE("Auto vacuum") {
 
     storage.pragma.auto_vacuum(2);
     REQUIRE(storage.pragma.auto_vacuum() == 2);
+
+    std::remove(filename);
 }
 
 TEST_CASE("busy_timeout") {
@@ -206,4 +208,6 @@ TEST_CASE("application_id") {
     auto storage = make_storage(filename);
     storage.pragma.application_id(3);
     REQUIRE(storage.pragma.application_id() == 3);
+
+    std::remove(filename);
 }

--- a/tests/sync_schema_tests.cpp
+++ b/tests/sync_schema_tests.cpp
@@ -479,6 +479,8 @@ TEST_CASE("sync_schema_simulate") {
 
     storage.sync_schema();
     storage.sync_schema_simulate();
+
+    std::remove("db");
 }
 
 #if SQLITE_VERSION_NUMBER >= 3031000


### PR DESCRIPTION
1) moved `cast_t` to `ast` folder to a dedicated file 
2) added unit test launch artifacts to gitignore which happens when you run unit tests from repo root not from `build` folder
3) added several `std::remove` to reduce creating unit tests artifacts. It may not run always cause in case of exception file will be preserved but anyway it reduces amount of artifacts