### PR TITLE
Generalize and streamline code base

### DIFF
--- a/dev/ast/set.h
+++ b/dev/ast/set.h
@@ -51,7 +51,7 @@ namespace sqlite_orm {
             template<class L, class R>
             void push_back(assign_t<L, R> assign) {
                 auto newContext = this->context;
-                newContext.skip_table_name = true;
+                newContext.omit_table_name = true;
                 // note: we are only interested in the table name on the left-hand side of the assignment operator expression
                 iterate_ast(assign.lhs, this->collector);
                 std::stringstream ss;
@@ -108,7 +108,6 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class S>
     internal::dynamic_set_t<internal::serializer_context<typename S::db_objects_type>> dynamic_set(const S& storage) {
-        internal::serializer_context_builder<S> builder(storage);
-        return builder();
+        return {obtain_db_objects(storage)};
     }
 }

--- a/dev/column_names_getter.h
+++ b/dev/column_names_getter.h
@@ -33,7 +33,7 @@ namespace sqlite_orm {
             if (definedOrder) {
                 auto& table = pick_table<mapped_type_proxy_t<T>>(context.db_objects);
                 collectedExpressions.reserve(collectedExpressions.size() + table.template count_of<is_column>());
-                table.for_each_column([qualified = !context.skip_table_name,
+                table.for_each_column([qualified = !context.omit_table_name,
                                        &tableName = table.name,
                                        &collectedExpressions](const column_identifier& column) {
                     if constexpr (is_alias<T>::value) {
@@ -50,7 +50,7 @@ namespace sqlite_orm {
                 collectedExpressions.reserve(collectedExpressions.size() + 1);
                 if constexpr (is_alias<T>::value) {
                     collectedExpressions.push_back(quote_identifier(alias_extractor<T>::extract()) + ".*");
-                } else if (!context.skip_table_name) {
+                } else if (!context.omit_table_name) {
                     const basic_table& table = pick_table<mapped_type_proxy_t<T>>(context.db_objects);
                     collectedExpressions.push_back(quote_identifier(table.name) + ".*");
                 } else {

--- a/dev/conditions.h
+++ b/dev/conditions.h
@@ -493,7 +493,7 @@ namespace sqlite_orm {
             template<class O>
             void push_back(order_by_t<O> orderBy) {
                 auto newContext = this->context;
-                newContext.skip_table_name = false;
+                newContext.omit_table_name = false;
                 auto columnName = serialize(orderBy._expression, newContext);
                 this->entries.emplace_back(std::move(columnName), std::move(orderBy._collate_argument), orderBy._order);
             }
@@ -1149,8 +1149,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     template<class S>
     internal::dynamic_order_by_t<internal::serializer_context<typename S::db_objects_type>>
     dynamic_order_by(const S& storage) {
-        internal::serializer_context_builder<S> builder(storage);
-        return builder();
+        return {obtain_db_objects(storage)};
     }
 
     /**

--- a/dev/cte_column_names_collector.h
+++ b/dev/cte_column_names_collector.h
@@ -57,7 +57,7 @@ namespace sqlite_orm {
             SQLITE_ORM_STATIC_CALLOP std::vector<std::string>
             operator()(const expression_type& t, const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
                 auto newContext = context;
-                newContext.skip_table_name = true;
+                newContext.omit_table_name = true;
                 std::string columnName = serialize(t, newContext);
                 if (columnName.empty()) {
                     throw std::system_error{orm_error_code::column_not_found};
@@ -137,7 +137,7 @@ namespace sqlite_orm {
                 std::vector<std::string> columnNames;
                 columnNames.reserve(size_t(cols.count));
                 auto newContext = context;
-                newContext.skip_table_name = true;
+                newContext.omit_table_name = true;
                 iterate_tuple(cols.columns, [&columnNames, &newContext](auto& m) {
                     using value_type = polyfill::remove_cvref_t<decltype(m)>;
 

--- a/dev/implementations/storage_definitions.h
+++ b/dev/implementations/storage_definitions.h
@@ -24,9 +24,9 @@ namespace sqlite_orm {
     namespace internal {
         template<class... DBO>
         template<class Table, satisfies<is_table, Table>>
-        sync_schema_result storage_t<DBO...>::sync_table([[maybe_unused]] const Table& table,
-                                                         [[maybe_unused]] sqlite3* db,
-                                                         [[maybe_unused]] bool preserve) {
+        sync_schema_result storage_t<DBO...>::sync_dbo([[maybe_unused]] const Table& table,
+                                                       [[maybe_unused]] sqlite3* db,
+                                                       [[maybe_unused]] bool preserve) {
             if constexpr (
 #ifdef SQLITE_ENABLE_DBSTAT_VTAB
                 std::is_same<object_type_t<Table>, dbstat>::value ||

--- a/dev/mapped_view.h
+++ b/dev/mapped_view.h
@@ -42,7 +42,7 @@ namespace sqlite_orm {
 
                 auto& dbObjects = obtain_db_objects(this->storage);
                 context_t context{dbObjects};
-                context.skip_table_name = false;
+                context.omit_table_name = false;
                 context.replace_bindable_with_question = true;
 
                 const std::string sql = serialize(this->expression, context);

--- a/dev/order_by_serializer.h
+++ b/dev/order_by_serializer.h
@@ -45,7 +45,7 @@ namespace sqlite_orm {
                                                             const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
                 std::stringstream ss;
                 auto newContext = context;
-                newContext.skip_table_name = false;
+                newContext.omit_table_name = false;
 
                 ss << serialize(orderBy._expression, newContext);
                 seralize_collate(ss, orderBy);

--- a/dev/prepared_statement.h
+++ b/dev/prepared_statement.h
@@ -310,6 +310,48 @@ namespace sqlite_orm {
 
         template<class T>
         using is_insert_constraint = std::is_same<T, insert_constraint>;
+
+        /**
+         *  Specialize if a type is a DML statement expression.
+         */
+        template<class T, class SFINAE = void>
+        inline constexpr bool is_raw_dml_expression_v = false;
+
+        template<class T>
+        using is_raw_dml_expression = polyfill::bool_constant<is_raw_dml_expression_v<T>>;
+
+        template<class DML>
+        inline constexpr bool is_raw_dml_expression_v<
+            DML,
+            std::enable_if_t<
+                polyfill::
+                    disjunction_v<is_insert_raw<DML>, is_replace_raw<DML>, is_update_all<DML>, is_remove_all<DML>>>> =
+            true;
+
+        template<class With>
+        inline constexpr bool is_raw_dml_expression_v<
+            With,
+            std::enable_if_t<polyfill::conjunction_v<is_with_clause<With>,
+                                                     polyfill::disjunction<is_insert_raw<expression_type_t<With>>,
+                                                                           is_replace_raw<expression_type_t<With>>,
+                                                                           is_update_all<expression_type_t<With>>,
+                                                                           is_remove_all<expression_type_t<With>>>>>> =
+            true;
+
+        /*  
+         *  Access the main select expression of a with clause or the passed in select expression.
+         */
+        template<class DML, satisfies<is_raw_dml_expression, DML> = true>
+        constexpr decltype(auto) access_main_dml(const DML& dml) {
+            if constexpr (is_with_clause_v<DML>) {
+                return (dml.expression);
+            } else {
+                return dml;
+            }
+        }
+
+        template<class DML>
+        using main_dml_t = polyfill::remove_cvref_t<decltype(access_main_dml(std::declval<DML>()))>;
     }
 }
 

--- a/dev/result_set_view.h
+++ b/dev/result_set_view.h
@@ -53,7 +53,7 @@ namespace sqlite_orm::internal {
             using context_t = serializer_context<ExprDBOs>;
 
             context_t context{exprDBOs};
-            context.skip_table_name = false;
+            context.omit_table_name = false;
             context.replace_bindable_with_question = true;
 
             const std::string sql = serialize(this->expression, context);

--- a/dev/schema/column.h
+++ b/dev/schema/column.h
@@ -118,6 +118,9 @@ namespace sqlite_orm {
         template<class T>
         using is_column = polyfill::bool_constant<is_column_v<T>>;
 
+        template<class Elements>
+        using col_index_sequence_of = filter_tuple_sequence_t<Elements, is_column>;
+
         template<class Elements, class F>
         using col_index_sequence_with_field_type =
             filter_tuple_sequence_t<Elements,

--- a/dev/schema/table.h
+++ b/dev/schema/table.h
@@ -264,8 +264,7 @@ namespace sqlite_orm {
              */
             template<class L>
             void for_each_column(L&& lambda) const {
-                using col_index_sequence = filter_tuple_sequence_t<elements_type, is_column>;
-                iterate_tuple(this->elements, col_index_sequence{}, lambda);
+                iterate_tuple(this->elements, col_index_sequence_of<elements_type>{}, lambda);
             }
 
             /**
@@ -379,8 +378,7 @@ namespace sqlite_orm {
              */
             template<class L>
             void for_each_column(L&& lambda) const {
-                using col_index_sequence = filter_tuple_sequence_t<columns_type, is_column>;
-                iterate_tuple(this->columns, col_index_sequence{}, lambda);
+                iterate_tuple(this->columns, col_index_sequence_of<columns_type>{}, lambda);
             }
 
             template<class M, satisfies<std::is_member_pointer, M> = true>

--- a/dev/select_constraints.h
+++ b/dev/select_constraints.h
@@ -421,10 +421,8 @@ namespace sqlite_orm {
         constexpr decltype(auto) access_main_select(const Select& select) {
             if constexpr (is_with_clause_v<Select>) {
                 return (select.expression);
-            } else if constexpr (is_select_v<Select>) {
-                return select;
             } else {
-                static_assert(polyfill::always_false_v<Select>);
+                return select;
             }
         }
 

--- a/dev/select_constraints.h
+++ b/dev/select_constraints.h
@@ -318,7 +318,16 @@ namespace sqlite_orm {
                 }
             }
         };
+
+        template<class T>
+        inline constexpr bool is_with_clause_v = polyfill::is_specialization_of<T, with_t>::value;
+#else
+        template<class T>
+        inline constexpr bool is_with_clause_v = false;
 #endif
+
+        template<class T>
+        using is_with_clause = polyfill::bool_constant<is_with_clause_v<T>>;
 
         template<class T>
         struct asterisk_t {
@@ -387,6 +396,40 @@ namespace sqlite_orm {
                 return {{std::move(this->case_expression)}, std::move(args), {std::move(el)}};
             }
         };
+
+        /**
+         *  Specialize if a type is a select statement expression.
+         */
+        template<class T, class SFINAE = void>
+        inline constexpr bool is_select_expression_v = false;
+
+        template<class T>
+        using is_select_expression = polyfill::bool_constant<is_select_expression_v<T>>;
+
+        template<class Select>
+        inline constexpr bool is_select_expression_v<Select, std::enable_if_t<is_select_v<Select>>> = true;
+
+        template<class With>
+        inline constexpr bool is_select_expression_v<
+            With,
+            std::enable_if_t<polyfill::conjunction_v<is_with_clause<With>, is_select<expression_type_t<With>>>>> = true;
+
+        /*  
+         *  Access the main select expression of a with clause or the passed in select expression.
+         */
+        template<class Select, satisfies<is_select_expression, Select> = true>
+        constexpr decltype(auto) access_main_select(const Select& select) {
+            if constexpr (is_with_clause_v<Select>) {
+                return (select.expression);
+            } else if constexpr (is_select_v<Select>) {
+                return select;
+            } else {
+                static_assert(polyfill::always_false_v<Select>);
+            }
+        }
+
+        template<class Select>
+        using main_select_t = polyfill::remove_cvref_t<decltype(access_main_select(std::declval<Select>()))>;
 
         template<class T, std::enable_if_t<!is_rowset_deduplicator_v<T>, bool> = true>
         const T& access_column_expression(const T& expression) {

--- a/dev/serializer_context.h
+++ b/dev/serializer_context.h
@@ -6,9 +6,9 @@ namespace sqlite_orm {
 
         struct serializer_context_base {
             bool replace_bindable_with_question = false;
-            bool skip_table_name = true;
+            bool omit_table_name = true;
             bool use_parentheses = true;
-            bool fts5_columns = false;
+            bool omit_column_type = false;
         };
 
         template<class DBOs>
@@ -18,20 +18,6 @@ namespace sqlite_orm {
             const db_objects_type& db_objects;
 
             serializer_context(const db_objects_type& dbObjects) : db_objects{dbObjects} {}
-        };
-
-        template<class S>
-        struct serializer_context_builder {
-            using storage_type = S;
-            using db_objects_type = typename storage_type::db_objects_type;
-
-            serializer_context_builder(const storage_type& storage_) : storage{storage_} {}
-
-            serializer_context<db_objects_type> operator()() const {
-                return {obtain_db_objects(this->storage)};
-            }
-
-            const storage_type& storage;
         };
     }
 

--- a/dev/serializing_util.h
+++ b/dev/serializing_util.h
@@ -433,7 +433,7 @@ namespace sqlite_orm {
                 ss << ' ' << serialize(constraint, context);
             });
             // add implicit null constraint
-            if (!context.fts5_columns) {
+            if (!context.omit_column_type) {
                 constexpr bool hasExplicitNullableConstraint =
                     mpl::invoke_t<mpl::disjunction<check_if_has_type<null_t>, check_if_has_type<not_null_t>>,
                                   constraints_tuple>::value;

--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -420,11 +420,11 @@ namespace sqlite_orm {
             SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& c,
                                                             const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
                 std::stringstream ss;
-                if (!context.skip_table_name) {
+                if (!context.omit_table_name) {
                     ss << streaming_identifier(alias_extractor<T>::extract()) << ".";
                 }
                 auto newContext = context;
-                newContext.skip_table_name = true;
+                newContext.omit_table_name = true;
                 ss << serialize(c.column, newContext);
                 return ss.str();
             }
@@ -442,7 +442,7 @@ namespace sqlite_orm {
                 std::stringstream ss;
                 if (auto* columnName = find_column_name(context.db_objects, e)) {
                     ss << streaming_identifier(
-                        !context.skip_table_name ? lookup_table_name<table_type_of_t<E>>(context.db_objects) : "",
+                        !context.omit_table_name ? lookup_table_name<table_type_of_t<E>>(context.db_objects) : "",
                         *columnName,
                         "");
                 } else {
@@ -504,7 +504,7 @@ namespace sqlite_orm {
             SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
                                                             const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
                 std::stringstream ss;
-                if (!context.skip_table_name) {
+                if (!context.omit_table_name) {
                     ss << streaming_identifier(lookup_table_name<O>(context.db_objects)) << ".";
                 }
                 ss << static_cast<std::string>(statement);
@@ -520,7 +520,7 @@ namespace sqlite_orm {
             SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
                                                             const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
                 std::stringstream ss;
-                if (!context.skip_table_name) {
+                if (!context.omit_table_name) {
                     ss << streaming_identifier(lookup_table_name<O>(context.db_objects)) << ".";
                 }
                 ss << static_cast<std::string>(statement);
@@ -536,7 +536,7 @@ namespace sqlite_orm {
             SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
                                                             const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
                 std::stringstream ss;
-                if (!context.skip_table_name) {
+                if (!context.omit_table_name) {
                     ss << streaming_identifier(lookup_table_name<O>(context.db_objects)) << ".";
                 }
                 ss << static_cast<std::string>(statement);
@@ -1305,7 +1305,7 @@ namespace sqlite_orm {
                                                             const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
                 std::stringstream ss;
                 ss << streaming_identifier(column.name);
-                if (!context.fts5_columns) {
+                if (!context.omit_column_type) {
                     ss << " " << type_printer<field_type_t<column_field<G, S>>>().print();
                 }
                 ss << streaming_column_constraints(
@@ -1452,7 +1452,7 @@ namespace sqlite_orm {
                 std::stringstream ss;
                 ss << "SET ";
                 auto leftContext = context;
-                leftContext.skip_table_name = true;
+                leftContext.omit_table_name = true;
                 iterate_tuple(statement.assigns, [&ss, &context, &leftContext, first = true](auto& value) mutable {
                     static constexpr std::array<orm_gsl::czstring, 2> sep = {", ", ""};
                     ss << sep[std::exchange(first, false)] << serialize(value.lhs, leftContext) << ' '
@@ -1612,7 +1612,7 @@ namespace sqlite_orm {
                     ss << ' ';
                     if constexpr (is_columns<value_type>::value) {
                         auto newContext = context;
-                        newContext.skip_table_name = true;
+                        newContext.omit_table_name = true;
                         newContext.use_parentheses = true;
                         ss << serialize(value, newContext);
                     } else if constexpr (is_values<value_type>::value || is_select<value_type>::value) {
@@ -1877,7 +1877,7 @@ namespace sqlite_orm {
             template<class Ctx>
             SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& sel,
                                                             Ctx context) SQLITE_ORM_OR_CONST_CALLOP {
-                context.skip_table_name = false;
+                context.omit_table_name = false;
                 // subqueries should always use parentheses in column names
                 auto subCtx = context;
                 subCtx.use_parentheses = true;
@@ -1961,7 +1961,7 @@ namespace sqlite_orm {
                 std::stringstream ss;
                 ss << "USING FTS5(";
                 auto subContext = context;
-                subContext.fts5_columns = true;
+                subContext.omit_column_type = true;
                 ss << streaming_expressions_tuple(statement.columns, subContext) << ")";
                 return ss.str();
             }
@@ -2051,7 +2051,7 @@ namespace sqlite_orm {
                 std::stringstream ss;
                 ss << "OLD.";
                 auto newContext = context;
-                newContext.skip_table_name = true;
+                newContext.omit_table_name = true;
                 ss << serialize(statement.expression, newContext);
                 return ss.str();
             }
@@ -2067,7 +2067,7 @@ namespace sqlite_orm {
                 std::stringstream ss;
                 ss << "NEW.";
                 auto newContext = context;
-                newContext.skip_table_name = true;
+                newContext.omit_table_name = true;
                 ss << serialize(statement.expression, newContext);
                 return ss.str();
             }
@@ -2310,7 +2310,7 @@ namespace sqlite_orm {
                                                             const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
                 std::stringstream ss;
                 auto newContext = context;
-                newContext.skip_table_name = false;
+                newContext.omit_table_name = false;
                 ss << static_cast<std::string>(on) << " " << serialize(on.arg, newContext) << " ";
                 return ss.str();
             }
@@ -2325,7 +2325,7 @@ namespace sqlite_orm {
                                                             const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
                 std::stringstream ss;
                 auto newContext = context;
-                newContext.skip_table_name = false;
+                newContext.omit_table_name = false;
                 ss << "GROUP BY " << streaming_expressions_tuple(statement.args, newContext) << " HAVING "
                    << serialize(statement.expression, context);
                 return ss.str();
@@ -2341,7 +2341,7 @@ namespace sqlite_orm {
                                                             const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
                 std::stringstream ss;
                 auto newContext = context;
-                newContext.skip_table_name = false;
+                newContext.omit_table_name = false;
                 ss << "GROUP BY " << streaming_expressions_tuple(statement.args, newContext);
                 return ss.str();
             }
@@ -2359,7 +2359,7 @@ namespace sqlite_orm {
             SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
                                                             const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
                 auto newContext = context;
-                newContext.skip_table_name = false;
+                newContext.omit_table_name = false;
                 std::stringstream ss;
                 ss << "LIMIT ";
                 if constexpr (HO) {
@@ -2401,7 +2401,7 @@ namespace sqlite_orm {
             SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
                                                             const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
                 auto newContext = context;
-                newContext.skip_table_name = true;
+                newContext.omit_table_name = true;
                 return static_cast<std::string>(statement) + " (" + serialize(statement.column, newContext) + ")";
             }
         };

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -1351,17 +1351,10 @@ namespace sqlite_orm {
 
             using storage_base::table_exists;  // now that it is in storage_base make it into overload set
 
-#if (SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
-            template<
-                class... CTEs,
-                class E,
-                std::enable_if_t<
-                    polyfill::disjunction_v<is_insert_raw<E>, is_replace_raw<E>, is_update_all<E>, is_remove_all<E>>,
-                    bool> = true>
-            prepared_statement_t<with_t<E, CTEs...>> prepare(with_t<E, CTEs...> sel) {
-                return this->prepare_impl<with_t<E, CTEs...>>(std::move(sel));
+            template<class DML, std::enable_if_t<is_raw_dml_expression_v<DML>, bool> = true>
+            prepared_statement_t<DML> prepare(DML statement) {
+                return this->prepare_impl(std::move(statement));
             }
-#endif
 
             template<class Select, satisfies<is_select_expression, Select> = true>
             prepared_statement_t<Select> prepare(Select statement) {
@@ -1381,16 +1374,6 @@ namespace sqlite_orm {
                 return this->prepare_impl(std::move(statement));
             }
 
-            template<class... Args>
-            prepared_statement_t<replace_raw_t<Args...>> prepare(replace_raw_t<Args...> statement) {
-                return this->prepare_impl(std::move(statement));
-            }
-
-            template<class... Args>
-            prepared_statement_t<insert_raw_t<Args...>> prepare(insert_raw_t<Args...> statement) {
-                return this->prepare_impl(std::move(statement));
-            }
-
 #ifdef SQLITE_ORM_OPTIONAL_SUPPORTED
             template<class T, class R, class... Args>
             prepared_statement_t<get_all_optional_t<T, R, Args...>>
@@ -1398,16 +1381,6 @@ namespace sqlite_orm {
                 return this->prepare_impl(std::move(statement));
             }
 #endif  // SQLITE_ORM_OPTIONAL_SUPPORTED
-
-            template<class S, class... Wargs>
-            prepared_statement_t<update_all_t<S, Wargs...>> prepare(update_all_t<S, Wargs...> statement) {
-                return this->prepare_impl(std::move(statement));
-            }
-
-            template<class T, class... Args>
-            prepared_statement_t<remove_all_t<T, Args...>> prepare(remove_all_t<T, Args...> statement) {
-                return this->prepare_impl(std::move(statement));
-            }
 
             template<class T, class... Ids>
             prepared_statement_t<get_t<T, Ids...>> prepare(get_t<T, Ids...> statement) {
@@ -1484,49 +1457,8 @@ namespace sqlite_orm {
                 return this->prepare_impl(std::move(statement));
             }
 
-            template<class... Args>
-            void execute(const prepared_statement_t<replace_raw_t<Args...>>& statement) {
-                sqlite3_stmt* stmt = reset_stmt(statement.stmt);
-                iterate_ast(statement.expression, conditional_binder{stmt});
-                std::string sql;
-                if (this->executor.will_run_query || this->executor.did_run_query) {
-                    sql = statement.sql();
-                }
-                if (this->executor.will_run_query) {
-                    this->executor.will_run_query(sql);
-                }
-                perform_step(stmt);
-                if (this->executor.did_run_query) {
-                    this->executor.did_run_query(sql);
-                }
-            }
-
-#if (SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
-            template<
-                class... CTEs,
-                class E,
-                std::enable_if_t<
-                    polyfill::disjunction_v<is_insert_raw<E>, is_replace_raw<E>, is_update_all<E>, is_remove_all<E>>,
-                    bool> = true>
-            void execute(const prepared_statement_t<with_t<E, CTEs...>>& statement) {
-                sqlite3_stmt* stmt = reset_stmt(statement.stmt);
-                iterate_ast(statement.expression, conditional_binder{stmt});
-                std::string sql;
-                if (this->executor.will_run_query || this->executor.did_run_query) {
-                    sql = statement.sql();
-                }
-                if (this->executor.will_run_query) {
-                    this->executor.will_run_query(sql);
-                }
-                perform_step(stmt);
-                if (this->executor.did_run_query) {
-                    this->executor.did_run_query(sql);
-                }
-            }
-#endif
-
-            template<class... Args>
-            void execute(const prepared_statement_t<insert_raw_t<Args...>>& statement) {
+            template<class DML, std::enable_if_t<is_raw_dml_expression_v<DML>, bool> = true>
+            void execute(const prepared_statement_t<DML>& statement) {
                 sqlite3_stmt* stmt = reset_stmt(statement.stmt);
                 iterate_ast(statement.expression, conditional_binder{stmt});
                 std::string sql;
@@ -1831,42 +1763,6 @@ namespace sqlite_orm {
                     }
                 }
 #endif
-            }
-
-            template<class T, class... Args>
-            void execute(const prepared_statement_t<remove_all_t<T, Args...>>& statement) {
-                sqlite3_stmt* stmt = reset_stmt(statement.stmt);
-                iterate_ast(statement.expression.conditions, conditional_binder{stmt});
-                std::string sql;
-                if (this->executor.will_run_query || this->executor.did_run_query) {
-                    sql = statement.sql();
-                }
-                if (this->executor.will_run_query) {
-                    this->executor.will_run_query(sql);
-                }
-                perform_step(stmt);
-                if (this->executor.did_run_query) {
-                    this->executor.did_run_query(sql);
-                }
-            }
-
-            template<class S, class... Wargs>
-            void execute(const prepared_statement_t<update_all_t<S, Wargs...>>& statement) {
-                sqlite3_stmt* stmt = reset_stmt(statement.stmt);
-                conditional_binder bindNode{stmt};
-                iterate_ast(statement.expression.set, bindNode);
-                iterate_ast(statement.expression.conditions, bindNode);
-                std::string sql;
-                if (this->executor.will_run_query || this->executor.did_run_query) {
-                    sql = statement.sql();
-                }
-                if (this->executor.will_run_query) {
-                    this->executor.will_run_query(sql);
-                }
-                perform_step(stmt);
-                if (this->executor.did_run_query) {
-                    this->executor.did_run_query(sql);
-                }
             }
 
             template<class Select, satisfies<is_select_expression, Select> = true>

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -221,7 +221,7 @@ namespace sqlite_orm {
             void assert_updatable_type() const {
                 using table_type = storage_pick_table_t<O, db_objects_type>;
                 using elements_type = elements_type_t<table_type>;
-                using col_index_sequence = filter_tuple_sequence_t<elements_type, is_column>;
+                using column_index_sequence = col_index_sequence_of<elements_type>;
                 using pk_index_sequence = filter_tuple_sequence_t<elements_type, is_primary_key>;
                 using pkcol_index_sequence = col_index_sequence_with<elements_type, is_primary_key>;
                 constexpr size_t dedicatedPrimaryKeyColumnsCount =
@@ -229,7 +229,7 @@ namespace sqlite_orm {
 
                 constexpr size_t primaryKeyColumnsCount =
                     dedicatedPrimaryKeyColumnsCount + pkcol_index_sequence::size();
-                constexpr ptrdiff_t nonPrimaryKeysColumnsCount = col_index_sequence::size() - primaryKeyColumnsCount;
+                constexpr ptrdiff_t nonPrimaryKeysColumnsCount = column_index_sequence::size() - primaryKeyColumnsCount;
                 static_assert(primaryKeyColumnsCount > 0, "A table without primary keys cannot be updated");
                 static_assert(
                     nonPrimaryKeysColumnsCount > 0,

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -1269,7 +1269,7 @@ namespace sqlite_orm {
                 context_t context{exprDBOs};
                 context.replace_bindable_with_question = parametrized;
                 // just like prepare_impl()
-                context.skip_table_name = false;
+                context.omit_table_name = false;
                 return serialize(expression, context);
             }
 
@@ -1287,7 +1287,7 @@ namespace sqlite_orm {
                 using context_t = serializer_context<polyfill::remove_cvref_t<decltype(exprDBOs)>>;
 
                 context_t context{exprDBOs};
-                context.skip_table_name = false;
+                context.omit_table_name = false;
                 context.replace_bindable_with_question = true;
 
                 auto conection = this->get_connection();

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -1220,7 +1220,7 @@ namespace sqlite_orm {
                 const auto res = sync_schema_result::already_in_sync;
                 context_t context{this->db_objects};
                 const auto sql = serialize(virtualTable, context);
-                this->executor.perform_void_exec(db, sql.data());
+                this->executor.perform_void_exec(db, sql.c_str());
                 return res;
             }
 
@@ -1231,7 +1231,7 @@ namespace sqlite_orm {
                 const auto res = sync_schema_result::already_in_sync;
                 context_t context{this->db_objects};
                 const auto sql = serialize(index, context);
-                this->executor.perform_void_exec(db, sql.data());
+                this->executor.perform_void_exec(db, sql.c_str());
                 return res;
             }
 
@@ -1242,7 +1242,7 @@ namespace sqlite_orm {
                 const auto res = sync_schema_result::already_in_sync;  // TODO Change accordingly
                 context_t context{this->db_objects};
                 const auto sql = serialize(trigger, context);
-                this->executor.perform_void_exec(db, sql.data());
+                this->executor.perform_void_exec(db, sql.c_str());
                 return res;
             }
 

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -299,37 +299,26 @@ namespace sqlite_orm {
 #endif
 
             /*  
-             *  Iterate over a result set of a select statement.
+             *  Iterate over a result set of a select statement or a select statement involving a common table expression.
              *  
              *  The returned C++ view models a C++ input range and is also a 'borrowed range',
              *  meaning that iterators obtained from it are not tied to the lifetime of the view instance.
              */
             template<class Select>
-#ifdef SQLITE_ORM_CONCEPTS_SUPPORTED
-                requires (is_select_v<Select>)
+#ifdef SQLITE_ORM_CPP20_CONCEPTS_SUPPORTED
+                requires (is_select_expression_v<Select>)
 #endif
             result_set_view<Select, db_objects_type> iterate(Select expression) {
-                expression.highest_level = true;
+#ifndef SQLITE_ORM_CPP20_CONCEPTS_SUPPORTED
+                static_assert(is_select_expression_v<Select>,
+                              "SQL expression must be a select expression or a with-clause with a select expression");
+#endif
+                if constexpr (is_select_v<Select>) {
+                    expression.highest_level = true;
+                }
                 auto con = this->get_connection();
                 return {this->db_objects, std::move(con), std::move(expression)};
             }
-
-#if (SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
-            /*  
-             *  Iterate over a result set of a select statement involving a common table expression.
-             *  
-             *  The returned C++ view models a C++ input range and is also a 'borrowed range',
-             *  meaning that iterators obtained from it are not tied to the lifetime of the view instance.
-             */
-            template<class... CTEs, class E>
-#ifdef SQLITE_ORM_CONCEPTS_SUPPORTED
-                requires (is_select_v<E>)
-#endif
-            result_set_view<with_t<E, CTEs...>, db_objects_type> iterate(with_t<E, CTEs...> expression) {
-                auto connection = this->get_connection();
-                return {this->db_objects, std::move(connection), std::move(expression)};
-            }
-#endif
 
 #ifdef SQLITE_ORM_CPP23_GENERATOR_SUPPORTED
             /*  
@@ -363,29 +352,15 @@ namespace sqlite_orm {
             }
 
             /*  
-             *  Iterate over a result set of a select statement in a coroutine.
+             *  Iterate over a result set of a select statement or a select statement involving a common table expression in a coroutine.
              */
             template<class Select>
-                requires (is_select_v<Select>)
+                requires (is_select_expression_v<Select>)
             auto yield(Select expression) -> std::generator<decltype(*this->iterate(std::move(expression)).begin())> {
                 for (auto row: this->iterate(std::move(expression))) {
                     co_yield row;
                 }
             }
-
-#if (SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
-            /*  
-             *  Iterate over a result set of a select statement involving a common table expression in a coroutine.
-             */
-            template<class... CTEs, class E>
-                requires (is_select_v<E>)
-            auto yield(with_t<E, CTEs...> expression)
-                -> std::generator<decltype(*this->iterate(std::move(expression)).begin())> {
-                for (auto row: this->iterate(std::move(expression))) {
-                    co_yield row;
-                }
-            }
-#endif
 #endif
 
             /**
@@ -1377,22 +1352,22 @@ namespace sqlite_orm {
             using storage_base::table_exists;  // now that it is in storage_base make it into overload set
 
 #if (SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
-            template<class... CTEs,
-                     class E,
-                     std::enable_if_t<polyfill::disjunction_v<is_select<E>,
-                                                              is_insert_raw<E>,
-                                                              is_replace_raw<E>,
-                                                              is_update_all<E>,
-                                                              is_remove_all<E>>,
-                                      bool> = true>
+            template<
+                class... CTEs,
+                class E,
+                std::enable_if_t<
+                    polyfill::disjunction_v<is_insert_raw<E>, is_replace_raw<E>, is_update_all<E>, is_remove_all<E>>,
+                    bool> = true>
             prepared_statement_t<with_t<E, CTEs...>> prepare(with_t<E, CTEs...> sel) {
                 return this->prepare_impl<with_t<E, CTEs...>>(std::move(sel));
             }
 #endif
 
-            template<class T, class... Args>
-            prepared_statement_t<select_t<T, Args...>> prepare(select_t<T, Args...> statement) {
-                statement.highest_level = true;
+            template<class Select, satisfies<is_select_expression, Select> = true>
+            prepared_statement_t<Select> prepare(Select statement) {
+                if constexpr (is_select_v<Select>) {
+                    statement.highest_level = true;
+                }
                 return this->prepare_impl(std::move(statement));
             }
 
@@ -1894,20 +1869,13 @@ namespace sqlite_orm {
                 }
             }
 
-#if (SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
-            template<class... CTEs, class T, class... Args>
-            auto execute(const prepared_statement_t<with_t<select_t<T, Args...>, CTEs...>>& statement) {
-                using ExprDBOs = decltype(db_objects_for_expression(this->db_objects, statement.expression));
+            template<class Select, satisfies<is_select_expression, Select> = true>
+            auto execute(const prepared_statement_t<Select>& statement) {
+                using ExprDBOs = polyfill::remove_cvref_t<decltype(db_objects_for_expression(this->db_objects,
+                                                                                             statement.expression))>;
                 // note: it is enough to only use the 'expression DBOs' at compile-time to determine the column results;
                 // because we cannot select objects/structs from a CTE, passing the permanently defined DBOs are enough.
-                using ColResult = column_result_of_t<ExprDBOs, T>;
-                return this->execute_select<ColResult>(statement);
-            }
-#endif
-
-            template<class T, class... Args>
-            auto execute(const prepared_statement_t<select_t<T, Args...>>& statement) {
-                using ColResult = column_result_of_t<db_objects_type, T>;
+                using ColResult = column_result_of_t<ExprDBOs, main_select_t<Select>>;
                 return this->execute_select<ColResult>(statement);
             }
 

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -1461,17 +1461,7 @@ namespace sqlite_orm {
             void execute(const prepared_statement_t<DML>& statement) {
                 sqlite3_stmt* stmt = reset_stmt(statement.stmt);
                 iterate_ast(statement.expression, conditional_binder{stmt});
-                std::string sql;
-                if (this->executor.will_run_query || this->executor.did_run_query) {
-                    sql = statement.sql();
-                }
-                if (this->executor.will_run_query) {
-                    this->executor.will_run_query(sql);
-                }
-                perform_step(stmt);
-                if (this->executor.did_run_query) {
-                    this->executor.did_run_query(sql);
-                }
+                this->executor.perform_single_step(stmt);
             }
 
             /** 
@@ -1489,17 +1479,8 @@ namespace sqlite_orm {
                     [&table = this->get_table<object_type>(), &object = statement.expression.obj](auto& memberPointer) {
                         return table.object_field_value(object, memberPointer);
                     });
-                std::string sql;
-                if (this->executor.will_run_query || this->executor.did_run_query) {
-                    sql = statement.sql();
-                }
-                if (this->executor.will_run_query) {
-                    this->executor.will_run_query(sql);
-                }
-                perform_step(stmt);
-                if (this->executor.did_run_query) {
-                    this->executor.did_run_query(sql);
-                }
+
+                this->executor.perform_single_step(stmt);
                 return sqlite3_last_insert_rowid(sqlite3_db_handle(stmt));
             }
 
@@ -1537,17 +1518,8 @@ namespace sqlite_orm {
                     const object_type& object = get_object(statement.expression);
                     processObject(object);
                 };
-                std::string sql;
-                if (this->executor.will_run_query || this->executor.did_run_query) {
-                    sql = statement.sql();
-                }
-                if (this->executor.will_run_query) {
-                    this->executor.will_run_query(sql);
-                }
-                perform_step(stmt);
-                if (this->executor.did_run_query) {
-                    this->executor.did_run_query(sql);
-                }
+
+                this->executor.perform_single_step(stmt);
             }
 
             /** 
@@ -1594,17 +1566,8 @@ namespace sqlite_orm {
                     const object_type& object = get_object(statement.expression);
                     processObject(object);
                 }
-                std::string sql;
-                if (this->executor.will_run_query || this->executor.did_run_query) {
-                    sql = statement.sql();
-                }
-                if (this->executor.will_run_query) {
-                    this->executor.will_run_query(sql);
-                }
-                perform_step(stmt);
-                if (this->executor.did_run_query) {
-                    this->executor.did_run_query(sql);
-                }
+
+                this->executor.perform_single_step(stmt);
                 return sqlite3_last_insert_rowid(sqlite3_db_handle(stmt));
             }
 
@@ -1612,17 +1575,7 @@ namespace sqlite_orm {
             void execute(const prepared_statement_t<remove_t<T, Ids...>>& statement) {
                 sqlite3_stmt* stmt = reset_stmt(statement.stmt);
                 iterate_ast(statement.expression.ids, conditional_binder{stmt});
-                std::string sql;
-                if (this->executor.will_run_query || this->executor.did_run_query) {
-                    sql = statement.sql();
-                }
-                if (this->executor.will_run_query) {
-                    this->executor.will_run_query(sql);
-                }
-                perform_step(stmt);
-                if (this->executor.did_run_query) {
-                    this->executor.did_run_query(sql);
-                }
+                this->executor.perform_single_step(stmt);
             }
 
             template<class T>
@@ -1645,17 +1598,8 @@ namespace sqlite_orm {
                         bindValue(polyfill::invoke(column.member_pointer, object));
                     }
                 });
-                std::string sql;
-                if (this->executor.will_run_query || this->executor.did_run_query) {
-                    sql = statement.sql();
-                }
-                if (this->executor.will_run_query) {
-                    this->executor.will_run_query(sql);
-                }
-                perform_step(stmt);
-                if (this->executor.did_run_query) {
-                    this->executor.did_run_query(sql);
-                }
+
+                this->executor.perform_single_step(stmt);
             }
 
             template<class T, class... Ids>
@@ -1665,21 +1609,11 @@ namespace sqlite_orm {
                 iterate_ast(statement.expression.ids, conditional_binder{stmt});
 
                 std::unique_ptr<T> res;
-                std::string sql;
-                if (this->executor.will_run_query || this->executor.did_run_query) {
-                    sql = statement.sql();
-                }
-                if (this->executor.will_run_query) {
-                    this->executor.will_run_query(sql);
-                }
-                perform_step(stmt, [&table = this->get_table<T>(), &res](sqlite3_stmt* stmt) {
+                this->executor.perform_step(stmt, [&table = this->get_table<T>(), &res](sqlite3_stmt* stmt) {
                     res = std::make_unique<T>();
                     object_from_column_builder<T> builder{*res, stmt};
                     table.for_each_column(builder);
                 });
-                if (this->executor.did_run_query) {
-                    this->executor.did_run_query(sql);
-                }
                 return res;
             }
 
@@ -1691,20 +1625,10 @@ namespace sqlite_orm {
                 iterate_ast(statement.expression.ids, conditional_binder{stmt});
 
                 std::optional<T> res;
-                std::string sql;
-                if (this->executor.will_run_query || this->executor.did_run_query) {
-                    sql = statement.sql();
-                }
-                if (this->executor.will_run_query) {
-                    this->executor.will_run_query(sql);
-                }
-                perform_step(stmt, [&table = this->get_table<T>(), &res](sqlite3_stmt* stmt) {
+                this->executor.perform_step(stmt, [&table = this->get_table<T>(), &res](sqlite3_stmt* stmt) {
                     object_from_column_builder<T> builder{res.emplace(), stmt};
                     table.for_each_column(builder);
                 });
-                if (this->executor.did_run_query) {
-                    this->executor.did_run_query(sql);
-                }
                 return res;
             }
 #endif  // SQLITE_ORM_OPTIONAL_SUPPORTED
@@ -1717,26 +1641,17 @@ namespace sqlite_orm {
 
 #ifdef SQLITE_ORM_OPTIONAL_SUPPORTED
                 std::optional<T> res;
-                std::string sql;
-                if (this->executor.will_run_query || this->executor.did_run_query) {
-                    sql = statement.sql();
-                }
-                if (this->executor.will_run_query) {
-                    this->executor.will_run_query(sql);
-                }
-                perform_step(stmt, [&table = this->get_table<T>(), &res](sqlite3_stmt* stmt) {
+                this->executor.perform_step(stmt, [&table = this->get_table<T>(), &res](sqlite3_stmt* stmt) {
                     object_from_column_builder<T> builder{res.emplace(), stmt};
                     table.for_each_column(builder);
                 });
-                if (this->executor.did_run_query) {
-                    this->executor.did_run_query(sql);
-                }
                 if (!res.has_value()) {
                     throw std::system_error{orm_error_code::not_found};
                 }
                 return std::move(res).value();
 #else
                 auto& table = this->get_table<T>();
+
                 std::string sql;
                 if (this->executor.will_run_query || this->executor.did_run_query) {
                     sql = statement.sql();
@@ -1744,24 +1659,27 @@ namespace sqlite_orm {
                 if (this->executor.will_run_query) {
                     this->executor.will_run_query(sql);
                 }
-                const auto stepRes = sqlite3_step(stmt);
+
+                switch (int rc = sqlite3_step(stmt)) {
+                    case SQLITE_ROW:
+                        break;
+                    case SQLITE_DONE: {
+                        throw std::system_error{orm_error_code::not_found};
+                    }
+                    default: {
+                        throw_translated_sqlite_error(stmt);
+                    }
+                }
+
+                T res;
+                object_from_column_builder<T> builder{res, stmt};
+                table.for_each_column(builder);
+
                 if (this->executor.did_run_query) {
                     this->executor.did_run_query(sql);
                 }
-                switch (stepRes) {
-                    case SQLITE_ROW: {
-                        T res;
-                        object_from_column_builder<T> builder{res, stmt};
-                        table.for_each_column(builder);
-                        return res;
-                    } break;
-                    case SQLITE_DONE: {
-                        throw std::system_error{orm_error_code::not_found};
-                    } break;
-                    default: {
-                        throw_translated_sqlite_error(rc);
-                    }
-                }
+
+                return res;
 #endif
             }
 

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -1214,7 +1214,7 @@ namespace sqlite_orm {
             }
 
             template<class M>
-            sync_schema_result sync_table(const virtual_table_t<M>& virtualTable, sqlite3* db, bool) {
+            sync_schema_result sync_dbo(const virtual_table_t<M>& virtualTable, sqlite3* db, bool) {
                 using context_t = serializer_context<db_objects_type>;
 
                 const auto res = sync_schema_result::already_in_sync;
@@ -1225,7 +1225,7 @@ namespace sqlite_orm {
             }
 
             template<class... Cols>
-            sync_schema_result sync_table(const index_t<Cols...>& index, sqlite3* db, bool) {
+            sync_schema_result sync_dbo(const index_t<Cols...>& index, sqlite3* db, bool) {
                 using context_t = serializer_context<db_objects_type>;
 
                 const auto res = sync_schema_result::already_in_sync;
@@ -1236,7 +1236,7 @@ namespace sqlite_orm {
             }
 
             template<class... Cols>
-            sync_schema_result sync_table(const trigger_t<Cols...>& trigger, sqlite3* db, bool) {
+            sync_schema_result sync_dbo(const trigger_t<Cols...>& trigger, sqlite3* db, bool) {
                 using context_t = serializer_context<db_objects_type>;
 
                 const auto res = sync_schema_result::already_in_sync;  // TODO Change accordingly
@@ -1247,7 +1247,7 @@ namespace sqlite_orm {
             }
 
             template<class Table, satisfies<is_table, Table> = true>
-            sync_schema_result sync_table(const Table& table, sqlite3* db, bool preserve);
+            sync_schema_result sync_dbo(const Table& table, sqlite3* db, bool preserve);
 
             template<class Table, satisfies<is_table, Table> = true>
             sync_schema_result sync_regular_table(const Table& table, sqlite3* db, bool preserve);
@@ -1353,7 +1353,7 @@ namespace sqlite_orm {
                 auto con = this->get_connection();
                 std::map<std::string, sync_schema_result> result;
                 iterate_tuple<true>(this->db_objects, [this, db = con.get(), preserve, &result](auto& schemaObject) {
-                    sync_schema_result status = this->sync_table(schemaObject, db, preserve);
+                    sync_schema_result status = this->sync_dbo(schemaObject, db, preserve);
                     result.emplace(schemaObject.name, status);
                 });
                 return result;

--- a/dev/storage_base.h
+++ b/dev/storage_base.h
@@ -156,7 +156,7 @@ namespace sqlite_orm {
                        << streaming_identifier(newName) << std::flush;
                     sql = ss.str();
                 }
-                this->executor.perform_void_exec(db, sql.data());
+                this->executor.perform_void_exec(db, sql.c_str());
             }
 
             /**
@@ -745,7 +745,7 @@ namespace sqlite_orm {
             void begin_transaction_internal(const std::string& sql) {
                 this->connection->retain();
                 sqlite3* db = this->connection->get();
-                this->executor.perform_void_exec(db, sql.data());
+                this->executor.perform_void_exec(db, sql.c_str());
             }
 
             connection_ref get_connection() {
@@ -781,7 +781,7 @@ namespace sqlite_orm {
                     ss << "PRAGMA foreign_keys = " << value << std::flush;
                     sql = ss.str();
                 }
-                this->executor.perform_void_exec(db, sql.data());
+                this->executor.perform_void_exec(db, sql.c_str());
             }
 
             bool foreign_keys(sqlite3* db) {
@@ -1004,7 +1004,7 @@ namespace sqlite_orm {
                     ss << ' ' << streaming_identifier(tableName) << std::flush;
                     sql = ss.str();
                 }
-                this->executor.perform_void_exec(db, sql.data());
+                this->executor.perform_void_exec(db, sql.c_str());
             }
 
             void drop_index_internal(const std::string& indexName, bool ifExists) {
@@ -1019,7 +1019,7 @@ namespace sqlite_orm {
                     sql = ss.str();
                 }
                 auto connection = this->get_connection();
-                this->executor.perform_void_exec(connection.get(), sql.data());
+                this->executor.perform_void_exec(connection.get(), sql.c_str());
             }
 
             void drop_trigger_internal(const std::string& triggerName, bool ifExists) {
@@ -1034,7 +1034,7 @@ namespace sqlite_orm {
                     sql = ss.str();
                 }
                 auto connection = this->get_connection();
-                this->executor.perform_void_exec(connection.get(), sql.data());
+                this->executor.perform_void_exec(connection.get(), sql.c_str());
             }
 
             static int

--- a/dev/storage_impl.h
+++ b/dev/storage_impl.h
@@ -103,7 +103,7 @@ namespace sqlite_orm {
                                                   const column_pointer<Moniker, alias_holder<ColAlias>>&) {
             using table_type = storage_pick_table_t<Moniker, DBOs>;
             using cte_colrefs_tuple = typename cte_mapper_type_t<table_type>::final_colrefs_tuple;
-            using column_index_sequence = filter_tuple_sequence_t<elements_type_t<table_type>, is_column>;
+            using column_index_sequence = col_index_sequence_of<elements_type_t<table_type>>;
 
             // note: even though the columns contain the [`aliased_field<>::*`] we perform the lookup using the column references.
             // lookup ColAlias in the final column references

--- a/dev/util.h
+++ b/dev/util.h
@@ -5,9 +5,6 @@
 #include <string>  //  std::string
 #include <utility>  //  std::move
 #include <functional>  //  std::function
-#ifdef SQLITE_ORM_STRING_VIEW_SUPPORTED
-#include <string_view>  //  std::string_view
-#endif
 #endif
 
 #include "functional/gsl.h"
@@ -59,88 +56,6 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 
 namespace sqlite_orm {
     namespace internal {
-
-        template<class L>
-        void perform_step(sqlite3_stmt* stmt, L&& lambda) {
-            switch (int rc = sqlite3_step(stmt)) {
-                case SQLITE_ROW: {
-                    lambda(stmt);
-                } break;
-                case SQLITE_DONE:
-                    return;
-                default: {
-                    throw_translated_sqlite_error(stmt);
-                }
-            }
-        }
-
-        struct sqlite_executor {
-            std::function<void(serialize_arg_type sql)> will_run_query;
-            std::function<void(serialize_arg_type sql)> did_run_query;
-
-            inline void perform_void_exec(sqlite3* db, orm_gsl::czstring sql) const {
-                if (this->will_run_query) {
-                    this->will_run_query(sql);
-                }
-                const int rc = sqlite3_exec(db, sql, nullptr, nullptr, nullptr);
-                if (rc != SQLITE_OK) {
-                    throw_translated_sqlite_error(rc);
-                }
-                if (this->did_run_query) {
-                    this->did_run_query(sql);
-                }
-            }
-
-            inline void perform_exec(sqlite3* db,
-                                     orm_gsl::czstring sql,
-                                     int (*callback)(void*, int, orm_gsl::zstring*, orm_gsl::zstring*),
-                                     void* user_data) const {
-                if (this->will_run_query) {
-                    this->will_run_query(sql);
-                }
-                const int rc = sqlite3_exec(db, sql, callback, user_data, nullptr);
-                if (rc != SQLITE_OK) {
-                    throw_translated_sqlite_error(rc);
-                }
-                if (this->did_run_query) {
-                    this->did_run_query(sql);
-                }
-            }
-
-            inline void perform_exec(sqlite3* db,
-                                     const std::string& query,
-                                     int (*callback)(void*, int, orm_gsl::zstring*, orm_gsl::zstring*),
-                                     void* user_data) const {
-                return perform_exec(db, query.c_str(), callback, user_data);
-            }
-
-            template<class L>
-            void perform_steps(sqlite3_stmt* stmt, L&& lambda) const {
-                orm_gsl::czstring sql = nullptr;
-                if (this->will_run_query || this->did_run_query) {
-                    sql = sqlite3_sql(stmt);
-                }
-                if (this->will_run_query) {
-                    this->will_run_query(sql);
-                }
-                for (;;) {
-                    switch (int rc = sqlite3_step(stmt)) {
-                        case SQLITE_ROW: {
-                            lambda(stmt);
-                        } break;
-                        case SQLITE_DONE:
-                            if (this->did_run_query) {
-                                this->did_run_query(sql);
-                            }
-                            return;
-                        default: {
-                            throw_translated_sqlite_error(stmt);
-                        }
-                    }
-                }
-            }
-        };
-
         // Wrapper to reduce boiler-plate code
         inline sqlite3_stmt* reset_stmt(sqlite3_stmt* stmt) {
             sqlite3_reset(stmt);
@@ -157,11 +72,139 @@ namespace sqlite_orm {
         }
 
         template<int expected = SQLITE_DONE>
-        void perform_step(sqlite3_stmt* stmt) {
+        void perform_single_step(sqlite3_stmt* stmt) {
             const int rc = sqlite3_step(stmt);
-            if (rc != expected) {
+            if (rc != expected) SQLITE_ORM_CPP_UNLIKELY /*possible but unexpected*/ {
                 throw_translated_sqlite_error(rc);
             }
         }
+
+        template<class L>
+        void perform_step(sqlite3_stmt* stmt, L&& lambda) {
+            switch (int rc = sqlite3_step(stmt)) {
+                case SQLITE_ROW: {
+                    lambda(stmt);
+                } break;
+                case SQLITE_DONE:
+                    return;
+                default:
+                    SQLITE_ORM_CPP_UNLIKELY /*possible but unexpected*/ {
+                        throw_translated_sqlite_error(stmt);
+                    }
+            }
+        }
+
+        template<class L>
+        void perform_steps(sqlite3_stmt* stmt, L&& lambda) {
+            for (;;) {
+                switch (int rc = sqlite3_step(stmt)) {
+                    case SQLITE_ROW: {
+                        lambda(stmt);
+                    } break;
+                    case SQLITE_DONE:
+                        return;
+                    default:
+                        SQLITE_ORM_CPP_UNLIKELY /*possible but unexpected*/ {
+                            throw_translated_sqlite_error(stmt);
+                        }
+                }
+            }
+        }
+
+        struct sqlite_executor {
+            std::function<void(serialize_arg_type sql)> will_run_query;
+            std::function<void(serialize_arg_type sql)> did_run_query;
+
+            void perform_void_exec(sqlite3* db, orm_gsl::czstring sql) const {
+                if (this->will_run_query) {
+                    this->will_run_query(sql);
+                }
+
+                const int rc = sqlite3_exec(db, sql, nullptr, nullptr, nullptr);
+                if (rc != SQLITE_OK) SQLITE_ORM_CPP_UNLIKELY /*possible but unexpected*/ {
+                    throw_translated_sqlite_error(rc);
+                }
+
+                if (this->did_run_query) {
+                    this->did_run_query(sql);
+                }
+            }
+
+            void perform_exec(sqlite3* db,
+                              orm_gsl::czstring sql,
+                              int (*callback)(void*, int, orm_gsl::zstring*, orm_gsl::zstring*),
+                              void* user_data) const {
+                if (this->will_run_query) {
+                    this->will_run_query(sql);
+                }
+
+                const int rc = sqlite3_exec(db, sql, callback, user_data, nullptr);
+                if (rc != SQLITE_OK) SQLITE_ORM_CPP_UNLIKELY /*possible but unexpected*/ {
+                    throw_translated_sqlite_error(rc);
+                }
+
+                if (this->did_run_query) {
+                    this->did_run_query(sql);
+                }
+            }
+
+            void perform_exec(sqlite3* db,
+                              const std::string& query,
+                              int (*callback)(void*, int, orm_gsl::zstring*, orm_gsl::zstring*),
+                              void* user_data) const {
+                return perform_exec(db, query.c_str(), callback, user_data);
+            }
+
+            template<int expected = SQLITE_DONE>
+            void perform_single_step(sqlite3_stmt* stmt) const {
+                orm_gsl::czstring sql = nullptr;
+                if (this->will_run_query || this->did_run_query) {
+                    sql = sqlite3_sql(stmt);
+                }
+                if (this->will_run_query) {
+                    this->will_run_query(sql);
+                }
+
+                internal::perform_single_step<expected>(stmt);
+
+                if (this->did_run_query) {
+                    this->did_run_query(sql);
+                }
+            }
+
+            template<class L>
+            void perform_step(sqlite3_stmt* stmt, L&& lambda) const {
+                orm_gsl::czstring sql = nullptr;
+                if (this->will_run_query || this->did_run_query) {
+                    sql = sqlite3_sql(stmt);
+                }
+                if (this->will_run_query) {
+                    this->will_run_query(sql);
+                }
+
+                internal::perform_step(stmt, lambda);
+
+                if (this->did_run_query) {
+                    this->did_run_query(sql);
+                }
+            }
+
+            template<class L>
+            void perform_steps(sqlite3_stmt* stmt, L&& lambda) const {
+                orm_gsl::czstring sql = nullptr;
+                if (this->will_run_query || this->did_run_query) {
+                    sql = sqlite3_sql(stmt);
+                }
+                if (this->will_run_query) {
+                    this->will_run_query(sql);
+                }
+
+                internal::perform_steps(stmt, lambda);
+
+                if (this->did_run_query) {
+                    this->did_run_query(sql);
+                }
+            }
+        };
     }
 }

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -8770,6 +8770,9 @@ namespace sqlite_orm {
         template<class T>
         using is_column = polyfill::bool_constant<is_column_v<T>>;
 
+        template<class Elements>
+        using col_index_sequence_of = filter_tuple_sequence_t<Elements, is_column>;
+
         template<class Elements, class F>
         using col_index_sequence_with_field_type =
             filter_tuple_sequence_t<Elements,
@@ -12625,8 +12628,7 @@ namespace sqlite_orm {
              */
             template<class L>
             void for_each_column(L&& lambda) const {
-                using col_index_sequence = filter_tuple_sequence_t<elements_type, is_column>;
-                iterate_tuple(this->elements, col_index_sequence{}, lambda);
+                iterate_tuple(this->elements, col_index_sequence_of<elements_type>{}, lambda);
             }
 
             /**
@@ -12740,8 +12742,7 @@ namespace sqlite_orm {
              */
             template<class L>
             void for_each_column(L&& lambda) const {
-                using col_index_sequence = filter_tuple_sequence_t<columns_type, is_column>;
-                iterate_tuple(this->columns, col_index_sequence{}, lambda);
+                iterate_tuple(this->columns, col_index_sequence_of<columns_type>{}, lambda);
             }
 
             template<class M, satisfies<std::is_member_pointer, M> = true>
@@ -12945,7 +12946,7 @@ namespace sqlite_orm {
                                                   const column_pointer<Moniker, alias_holder<ColAlias>>&) {
             using table_type = storage_pick_table_t<Moniker, DBOs>;
             using cte_colrefs_tuple = typename cte_mapper_type_t<table_type>::final_colrefs_tuple;
-            using column_index_sequence = filter_tuple_sequence_t<elements_type_t<table_type>, is_column>;
+            using column_index_sequence = col_index_sequence_of<elements_type_t<table_type>>;
 
             // note: even though the columns contain the [`aliased_field<>::*`] we perform the lookup using the column references.
             // lookup ColAlias in the final column references
@@ -23335,7 +23336,7 @@ namespace sqlite_orm {
             void assert_updatable_type() const {
                 using table_type = storage_pick_table_t<O, db_objects_type>;
                 using elements_type = elements_type_t<table_type>;
-                using col_index_sequence = filter_tuple_sequence_t<elements_type, is_column>;
+                using column_index_sequence = col_index_sequence_of<elements_type>;
                 using pk_index_sequence = filter_tuple_sequence_t<elements_type, is_primary_key>;
                 using pkcol_index_sequence = col_index_sequence_with<elements_type, is_primary_key>;
                 constexpr size_t dedicatedPrimaryKeyColumnsCount =
@@ -23343,7 +23344,7 @@ namespace sqlite_orm {
 
                 constexpr size_t primaryKeyColumnsCount =
                     dedicatedPrimaryKeyColumnsCount + pkcol_index_sequence::size();
-                constexpr ptrdiff_t nonPrimaryKeysColumnsCount = col_index_sequence::size() - primaryKeyColumnsCount;
+                constexpr ptrdiff_t nonPrimaryKeysColumnsCount = column_index_sequence::size() - primaryKeyColumnsCount;
                 static_assert(primaryKeyColumnsCount > 0, "A table without primary keys cannot be updated");
                 static_assert(
                     nonPrimaryKeysColumnsCount > 0,

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -13858,9 +13858,6 @@ namespace sqlite_orm {
 #include <string>  //  std::string
 #include <utility>  //  std::move
 #include <functional>  //  std::function
-#ifdef SQLITE_ORM_STRING_VIEW_SUPPORTED
-#include <string_view>  //  std::string_view
-#endif
 #endif
 
 // #include "functional/gsl.h"
@@ -13914,88 +13911,6 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 
 namespace sqlite_orm {
     namespace internal {
-
-        template<class L>
-        void perform_step(sqlite3_stmt* stmt, L&& lambda) {
-            switch (int rc = sqlite3_step(stmt)) {
-                case SQLITE_ROW: {
-                    lambda(stmt);
-                } break;
-                case SQLITE_DONE:
-                    return;
-                default: {
-                    throw_translated_sqlite_error(stmt);
-                }
-            }
-        }
-
-        struct sqlite_executor {
-            std::function<void(serialize_arg_type sql)> will_run_query;
-            std::function<void(serialize_arg_type sql)> did_run_query;
-
-            inline void perform_void_exec(sqlite3* db, orm_gsl::czstring sql) const {
-                if (this->will_run_query) {
-                    this->will_run_query(sql);
-                }
-                const int rc = sqlite3_exec(db, sql, nullptr, nullptr, nullptr);
-                if (rc != SQLITE_OK) {
-                    throw_translated_sqlite_error(rc);
-                }
-                if (this->did_run_query) {
-                    this->did_run_query(sql);
-                }
-            }
-
-            inline void perform_exec(sqlite3* db,
-                                     orm_gsl::czstring sql,
-                                     int (*callback)(void*, int, orm_gsl::zstring*, orm_gsl::zstring*),
-                                     void* user_data) const {
-                if (this->will_run_query) {
-                    this->will_run_query(sql);
-                }
-                const int rc = sqlite3_exec(db, sql, callback, user_data, nullptr);
-                if (rc != SQLITE_OK) {
-                    throw_translated_sqlite_error(rc);
-                }
-                if (this->did_run_query) {
-                    this->did_run_query(sql);
-                }
-            }
-
-            inline void perform_exec(sqlite3* db,
-                                     const std::string& query,
-                                     int (*callback)(void*, int, orm_gsl::zstring*, orm_gsl::zstring*),
-                                     void* user_data) const {
-                return perform_exec(db, query.c_str(), callback, user_data);
-            }
-
-            template<class L>
-            void perform_steps(sqlite3_stmt* stmt, L&& lambda) const {
-                orm_gsl::czstring sql = nullptr;
-                if (this->will_run_query || this->did_run_query) {
-                    sql = sqlite3_sql(stmt);
-                }
-                if (this->will_run_query) {
-                    this->will_run_query(sql);
-                }
-                for (;;) {
-                    switch (int rc = sqlite3_step(stmt)) {
-                        case SQLITE_ROW: {
-                            lambda(stmt);
-                        } break;
-                        case SQLITE_DONE:
-                            if (this->did_run_query) {
-                                this->did_run_query(sql);
-                            }
-                            return;
-                        default: {
-                            throw_translated_sqlite_error(stmt);
-                        }
-                    }
-                }
-            }
-        };
-
         // Wrapper to reduce boiler-plate code
         inline sqlite3_stmt* reset_stmt(sqlite3_stmt* stmt) {
             sqlite3_reset(stmt);
@@ -14012,12 +13927,140 @@ namespace sqlite_orm {
         }
 
         template<int expected = SQLITE_DONE>
-        void perform_step(sqlite3_stmt* stmt) {
+        void perform_single_step(sqlite3_stmt* stmt) {
             const int rc = sqlite3_step(stmt);
-            if (rc != expected) {
+            if (rc != expected) SQLITE_ORM_CPP_UNLIKELY /*possible but unexpected*/ {
                 throw_translated_sqlite_error(rc);
             }
         }
+
+        template<class L>
+        void perform_step(sqlite3_stmt* stmt, L&& lambda) {
+            switch (int rc = sqlite3_step(stmt)) {
+                case SQLITE_ROW: {
+                    lambda(stmt);
+                } break;
+                case SQLITE_DONE:
+                    return;
+                default:
+                    SQLITE_ORM_CPP_UNLIKELY /*possible but unexpected*/ {
+                        throw_translated_sqlite_error(stmt);
+                    }
+            }
+        }
+
+        template<class L>
+        void perform_steps(sqlite3_stmt* stmt, L&& lambda) {
+            for (;;) {
+                switch (int rc = sqlite3_step(stmt)) {
+                    case SQLITE_ROW: {
+                        lambda(stmt);
+                    } break;
+                    case SQLITE_DONE:
+                        return;
+                    default:
+                        SQLITE_ORM_CPP_UNLIKELY /*possible but unexpected*/ {
+                            throw_translated_sqlite_error(stmt);
+                        }
+                }
+            }
+        }
+
+        struct sqlite_executor {
+            std::function<void(serialize_arg_type sql)> will_run_query;
+            std::function<void(serialize_arg_type sql)> did_run_query;
+
+            void perform_void_exec(sqlite3* db, orm_gsl::czstring sql) const {
+                if (this->will_run_query) {
+                    this->will_run_query(sql);
+                }
+
+                const int rc = sqlite3_exec(db, sql, nullptr, nullptr, nullptr);
+                if (rc != SQLITE_OK) SQLITE_ORM_CPP_UNLIKELY /*possible but unexpected*/ {
+                    throw_translated_sqlite_error(rc);
+                }
+
+                if (this->did_run_query) {
+                    this->did_run_query(sql);
+                }
+            }
+
+            void perform_exec(sqlite3* db,
+                              orm_gsl::czstring sql,
+                              int (*callback)(void*, int, orm_gsl::zstring*, orm_gsl::zstring*),
+                              void* user_data) const {
+                if (this->will_run_query) {
+                    this->will_run_query(sql);
+                }
+
+                const int rc = sqlite3_exec(db, sql, callback, user_data, nullptr);
+                if (rc != SQLITE_OK) SQLITE_ORM_CPP_UNLIKELY /*possible but unexpected*/ {
+                    throw_translated_sqlite_error(rc);
+                }
+
+                if (this->did_run_query) {
+                    this->did_run_query(sql);
+                }
+            }
+
+            void perform_exec(sqlite3* db,
+                              const std::string& query,
+                              int (*callback)(void*, int, orm_gsl::zstring*, orm_gsl::zstring*),
+                              void* user_data) const {
+                return perform_exec(db, query.c_str(), callback, user_data);
+            }
+
+            template<int expected = SQLITE_DONE>
+            void perform_single_step(sqlite3_stmt* stmt) const {
+                orm_gsl::czstring sql = nullptr;
+                if (this->will_run_query || this->did_run_query) {
+                    sql = sqlite3_sql(stmt);
+                }
+                if (this->will_run_query) {
+                    this->will_run_query(sql);
+                }
+
+                internal::perform_single_step<expected>(stmt);
+
+                if (this->did_run_query) {
+                    this->did_run_query(sql);
+                }
+            }
+
+            template<class L>
+            void perform_step(sqlite3_stmt* stmt, L&& lambda) const {
+                orm_gsl::czstring sql = nullptr;
+                if (this->will_run_query || this->did_run_query) {
+                    sql = sqlite3_sql(stmt);
+                }
+                if (this->will_run_query) {
+                    this->will_run_query(sql);
+                }
+
+                internal::perform_step(stmt, lambda);
+
+                if (this->did_run_query) {
+                    this->did_run_query(sql);
+                }
+            }
+
+            template<class L>
+            void perform_steps(sqlite3_stmt* stmt, L&& lambda) const {
+                orm_gsl::czstring sql = nullptr;
+                if (this->will_run_query || this->did_run_query) {
+                    sql = sqlite3_sql(stmt);
+                }
+                if (this->will_run_query) {
+                    this->will_run_query(sql);
+                }
+
+                internal::perform_steps(stmt, lambda);
+
+                if (this->did_run_query) {
+                    this->did_run_query(sql);
+                }
+            }
+        };
     }
 }
 
@@ -24659,17 +24702,7 @@ namespace sqlite_orm {
             void execute(const prepared_statement_t<DML>& statement) {
                 sqlite3_stmt* stmt = reset_stmt(statement.stmt);
                 iterate_ast(statement.expression, conditional_binder{stmt});
-                std::string sql;
-                if (this->executor.will_run_query || this->executor.did_run_query) {
-                    sql = statement.sql();
-                }
-                if (this->executor.will_run_query) {
-                    this->executor.will_run_query(sql);
-                }
-                perform_step(stmt);
-                if (this->executor.did_run_query) {
-                    this->executor.did_run_query(sql);
-                }
+                this->executor.perform_single_step(stmt);
             }
 
             /** 
@@ -24687,17 +24720,8 @@ namespace sqlite_orm {
                     [&table = this->get_table<object_type>(), &object = statement.expression.obj](auto& memberPointer) {
                         return table.object_field_value(object, memberPointer);
                     });
-                std::string sql;
-                if (this->executor.will_run_query || this->executor.did_run_query) {
-                    sql = statement.sql();
-                }
-                if (this->executor.will_run_query) {
-                    this->executor.will_run_query(sql);
-                }
-                perform_step(stmt);
-                if (this->executor.did_run_query) {
-                    this->executor.did_run_query(sql);
-                }
+
+                this->executor.perform_single_step(stmt);
                 return sqlite3_last_insert_rowid(sqlite3_db_handle(stmt));
             }
 
@@ -24735,17 +24759,8 @@ namespace sqlite_orm {
                     const object_type& object = get_object(statement.expression);
                     processObject(object);
                 };
-                std::string sql;
-                if (this->executor.will_run_query || this->executor.did_run_query) {
-                    sql = statement.sql();
-                }
-                if (this->executor.will_run_query) {
-                    this->executor.will_run_query(sql);
-                }
-                perform_step(stmt);
-                if (this->executor.did_run_query) {
-                    this->executor.did_run_query(sql);
-                }
+
+                this->executor.perform_single_step(stmt);
             }
 
             /** 
@@ -24792,17 +24807,8 @@ namespace sqlite_orm {
                     const object_type& object = get_object(statement.expression);
                     processObject(object);
                 }
-                std::string sql;
-                if (this->executor.will_run_query || this->executor.did_run_query) {
-                    sql = statement.sql();
-                }
-                if (this->executor.will_run_query) {
-                    this->executor.will_run_query(sql);
-                }
-                perform_step(stmt);
-                if (this->executor.did_run_query) {
-                    this->executor.did_run_query(sql);
-                }
+
+                this->executor.perform_single_step(stmt);
                 return sqlite3_last_insert_rowid(sqlite3_db_handle(stmt));
             }
 
@@ -24810,17 +24816,7 @@ namespace sqlite_orm {
             void execute(const prepared_statement_t<remove_t<T, Ids...>>& statement) {
                 sqlite3_stmt* stmt = reset_stmt(statement.stmt);
                 iterate_ast(statement.expression.ids, conditional_binder{stmt});
-                std::string sql;
-                if (this->executor.will_run_query || this->executor.did_run_query) {
-                    sql = statement.sql();
-                }
-                if (this->executor.will_run_query) {
-                    this->executor.will_run_query(sql);
-                }
-                perform_step(stmt);
-                if (this->executor.did_run_query) {
-                    this->executor.did_run_query(sql);
-                }
+                this->executor.perform_single_step(stmt);
             }
 
             template<class T>
@@ -24843,17 +24839,8 @@ namespace sqlite_orm {
                         bindValue(polyfill::invoke(column.member_pointer, object));
                     }
                 });
-                std::string sql;
-                if (this->executor.will_run_query || this->executor.did_run_query) {
-                    sql = statement.sql();
-                }
-                if (this->executor.will_run_query) {
-                    this->executor.will_run_query(sql);
-                }
-                perform_step(stmt);
-                if (this->executor.did_run_query) {
-                    this->executor.did_run_query(sql);
-                }
+
+                this->executor.perform_single_step(stmt);
             }
 
             template<class T, class... Ids>
@@ -24863,21 +24850,11 @@ namespace sqlite_orm {
                 iterate_ast(statement.expression.ids, conditional_binder{stmt});
 
                 std::unique_ptr<T> res;
-                std::string sql;
-                if (this->executor.will_run_query || this->executor.did_run_query) {
-                    sql = statement.sql();
-                }
-                if (this->executor.will_run_query) {
-                    this->executor.will_run_query(sql);
-                }
-                perform_step(stmt, [&table = this->get_table<T>(), &res](sqlite3_stmt* stmt) {
+                this->executor.perform_step(stmt, [&table = this->get_table<T>(), &res](sqlite3_stmt* stmt) {
                     res = std::make_unique<T>();
                     object_from_column_builder<T> builder{*res, stmt};
                     table.for_each_column(builder);
                 });
-                if (this->executor.did_run_query) {
-                    this->executor.did_run_query(sql);
-                }
                 return res;
             }
 
@@ -24889,20 +24866,10 @@ namespace sqlite_orm {
                 iterate_ast(statement.expression.ids, conditional_binder{stmt});
 
                 std::optional<T> res;
-                std::string sql;
-                if (this->executor.will_run_query || this->executor.did_run_query) {
-                    sql = statement.sql();
-                }
-                if (this->executor.will_run_query) {
-                    this->executor.will_run_query(sql);
-                }
-                perform_step(stmt, [&table = this->get_table<T>(), &res](sqlite3_stmt* stmt) {
+                this->executor.perform_step(stmt, [&table = this->get_table<T>(), &res](sqlite3_stmt* stmt) {
                     object_from_column_builder<T> builder{res.emplace(), stmt};
                     table.for_each_column(builder);
                 });
-                if (this->executor.did_run_query) {
-                    this->executor.did_run_query(sql);
-                }
                 return res;
             }
 #endif  // SQLITE_ORM_OPTIONAL_SUPPORTED
@@ -24915,26 +24882,17 @@ namespace sqlite_orm {
 
 #ifdef SQLITE_ORM_OPTIONAL_SUPPORTED
                 std::optional<T> res;
-                std::string sql;
-                if (this->executor.will_run_query || this->executor.did_run_query) {
-                    sql = statement.sql();
-                }
-                if (this->executor.will_run_query) {
-                    this->executor.will_run_query(sql);
-                }
-                perform_step(stmt, [&table = this->get_table<T>(), &res](sqlite3_stmt* stmt) {
+                this->executor.perform_step(stmt, [&table = this->get_table<T>(), &res](sqlite3_stmt* stmt) {
                     object_from_column_builder<T> builder{res.emplace(), stmt};
                     table.for_each_column(builder);
                 });
-                if (this->executor.did_run_query) {
-                    this->executor.did_run_query(sql);
-                }
                 if (!res.has_value()) {
                     throw std::system_error{orm_error_code::not_found};
                 }
                 return std::move(res).value();
 #else
                 auto& table = this->get_table<T>();
+
                 std::string sql;
                 if (this->executor.will_run_query || this->executor.did_run_query) {
                     sql = statement.sql();
@@ -24942,24 +24900,27 @@ namespace sqlite_orm {
                 if (this->executor.will_run_query) {
                     this->executor.will_run_query(sql);
                 }
-                const auto stepRes = sqlite3_step(stmt);
+
+                switch (int rc = sqlite3_step(stmt)) {
+                    case SQLITE_ROW:
+                        break;
+                    case SQLITE_DONE: {
+                        throw std::system_error{orm_error_code::not_found};
+                    }
+                    default: {
+                        throw_translated_sqlite_error(stmt);
+                    }
+                }
+
+                T res;
+                object_from_column_builder<T> builder{res, stmt};
+                table.for_each_column(builder);
+
                 if (this->executor.did_run_query) {
                     this->executor.did_run_query(sql);
                 }
-                switch (stepRes) {
-                    case SQLITE_ROW: {
-                        T res;
-                        object_from_column_builder<T> builder{res, stmt};
-                        table.for_each_column(builder);
-                        return res;
-                    } break;
-                    case SQLITE_DONE: {
-                        throw std::system_error{orm_error_code::not_found};
-                    } break;
-                    default: {
-                        throw_translated_sqlite_error(rc);
-                    }
-                }
+
+                return res;
 #endif
             }
 

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -9141,7 +9141,16 @@ namespace sqlite_orm {
                 }
             }
         };
+
+        template<class T>
+        inline constexpr bool is_with_clause_v = polyfill::is_specialization_of<T, with_t>::value;
+#else
+        template<class T>
+        inline constexpr bool is_with_clause_v = false;
 #endif
+
+        template<class T>
+        using is_with_clause = polyfill::bool_constant<is_with_clause_v<T>>;
 
         template<class T>
         struct asterisk_t {
@@ -9210,6 +9219,40 @@ namespace sqlite_orm {
                 return {{std::move(this->case_expression)}, std::move(args), {std::move(el)}};
             }
         };
+
+        /**
+         *  Specialize if a type is a select statement expression.
+         */
+        template<class T, class SFINAE = void>
+        inline constexpr bool is_select_expression_v = false;
+
+        template<class T>
+        using is_select_expression = polyfill::bool_constant<is_select_expression_v<T>>;
+
+        template<class Select>
+        inline constexpr bool is_select_expression_v<Select, std::enable_if_t<is_select_v<Select>>> = true;
+
+        template<class With>
+        inline constexpr bool is_select_expression_v<
+            With,
+            std::enable_if_t<polyfill::conjunction_v<is_with_clause<With>, is_select<expression_type_t<With>>>>> = true;
+
+        /*  
+         *  Access the main select expression of a with clause or the passed in select expression.
+         */
+        template<class Select, satisfies<is_select_expression, Select> = true>
+        constexpr decltype(auto) access_main_select(const Select& select) {
+            if constexpr (is_with_clause_v<Select>) {
+                return (select.expression);
+            } else if constexpr (is_select_v<Select>) {
+                return select;
+            } else {
+                static_assert(polyfill::always_false_v<Select>);
+            }
+        }
+
+        template<class Select>
+        using main_select_t = polyfill::remove_cvref_t<decltype(access_main_select(std::declval<Select>()))>;
 
         template<class T, std::enable_if_t<!is_rowset_deduplicator_v<T>, bool> = true>
         const T& access_column_expression(const T& expression) {
@@ -23414,37 +23457,26 @@ namespace sqlite_orm {
 #endif
 
             /*  
-             *  Iterate over a result set of a select statement.
+             *  Iterate over a result set of a select statement or a select statement involving a common table expression.
              *  
              *  The returned C++ view models a C++ input range and is also a 'borrowed range',
              *  meaning that iterators obtained from it are not tied to the lifetime of the view instance.
              */
             template<class Select>
-#ifdef SQLITE_ORM_CONCEPTS_SUPPORTED
-                requires (is_select_v<Select>)
+#ifdef SQLITE_ORM_CPP20_CONCEPTS_SUPPORTED
+                requires (is_select_expression_v<Select>)
 #endif
             result_set_view<Select, db_objects_type> iterate(Select expression) {
-                expression.highest_level = true;
+#ifndef SQLITE_ORM_CPP20_CONCEPTS_SUPPORTED
+                static_assert(is_select_expression_v<Select>,
+                              "SQL expression must be a select expression or a with-clause with a select expression");
+#endif
+                if constexpr (is_select_v<Select>) {
+                    expression.highest_level = true;
+                }
                 auto con = this->get_connection();
                 return {this->db_objects, std::move(con), std::move(expression)};
             }
-
-#if (SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
-            /*  
-             *  Iterate over a result set of a select statement involving a common table expression.
-             *  
-             *  The returned C++ view models a C++ input range and is also a 'borrowed range',
-             *  meaning that iterators obtained from it are not tied to the lifetime of the view instance.
-             */
-            template<class... CTEs, class E>
-#ifdef SQLITE_ORM_CONCEPTS_SUPPORTED
-                requires (is_select_v<E>)
-#endif
-            result_set_view<with_t<E, CTEs...>, db_objects_type> iterate(with_t<E, CTEs...> expression) {
-                auto connection = this->get_connection();
-                return {this->db_objects, std::move(connection), std::move(expression)};
-            }
-#endif
 
 #ifdef SQLITE_ORM_CPP23_GENERATOR_SUPPORTED
             /*  
@@ -23478,29 +23510,15 @@ namespace sqlite_orm {
             }
 
             /*  
-             *  Iterate over a result set of a select statement in a coroutine.
+             *  Iterate over a result set of a select statement or a select statement involving a common table expression in a coroutine.
              */
             template<class Select>
-                requires (is_select_v<Select>)
+                requires (is_select_expression_v<Select>)
             auto yield(Select expression) -> std::generator<decltype(*this->iterate(std::move(expression)).begin())> {
                 for (auto row: this->iterate(std::move(expression))) {
                     co_yield row;
                 }
             }
-
-#if (SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
-            /*  
-             *  Iterate over a result set of a select statement involving a common table expression in a coroutine.
-             */
-            template<class... CTEs, class E>
-                requires (is_select_v<E>)
-            auto yield(with_t<E, CTEs...> expression)
-                -> std::generator<decltype(*this->iterate(std::move(expression)).begin())> {
-                for (auto row: this->iterate(std::move(expression))) {
-                    co_yield row;
-                }
-            }
-#endif
 #endif
 
             /**
@@ -24492,22 +24510,22 @@ namespace sqlite_orm {
             using storage_base::table_exists;  // now that it is in storage_base make it into overload set
 
 #if (SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
-            template<class... CTEs,
-                     class E,
-                     std::enable_if_t<polyfill::disjunction_v<is_select<E>,
-                                                              is_insert_raw<E>,
-                                                              is_replace_raw<E>,
-                                                              is_update_all<E>,
-                                                              is_remove_all<E>>,
-                                      bool> = true>
+            template<
+                class... CTEs,
+                class E,
+                std::enable_if_t<
+                    polyfill::disjunction_v<is_insert_raw<E>, is_replace_raw<E>, is_update_all<E>, is_remove_all<E>>,
+                    bool> = true>
             prepared_statement_t<with_t<E, CTEs...>> prepare(with_t<E, CTEs...> sel) {
                 return this->prepare_impl<with_t<E, CTEs...>>(std::move(sel));
             }
 #endif
 
-            template<class T, class... Args>
-            prepared_statement_t<select_t<T, Args...>> prepare(select_t<T, Args...> statement) {
-                statement.highest_level = true;
+            template<class Select, satisfies<is_select_expression, Select> = true>
+            prepared_statement_t<Select> prepare(Select statement) {
+                if constexpr (is_select_v<Select>) {
+                    statement.highest_level = true;
+                }
                 return this->prepare_impl(std::move(statement));
             }
 
@@ -25009,20 +25027,13 @@ namespace sqlite_orm {
                 }
             }
 
-#if (SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
-            template<class... CTEs, class T, class... Args>
-            auto execute(const prepared_statement_t<with_t<select_t<T, Args...>, CTEs...>>& statement) {
-                using ExprDBOs = decltype(db_objects_for_expression(this->db_objects, statement.expression));
+            template<class Select, satisfies<is_select_expression, Select> = true>
+            auto execute(const prepared_statement_t<Select>& statement) {
+                using ExprDBOs = polyfill::remove_cvref_t<decltype(db_objects_for_expression(this->db_objects,
+                                                                                             statement.expression))>;
                 // note: it is enough to only use the 'expression DBOs' at compile-time to determine the column results;
                 // because we cannot select objects/structs from a CTE, passing the permanently defined DBOs are enough.
-                using ColResult = column_result_of_t<ExprDBOs, T>;
-                return this->execute_select<ColResult>(statement);
-            }
-#endif
-
-            template<class T, class... Args>
-            auto execute(const prepared_statement_t<select_t<T, Args...>>& statement) {
-                using ColResult = column_result_of_t<db_objects_type, T>;
+                using ColResult = column_result_of_t<ExprDBOs, main_select_t<Select>>;
                 return this->execute_select<ColResult>(statement);
             }
 

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -4994,9 +4994,9 @@ namespace sqlite_orm {
 
         struct serializer_context_base {
             bool replace_bindable_with_question = false;
-            bool skip_table_name = true;
+            bool omit_table_name = true;
             bool use_parentheses = true;
-            bool fts5_columns = false;
+            bool omit_column_type = false;
         };
 
         template<class DBOs>
@@ -5006,20 +5006,6 @@ namespace sqlite_orm {
             const db_objects_type& db_objects;
 
             serializer_context(const db_objects_type& dbObjects) : db_objects{dbObjects} {}
-        };
-
-        template<class S>
-        struct serializer_context_builder {
-            using storage_type = S;
-            using db_objects_type = typename storage_type::db_objects_type;
-
-            serializer_context_builder(const storage_type& storage_) : storage{storage_} {}
-
-            serializer_context<db_objects_type> operator()() const {
-                return {obtain_db_objects(this->storage)};
-            }
-
-            const storage_type& storage;
         };
     }
 
@@ -5632,7 +5618,7 @@ namespace sqlite_orm {
             template<class O>
             void push_back(order_by_t<O> orderBy) {
                 auto newContext = this->context;
-                newContext.skip_table_name = false;
+                newContext.omit_table_name = false;
                 auto columnName = serialize(orderBy._expression, newContext);
                 this->entries.emplace_back(std::move(columnName), std::move(orderBy._collate_argument), orderBy._order);
             }
@@ -6288,8 +6274,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     template<class S>
     internal::dynamic_order_by_t<internal::serializer_context<typename S::db_objects_type>>
     dynamic_order_by(const S& storage) {
-        internal::serializer_context_builder<S> builder(storage);
-        return builder();
+        return {obtain_db_objects(storage)};
     }
 
     /**
@@ -14749,7 +14734,7 @@ namespace sqlite_orm {
             template<class L, class R>
             void push_back(assign_t<L, R> assign) {
                 auto newContext = this->context;
-                newContext.skip_table_name = true;
+                newContext.omit_table_name = true;
                 // note: we are only interested in the table name on the left-hand side of the assignment operator expression
                 iterate_ast(assign.lhs, this->collector);
                 std::stringstream ss;
@@ -14806,8 +14791,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class S>
     internal::dynamic_set_t<internal::serializer_context<typename S::db_objects_type>> dynamic_set(const S& storage) {
-        internal::serializer_context_builder<S> builder(storage);
-        return builder();
+        return {obtain_db_objects(storage)};
     }
 }
 
@@ -16514,7 +16498,7 @@ namespace sqlite_orm {
 
                 auto& dbObjects = obtain_db_objects(this->storage);
                 context_t context{dbObjects};
-                context.skip_table_name = false;
+                context.omit_table_name = false;
                 context.replace_bindable_with_question = true;
 
                 const std::string sql = serialize(this->expression, context);
@@ -16692,7 +16676,7 @@ namespace sqlite_orm::internal {
             using context_t = serializer_context<ExprDBOs>;
 
             context_t context{exprDBOs};
-            context.skip_table_name = false;
+            context.omit_table_name = false;
             context.replace_bindable_with_question = true;
 
             const std::string sql = serialize(this->expression, context);
@@ -17254,7 +17238,7 @@ namespace sqlite_orm {
                 ss << ' ' << serialize(constraint, context);
             });
             // add implicit null constraint
-            if (!context.fts5_columns) {
+            if (!context.omit_column_type) {
                 constexpr bool hasExplicitNullableConstraint =
                     mpl::invoke_t<mpl::disjunction<check_if_has_type<null_t>, check_if_has_type<not_null_t>>,
                                   constraints_tuple>::value;
@@ -19625,7 +19609,7 @@ namespace sqlite_orm {
             if (definedOrder) {
                 auto& table = pick_table<mapped_type_proxy_t<T>>(context.db_objects);
                 collectedExpressions.reserve(collectedExpressions.size() + table.template count_of<is_column>());
-                table.for_each_column([qualified = !context.skip_table_name,
+                table.for_each_column([qualified = !context.omit_table_name,
                                        &tableName = table.name,
                                        &collectedExpressions](const column_identifier& column) {
                     if constexpr (is_alias<T>::value) {
@@ -19642,7 +19626,7 @@ namespace sqlite_orm {
                 collectedExpressions.reserve(collectedExpressions.size() + 1);
                 if constexpr (is_alias<T>::value) {
                     collectedExpressions.push_back(quote_identifier(alias_extractor<T>::extract()) + ".*");
-                } else if (!context.skip_table_name) {
+                } else if (!context.omit_table_name) {
                     const basic_table& table = pick_table<mapped_type_proxy_t<T>>(context.db_objects);
                     collectedExpressions.push_back(quote_identifier(table.name) + ".*");
                 } else {
@@ -19787,7 +19771,7 @@ namespace sqlite_orm {
             SQLITE_ORM_STATIC_CALLOP std::vector<std::string>
             operator()(const expression_type& t, const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
                 auto newContext = context;
-                newContext.skip_table_name = true;
+                newContext.omit_table_name = true;
                 std::string columnName = serialize(t, newContext);
                 if (columnName.empty()) {
                     throw std::system_error{orm_error_code::column_not_found};
@@ -19867,7 +19851,7 @@ namespace sqlite_orm {
                 std::vector<std::string> columnNames;
                 columnNames.reserve(size_t(cols.count));
                 auto newContext = context;
-                newContext.skip_table_name = true;
+                newContext.omit_table_name = true;
                 iterate_tuple(cols.columns, [&columnNames, &newContext](auto& m) {
                     using value_type = polyfill::remove_cvref_t<decltype(m)>;
 
@@ -20002,7 +19986,7 @@ namespace sqlite_orm {
                                                             const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
                 std::stringstream ss;
                 auto newContext = context;
-                newContext.skip_table_name = false;
+                newContext.omit_table_name = false;
 
                 ss << serialize(orderBy._expression, newContext);
                 seralize_collate(ss, orderBy);
@@ -20704,11 +20688,11 @@ namespace sqlite_orm {
             SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& c,
                                                             const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
                 std::stringstream ss;
-                if (!context.skip_table_name) {
+                if (!context.omit_table_name) {
                     ss << streaming_identifier(alias_extractor<T>::extract()) << ".";
                 }
                 auto newContext = context;
-                newContext.skip_table_name = true;
+                newContext.omit_table_name = true;
                 ss << serialize(c.column, newContext);
                 return ss.str();
             }
@@ -20726,7 +20710,7 @@ namespace sqlite_orm {
                 std::stringstream ss;
                 if (auto* columnName = find_column_name(context.db_objects, e)) {
                     ss << streaming_identifier(
-                        !context.skip_table_name ? lookup_table_name<table_type_of_t<E>>(context.db_objects) : "",
+                        !context.omit_table_name ? lookup_table_name<table_type_of_t<E>>(context.db_objects) : "",
                         *columnName,
                         "");
                 } else {
@@ -20788,7 +20772,7 @@ namespace sqlite_orm {
             SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
                                                             const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
                 std::stringstream ss;
-                if (!context.skip_table_name) {
+                if (!context.omit_table_name) {
                     ss << streaming_identifier(lookup_table_name<O>(context.db_objects)) << ".";
                 }
                 ss << static_cast<std::string>(statement);
@@ -20804,7 +20788,7 @@ namespace sqlite_orm {
             SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
                                                             const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
                 std::stringstream ss;
-                if (!context.skip_table_name) {
+                if (!context.omit_table_name) {
                     ss << streaming_identifier(lookup_table_name<O>(context.db_objects)) << ".";
                 }
                 ss << static_cast<std::string>(statement);
@@ -20820,7 +20804,7 @@ namespace sqlite_orm {
             SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
                                                             const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
                 std::stringstream ss;
-                if (!context.skip_table_name) {
+                if (!context.omit_table_name) {
                     ss << streaming_identifier(lookup_table_name<O>(context.db_objects)) << ".";
                 }
                 ss << static_cast<std::string>(statement);
@@ -21589,7 +21573,7 @@ namespace sqlite_orm {
                                                             const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
                 std::stringstream ss;
                 ss << streaming_identifier(column.name);
-                if (!context.fts5_columns) {
+                if (!context.omit_column_type) {
                     ss << " " << type_printer<field_type_t<column_field<G, S>>>().print();
                 }
                 ss << streaming_column_constraints(
@@ -21736,7 +21720,7 @@ namespace sqlite_orm {
                 std::stringstream ss;
                 ss << "SET ";
                 auto leftContext = context;
-                leftContext.skip_table_name = true;
+                leftContext.omit_table_name = true;
                 iterate_tuple(statement.assigns, [&ss, &context, &leftContext, first = true](auto& value) mutable {
                     static constexpr std::array<orm_gsl::czstring, 2> sep = {", ", ""};
                     ss << sep[std::exchange(first, false)] << serialize(value.lhs, leftContext) << ' '
@@ -21896,7 +21880,7 @@ namespace sqlite_orm {
                     ss << ' ';
                     if constexpr (is_columns<value_type>::value) {
                         auto newContext = context;
-                        newContext.skip_table_name = true;
+                        newContext.omit_table_name = true;
                         newContext.use_parentheses = true;
                         ss << serialize(value, newContext);
                     } else if constexpr (is_values<value_type>::value || is_select<value_type>::value) {
@@ -22161,7 +22145,7 @@ namespace sqlite_orm {
             template<class Ctx>
             SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& sel,
                                                             Ctx context) SQLITE_ORM_OR_CONST_CALLOP {
-                context.skip_table_name = false;
+                context.omit_table_name = false;
                 // subqueries should always use parentheses in column names
                 auto subCtx = context;
                 subCtx.use_parentheses = true;
@@ -22245,7 +22229,7 @@ namespace sqlite_orm {
                 std::stringstream ss;
                 ss << "USING FTS5(";
                 auto subContext = context;
-                subContext.fts5_columns = true;
+                subContext.omit_column_type = true;
                 ss << streaming_expressions_tuple(statement.columns, subContext) << ")";
                 return ss.str();
             }
@@ -22335,7 +22319,7 @@ namespace sqlite_orm {
                 std::stringstream ss;
                 ss << "OLD.";
                 auto newContext = context;
-                newContext.skip_table_name = true;
+                newContext.omit_table_name = true;
                 ss << serialize(statement.expression, newContext);
                 return ss.str();
             }
@@ -22351,7 +22335,7 @@ namespace sqlite_orm {
                 std::stringstream ss;
                 ss << "NEW.";
                 auto newContext = context;
-                newContext.skip_table_name = true;
+                newContext.omit_table_name = true;
                 ss << serialize(statement.expression, newContext);
                 return ss.str();
             }
@@ -22594,7 +22578,7 @@ namespace sqlite_orm {
                                                             const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
                 std::stringstream ss;
                 auto newContext = context;
-                newContext.skip_table_name = false;
+                newContext.omit_table_name = false;
                 ss << static_cast<std::string>(on) << " " << serialize(on.arg, newContext) << " ";
                 return ss.str();
             }
@@ -22609,7 +22593,7 @@ namespace sqlite_orm {
                                                             const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
                 std::stringstream ss;
                 auto newContext = context;
-                newContext.skip_table_name = false;
+                newContext.omit_table_name = false;
                 ss << "GROUP BY " << streaming_expressions_tuple(statement.args, newContext) << " HAVING "
                    << serialize(statement.expression, context);
                 return ss.str();
@@ -22625,7 +22609,7 @@ namespace sqlite_orm {
                                                             const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
                 std::stringstream ss;
                 auto newContext = context;
-                newContext.skip_table_name = false;
+                newContext.omit_table_name = false;
                 ss << "GROUP BY " << streaming_expressions_tuple(statement.args, newContext);
                 return ss.str();
             }
@@ -22643,7 +22627,7 @@ namespace sqlite_orm {
             SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
                                                             const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
                 auto newContext = context;
-                newContext.skip_table_name = false;
+                newContext.omit_table_name = false;
                 std::stringstream ss;
                 ss << "LIMIT ";
                 if constexpr (HO) {
@@ -22685,7 +22669,7 @@ namespace sqlite_orm {
             SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
                                                             const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
                 auto newContext = context;
-                newContext.skip_table_name = true;
+                newContext.omit_table_name = true;
                 return static_cast<std::string>(statement) + " (" + serialize(statement.column, newContext) + ")";
             }
         };
@@ -24510,7 +24494,7 @@ namespace sqlite_orm {
                 context_t context{exprDBOs};
                 context.replace_bindable_with_question = parametrized;
                 // just like prepare_impl()
-                context.skip_table_name = false;
+                context.omit_table_name = false;
                 return serialize(expression, context);
             }
 
@@ -24528,7 +24512,7 @@ namespace sqlite_orm {
                 using context_t = serializer_context<polyfill::remove_cvref_t<decltype(exprDBOs)>>;
 
                 context_t context{exprDBOs};
-                context.skip_table_name = false;
+                context.omit_table_name = false;
                 context.replace_bindable_with_question = true;
 
                 auto conection = this->get_connection();

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -18274,7 +18274,7 @@ namespace sqlite_orm {
                        << streaming_identifier(newName) << std::flush;
                     sql = ss.str();
                 }
-                this->executor.perform_void_exec(db, sql.data());
+                this->executor.perform_void_exec(db, sql.c_str());
             }
 
             /**
@@ -18863,7 +18863,7 @@ namespace sqlite_orm {
             void begin_transaction_internal(const std::string& sql) {
                 this->connection->retain();
                 sqlite3* db = this->connection->get();
-                this->executor.perform_void_exec(db, sql.data());
+                this->executor.perform_void_exec(db, sql.c_str());
             }
 
             connection_ref get_connection() {
@@ -18899,7 +18899,7 @@ namespace sqlite_orm {
                     ss << "PRAGMA foreign_keys = " << value << std::flush;
                     sql = ss.str();
                 }
-                this->executor.perform_void_exec(db, sql.data());
+                this->executor.perform_void_exec(db, sql.c_str());
             }
 
             bool foreign_keys(sqlite3* db) {
@@ -19122,7 +19122,7 @@ namespace sqlite_orm {
                     ss << ' ' << streaming_identifier(tableName) << std::flush;
                     sql = ss.str();
                 }
-                this->executor.perform_void_exec(db, sql.data());
+                this->executor.perform_void_exec(db, sql.c_str());
             }
 
             void drop_index_internal(const std::string& indexName, bool ifExists) {
@@ -19137,7 +19137,7 @@ namespace sqlite_orm {
                     sql = ss.str();
                 }
                 auto connection = this->get_connection();
-                this->executor.perform_void_exec(connection.get(), sql.data());
+                this->executor.perform_void_exec(connection.get(), sql.c_str());
             }
 
             void drop_trigger_internal(const std::string& triggerName, bool ifExists) {
@@ -19152,7 +19152,7 @@ namespace sqlite_orm {
                     sql = ss.str();
                 }
                 auto connection = this->get_connection();
-                this->executor.perform_void_exec(connection.get(), sql.data());
+                this->executor.perform_void_exec(connection.get(), sql.c_str());
             }
 
             static int
@@ -24334,7 +24334,7 @@ namespace sqlite_orm {
                 const auto res = sync_schema_result::already_in_sync;
                 context_t context{this->db_objects};
                 const auto sql = serialize(virtualTable, context);
-                this->executor.perform_void_exec(db, sql.data());
+                this->executor.perform_void_exec(db, sql.c_str());
                 return res;
             }
 
@@ -24345,7 +24345,7 @@ namespace sqlite_orm {
                 const auto res = sync_schema_result::already_in_sync;
                 context_t context{this->db_objects};
                 const auto sql = serialize(index, context);
-                this->executor.perform_void_exec(db, sql.data());
+                this->executor.perform_void_exec(db, sql.c_str());
                 return res;
             }
 
@@ -24356,7 +24356,7 @@ namespace sqlite_orm {
                 const auto res = sync_schema_result::already_in_sync;  // TODO Change accordingly
                 context_t context{this->db_objects};
                 const auto sql = serialize(trigger, context);
-                this->executor.perform_void_exec(db, sql.data());
+                this->executor.perform_void_exec(db, sql.c_str());
                 return res;
             }
 

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -9244,10 +9244,8 @@ namespace sqlite_orm {
         constexpr decltype(auto) access_main_select(const Select& select) {
             if constexpr (is_with_clause_v<Select>) {
                 return (select.expression);
-            } else if constexpr (is_select_v<Select>) {
-                return select;
             } else {
-                static_assert(polyfill::always_false_v<Select>);
+                return select;
             }
         }
 
@@ -15059,6 +15057,48 @@ namespace sqlite_orm {
 
         template<class T>
         using is_insert_constraint = std::is_same<T, insert_constraint>;
+
+        /**
+         *  Specialize if a type is a DML statement expression.
+         */
+        template<class T, class SFINAE = void>
+        inline constexpr bool is_raw_dml_expression_v = false;
+
+        template<class T>
+        using is_raw_dml_expression = polyfill::bool_constant<is_raw_dml_expression_v<T>>;
+
+        template<class DML>
+        inline constexpr bool is_raw_dml_expression_v<
+            DML,
+            std::enable_if_t<
+                polyfill::
+                    disjunction_v<is_insert_raw<DML>, is_replace_raw<DML>, is_update_all<DML>, is_remove_all<DML>>>> =
+            true;
+
+        template<class With>
+        inline constexpr bool is_raw_dml_expression_v<
+            With,
+            std::enable_if_t<polyfill::conjunction_v<is_with_clause<With>,
+                                                     polyfill::disjunction<is_insert_raw<expression_type_t<With>>,
+                                                                           is_replace_raw<expression_type_t<With>>,
+                                                                           is_update_all<expression_type_t<With>>,
+                                                                           is_remove_all<expression_type_t<With>>>>>> =
+            true;
+
+        /*  
+         *  Access the main select expression of a with clause or the passed in select expression.
+         */
+        template<class DML, satisfies<is_raw_dml_expression, DML> = true>
+        constexpr decltype(auto) access_main_dml(const DML& dml) {
+            if constexpr (is_with_clause_v<DML>) {
+                return (dml.expression);
+            } else {
+                return dml;
+            }
+        }
+
+        template<class DML>
+        using main_dml_t = polyfill::remove_cvref_t<decltype(access_main_dml(std::declval<DML>()))>;
     }
 }
 
@@ -24509,17 +24549,10 @@ namespace sqlite_orm {
 
             using storage_base::table_exists;  // now that it is in storage_base make it into overload set
 
-#if (SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
-            template<
-                class... CTEs,
-                class E,
-                std::enable_if_t<
-                    polyfill::disjunction_v<is_insert_raw<E>, is_replace_raw<E>, is_update_all<E>, is_remove_all<E>>,
-                    bool> = true>
-            prepared_statement_t<with_t<E, CTEs...>> prepare(with_t<E, CTEs...> sel) {
-                return this->prepare_impl<with_t<E, CTEs...>>(std::move(sel));
+            template<class DML, std::enable_if_t<is_raw_dml_expression_v<DML>, bool> = true>
+            prepared_statement_t<DML> prepare(DML statement) {
+                return this->prepare_impl(std::move(statement));
             }
-#endif
 
             template<class Select, satisfies<is_select_expression, Select> = true>
             prepared_statement_t<Select> prepare(Select statement) {
@@ -24539,16 +24572,6 @@ namespace sqlite_orm {
                 return this->prepare_impl(std::move(statement));
             }
 
-            template<class... Args>
-            prepared_statement_t<replace_raw_t<Args...>> prepare(replace_raw_t<Args...> statement) {
-                return this->prepare_impl(std::move(statement));
-            }
-
-            template<class... Args>
-            prepared_statement_t<insert_raw_t<Args...>> prepare(insert_raw_t<Args...> statement) {
-                return this->prepare_impl(std::move(statement));
-            }
-
 #ifdef SQLITE_ORM_OPTIONAL_SUPPORTED
             template<class T, class R, class... Args>
             prepared_statement_t<get_all_optional_t<T, R, Args...>>
@@ -24556,16 +24579,6 @@ namespace sqlite_orm {
                 return this->prepare_impl(std::move(statement));
             }
 #endif  // SQLITE_ORM_OPTIONAL_SUPPORTED
-
-            template<class S, class... Wargs>
-            prepared_statement_t<update_all_t<S, Wargs...>> prepare(update_all_t<S, Wargs...> statement) {
-                return this->prepare_impl(std::move(statement));
-            }
-
-            template<class T, class... Args>
-            prepared_statement_t<remove_all_t<T, Args...>> prepare(remove_all_t<T, Args...> statement) {
-                return this->prepare_impl(std::move(statement));
-            }
 
             template<class T, class... Ids>
             prepared_statement_t<get_t<T, Ids...>> prepare(get_t<T, Ids...> statement) {
@@ -24642,49 +24655,8 @@ namespace sqlite_orm {
                 return this->prepare_impl(std::move(statement));
             }
 
-            template<class... Args>
-            void execute(const prepared_statement_t<replace_raw_t<Args...>>& statement) {
-                sqlite3_stmt* stmt = reset_stmt(statement.stmt);
-                iterate_ast(statement.expression, conditional_binder{stmt});
-                std::string sql;
-                if (this->executor.will_run_query || this->executor.did_run_query) {
-                    sql = statement.sql();
-                }
-                if (this->executor.will_run_query) {
-                    this->executor.will_run_query(sql);
-                }
-                perform_step(stmt);
-                if (this->executor.did_run_query) {
-                    this->executor.did_run_query(sql);
-                }
-            }
-
-#if (SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
-            template<
-                class... CTEs,
-                class E,
-                std::enable_if_t<
-                    polyfill::disjunction_v<is_insert_raw<E>, is_replace_raw<E>, is_update_all<E>, is_remove_all<E>>,
-                    bool> = true>
-            void execute(const prepared_statement_t<with_t<E, CTEs...>>& statement) {
-                sqlite3_stmt* stmt = reset_stmt(statement.stmt);
-                iterate_ast(statement.expression, conditional_binder{stmt});
-                std::string sql;
-                if (this->executor.will_run_query || this->executor.did_run_query) {
-                    sql = statement.sql();
-                }
-                if (this->executor.will_run_query) {
-                    this->executor.will_run_query(sql);
-                }
-                perform_step(stmt);
-                if (this->executor.did_run_query) {
-                    this->executor.did_run_query(sql);
-                }
-            }
-#endif
-
-            template<class... Args>
-            void execute(const prepared_statement_t<insert_raw_t<Args...>>& statement) {
+            template<class DML, std::enable_if_t<is_raw_dml_expression_v<DML>, bool> = true>
+            void execute(const prepared_statement_t<DML>& statement) {
                 sqlite3_stmt* stmt = reset_stmt(statement.stmt);
                 iterate_ast(statement.expression, conditional_binder{stmt});
                 std::string sql;
@@ -24989,42 +24961,6 @@ namespace sqlite_orm {
                     }
                 }
 #endif
-            }
-
-            template<class T, class... Args>
-            void execute(const prepared_statement_t<remove_all_t<T, Args...>>& statement) {
-                sqlite3_stmt* stmt = reset_stmt(statement.stmt);
-                iterate_ast(statement.expression.conditions, conditional_binder{stmt});
-                std::string sql;
-                if (this->executor.will_run_query || this->executor.did_run_query) {
-                    sql = statement.sql();
-                }
-                if (this->executor.will_run_query) {
-                    this->executor.will_run_query(sql);
-                }
-                perform_step(stmt);
-                if (this->executor.did_run_query) {
-                    this->executor.did_run_query(sql);
-                }
-            }
-
-            template<class S, class... Wargs>
-            void execute(const prepared_statement_t<update_all_t<S, Wargs...>>& statement) {
-                sqlite3_stmt* stmt = reset_stmt(statement.stmt);
-                conditional_binder bindNode{stmt};
-                iterate_ast(statement.expression.set, bindNode);
-                iterate_ast(statement.expression.conditions, bindNode);
-                std::string sql;
-                if (this->executor.will_run_query || this->executor.did_run_query) {
-                    sql = statement.sql();
-                }
-                if (this->executor.will_run_query) {
-                    this->executor.will_run_query(sql);
-                }
-                perform_step(stmt);
-                if (this->executor.did_run_query) {
-                    this->executor.did_run_query(sql);
-                }
             }
 
             template<class Select, satisfies<is_select_expression, Select> = true>

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -24328,7 +24328,7 @@ namespace sqlite_orm {
             }
 
             template<class M>
-            sync_schema_result sync_table(const virtual_table_t<M>& virtualTable, sqlite3* db, bool) {
+            sync_schema_result sync_dbo(const virtual_table_t<M>& virtualTable, sqlite3* db, bool) {
                 using context_t = serializer_context<db_objects_type>;
 
                 const auto res = sync_schema_result::already_in_sync;
@@ -24339,7 +24339,7 @@ namespace sqlite_orm {
             }
 
             template<class... Cols>
-            sync_schema_result sync_table(const index_t<Cols...>& index, sqlite3* db, bool) {
+            sync_schema_result sync_dbo(const index_t<Cols...>& index, sqlite3* db, bool) {
                 using context_t = serializer_context<db_objects_type>;
 
                 const auto res = sync_schema_result::already_in_sync;
@@ -24350,7 +24350,7 @@ namespace sqlite_orm {
             }
 
             template<class... Cols>
-            sync_schema_result sync_table(const trigger_t<Cols...>& trigger, sqlite3* db, bool) {
+            sync_schema_result sync_dbo(const trigger_t<Cols...>& trigger, sqlite3* db, bool) {
                 using context_t = serializer_context<db_objects_type>;
 
                 const auto res = sync_schema_result::already_in_sync;  // TODO Change accordingly
@@ -24361,7 +24361,7 @@ namespace sqlite_orm {
             }
 
             template<class Table, satisfies<is_table, Table> = true>
-            sync_schema_result sync_table(const Table& table, sqlite3* db, bool preserve);
+            sync_schema_result sync_dbo(const Table& table, sqlite3* db, bool preserve);
 
             template<class Table, satisfies<is_table, Table> = true>
             sync_schema_result sync_regular_table(const Table& table, sqlite3* db, bool preserve);
@@ -24467,7 +24467,7 @@ namespace sqlite_orm {
                 auto con = this->get_connection();
                 std::map<std::string, sync_schema_result> result;
                 iterate_tuple<true>(this->db_objects, [this, db = con.get(), preserve, &result](auto& schemaObject) {
-                    sync_schema_result status = this->sync_table(schemaObject, db, preserve);
+                    sync_schema_result status = this->sync_dbo(schemaObject, db, preserve);
                     result.emplace(schemaObject.name, status);
                 });
                 return result;
@@ -25416,9 +25416,9 @@ namespace sqlite_orm {
     namespace internal {
         template<class... DBO>
         template<class Table, satisfies<is_table, Table>>
-        sync_schema_result storage_t<DBO...>::sync_table([[maybe_unused]] const Table& table,
-                                                         [[maybe_unused]] sqlite3* db,
-                                                         [[maybe_unused]] bool preserve) {
+        sync_schema_result storage_t<DBO...>::sync_dbo([[maybe_unused]] const Table& table,
+                                                       [[maybe_unused]] sqlite3* db,
+                                                       [[maybe_unused]] bool preserve) {
             if constexpr (
 #ifdef SQLITE_ENABLE_DBSTAT_VTAB
                 std::is_same<object_type_t<Table>, dbstat>::value ||

--- a/tests/statement_serializer_tests/column_names.cpp
+++ b/tests/statement_serializer_tests/column_names.cpp
@@ -21,7 +21,7 @@ TEST_CASE("statement_serializer column names") {
                     REQUIRE(value == R"("id")");
                 }
                 SECTION("don't skip table name") {
-                    context.skip_table_name = false;
+                    context.omit_table_name = false;
                     auto value = serialize(&User::id, context);
                     REQUIRE(value == R"("users"."id")");
                 }
@@ -159,7 +159,7 @@ TEST_CASE("statement_serializer column names") {
         SECTION("regular") {
             using context_t = internal::serializer_context<db_objects_t>;
             context_t context{dbObjects};
-            context.skip_table_name = false;
+            context.omit_table_name = false;
             using als = alias_a<Object>;
             auto value = serialize(alias_column<als>(&Object::id), context);
             REQUIRE(value == R"("a"."id")");
@@ -171,7 +171,7 @@ TEST_CASE("statement_serializer column names") {
                 internal::db_objects_cat(dbObjects, internal::make_cte_table(dbObjects, 1_ctealias().as(select(1))));
             using context_t = internal::serializer_context<decltype(dbObjects2)>;
             context_t context{dbObjects2};
-            context.skip_table_name = false;
+            context.omit_table_name = false;
             constexpr auto als = "a"_alias.for_<1_ctealias>();
             auto value = serialize(als->*1_colalias, context);
             REQUIRE(value == R"("a"."1")");

--- a/tests/statement_serializer_tests/schema/column.cpp
+++ b/tests/statement_serializer_tests/schema/column.cpp
@@ -14,7 +14,7 @@ TEST_CASE("statement_serializer column") {
     std::string value;
     std::string expected;
     SECTION("with types and constraints") {
-        context.fts5_columns = false;
+        context.omit_column_type = false;
         SECTION("id INTEGER (implicit) NOT NULL") {
             auto column = make_column("id", &User::id);
             value = serialize(column, context);
@@ -82,7 +82,7 @@ TEST_CASE("statement_serializer column") {
         }
     }
     SECTION("without types and constraints") {
-        context.fts5_columns = true;
+        context.omit_column_type = true;
         SECTION("id INTEGER NOT NULL") {
             auto column = make_column("id", &User::id);
             value = serialize(column, context);

--- a/tests/statement_serializer_tests/statements/select.cpp
+++ b/tests/statement_serializer_tests/statements/select.cpp
@@ -192,7 +192,7 @@ TEST_CASE("statement_serializer select_t") {
             // issue #1106
             SECTION("multi") {
                 auto expression = columns(asterisk<User>(), asterisk<User>(true));
-                context.skip_table_name = false;
+                context.omit_table_name = false;
                 context.use_parentheses = false;
                 stringValue = serialize(expression, context);
                 expected = R"("users".*, "users"."id", "users"."name")";
@@ -228,7 +228,7 @@ TEST_CASE("statement_serializer select_t") {
                                          where(is_null(alias_column<als_e>(&Employee::m_deptno))));
                 expression.highest_level = true;
                 internal::serializer_context<db_objects_t> context{storage};
-                context.skip_table_name = false;
+                context.omit_table_name = false;
                 stringValue = serialize(expression, context);
                 expected =
                     R"(SELECT "d".* FROM "Dept" "d" LEFT JOIN "Emp" "e" ON "d"."deptno" = "e"."deptno"  WHERE ("e"."deptno" IS NULL))";

--- a/tests/statement_serializer_tests/table_constraints/primary_key.cpp
+++ b/tests/statement_serializer_tests/table_constraints/primary_key.cpp
@@ -24,7 +24,7 @@ TEST_CASE("statement_serializer primary key table constraint") {
         auto dbObjects = db_objects_t{table1, table2};
         using context_t = internal::serializer_context<db_objects_t>;
         context_t context{dbObjects};
-        context.skip_table_name = false;
+        context.omit_table_name = false;
 
         SECTION("single column pk") {
             constexpr auto pk = primary_key(&User::id);

--- a/tests/static_tests/table_static_tests.cpp
+++ b/tests/static_tests/table_static_tests.cpp
@@ -2,6 +2,8 @@
 #include <catch2/catch_all.hpp>
 
 using namespace sqlite_orm;
+using internal::col_index_sequence_of, internal::col_index_sequence_excluding, internal::col_index_sequence_with,
+    internal::col_index_sequence_with_field_type;
 using internal::is_column;
 using internal::is_primary_key;
 
@@ -18,84 +20,139 @@ TEST_CASE("table static count_of<is_column>()") {
     };
     {  //  1 column no pk
         auto table = make_table("users", make_column("id", &User::id));
+        using elements_type = decltype(table.elements);
         STATIC_REQUIRE(table.count_of<is_column>() == 1);
         STATIC_REQUIRE(table.count_of<is_primary_key>() == 0);
         STATIC_REQUIRE(table.count_of_columns_with<is_primary_key>() == 0);
-        STATIC_REQUIRE(dedicated_pk_columns_count_t<decltype(table.elements)>::value == 0);
+        STATIC_REQUIRE(col_index_sequence_of<elements_type>::size() == 1);
+        STATIC_REQUIRE(col_index_sequence_with<elements_type, is_primary_key>::size() == 0);
+        STATIC_REQUIRE(col_index_sequence_excluding<elements_type, is_primary_key>::size() == 1);
+        STATIC_REQUIRE(col_index_sequence_with_field_type<elements_type, int>::size() == 1);
+        STATIC_REQUIRE(dedicated_pk_columns_count_t<elements_type>::value == 0);
     }
     {  //  1 column with 1 inline pk
         auto table = make_table("users", make_column("id", &User::id, primary_key()));
+        using elements_type = decltype(table.elements);
         STATIC_REQUIRE(table.count_of<is_column>() == 1);
         STATIC_REQUIRE(table.count_of<is_primary_key>() == 0);
         STATIC_REQUIRE(table.count_of_columns_with<is_primary_key>() == 1);
-        STATIC_REQUIRE(dedicated_pk_columns_count_t<decltype(table.elements)>::value == 0);
+        STATIC_REQUIRE(col_index_sequence_of<elements_type>::size() == 1);
+        STATIC_REQUIRE(col_index_sequence_with<elements_type, is_primary_key>::size() == 1);
+        STATIC_REQUIRE(col_index_sequence_excluding<elements_type, is_primary_key>::size() == 0);
+        STATIC_REQUIRE(col_index_sequence_with_field_type<elements_type, int>::size() == 1);
+        STATIC_REQUIRE(dedicated_pk_columns_count_t<elements_type>::value == 0);
     }
     {  //  1 column with 1 inline pk autoincrement
         auto table = make_table("users", make_column("id", &User::id, primary_key().autoincrement()));
+        using elements_type = decltype(table.elements);
         STATIC_REQUIRE(table.count_of<is_column>() == 1);
         STATIC_REQUIRE(table.count_of<is_primary_key>() == 0);
         STATIC_REQUIRE(table.count_of_columns_with<is_primary_key>() == 1);
-        STATIC_REQUIRE(dedicated_pk_columns_count_t<decltype(table.elements)>::value == 0);
+        STATIC_REQUIRE(col_index_sequence_of<elements_type>::size() == 1);
+        STATIC_REQUIRE(col_index_sequence_with<elements_type, is_primary_key>::size() == 1);
+        STATIC_REQUIRE(col_index_sequence_excluding<elements_type, is_primary_key>::size() == 0);
+        STATIC_REQUIRE(col_index_sequence_with_field_type<elements_type, int>::size() == 1);
+        STATIC_REQUIRE(dedicated_pk_columns_count_t<elements_type>::value == 0);
     }
     {  //  1 column with 1 dedicated pk
         auto table = make_table("users", make_column("id", &User::id), primary_key(&User::id));
+        using elements_type = decltype(table.elements);
         STATIC_REQUIRE(table.count_of<is_column>() == 1);
         STATIC_REQUIRE(table.count_of<is_primary_key>() == 1);
         STATIC_REQUIRE(table.count_of_columns_with<is_primary_key>() == 0);
-        STATIC_REQUIRE(dedicated_pk_columns_count_t<decltype(table.elements)>::value == 1);
+        STATIC_REQUIRE(dedicated_pk_columns_count_t<elements_type>::value == 1);
+        STATIC_REQUIRE(col_index_sequence_of<elements_type>::size() == 1);
+        STATIC_REQUIRE(col_index_sequence_with<elements_type, is_primary_key>::size() == 0);
+        STATIC_REQUIRE(col_index_sequence_excluding<elements_type, is_primary_key>::size() == 1);
+        STATIC_REQUIRE(col_index_sequence_with_field_type<elements_type, int>::size() == 1);
     }
     {  //  1 column with 1 dedicated pk autoincrement
         auto table = make_table("users", make_column("id", &User::id), primary_key(&User::id).autoincrement());
+        using elements_type = decltype(table.elements);
         STATIC_REQUIRE(table.count_of<is_column>() == 1);
         STATIC_REQUIRE(table.count_of<is_primary_key>() == 1);
         STATIC_REQUIRE(table.count_of_columns_with<is_primary_key>() == 0);
-        STATIC_REQUIRE(dedicated_pk_columns_count_t<decltype(table.elements)>::value == 1);
+        STATIC_REQUIRE(col_index_sequence_of<elements_type>::size() == 1);
+        STATIC_REQUIRE(col_index_sequence_with<elements_type, is_primary_key>::size() == 0);
+        STATIC_REQUIRE(col_index_sequence_excluding<elements_type, is_primary_key>::size() == 1);
+        STATIC_REQUIRE(col_index_sequence_with_field_type<elements_type, int>::size() == 1);
+        STATIC_REQUIRE(dedicated_pk_columns_count_t<elements_type>::value == 1);
     }
     {  //  2 columns no pk
         auto table = make_table("users", make_column("id", &User::id), make_column("id", &User::name));
+        using elements_type = decltype(table.elements);
         STATIC_REQUIRE(table.count_of<is_column>() == 2);
         STATIC_REQUIRE(table.count_of<is_primary_key>() == 0);
         STATIC_REQUIRE(table.count_of_columns_with<is_primary_key>() == 0);
-        STATIC_REQUIRE(dedicated_pk_columns_count_t<decltype(table.elements)>::value == 0);
+        STATIC_REQUIRE(col_index_sequence_of<elements_type>::size() == 2);
+        STATIC_REQUIRE(col_index_sequence_with<elements_type, is_primary_key>::size() == 0);
+        STATIC_REQUIRE(col_index_sequence_excluding<elements_type, is_primary_key>::size() == 2);
+        STATIC_REQUIRE(col_index_sequence_with_field_type<elements_type, int>::size() == 1);
+        STATIC_REQUIRE(dedicated_pk_columns_count_t<elements_type>::value == 0);
     }
     {  //  2 columns with 1 inline id pk
         auto table = make_table("users", make_column("id", &User::id, primary_key()), make_column("id", &User::name));
+        using elements_type = decltype(table.elements);
         STATIC_REQUIRE(table.count_of<is_column>() == 2);
         STATIC_REQUIRE(table.count_of<is_primary_key>() == 0);
         STATIC_REQUIRE(table.count_of_columns_with<is_primary_key>() == 1);
-        STATIC_REQUIRE(dedicated_pk_columns_count_t<decltype(table.elements)>::value == 0);
+        STATIC_REQUIRE(col_index_sequence_of<elements_type>::size() == 2);
+        STATIC_REQUIRE(col_index_sequence_with<elements_type, is_primary_key>::size() == 1);
+        STATIC_REQUIRE(col_index_sequence_excluding<elements_type, is_primary_key>::size() == 1);
+        STATIC_REQUIRE(col_index_sequence_with_field_type<elements_type, int>::size() == 1);
+        STATIC_REQUIRE(dedicated_pk_columns_count_t<elements_type>::value == 0);
     }
     {  //  2 columns with 1 inline name pk
         auto table = make_table("users", make_column("id", &User::id), make_column("id", &User::name, primary_key()));
+        using elements_type = decltype(table.elements);
         STATIC_REQUIRE(table.count_of<is_column>() == 2);
         STATIC_REQUIRE(table.count_of<is_primary_key>() == 0);
         STATIC_REQUIRE(table.count_of_columns_with<is_primary_key>() == 1);
-        STATIC_REQUIRE(dedicated_pk_columns_count_t<decltype(table.elements)>::value == 0);
+        STATIC_REQUIRE(col_index_sequence_of<elements_type>::size() == 2);
+        STATIC_REQUIRE(col_index_sequence_with<elements_type, is_primary_key>::size() == 1);
+        STATIC_REQUIRE(col_index_sequence_excluding<elements_type, is_primary_key>::size() == 1);
+        STATIC_REQUIRE(col_index_sequence_with_field_type<elements_type, int>::size() == 1);
+        STATIC_REQUIRE(dedicated_pk_columns_count_t<elements_type>::value == 0);
     }
     {  //  2 columns with 1 dedicated id pk
         auto table =
             make_table("users", make_column("id", &User::id), make_column("id", &User::name), primary_key(&User::id));
+        using elements_type = decltype(table.elements);
         STATIC_REQUIRE(table.count_of<is_column>() == 2);
         STATIC_REQUIRE(table.count_of<is_primary_key>() == 1);
         STATIC_REQUIRE(table.count_of_columns_with<is_primary_key>() == 0);
-        STATIC_REQUIRE(dedicated_pk_columns_count_t<decltype(table.elements)>::value == 1);
+        STATIC_REQUIRE(col_index_sequence_of<elements_type>::size() == 2);
+        STATIC_REQUIRE(col_index_sequence_with<elements_type, is_primary_key>::size() == 0);
+        STATIC_REQUIRE(col_index_sequence_excluding<elements_type, is_primary_key>::size() == 2);
+        STATIC_REQUIRE(col_index_sequence_with_field_type<elements_type, int>::size() == 1);
+        STATIC_REQUIRE(dedicated_pk_columns_count_t<elements_type>::value == 1);
     }
     {  //  2 columns with 1 dedicated name pk
         auto table =
             make_table("users", make_column("id", &User::id), make_column("id", &User::name), primary_key(&User::name));
+        using elements_type = decltype(table.elements);
         STATIC_REQUIRE(table.count_of<is_column>() == 2);
         STATIC_REQUIRE(table.count_of<is_primary_key>() == 1);
         STATIC_REQUIRE(table.count_of_columns_with<is_primary_key>() == 0);
-        STATIC_REQUIRE(dedicated_pk_columns_count_t<decltype(table.elements)>::value == 1);
+        STATIC_REQUIRE(col_index_sequence_of<elements_type>::size() == 2);
+        STATIC_REQUIRE(col_index_sequence_with<elements_type, is_primary_key>::size() == 0);
+        STATIC_REQUIRE(col_index_sequence_excluding<elements_type, is_primary_key>::size() == 2);
+        STATIC_REQUIRE(col_index_sequence_with_field_type<elements_type, int>::size() == 1);
+        STATIC_REQUIRE(dedicated_pk_columns_count_t<elements_type>::value == 1);
     }
     {  //  2 columns with 2 dedicated pks
         auto table = make_table("users",
                                 make_column("id", &User::id),
                                 make_column("id", &User::name),
                                 primary_key(&User::id, &User::name));
+        using elements_type = decltype(table.elements);
         STATIC_REQUIRE(table.count_of<is_column>() == 2);
         STATIC_REQUIRE(table.count_of<is_primary_key>() == 1);
         STATIC_REQUIRE(table.count_of_columns_with<is_primary_key>() == 0);
-        STATIC_REQUIRE(dedicated_pk_columns_count_t<decltype(table.elements)>::value == 2);
+        STATIC_REQUIRE(col_index_sequence_of<elements_type>::size() == 2);
+        STATIC_REQUIRE(col_index_sequence_with<elements_type, is_primary_key>::size() == 0);
+        STATIC_REQUIRE(col_index_sequence_excluding<elements_type, is_primary_key>::size() == 2);
+        STATIC_REQUIRE(col_index_sequence_with_field_type<elements_type, int>::size() == 1);
+        STATIC_REQUIRE(dedicated_pk_columns_count_t<elements_type>::value == 2);
     }
 }


### PR DESCRIPTION
While working on [sql views](../tree/experimental/sql-view), I came across some parts that I thought would be worth generalizing and streamlining the code base before making other, more profound changes.

In this PR:
* Removed superfluous `serializer_context_builder`.
* Renamed serializer context flag variables - e.g. omitting column types with the `fts5_column` flag will be needed for views as well.
* Encapsulated logging executes SQL statements in all locations, while step functions are kept in their respective functions for greater clarity.
* Select statements and "raw" DML (Data Modification Language) statements are now treated uniformly, regardless of whether they are used directly or embedded as the main statement in a With clause.
* Used `c_str()` instead of `data()` to more clearly express the intent where it makes sense.p
* Simplified code involving column filters with a new alias template.
* Renamed `storage_t<>::sync_table()` -> `storage_t<>::sync_dbo()` as this method is overloaded for all possible database object types.