### PR TITLE
#1429 sync_schema does not sync triggers

### DIFF
--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -2191,9 +2191,10 @@ namespace sqlite_orm {
             SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
                                                             const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
                 std::stringstream ss;
+                ss << "DROP TRIGGER IF EXISTS " << streaming_identifier(statement.name) << ";";
                 ss << "CREATE ";
 
-                ss << "TRIGGER IF NOT EXISTS " << streaming_identifier(statement.name) << " "
+                ss << "TRIGGER " << streaming_identifier(statement.name) << " "
                    << serialize(statement.base, context);
                 ss << " BEGIN ";
                 iterate_tuple(statement.elements, [&ss, &context](auto& element) {

--- a/dev/storage_base.h
+++ b/dev/storage_base.h
@@ -278,25 +278,16 @@ namespace sqlite_orm {
              *  @return Returns list of tables in database.
              */
             std::vector<std::string> table_names() {
-                using data_t = std::vector<std::string>;
+                return this->object_names("table");
+            }
 
-                auto connection = this->get_connection();
-                data_t tableNames;
-                this->executor.perform_exec(
-                    connection.get(),
-                    "SELECT name FROM sqlite_master WHERE type='table'",
-                    [](void* data, int argc, char** argv, char** /*columnName*/) -> int {
-                        auto& tableNames_ = *(data_t*)data;
-                        for (int i = 0; i < argc; ++i) {
-                            if (argv[i]) {
-                                tableNames_.emplace_back(argv[i]);
-                            }
-                        }
-                        return 0;
-                    },
-                    &tableNames);
-                tableNames.shrink_to_fit();
-                return tableNames;
+            /**
+             *  Returns existing permanent trigger names in database. Doesn't check storage itself - works only with
+             * actual database.
+             *  @return Returns list of triggers in database.
+             */
+            std::vector<std::string> trigger_names() {
+                return this->object_names("trigger");
             }
 
             /**
@@ -762,6 +753,30 @@ namespace sqlite_orm {
             connection_ref get_connection() {
                 connection_ref res{*this->connection};
                 return res;
+            }
+
+            std::vector<std::string> object_names(const std::string& type) {
+                using data_t = std::vector<std::string>;
+
+                auto connection = this->get_connection();
+                data_t objectNames;
+                std::stringstream ss;
+                ss << "SELECT name FROM sqlite_master WHERE type=" << quote_string_literal(type);
+                this->executor.perform_exec(
+                    connection.get(),
+                    ss.str(),
+                    [](void* data, int argc, char** argv, char** /*columnName*/) -> int {
+                        auto& objectNames_ = *(data_t*)data;
+                        for (int i = 0; i < argc; ++i) {
+                            if (argv[i]) {
+                                objectNames_.emplace_back(argv[i]);
+                            }
+                        }
+                        return 0;
+                    },
+                    &objectNames);
+                objectNames.shrink_to_fit();
+                return objectNames;
             }
 
 #if SQLITE_VERSION_NUMBER >= 3006019

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -18208,25 +18208,16 @@ namespace sqlite_orm {
              *  @return Returns list of tables in database.
              */
             std::vector<std::string> table_names() {
-                using data_t = std::vector<std::string>;
+                return this->object_names("table");
+            }
 
-                auto connection = this->get_connection();
-                data_t tableNames;
-                this->executor.perform_exec(
-                    connection.get(),
-                    "SELECT name FROM sqlite_master WHERE type='table'",
-                    [](void* data, int argc, char** argv, char** /*columnName*/) -> int {
-                        auto& tableNames_ = *(data_t*)data;
-                        for (int i = 0; i < argc; ++i) {
-                            if (argv[i]) {
-                                tableNames_.emplace_back(argv[i]);
-                            }
-                        }
-                        return 0;
-                    },
-                    &tableNames);
-                tableNames.shrink_to_fit();
-                return tableNames;
+            /**
+             *  Returns existing permanent trigger names in database. Doesn't check storage itself - works only with
+             * actual database.
+             *  @return Returns list of triggers in database.
+             */
+            std::vector<std::string> trigger_names() {
+                return this->object_names("trigger");
             }
 
             /**
@@ -18692,6 +18683,30 @@ namespace sqlite_orm {
             connection_ref get_connection() {
                 connection_ref res{*this->connection};
                 return res;
+            }
+
+            std::vector<std::string> object_names(const std::string& type) {
+                using data_t = std::vector<std::string>;
+
+                auto connection = this->get_connection();
+                data_t objectNames;
+                std::stringstream ss;
+                ss << "SELECT name FROM sqlite_master WHERE type=" << quote_string_literal(type);
+                this->executor.perform_exec(
+                    connection.get(),
+                    ss.str(),
+                    [](void* data, int argc, char** argv, char** /*columnName*/) -> int {
+                        auto& objectNames_ = *(data_t*)data;
+                        for (int i = 0; i < argc; ++i) {
+                            if (argv[i]) {
+                                objectNames_.emplace_back(argv[i]);
+                            }
+                        }
+                        return 0;
+                    },
+                    &objectNames);
+                objectNames.shrink_to_fit();
+                return objectNames;
             }
 
 #if SQLITE_VERSION_NUMBER >= 3006019

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -22146,9 +22146,10 @@ namespace sqlite_orm {
             SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
                                                             const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
                 std::stringstream ss;
+                ss << "DROP TRIGGER IF EXISTS " << streaming_identifier(statement.name) << ";";
                 ss << "CREATE ";
 
-                ss << "TRIGGER IF NOT EXISTS " << streaming_identifier(statement.name) << " "
+                ss << "TRIGGER " << streaming_identifier(statement.name) << " "
                    << serialize(statement.base, context);
                 ss << " BEGIN ";
                 iterate_tuple(statement.elements, [&ss, &context](auto& element) {

--- a/tests/statement_serializer_tests/schema/trigger.cpp
+++ b/tests/statement_serializer_tests/schema/trigger.cpp
@@ -36,7 +36,8 @@ TEST_CASE("statement_serializer trigger") {
                                            .end());
         value = serialize(expression, context);
         expected =
-            R"(CREATE TRIGGER IF NOT EXISTS "validate_email_before_insert_leads" BEFORE INSERT ON "leads" BEGIN SELECT )"
+            R"(DROP TRIGGER IF EXISTS "validate_email_before_insert_leads";)"
+            R"(CREATE TRIGGER "validate_email_before_insert_leads" BEFORE INSERT ON "leads" BEGIN SELECT )"
             R"(CASE WHEN NOT NEW."email" LIKE '%_@__%.__%' THEN RAISE(ABORT, 'Invalid email address') END; END)";
     }
     REQUIRE(value == expected);

--- a/tests/trigger_tests.cpp
+++ b/tests/trigger_tests.cpp
@@ -104,6 +104,35 @@ TEST_CASE("triggers_basics") {
     }
 }
 
+TEST_CASE("trigger_names") {
+    auto storagePath = "trigger_names.sqlite";
+    struct X {
+        int test = 0;
+    };
+
+    {
+        auto storage = make_storage(
+            storagePath,
+            make_trigger("trigger1", after().insert().on<X>().begin(update_all(set(c(&X::test) = 1))).end()),
+            make_trigger("trigger2", after().insert().on<X>().begin(update_all(set(c(&X::test) = 2))).end()),
+            make_table("x",
+                make_column("test", &X::test)));
+        storage.sync_schema();
+    }
+    {
+        auto storage = make_storage(
+            storagePath,
+            make_trigger("trigger2", after().insert().on<X>().begin(update_all(set(c(&X::test) = 2))).end()),
+            make_trigger("trigger3", after().insert().on<X>().begin(update_all(set(c(&X::test) = 3))).end()),
+            make_table("x",
+                make_column("test", &X::test)));
+        storage.sync_schema();
+
+        auto trigger_names=storage.trigger_names();
+        REQUIRE_THAT(trigger_names, Catch::Matchers::UnorderedEquals(std::vector<std::string>{"trigger1", "trigger2", "trigger3"}));
+    }
+}
+
 TEST_CASE("issue1429") {
     auto storagePath = "issue1429.sqlite";
     struct X {

--- a/tests/trigger_tests.cpp
+++ b/tests/trigger_tests.cpp
@@ -104,6 +104,42 @@ TEST_CASE("triggers_basics") {
     }
 }
 
+TEST_CASE("issue1429") {
+    auto storagePath = "issue1429.sqlite";
+    struct X {
+        int test = 0;
+    };
+
+    {
+        auto storage = make_storage(
+            storagePath,
+            make_trigger("table_insert_InsertTest", after().insert().on<X>().begin(update_all(set(c(&X::test) = 5))).end()),
+            make_table("x",
+                make_column("test", &X::test)));
+        auto simulated = storage.sync_schema_simulate();
+        auto ssr = storage.sync_schema();
+        REQUIRE(ssr == simulated);
+
+        storage.insert(X{1});
+        auto records = storage.get_all<X>();
+        REQUIRE(records[0].test == 5);
+    }
+    {
+        auto storage = make_storage(
+            storagePath,
+            make_trigger("table_insert_InsertTest", after().insert().on<X>().begin(update_all(set(c(&X::test) = 6))).end()),
+            make_table("x",
+                make_column("test", &X::test)));
+        auto simulated = storage.sync_schema_simulate();
+        auto ssr = storage.sync_schema();
+        REQUIRE(ssr == simulated);
+
+        storage.insert(X{1});
+        auto records = storage.get_all<X>();
+        REQUIRE(records[0].test == 6);
+    }
+}
+
 TEST_CASE("issue1280") {
     struct X {
         int test = 0;


### PR DESCRIPTION
In order to deal with #1429, I made two changes:

1. Instead of using `CREATE TRIGGER IF NOT EXISTS...`, it now uses `DROP TRIGGER IF EXISTS <triggername>;CREATE TRIGGER <triggername>....`. This ensures that the trigger is recreated as specified in the `make_storage` call.
2. I added a method `trigger_names`, similar to the method `table_names`. This can be used to see which triggers actually exist in the database, so you can decide e.g. to use `drop_trigger()` to delete any triggers that you do not want.

I also added tests to test these changes.