### PR TITLE
Allow retrieval of all existing triggers (issue #1429)

### DIFF
--- a/dev/storage_base.h
+++ b/dev/storage_base.h
@@ -755,23 +755,19 @@ namespace sqlite_orm {
                 return res;
             }
 
-            std::vector<std::string> object_names(const std::string& type) {
+            std::vector<std::string> object_names(string_constant_type type) {
                 using data_t = std::vector<std::string>;
 
                 auto connection = this->get_connection();
                 data_t objectNames;
                 std::stringstream ss;
-                ss << "SELECT name FROM sqlite_master WHERE type = " << quote_string_literal(type);
+                ss << "SELECT name FROM sqlite_master WHERE type=" << quote_string_literal(type);
                 this->executor.perform_exec(
                     connection.get(),
                     ss.str(),
                     [](void* data, int argc, orm_gsl::zstring* argv, orm_gsl::zstring* /*columnName*/) -> int {
                         auto& objectNames_ = *(data_t*)data;
-                        for (int i = 0; i < argc; ++i) {
-                            if (argv[i]) {
-                                objectNames_.emplace_back(argv[i]);
-                            }
-                        }
+                        objectNames_.emplace_back(argv[0]);
                         return 0;
                     },
                     &objectNames);

--- a/dev/storage_base.h
+++ b/dev/storage_base.h
@@ -278,25 +278,16 @@ namespace sqlite_orm {
              *  @return Returns list of tables in database.
              */
             std::vector<std::string> table_names() {
-                using data_t = std::vector<std::string>;
+                return this->object_names("table");
+            }
 
-                auto connection = this->get_connection();
-                data_t tableNames;
-                this->executor.perform_exec(
-                    connection.get(),
-                    "SELECT name FROM sqlite_master WHERE type='table'",
-                    [](void* data, int argc, orm_gsl::zstring* argv, orm_gsl::zstring* /*columnName*/) -> int {
-                        auto& tableNames_ = *(data_t*)data;
-                        for (int i = 0; i < argc; ++i) {
-                            if (argv[i]) {
-                                tableNames_.emplace_back(argv[i]);
-                            }
-                        }
-                        return 0;
-                    },
-                    &tableNames);
-                tableNames.shrink_to_fit();
-                return tableNames;
+            /**
+             *  Returns existing permanent trigger names in database. Doesn't check storage itself - works only with
+             * actual database.
+             *  @return Returns list of triggers in database.
+             */
+            std::vector<std::string> trigger_names() {
+                return this->object_names("trigger");
             }
 
             /**
@@ -762,6 +753,30 @@ namespace sqlite_orm {
             connection_ref get_connection() {
                 connection_ref res{*this->connection};
                 return res;
+            }
+
+            std::vector<std::string> object_names(const std::string& type) {
+                using data_t = std::vector<std::string>;
+
+                auto connection = this->get_connection();
+                data_t objectNames;
+                std::stringstream ss;
+                ss << "SELECT name FROM sqlite_master WHERE type = " << quote_string_literal(type);
+                this->executor.perform_exec(
+                    connection.get(),
+                    ss.str(),
+                    [](void* data, int argc, orm_gsl::zstring* argv, orm_gsl::zstring* /*columnName*/) -> int {
+                        auto& objectNames_ = *(data_t*)data;
+                        for (int i = 0; i < argc; ++i) {
+                            if (argv[i]) {
+                                objectNames_.emplace_back(argv[i]);
+                            }
+                        }
+                        return 0;
+                    },
+                    &objectNames);
+                objectNames.shrink_to_fit();
+                return objectNames;
             }
 
 #if SQLITE_VERSION_NUMBER >= 3006019

--- a/dev/storage_base.h
+++ b/dev/storage_base.h
@@ -761,7 +761,7 @@ namespace sqlite_orm {
                 auto connection = this->get_connection();
                 data_t objectNames;
                 std::stringstream ss;
-                ss << "SELECT name FROM sqlite_master WHERE type=" << quote_string_literal(type);
+                ss << "SELECT name FROM sqlite_master WHERE type=" << quote_string_literal(std::string(type));
                 this->executor.perform_exec(
                     connection.get(),
                     ss.str(),

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -18793,7 +18793,7 @@ namespace sqlite_orm {
                 auto connection = this->get_connection();
                 data_t objectNames;
                 std::stringstream ss;
-                ss << "SELECT name FROM sqlite_master WHERE type=" << quote_string_literal(type);
+                ss << "SELECT name FROM sqlite_master WHERE type=" << quote_string_literal(std::string(type));
                 this->executor.perform_exec(
                     connection.get(),
                     ss.str(),

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -18310,25 +18310,16 @@ namespace sqlite_orm {
              *  @return Returns list of tables in database.
              */
             std::vector<std::string> table_names() {
-                using data_t = std::vector<std::string>;
+                return this->object_names("table");
+            }
 
-                auto connection = this->get_connection();
-                data_t tableNames;
-                this->executor.perform_exec(
-                    connection.get(),
-                    "SELECT name FROM sqlite_master WHERE type='table'",
-                    [](void* data, int argc, orm_gsl::zstring* argv, orm_gsl::zstring* /*columnName*/) -> int {
-                        auto& tableNames_ = *(data_t*)data;
-                        for (int i = 0; i < argc; ++i) {
-                            if (argv[i]) {
-                                tableNames_.emplace_back(argv[i]);
-                            }
-                        }
-                        return 0;
-                    },
-                    &tableNames);
-                tableNames.shrink_to_fit();
-                return tableNames;
+            /**
+             *  Returns existing permanent trigger names in database. Doesn't check storage itself - works only with
+             * actual database.
+             *  @return Returns list of triggers in database.
+             */
+            std::vector<std::string> trigger_names() {
+                return this->object_names("trigger");
             }
 
             /**
@@ -18794,6 +18785,30 @@ namespace sqlite_orm {
             connection_ref get_connection() {
                 connection_ref res{*this->connection};
                 return res;
+            }
+
+            std::vector<std::string> object_names(const std::string& type) {
+                using data_t = std::vector<std::string>;
+
+                auto connection = this->get_connection();
+                data_t objectNames;
+                std::stringstream ss;
+                ss << "SELECT name FROM sqlite_master WHERE type = " << quote_string_literal(type);
+                this->executor.perform_exec(
+                    connection.get(),
+                    ss.str(),
+                    [](void* data, int argc, orm_gsl::zstring* argv, orm_gsl::zstring* /*columnName*/) -> int {
+                        auto& objectNames_ = *(data_t*)data;
+                        for (int i = 0; i < argc; ++i) {
+                            if (argv[i]) {
+                                objectNames_.emplace_back(argv[i]);
+                            }
+                        }
+                        return 0;
+                    },
+                    &objectNames);
+                objectNames.shrink_to_fit();
+                return objectNames;
             }
 
 #if SQLITE_VERSION_NUMBER >= 3006019

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -18787,23 +18787,19 @@ namespace sqlite_orm {
                 return res;
             }
 
-            std::vector<std::string> object_names(const std::string& type) {
+            std::vector<std::string> object_names(string_constant_type type) {
                 using data_t = std::vector<std::string>;
 
                 auto connection = this->get_connection();
                 data_t objectNames;
                 std::stringstream ss;
-                ss << "SELECT name FROM sqlite_master WHERE type = " << quote_string_literal(type);
+                ss << "SELECT name FROM sqlite_master WHERE type=" << quote_string_literal(type);
                 this->executor.perform_exec(
                     connection.get(),
                     ss.str(),
                     [](void* data, int argc, orm_gsl::zstring* argv, orm_gsl::zstring* /*columnName*/) -> int {
                         auto& objectNames_ = *(data_t*)data;
-                        for (int i = 0; i < argc; ++i) {
-                            if (argv[i]) {
-                                objectNames_.emplace_back(argv[i]);
-                            }
-                        }
+                        objectNames_.emplace_back(argv[0]);
                         return 0;
                     },
                     &objectNames);

--- a/tests/trigger_tests.cpp
+++ b/tests/trigger_tests.cpp
@@ -104,6 +104,34 @@ TEST_CASE("triggers_basics") {
     }
 }
 
+TEST_CASE("trigger_names") {
+    auto storagePath = "trigger_names.sqlite";
+    struct X {
+        int test = 0;
+    };
+
+    {
+        auto storage = make_storage(
+            storagePath,
+            make_trigger("trigger1", after().insert().on<X>().begin(update_all(set(c(&X::test) = 1))).end()),
+            make_trigger("trigger2", after().insert().on<X>().begin(update_all(set(c(&X::test) = 2))).end()),
+            make_table("x", make_column("test", &X::test)));
+        storage.sync_schema();
+    }
+    {
+        auto storage = make_storage(
+            storagePath,
+            make_trigger("trigger2", after().insert().on<X>().begin(update_all(set(c(&X::test) = 2))).end()),
+            make_trigger("trigger3", after().insert().on<X>().begin(update_all(set(c(&X::test) = 3))).end()),
+            make_table("x", make_column("test", &X::test)));
+        storage.sync_schema();
+
+        auto trigger_names=storage.trigger_names();
+        REQUIRE_THAT(trigger_names,
+                     Catch::Matchers::UnorderedEquals(std::vector<std::string>{"trigger1", "trigger2", "trigger3"}));
+    }
+}
+
 TEST_CASE("issue1280") {
     struct X {
         int test = 0;

--- a/tests/trigger_tests.cpp
+++ b/tests/trigger_tests.cpp
@@ -126,7 +126,7 @@ TEST_CASE("trigger_names") {
             make_table("x", make_column("test", &X::test)));
         storage.sync_schema();
 
-        auto trigger_names=storage.trigger_names();
+        auto trigger_names = storage.trigger_names();
         REQUIRE_THAT(trigger_names,
                      Catch::Matchers::UnorderedEquals(std::vector<std::string>{"trigger1", "trigger2", "trigger3"}));
     }


### PR DESCRIPTION
This pull requests adds a `trigger_names` method, that can be used to list all existing triggers in the database.