### PR TITLE
fixed cross join serialization

### DIFF
--- a/dev/ast/cross_join.h
+++ b/dev/ast/cross_join.h
@@ -1,0 +1,31 @@
+#include "../functional/config.h"
+#include "../functional/cxx_type_traits_polyfill.h"
+
+namespace sqlite_orm {
+    namespace internal {
+
+        /**
+         *  CROSS JOIN holder.
+         *  T is joined type which represents any mapped table.
+         */
+        template<class T>
+        struct cross_join_t {
+            using type = T;
+        };
+
+        template<class T>
+        using is_cross_join = polyfill::is_specialization_of<T, cross_join_t>;
+    }
+}
+
+SQLITE_ORM_EXPORT namespace sqlite_orm {
+
+    /**
+     *  CROSS JOIN function. Usage:
+     *  `cross_join<User>();`
+     */
+    template<class T>
+    internal::cross_join_t<T> cross_join() {
+        return {};
+    }
+}

--- a/dev/ast/cross_join.h
+++ b/dev/ast/cross_join.h
@@ -1,4 +1,3 @@
-#include "../functional/config.h"
 #include "../functional/cxx_type_traits_polyfill.h"
 
 namespace sqlite_orm {
@@ -12,9 +11,6 @@ namespace sqlite_orm {
         struct cross_join_t {
             using type = T;
         };
-
-        template<class T>
-        using is_cross_join = polyfill::is_specialization_of<T, cross_join_t>;
     }
 }
 

--- a/dev/conditions.h
+++ b/dev/conditions.h
@@ -31,7 +31,6 @@
 namespace sqlite_orm {
 
     namespace internal {
-
         /**
          *  Collated something
          */
@@ -730,6 +729,13 @@ namespace sqlite_orm {
 
         template<class T>
         using is_constrained_join = polyfill::is_detected<on_type_t, T>;
+
+        template<class T>
+        using is_any_join = mpl::invoke_t<mpl::disjunction<check_if<is_constrained_join>,
+                                                           check_if_is_template<cross_join_t>,
+                                                           check_if_is_template<natural_join_t>>,
+                                          T>;
+
     }
 }
 

--- a/dev/conditions.h
+++ b/dev/conditions.h
@@ -26,6 +26,7 @@
 #include "tags.h"
 #include "type_printer.h"
 #include "literal.h"
+#include "ast/cross_join.h"
 
 namespace sqlite_orm {
 
@@ -595,33 +596,12 @@ namespace sqlite_orm {
             glob_t(arg_t arg_, pattern_t pattern_) : arg(std::move(arg_)), pattern(std::move(pattern_)) {}
         };
 
-        struct cross_join_string {
-            operator std::string() const {
-                return "CROSS JOIN";
-            }
-        };
-
-        /**
-         *  CROSS JOIN holder.
-         *  T is joined type which represents any mapped table.
-         */
-        template<class T>
-        struct cross_join_t : cross_join_string {
-            using type = T;
-        };
-
-        struct natural_join_string {
-            operator std::string() const {
-                return "NATURAL JOIN";
-            }
-        };
-
         /**
          *  NATURAL JOIN holder.
          *  T is joined type which represents any mapped table.
          */
         template<class T>
-        struct natural_join_t : natural_join_string {
+        struct natural_join_t {
             using type = T;
         };
 
@@ -905,11 +885,6 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     template<class T>
     internal::on_t<T> on(T t) {
         return {std::move(t)};
-    }
-
-    template<class T>
-    internal::cross_join_t<T> cross_join() {
-        return {};
     }
 
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES

--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -1946,21 +1946,23 @@ namespace sqlite_orm {
                 using conditions_tuple = typename statement_type::conditions_type;
                 constexpr bool hasExplicitFrom = tuple_has<conditions_tuple, is_from>::value;
                 if constexpr (!hasExplicitFrom) {
-                    using joins_index_sequence = filter_tuple_sequence_t<conditions_tuple, is_constrained_join>;
-                    using cross_join_index_sequence = filter_tuple_sequence_t<conditions_tuple, is_cross_join>;
+                    using joins_index_sequence = filter_tuple_sequence_t<conditions_tuple, is_any_join>;
 
                     auto tableNames = collect_table_names(sel, context);
-                    auto joinLambda = [&tableNames, &context](auto& join) {
-                        using original_join_type = typename std::remove_reference_t<decltype(join)>::type;
-                        using cross_join_type = mapped_type_proxy_t<original_join_type>;
-                        std::pair<const std::string&, std::string> tableNameWithAlias{
-                            lookup_table_name<cross_join_type>(context.db_objects),
-                            alias_extractor<original_join_type>::as_alias()};
-                        tableNames.erase(tableNameWithAlias);
-                    };
                     // deduplicate table names of constrained join statements
-                    iterate_tuple(sel.conditions, joins_index_sequence{}, joinLambda);
-                    iterate_tuple(sel.conditions, cross_join_index_sequence{}, joinLambda);
+                    iterate_tuple(sel.conditions, joins_index_sequence{}, [&tableNames, &context](auto& join) {
+                        using original_join_type = typename std::remove_reference_t<decltype(join)>::type;
+                        using join_type = mapped_type_proxy_t<original_join_type>;
+
+                        const auto& tableName = lookup_table_name<join_type>(context.db_objects);
+                        auto it = std::find_if(tableNames.begin(), tableNames.end(), [&tableName](const auto& pair) {
+                            return pair.first == tableName;
+                        });
+                        if (it == tableNames.end()) {
+                            return;
+                        }
+                        tableNames.erase(it);
+                    });
 
                     if (!tableNames.empty() && !is_compound_operator<T>::value) {
                         ss << " FROM " << streaming_identifiers(tableNames);
@@ -2295,17 +2297,19 @@ namespace sqlite_orm {
             using statement_type = Join;
 
             template<class Ctx>
-            SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& join,
+            SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& /*join*/,
                                                             const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
                 std::stringstream ss;
-                if constexpr (polyfill::is_specialization_of<Join, cross_join_t>::value) {
+                if constexpr (polyfill::is_specialization_of<statement_type, cross_join_t>::value) {
                     ss << "CROSS JOIN";
-                } else if constexpr (polyfill::is_specialization_of<Join, natural_join_t>::value) {
+                } else if constexpr (polyfill::is_specialization_of<statement_type, natural_join_t>::value) {
                     ss << "NATURAL JOIN";
                 } else {
                     static_assert(polyfill::always_false_v<statement_type>);
                 }
-                ss << " " << streaming_identifier(lookup_table_name<type_t<Join>>(context.db_objects));
+                ss << " "
+                   << streaming_identifier(
+                          lookup_table_name<mapped_type_proxy_t<type_t<statement_type>>>(context.db_objects));
                 return ss.str();
             }
         };

--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -1946,17 +1946,22 @@ namespace sqlite_orm {
                 using conditions_tuple = typename statement_type::conditions_type;
                 constexpr bool hasExplicitFrom = tuple_has<conditions_tuple, is_from>::value;
                 if constexpr (!hasExplicitFrom) {
-                    auto tableNames = collect_table_names(sel, context);
                     using joins_index_sequence = filter_tuple_sequence_t<conditions_tuple, is_constrained_join>;
-                    // deduplicate table names of constrained join statements
-                    iterate_tuple(sel.conditions, joins_index_sequence{}, [&tableNames, &context](auto& join) {
+                    using cross_join_index_sequence = filter_tuple_sequence_t<conditions_tuple, is_cross_join>;
+
+                    auto tableNames = collect_table_names(sel, context);
+                    auto joinLambda = [&tableNames, &context](auto& join) {
                         using original_join_type = typename std::remove_reference_t<decltype(join)>::type;
                         using cross_join_type = mapped_type_proxy_t<original_join_type>;
                         std::pair<const std::string&, std::string> tableNameWithAlias{
                             lookup_table_name<cross_join_type>(context.db_objects),
                             alias_extractor<original_join_type>::as_alias()};
                         tableNames.erase(tableNameWithAlias);
-                    });
+                    };
+                    // deduplicate table names of constrained join statements
+                    iterate_tuple(sel.conditions, joins_index_sequence{}, joinLambda);
+                    iterate_tuple(sel.conditions, cross_join_index_sequence{}, joinLambda);
+
                     if (!tableNames.empty() && !is_compound_operator<T>::value) {
                         ss << " FROM " << streaming_identifiers(tableNames);
                     }
@@ -2293,8 +2298,14 @@ namespace sqlite_orm {
             SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& join,
                                                             const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
                 std::stringstream ss;
-                ss << static_cast<std::string>(join) << " "
-                   << streaming_identifier(lookup_table_name<type_t<Join>>(context.db_objects));
+                if constexpr (polyfill::is_specialization_of<Join, cross_join_t>::value) {
+                    ss << "CROSS JOIN";
+                } else if constexpr (polyfill::is_specialization_of<Join, natural_join_t>::value) {
+                    ss << "NATURAL JOIN";
+                } else {
+                    static_assert(polyfill::always_false_v<statement_type>);
+                }
+                ss << " " << streaming_identifier(lookup_table_name<type_t<Join>>(context.db_objects));
                 return ss.str();
             }
         };

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -5197,6 +5197,40 @@ namespace sqlite_orm {
     }
 }
 
+// #include "ast/cross_join.h"
+// #include "../functional/config.h"
+
+// #include "../functional/cxx_type_traits_polyfill.h"
+
+namespace sqlite_orm {
+    namespace internal {
+
+        /**
+         *  CROSS JOIN holder.
+         *  T is joined type which represents any mapped table.
+         */
+        template<class T>
+        struct cross_join_t {
+            using type = T;
+        };
+
+        template<class T>
+        using is_cross_join = polyfill::is_specialization_of<T, cross_join_t>;
+    }
+}
+
+SQLITE_ORM_EXPORT namespace sqlite_orm {
+
+    /**
+     *  CROSS JOIN function. Usage:
+     *  `cross_join<User>();`
+     */
+    template<class T>
+    internal::cross_join_t<T> cross_join() {
+        return {};
+    }
+}
+
 namespace sqlite_orm {
 
     namespace internal {
@@ -5765,33 +5799,12 @@ namespace sqlite_orm {
             glob_t(arg_t arg_, pattern_t pattern_) : arg(std::move(arg_)), pattern(std::move(pattern_)) {}
         };
 
-        struct cross_join_string {
-            operator std::string() const {
-                return "CROSS JOIN";
-            }
-        };
-
-        /**
-         *  CROSS JOIN holder.
-         *  T is joined type which represents any mapped table.
-         */
-        template<class T>
-        struct cross_join_t : cross_join_string {
-            using type = T;
-        };
-
-        struct natural_join_string {
-            operator std::string() const {
-                return "NATURAL JOIN";
-            }
-        };
-
         /**
          *  NATURAL JOIN holder.
          *  T is joined type which represents any mapped table.
          */
         template<class T>
-        struct natural_join_t : natural_join_string {
+        struct natural_join_t {
             using type = T;
         };
 
@@ -6075,11 +6088,6 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     template<class T>
     internal::on_t<T> on(T t) {
         return {std::move(t)};
-    }
-
-    template<class T>
-    internal::cross_join_t<T> cross_join() {
-        return {};
     }
 
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
@@ -22358,17 +22366,22 @@ namespace sqlite_orm {
                 using conditions_tuple = typename statement_type::conditions_type;
                 constexpr bool hasExplicitFrom = tuple_has<conditions_tuple, is_from>::value;
                 if constexpr (!hasExplicitFrom) {
-                    auto tableNames = collect_table_names(sel, context);
                     using joins_index_sequence = filter_tuple_sequence_t<conditions_tuple, is_constrained_join>;
-                    // deduplicate table names of constrained join statements
-                    iterate_tuple(sel.conditions, joins_index_sequence{}, [&tableNames, &context](auto& join) {
+                    using cross_join_index_sequence = filter_tuple_sequence_t<conditions_tuple, is_cross_join>;
+
+                    auto tableNames = collect_table_names(sel, context);
+                    auto joinLambda = [&tableNames, &context](auto& join) {
                         using original_join_type = typename std::remove_reference_t<decltype(join)>::type;
                         using cross_join_type = mapped_type_proxy_t<original_join_type>;
                         std::pair<const std::string&, std::string> tableNameWithAlias{
                             lookup_table_name<cross_join_type>(context.db_objects),
                             alias_extractor<original_join_type>::as_alias()};
                         tableNames.erase(tableNameWithAlias);
-                    });
+                    };
+                    // deduplicate table names of constrained join statements
+                    iterate_tuple(sel.conditions, joins_index_sequence{}, joinLambda);
+                    iterate_tuple(sel.conditions, cross_join_index_sequence{}, joinLambda);
+
                     if (!tableNames.empty() && !is_compound_operator<T>::value) {
                         ss << " FROM " << streaming_identifiers(tableNames);
                     }
@@ -22705,8 +22718,14 @@ namespace sqlite_orm {
             SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& join,
                                                             const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
                 std::stringstream ss;
-                ss << static_cast<std::string>(join) << " "
-                   << streaming_identifier(lookup_table_name<type_t<Join>>(context.db_objects));
+                if constexpr (polyfill::is_specialization_of<Join, cross_join_t>::value) {
+                    ss << "CROSS JOIN";
+                } else if constexpr (polyfill::is_specialization_of<Join, natural_join_t>::value) {
+                    ss << "NATURAL JOIN";
+                } else {
+                    static_assert(polyfill::always_false_v<statement_type>);
+                }
+                ss << " " << streaming_identifier(lookup_table_name<type_t<Join>>(context.db_objects));
                 return ss.str();
             }
         };

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -5198,8 +5198,6 @@ namespace sqlite_orm {
 }
 
 // #include "ast/cross_join.h"
-// #include "../functional/config.h"
-
 // #include "../functional/cxx_type_traits_polyfill.h"
 
 namespace sqlite_orm {
@@ -5213,9 +5211,6 @@ namespace sqlite_orm {
         struct cross_join_t {
             using type = T;
         };
-
-        template<class T>
-        using is_cross_join = polyfill::is_specialization_of<T, cross_join_t>;
     }
 }
 
@@ -5234,7 +5229,6 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 namespace sqlite_orm {
 
     namespace internal {
-
         /**
          *  Collated something
          */
@@ -5933,6 +5927,13 @@ namespace sqlite_orm {
 
         template<class T>
         using is_constrained_join = polyfill::is_detected<on_type_t, T>;
+
+        template<class T>
+        using is_any_join = mpl::invoke_t<mpl::disjunction<check_if<is_constrained_join>,
+                                                           check_if_is_template<cross_join_t>,
+                                                           check_if_is_template<natural_join_t>>,
+                                          T>;
+
     }
 }
 
@@ -22366,21 +22367,23 @@ namespace sqlite_orm {
                 using conditions_tuple = typename statement_type::conditions_type;
                 constexpr bool hasExplicitFrom = tuple_has<conditions_tuple, is_from>::value;
                 if constexpr (!hasExplicitFrom) {
-                    using joins_index_sequence = filter_tuple_sequence_t<conditions_tuple, is_constrained_join>;
-                    using cross_join_index_sequence = filter_tuple_sequence_t<conditions_tuple, is_cross_join>;
+                    using joins_index_sequence = filter_tuple_sequence_t<conditions_tuple, is_any_join>;
 
                     auto tableNames = collect_table_names(sel, context);
-                    auto joinLambda = [&tableNames, &context](auto& join) {
-                        using original_join_type = typename std::remove_reference_t<decltype(join)>::type;
-                        using cross_join_type = mapped_type_proxy_t<original_join_type>;
-                        std::pair<const std::string&, std::string> tableNameWithAlias{
-                            lookup_table_name<cross_join_type>(context.db_objects),
-                            alias_extractor<original_join_type>::as_alias()};
-                        tableNames.erase(tableNameWithAlias);
-                    };
                     // deduplicate table names of constrained join statements
-                    iterate_tuple(sel.conditions, joins_index_sequence{}, joinLambda);
-                    iterate_tuple(sel.conditions, cross_join_index_sequence{}, joinLambda);
+                    iterate_tuple(sel.conditions, joins_index_sequence{}, [&tableNames, &context](auto& join) {
+                        using original_join_type = typename std::remove_reference_t<decltype(join)>::type;
+                        using join_type = mapped_type_proxy_t<original_join_type>;
+
+                        const auto& tableName = lookup_table_name<join_type>(context.db_objects);
+                        auto it = std::find_if(tableNames.begin(), tableNames.end(), [&tableName](const auto& pair) {
+                            return pair.first == tableName;
+                        });
+                        if (it == tableNames.end()) {
+                            return;
+                        }
+                        tableNames.erase(it);
+                    });
 
                     if (!tableNames.empty() && !is_compound_operator<T>::value) {
                         ss << " FROM " << streaming_identifiers(tableNames);
@@ -22715,17 +22718,19 @@ namespace sqlite_orm {
             using statement_type = Join;
 
             template<class Ctx>
-            SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& join,
+            SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& /*join*/,
                                                             const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
                 std::stringstream ss;
-                if constexpr (polyfill::is_specialization_of<Join, cross_join_t>::value) {
+                if constexpr (polyfill::is_specialization_of<statement_type, cross_join_t>::value) {
                     ss << "CROSS JOIN";
-                } else if constexpr (polyfill::is_specialization_of<Join, natural_join_t>::value) {
+                } else if constexpr (polyfill::is_specialization_of<statement_type, natural_join_t>::value) {
                     ss << "NATURAL JOIN";
                 } else {
                     static_assert(polyfill::always_false_v<statement_type>);
                 }
-                ss << " " << streaming_identifier(lookup_table_name<type_t<Join>>(context.db_objects));
+                ss << " "
+                   << streaming_identifier(
+                          lookup_table_name<mapped_type_proxy_t<type_t<statement_type>>>(context.db_objects));
                 return ss.str();
             }
         };

--- a/tests/statement_serializer_tests/ast/cross_join.cpp
+++ b/tests/statement_serializer_tests/ast/cross_join.cpp
@@ -16,7 +16,15 @@ TEST_CASE("cross_join") {
     auto dbObjects = db_objects_t{table};
     using context_t = internal::serializer_context<db_objects_t>;
     context_t context{dbObjects};
-    auto node = cross_join<User>();
-    auto value = serialize(node, context);
+    std::string value;
+    SECTION("straight") {
+        auto node = cross_join<User>();
+        value = serialize(node, context);
+    }
+    SECTION("alias") {
+        using user_s = alias_s<User>;
+        auto node = cross_join<user_s>();
+        value = serialize(node, context);
+    }
     REQUIRE(value == R"(CROSS JOIN "users")");
 }

--- a/tests/statement_serializer_tests/ast/cross_join.cpp
+++ b/tests/statement_serializer_tests/ast/cross_join.cpp
@@ -1,0 +1,22 @@
+#include <sqlite_orm/sqlite_orm.h>
+#include <catch2/catch_all.hpp>
+
+using namespace sqlite_orm;
+
+TEST_CASE("cross_join") {
+    using internal::serialize;
+
+    struct User {
+        int id = 0;
+        std::string name;
+    };
+    auto table =
+        make_virtual_table("users", using_fts5(make_column("id", &User::id), make_column("name", &User::name)));
+    using db_objects_t = internal::db_objects_tuple<decltype(table)>;
+    auto dbObjects = db_objects_t{table};
+    using context_t = internal::serializer_context<db_objects_t>;
+    context_t context{dbObjects};
+    auto node = cross_join<User>();
+    auto value = serialize(node, context);
+    REQUIRE(value == R"(CROSS JOIN "users")");
+}

--- a/tests/statement_serializer_tests/ast/natural_join.cpp
+++ b/tests/statement_serializer_tests/ast/natural_join.cpp
@@ -3,7 +3,7 @@
 
 using namespace sqlite_orm;
 
-TEST_CASE("cross_join") {
+TEST_CASE("natural_join") {
     using internal::serialize;
 
     struct User {
@@ -17,13 +17,13 @@ TEST_CASE("cross_join") {
     context_t context{dbObjects};
     std::string value;
     SECTION("straight") {
-        auto node = cross_join<User>();
+        auto node = natural_join<User>();
         value = serialize(node, context);
     }
     SECTION("alias") {
         using user_s = alias_s<User>;
-        auto node = cross_join<user_s>();
+        auto node = natural_join<user_s>();
         value = serialize(node, context);
     }
-    REQUIRE(value == R"(CROSS JOIN "users")");
+    REQUIRE(value == R"(NATURAL JOIN "users")");
 }

--- a/tests/statement_serializer_tests/statements/select.cpp
+++ b/tests/statement_serializer_tests/statements/select.cpp
@@ -9,6 +9,7 @@ TEST_CASE("statement_serializer select_t") {
         int id = 0;
         std::string name;
     };
+
     auto table = make_table("users", make_column("id", &User::id), make_column("name", &User::name));
     using db_objects_t = internal::db_objects_tuple<decltype(table)>;
     db_objects_t dbObjects{table};
@@ -291,6 +292,26 @@ TEST_CASE("statement_serializer select_t") {
                 expected = R"((SELECT COUNT(DISTINCT "users"."name") FROM "users"))";
             }
         }
+    }
+    SECTION("cross join") {
+        struct Rank {
+            std::string rank;
+        };
+
+        struct Suit {
+            std::string suit;
+        };
+        auto rankTable = make_table("ranks", make_column("rank", &Rank::rank));
+        auto suitTable = make_table("suits", make_column("suit", &Suit::suit));
+
+        using db_objects_t = internal::db_objects_tuple<decltype(rankTable), decltype(suitTable)>;
+        db_objects_t dbObjects{rankTable, suitTable};
+        internal::serializer_context<db_objects_t> context{dbObjects};
+
+        auto expression = select(columns(&Rank::rank, &Suit::suit), cross_join<Suit>(), order_by(&Suit::suit));
+        expression.highest_level = true;
+        stringValue = serialize(expression, context);
+        expected = R"(SELECT "ranks"."rank", "suits"."suit" FROM "ranks" CROSS JOIN "suits" ORDER BY "suits"."suit")";
     }
     REQUIRE(stringValue == expected);
 }

--- a/tests/statement_serializer_tests/statements/select.cpp
+++ b/tests/statement_serializer_tests/statements/select.cpp
@@ -1,3 +1,4 @@
+#include <chrono>
 #include <sqlite_orm/sqlite_orm.h>
 #include <catch2/catch_all.hpp>
 
@@ -293,7 +294,7 @@ TEST_CASE("statement_serializer select_t") {
             }
         }
     }
-    SECTION("cross join") {
+    SECTION("{cross, natural} join") {
         struct Rank {
             std::string rank;
         };
@@ -307,19 +308,39 @@ TEST_CASE("statement_serializer select_t") {
         using db_objects_t = internal::db_objects_tuple<decltype(rankTable), decltype(suitTable)>;
         db_objects_t dbObjects{rankTable, suitTable};
         internal::serializer_context<db_objects_t> context{dbObjects};
-
-        SECTION("straight") {
-            auto expression = select(columns(&Rank::rank, &Suit::suit), cross_join<Suit>(), order_by(&Suit::suit));
-            expression.highest_level = true;
-            stringValue = serialize(expression, context);
+        SECTION("cross join") {
+            SECTION("straight") {
+                auto expression = select(columns(&Rank::rank, &Suit::suit), cross_join<Suit>(), order_by(&Suit::suit));
+                expression.highest_level = true;
+                stringValue = serialize(expression, context);
+            }
+            SECTION("alias") {
+                using suit_s = alias_s<Suit>;
+                auto expression =
+                    select(columns(&Rank::rank, &Suit::suit), cross_join<suit_s>(), order_by(&Suit::suit));
+                expression.highest_level = true;
+                stringValue = serialize(expression, context);
+            }
+            expected =
+                R"(SELECT "ranks"."rank", "suits"."suit" FROM "ranks" CROSS JOIN "suits" ORDER BY "suits"."suit")";
         }
-        SECTION("alias") {
-            using suit_s = alias_s<Suit>;
-            auto expression = select(columns(&Rank::rank, &Suit::suit), cross_join<suit_s>(), order_by(&Suit::suit));
-            expression.highest_level = true;
-            stringValue = serialize(expression, context);
+        SECTION("natural join") {
+            SECTION("straight") {
+                auto expression =
+                    select(columns(&Rank::rank, &Suit::suit), natural_join<Suit>(), order_by(&Suit::suit));
+                expression.highest_level = true;
+                stringValue = serialize(expression, context);
+            }
+            SECTION("alias") {
+                using suit_s = alias_s<Suit>;
+                auto expression =
+                    select(columns(&Rank::rank, &Suit::suit), natural_join<suit_s>(), order_by(&Suit::suit));
+                expression.highest_level = true;
+                stringValue = serialize(expression, context);
+            }
+            expected =
+                R"(SELECT "ranks"."rank", "suits"."suit" FROM "ranks" NATURAL JOIN "suits" ORDER BY "suits"."suit")";
         }
-        expected = R"(SELECT "ranks"."rank", "suits"."suit" FROM "ranks" CROSS JOIN "suits" ORDER BY "suits"."suit")";
     }
     REQUIRE(stringValue == expected);
 }

--- a/tests/statement_serializer_tests/statements/select.cpp
+++ b/tests/statement_serializer_tests/statements/select.cpp
@@ -308,9 +308,17 @@ TEST_CASE("statement_serializer select_t") {
         db_objects_t dbObjects{rankTable, suitTable};
         internal::serializer_context<db_objects_t> context{dbObjects};
 
-        auto expression = select(columns(&Rank::rank, &Suit::suit), cross_join<Suit>(), order_by(&Suit::suit));
-        expression.highest_level = true;
-        stringValue = serialize(expression, context);
+        SECTION("straight") {
+            auto expression = select(columns(&Rank::rank, &Suit::suit), cross_join<Suit>(), order_by(&Suit::suit));
+            expression.highest_level = true;
+            stringValue = serialize(expression, context);
+        }
+        SECTION("alias") {
+            using suit_s = alias_s<Suit>;
+            auto expression = select(columns(&Rank::rank, &Suit::suit), cross_join<suit_s>(), order_by(&Suit::suit));
+            expression.highest_level = true;
+            stringValue = serialize(expression, context);
+        }
         expected = R"(SELECT "ranks"."rank", "suits"."suit" FROM "ranks" CROSS JOIN "suits" ORDER BY "suits"."suit")";
     }
     REQUIRE(stringValue == expected);


### PR DESCRIPTION
- fixed `cross_join` serialization and fixed `cross_join.cpp` example
- moved `cross_join_t` to a dedicated file in `ast` folder
- added `is_cross_join` trait
- removed cross join and natural join string superclasses and moved all serialization logic to `statement_serializer`

@trueqbit probably I messed up with polyfill API - please feel free to add comments