### PR TITLE
Corrected expressions with table references

### DIFF
--- a/dev/alias.h
+++ b/dev/alias.h
@@ -163,7 +163,13 @@ namespace sqlite_orm {
                 return {};
             }
 
-            template<auto t>
+            template<orm_table_reference auto t>
+            [[nodiscard]] consteval auto for_() const {
+                using T = auto_decay_table_ref_t<t>;
+                return recordset_alias<T, A, X...>{};
+            }
+
+            template<orm_recordset_alias auto t>
             [[nodiscard]] consteval auto for_() const {
                 using T = std::remove_const_t<decltype(t)>;
                 return recordset_alias<T, A, X...>{};

--- a/dev/ast/into.h
+++ b/dev/ast/into.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../functional/cxx_type_traits_polyfill.h"
+#include "../table_reference.h"
 
 namespace sqlite_orm {
     namespace internal {
@@ -20,4 +21,11 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     internal::into_t<T> into() {
         return {};
     }
+
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+    template<orm_table_reference auto table>
+    auto into() {
+        return into<internal::auto_decay_table_ref_t<table>>();
+    }
+#endif
 }

--- a/dev/conditions.h
+++ b/dev/conditions.h
@@ -912,10 +912,24 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
         return {};
     }
 
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+    template<orm_refers_to_recordset auto alias>
+    auto cross_join() {
+        return cross_join<internal::auto_decay_table_ref_t<alias>>();
+    }
+#endif
+
     template<class T>
     internal::natural_join_t<T> natural_join() {
         return {};
     }
+
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+    template<orm_refers_to_recordset auto alias>
+    auto natural_join() {
+        return natural_join<internal::auto_decay_table_ref_t<alias>>();
+    }
+#endif
 
     template<class T, class O>
     internal::left_join_t<T, O> left_join(O o) {

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -6059,10 +6059,24 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
         return {};
     }
 
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+    template<orm_refers_to_recordset auto alias>
+    auto cross_join() {
+        return cross_join<internal::auto_decay_table_ref_t<alias>>();
+    }
+#endif
+
     template<class T>
     internal::natural_join_t<T> natural_join() {
         return {};
     }
+
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+    template<orm_refers_to_recordset auto alias>
+    auto natural_join() {
+        return natural_join<internal::auto_decay_table_ref_t<alias>>();
+    }
+#endif
 
     template<class T, class O>
     internal::left_join_t<T, O> left_join(O o) {
@@ -6348,6 +6362,8 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 
 // #include "../functional/cxx_type_traits_polyfill.h"
 
+// #include "../table_reference.h"
+
 namespace sqlite_orm {
     namespace internal {
 
@@ -6366,6 +6382,13 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     internal::into_t<T> into() {
         return {};
     }
+
+#ifdef SQLITE_ORM_WITH_CPP20_ALIASES
+    template<orm_table_reference auto table>
+    auto into() {
+        return into<internal::auto_decay_table_ref_t<table>>();
+    }
+#endif
 }
 
 namespace sqlite_orm {

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -2640,7 +2640,13 @@ namespace sqlite_orm {
                 return {};
             }
 
-            template<auto t>
+            template<orm_table_reference auto t>
+            [[nodiscard]] consteval auto for_() const {
+                using T = auto_decay_table_ref_t<t>;
+                return recordset_alias<T, A, X...>{};
+            }
+
+            template<orm_recordset_alias auto t>
             [[nodiscard]] consteval auto for_() const {
                 using T = std::remove_const_t<decltype(t)>;
                 return recordset_alias<T, A, X...>{};

--- a/tests/static_tests/alias.cpp
+++ b/tests/static_tests/alias.cpp
@@ -107,6 +107,8 @@ TEST_CASE("aliases") {
     SECTION("table alias expressions") {
         constexpr auto derived_user = c<DerivedUser>();
         constexpr auto d_alias = "d"_alias.for_<DerivedUser>();
+        constexpr auto tableref_alias = "d"_alias.for_<derived_user>();
+        STATIC_REQUIRE(std::is_same_v<decltype(tableref_alias), decltype(d_alias)>);
         using d_alias_type = decltype("d"_alias.for_<DerivedUser>());
         runTest<internal::from_t<d_alias_type>>(from<d_alias>());
         runTest<internal::asterisk_t<d_alias_type>>(asterisk<d_alias>());

--- a/tests/static_tests/column_pointer.cpp
+++ b/tests/static_tests/column_pointer.cpp
@@ -149,6 +149,7 @@ TEST_CASE("column pointers") {
     SECTION("table reference expressions") {
         runTest<internal::base_table<DerivedUser, std::false_type>>(make_table<derived_user>("derived_user"));
         runTest<internal::from_t<DerivedUser>>(from<derived_user>());
+        runTest<internal::into_t<DerivedUser>>(into<derived_user>());
         runTest<internal::asterisk_t<DerivedUser>>(asterisk<derived_user>());
         runTest<internal::object_t<DerivedUser>>(object<derived_user>());
         runTest<internal::count_asterisk_t<DerivedUser>>(count<derived_user>());
@@ -162,6 +163,8 @@ TEST_CASE("column pointers") {
             left_outer_join<derived_user>(using_(derived_user->*&DerivedUser::id)));
         runTest<internal::inner_join_t<DerivedUser, using_t<DerivedUser, decltype(&DerivedUser::id)>>>(
             inner_join<derived_user>(using_(derived_user->*&DerivedUser::id)));
+        runTest<internal::cross_join_t<DerivedUser>>(cross_join<derived_user>());
+        runTest<internal::natural_join_t<DerivedUser>>(natural_join<derived_user>());
 
         STATIC_REQUIRE(refers_to_recordset_callable<derived_user>);
         STATIC_REQUIRE(refers_to_table_callable<derived_user>);


### PR DESCRIPTION
* Added missing expressions with table references: `cross_join<>()`, `natural_join<>()`, `into<>()`.
* Fixed aliasing a table reference.
  Let `user_table` be a table reference of `User`, then `"u"_alias.for_<user_table>()` must be the same as `"u"_alias.for_<User>()`.