### PR TITLE
Tidy up warnings

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -108,7 +108,7 @@ for:
   install:
     - |-
       cd C:\Tools\vcpkg
-      git fetch --tags && git checkout 2025.08.27
+      git fetch --tags && git checkout 2025.09.17
       cd %APPVEYOR_BUILD_FOLDER%
       C:\Tools\vcpkg\bootstrap-vcpkg.bat -disableMetrics
       C:\Tools\vcpkg\vcpkg integrate install
@@ -142,7 +142,7 @@ for:
   install:
     - |-
       pushd $HOME/vcpkg
-      git fetch --tags && git checkout 2025.08.27
+      git fetch --tags && git checkout 2025.09.17
       popd
       $HOME/vcpkg/bootstrap-vcpkg.sh -disableMetrics
       $HOME/vcpkg/vcpkg integrate install --overlay-triplets=vcpkg/triplets
@@ -170,7 +170,7 @@ for:
   # using custom vcpkg triplets for building and linking dynamic dependent libraries
   install:
     - |-
-      git clone --depth 1 --branch 2025.08.27 https://github.com/microsoft/vcpkg.git $HOME/vcpkg
+      git clone --depth 1 --branch 2025.09.17 https://github.com/microsoft/vcpkg.git $HOME/vcpkg
       $HOME/vcpkg/bootstrap-vcpkg.sh -disableMetrics
       $HOME/vcpkg/vcpkg integrate install --overlay-triplets=vcpkg/triplets
       vcpkg install sqlite3[core,dbstat,math,json1,fts5,rtree,soundex] catch2 --overlay-triplets=vcpkg/triplets

--- a/dev/functional/config.h
+++ b/dev/functional/config.h
@@ -2,6 +2,8 @@
 
 #include "cxx_universal.h"
 #include "platform_definitions.h"
+// pull in SQLite3 configuration early, such that version and feature macros are globally available in sqlite_orm
+#include "sqlite3_config.h"
 
 #ifdef BUILD_SQLITE_ORM_MODULE
 #define SQLITE_ORM_EXPORT export

--- a/dev/functional/cxx_compiler_quirks.h
+++ b/dev/functional/cxx_compiler_quirks.h
@@ -20,6 +20,16 @@
 #define SQLITE_ORM_CLANG_SUPPRESS(warnoption, ...) __VA_ARGS__
 #endif
 
+#if defined(_MSC_VER) && !defined(__clang__)
+#define SQLITE_ORM_DO_PRAGMA(...) __pragma(__VA_ARGS__)
+#endif
+
+#if defined(_MSC_VER) && !defined(__clang__)
+#define SQLITE_ORM_MSVC_SUPPRESS(warncode, ...) SQLITE_ORM_DO_PRAGMA(warning(suppress : warncode))
+#else
+#define SQLITE_ORM_MSVC_SUPPRESS(warcode, ...) __VA_ARGS__
+#endif
+
 // clang has the bad habit of diagnosing missing brace-init-lists when constructing aggregates with base classes.
 // This is a false positive, since the C++ standard is quite clear that braces for nested or base objects may be omitted,
 // see https://en.cppreference.com/w/cpp/language/aggregate_initialization:
@@ -29,6 +39,9 @@
 // In this sense clang should only warn about missing field initializers.
 // Because we know what we are doing, we suppress the diagnostic message
 #define SQLITE_ORM_CLANG_SUPPRESS_MISSING_BRACES(...) SQLITE_ORM_CLANG_SUPPRESS("-Wmissing-braces", __VA_ARGS__)
+
+// msvc has the bad habit of diagnosing overalignment of types with an explicit alignment specifier.
+#define SQLITE_ORM_MSVC_SUPPRESS_OVERALIGNMENT(...) SQLITE_ORM_MSVC_SUPPRESS(4324, __VA_ARGS__)
 
 #if defined(_MSC_VER) && (_MSC_VER < 1920)
 #define SQLITE_ORM_BROKEN_VARIADIC_PACK_EXPANSION

--- a/dev/functional/finish_macros.h
+++ b/dev/functional/finish_macros.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
 #if defined(_MSC_VER)
 __pragma(pop_macro("max"))
 __pragma(pop_macro("min"))
-#endif  // defined(_MSC_VER)
+#endif

--- a/dev/functional/start_macros.h
+++ b/dev/functional/start_macros.h
@@ -1,5 +1,13 @@
 #pragma once
 
+// Clang has the annoying habit of warning about future C++ features that it claims to support through a feature macro.
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wc++20-extensions"
+#pragma clang diagnostic ignored "-Wc++23-extensions"
+#pragma clang diagnostic ignored "-Wc++26-extensions"
+#endif
+
 #if defined(_MSC_VER)
 __pragma(push_macro("min"))
 #undef min

--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -1511,7 +1511,7 @@ namespace sqlite_orm {
 
         template<class Ctx, class... Args>
         std::set<std::pair<std::string, std::string>> collect_table_names(const set_t<Args...>& set, const Ctx& ctx) {
-            auto collector = make_table_name_collector(ctx.db_objects);
+            table_name_collector collector{ctx.db_objects};
             // note: we are only interested in the table name on the left-hand side of the assignment operator expression
             iterate_tuple(set.assigns, [&collector](const auto& assignmentOperator) {
                 iterate_ast(assignmentOperator.lhs, collector);
@@ -1527,7 +1527,7 @@ namespace sqlite_orm {
 
         template<class Ctx, class T, satisfies<is_select, T> = true>
         std::set<std::pair<std::string, std::string>> collect_table_names(const T& sel, const Ctx& ctx) {
-            auto collector = make_table_name_collector(ctx.db_objects);
+            table_name_collector collector{ctx.db_objects};
             iterate_ast(sel, collector);
             return std::move(collector.table_names);
         }

--- a/dev/storage_base.h
+++ b/dev/storage_base.h
@@ -724,7 +724,7 @@ namespace sqlite_orm {
                     *other.connection,
                     std::bind(&storage_base::on_open_internal, this, std::placeholders::_1))),
                 cachedForeignKeysCount(other.cachedForeignKeysCount),
-                executor{std::move(other.executor.will_run_query), std::move(other.executor.did_run_query)} {
+                executor{other.executor.will_run_query, other.executor.did_run_query} {
                 if (this->inMemory) {
                     this->connection->retain();
                 }

--- a/dev/table_name_collector.h
+++ b/dev/table_name_collector.h
@@ -92,12 +92,6 @@ namespace sqlite_orm {
                 this->table_names.emplace(lookup_table_name<T>(this->db_objects), "");
             }
         };
-
-        template<class DBOs, satisfies<is_db_objects, DBOs> = true>
-        table_name_collector<DBOs> make_table_name_collector(const DBOs& dbObjects) {
-            return {dbObjects};
-        }
-
     }
 
 }

--- a/dev/type_traits.h
+++ b/dev/type_traits.h
@@ -9,7 +9,6 @@
 #endif
 #endif
 
-#include "functional/cxx_core_features.h"
 #include "functional/cxx_type_traits_polyfill.h"
 
 namespace sqlite_orm {

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -163,6 +163,16 @@ using std::nullptr_t;
 #define SQLITE_ORM_CLANG_SUPPRESS(warnoption, ...) __VA_ARGS__
 #endif
 
+#if defined(_MSC_VER) && !defined(__clang__)
+#define SQLITE_ORM_DO_PRAGMA(...) __pragma(__VA_ARGS__)
+#endif
+
+#if defined(_MSC_VER) && !defined(__clang__)
+#define SQLITE_ORM_MSVC_SUPPRESS(warncode, ...) SQLITE_ORM_DO_PRAGMA(warning(suppress : warncode))
+#else
+#define SQLITE_ORM_MSVC_SUPPRESS(warcode, ...) __VA_ARGS__
+#endif
+
 // clang has the bad habit of diagnosing missing brace-init-lists when constructing aggregates with base classes.
 // This is a false positive, since the C++ standard is quite clear that braces for nested or base objects may be omitted,
 // see https://en.cppreference.com/w/cpp/language/aggregate_initialization:
@@ -172,6 +182,9 @@ using std::nullptr_t;
 // In this sense clang should only warn about missing field initializers.
 // Because we know what we are doing, we suppress the diagnostic message
 #define SQLITE_ORM_CLANG_SUPPRESS_MISSING_BRACES(...) SQLITE_ORM_CLANG_SUPPRESS("-Wmissing-braces", __VA_ARGS__)
+
+// msvc has the bad habit of diagnosing overalignment of types with an explicit alignment specifier.
+#define SQLITE_ORM_MSVC_SUPPRESS_OVERALIGNMENT(...) SQLITE_ORM_MSVC_SUPPRESS(4324, __VA_ARGS__)
 
 #if defined(_MSC_VER) && (_MSC_VER < 1920)
 #define SQLITE_ORM_BROKEN_VARIADIC_PACK_EXPANSION

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -1828,8 +1828,6 @@ namespace sqlite_orm {
 #endif
 #endif
 
-// #include "functional/cxx_core_features.h"
-
 // #include "functional/cxx_type_traits_polyfill.h"
 
 namespace sqlite_orm {
@@ -14678,12 +14676,6 @@ namespace sqlite_orm {
                 this->table_names.emplace(lookup_table_name<T>(this->db_objects), "");
             }
         };
-
-        template<class DBOs, satisfies<is_db_objects, DBOs> = true>
-        table_name_collector<DBOs> make_table_name_collector(const DBOs& dbObjects) {
-            return {dbObjects};
-        }
-
     }
 
 }
@@ -21934,7 +21926,7 @@ namespace sqlite_orm {
 
         template<class Ctx, class... Args>
         std::set<std::pair<std::string, std::string>> collect_table_names(const set_t<Args...>& set, const Ctx& ctx) {
-            auto collector = make_table_name_collector(ctx.db_objects);
+            table_name_collector collector{ctx.db_objects};
             // note: we are only interested in the table name on the left-hand side of the assignment operator expression
             iterate_tuple(set.assigns, [&collector](const auto& assignmentOperator) {
                 iterate_ast(assignmentOperator.lhs, collector);
@@ -21950,7 +21942,7 @@ namespace sqlite_orm {
 
         template<class Ctx, class T, satisfies<is_select, T> = true>
         std::set<std::pair<std::string, std::string>> collect_table_names(const T& sel, const Ctx& ctx) {
-            auto collector = make_table_name_collector(ctx.db_objects);
+            table_name_collector collector{ctx.db_objects};
             iterate_ast(sel, collector);
             return std::move(collector.table_names);
         }

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -18950,7 +18950,7 @@ namespace sqlite_orm {
                     *other.connection,
                     std::bind(&storage_base::on_open_internal, this, std::placeholders::_1))),
                 cachedForeignKeysCount(other.cachedForeignKeysCount),
-                executor{std::move(other.executor.will_run_query), std::move(other.executor.did_run_query)} {
+                executor{other.executor.will_run_query, other.executor.did_run_query} {
                 if (this->inMemory) {
                     this->connection->retain();
                 }

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -8,9 +8,6 @@ __pragma(push_macro("max"))
 #endif  // defined(_MSC_VER)
 #pragma once
 
-#include <sqlite3.h>
-#pragma once
-
 // #include "cxx_universal.h"
 
 /*
@@ -237,6 +234,11 @@ using std::nullptr_t;
 #else
 #error "Unknown target platform detected"
 #endif
+
+// pull in SQLite3 configuration early, such that version and feature macros are globally available in sqlite_orm
+// #include "sqlite3_config.h"
+
+#include <sqlite3.h>
 
 #ifdef BUILD_SQLITE_ORM_MODULE
 #define SQLITE_ORM_EXPORT export

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -1,5 +1,13 @@
 #pragma once
 
+// Clang has the annoying habit of warning about future C++ features that it claims to support through a feature macro.
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wc++20-extensions"
+#pragma clang diagnostic ignored "-Wc++23-extensions"
+#pragma clang diagnostic ignored "-Wc++26-extensions"
+#endif
+
 #if defined(_MSC_VER)
 __pragma(push_macro("min"))
 #undef min
@@ -26443,7 +26451,11 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 #endif
 #pragma once
 
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
 #if defined(_MSC_VER)
 __pragma(pop_macro("max"))
 __pragma(pop_macro("min"))
-#endif  // defined(_MSC_VER)
+#endif

--- a/not_single_header_include/sqlite_orm/sqlite_orm.h
+++ b/not_single_header_include/sqlite_orm/sqlite_orm.h
@@ -1,7 +1,5 @@
 #pragma once
 #include "../../dev/functional/start_macros.h"
-// pull in the SQLite3 configuration early, such that version and feature macros are globally available in sqlite_orm
-#include "../../dev/functional/sqlite3_config.h"
 // though each header is required to include everything it needs
 // we include the configuration and all underlying c++ core features in order to make it universally available
 #include "../../dev/functional/config.h"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -74,6 +74,11 @@ if(MSVC)
         target_link_options(unit_tests PRIVATE "/ENTRY:wmainCRTStartup")
     endif()
 endif()
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    target_compile_options(unit_tests PUBLIC
+        # disabled due to unit tests still testing deprecated features
+        -Wno-deprecated-declarations)
+endif()
 
 target_precompile_headers(unit_tests PRIVATE
     <sqlite3.h>

--- a/tests/ast_iterator_tests.cpp
+++ b/tests/ast_iterator_tests.cpp
@@ -34,15 +34,14 @@ TEST_CASE("ast_iterator") {
     };
 #ifdef SQLITE_ORM_EXPLICIT_GENERIC_LAMBDA_SUPPORTED
     const auto nodeLambda = overloaded{
-        [&typeIndexes]<class UDF, class... CallArgs>(polyfill::bool_constant<true>,
+        [&typeIndexes]<class UDF, class... CallArgs>(std::true_type,
                                                      const internal::function_call<UDF, CallArgs...>& udfCall) {
             typeIndexes.push_back(typeid(udfCall.name));
         },
-        [&typeIndexes](polyfill::bool_constant<true>, const internal::named_collate_base& collateCall) {
+        [&typeIndexes](std::true_type, const internal::named_collate_base& collateCall) {
             typeIndexes.push_back(typeid(collateCall));
         },
-        [&typeIndexes]<class T, class X, class Y, class Z>(polyfill::bool_constant<true>,
-                                                           const internal::highlight_t<T, X, Y, Z>&) {
+        [&typeIndexes]<class T, class X, class Y, class Z>(std::true_type, const internal::highlight_t<T, X, Y, Z>&) {
             typeIndexes.push_back(typeid(T));
         },
         // swallow leaf expressions

--- a/tests/pointer_passing_interface.cpp
+++ b/tests/pointer_passing_interface.cpp
@@ -48,8 +48,6 @@ TEST_CASE("pointer-passing") {
 
         int64_pointer_binding operator()() const {
             return bind_pointer<int64_pointer_binding>(new int64{-1});
-            // outline: low-level; must compile
-            return bind_carray_pointer(new int64{-1}, delete_int64{});
         }
 
         static const char* name() {

--- a/tests/table_name_collector.cpp
+++ b/tests/table_name_collector.cpp
@@ -10,45 +10,44 @@ TEST_CASE("table name collector") {
         std::string name;
     };
 
-    auto table = make_table("users", make_column("id", &User::id), make_column("name", &User::name));
-    using db_objects_t = internal::db_objects_tuple<decltype(table)>;
-    auto dbObjects = db_objects_t{table};
-    internal::table_name_collector_base::table_name_set expected;
+    const std::tuple dbObjects{make_table("users", make_column("id", &User::id), make_column("name", &User::name))};
 
-    internal::serializer_context<db_objects_t> context{dbObjects};
-    auto collector = internal::make_table_name_collector(context.db_objects);
+    internal::table_name_collector_base::table_name_set expected;
 
     SECTION("static tests") {
         STATIC_REQUIRE(polyfill::is_invocable<internal::table_name_collector<std::tuple<>>,
-                                              polyfill::bool_constant<true>,
+                                              std::true_type,
                                               const internal::highlight_t<User, int, int, int>&>::value);
     }
     SECTION("from table") {
+        const std::string& tableName = std::get<0>(dbObjects).name;
+        internal::table_name_collector collector(dbObjects);
+
         SECTION("regular column") {
             auto expression = &User::id;
-            expected.emplace(table.name, "");
+            expected.emplace(tableName, "");
             iterate_ast(expression, collector);
         }
         SECTION("regular column pointer") {
             auto expression = column<User>(&User::id);
-            expected.emplace(table.name, "");
+            expected.emplace(tableName, "");
             iterate_ast(expression, collector);
         }
         SECTION("aliased regular column") {
             using als = alias_z<User>;
             auto expression = alias_column<als>(&User::id);
-            expected.emplace(table.name, "z");
+            expected.emplace(tableName, "z");
             iterate_ast(expression, collector);
         }
         SECTION("aliased regular column pointer") {
             using als = alias_z<User>;
             auto expression = alias_column<als>(column<User>(&User::id));
-            expected.emplace(table.name, "z");
+            expected.emplace(tableName, "z");
             iterate_ast(expression, collector);
         }
         SECTION("count asterisk") {
             auto expression = count<User>();
-            expected.emplace(table.name, "");
+            expected.emplace(tableName, "");
             iterate_ast(expression, collector);
         }
         REQUIRE(collector.table_names == expected);
@@ -56,28 +55,27 @@ TEST_CASE("table name collector") {
 
 #if (SQLITE_VERSION_NUMBER >= 3008003) && defined(SQLITE_ORM_WITH_CTE)
     SECTION("from CTE") {
-        auto dbObjects2 =
+        const auto dbObjects2 =
             internal::db_objects_cat(dbObjects, internal::make_cte_db_object(dbObjects, 1_ctealias().as(select(1))));
-        using context_t = internal::serializer_context<decltype(dbObjects2)>;
-        context_t context{dbObjects2};
-        auto collector = internal::make_table_name_collector(context.db_objects);
+        const std::string& tableName = std::get<0>(dbObjects2).name;
+        internal::table_name_collector collector(dbObjects2);
 
         SECTION("CTE column") {
             using cte_1 = decltype(1_ctealias);
             auto expression = column<cte_1>(&User::id);
-            expected.emplace(alias_extractor<cte_1>::extract(), "");
+            expected.emplace(tableName, "");
             iterate_ast(expression, collector);
         }
         SECTION("CTE column alias") {
             using cte_1 = decltype(1_ctealias);
             auto expression = column<cte_1>(1_colalias);
-            expected.emplace(alias_extractor<cte_1>::extract(), "");
+            expected.emplace(tableName, "");
             iterate_ast(expression, collector);
         }
         SECTION("CTE count asterisk") {
             using cte_1 = decltype(1_ctealias);
             auto expression = count<cte_1>();
-            expected.emplace(alias_extractor<cte_1>::extract(), "");
+            expected.emplace(tableName, "");
             iterate_ast(expression, collector);
         }
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
@@ -85,20 +83,20 @@ TEST_CASE("table name collector") {
             constexpr auto c = "1"_cte;
             constexpr auto z_alias = "z"_alias.for_<c>();
             auto expression = z_alias->*&User::id;
-            expected.emplace(alias_extractor<decltype(c)>::extract(), "z");
+            expected.emplace(tableName, "z");
             iterate_ast(expression, collector);
         }
         SECTION("aliased CTE column alias") {
             constexpr auto c = "1"_cte;
             constexpr auto z_alias = "z"_alias.for_<c>();
             auto expression = z_alias->*1_colalias;
-            expected.emplace(alias_extractor<decltype(c)>::extract(), "z");
+            expected.emplace(tableName, "z");
             iterate_ast(expression, collector);
         }
         SECTION("CTE count asterisk 2") {
             constexpr auto c = 1_ctealias;
             auto expression = count<c>();
-            expected.emplace(alias_extractor<decltype(c)>::extract(), "");
+            expected.emplace(tableName, "");
             iterate_ast(expression, collector);
         }
 #endif
@@ -106,15 +104,19 @@ TEST_CASE("table name collector") {
     }
 #endif
     SECTION("highlight") {
+        const std::string& tableName = std::get<0>(dbObjects).name;
+        internal::table_name_collector collector(dbObjects);
+
         SECTION("simple") {
             auto expression = highlight<User>(0, "<b>", "</b>");
-            expected.emplace(table.name, "");
+            expected.emplace(tableName, "");
             iterate_ast(expression, collector);
         }
         SECTION("in columns") {
             auto expression = columns(highlight<User>(0, "<b>", "</b>"));
-            expected.emplace(table.name, "");
+            expected.emplace(tableName, "");
             iterate_ast(expression, collector);
         }
+        REQUIRE(collector.table_names == expected);
     }
 }

--- a/tests/user_defined_functions.cpp
+++ b/tests/user_defined_functions.cpp
@@ -190,8 +190,7 @@ int MultiSum::objectsCount = 0;
 int FirstFunction::objectsCount = 0;
 int FirstFunction::callsCount = 0;
 
-#if __cpp_aligned_new >= 201606L
-struct alignas(2 * __STDCPP_DEFAULT_NEW_ALIGNMENT__) OverAlignedScalarFunction {
+struct SQLITE_ORM_MSVC_SUPPRESS_OVERALIGNMENT(alignas(2 * __STDCPP_DEFAULT_NEW_ALIGNMENT__)) OverAlignedScalarFunction {
     int operator()(int arg) const {
         return arg;
     }
@@ -201,7 +200,8 @@ struct alignas(2 * __STDCPP_DEFAULT_NEW_ALIGNMENT__) OverAlignedScalarFunction {
     }
 };
 
-struct alignas(2 * __STDCPP_DEFAULT_NEW_ALIGNMENT__) OverAlignedAggregateFunction {
+struct SQLITE_ORM_MSVC_SUPPRESS_OVERALIGNMENT(alignas(2 *
+                                                      __STDCPP_DEFAULT_NEW_ALIGNMENT__)) OverAlignedAggregateFunction {
     double sum = 0;
 
     void step(double arg) {
@@ -215,7 +215,6 @@ struct alignas(2 * __STDCPP_DEFAULT_NEW_ALIGNMENT__) OverAlignedAggregateFunctio
         return "OVERALIGNED2";
     }
 };
-#endif
 
 #ifdef SQLITE_ORM_STATIC_CALL_OPERATOR_SUPPORTED
 struct StaticCallOpFunction {
@@ -486,14 +485,12 @@ TEST_CASE("custom functions") {
     }
     storage.delete_aggregate_function<MultiSum>();
 
-#if __cpp_aligned_new >= 201606L
     {
         storage.create_scalar_function<OverAlignedScalarFunction>();
         REQUIRE_NOTHROW(storage.delete_scalar_function<OverAlignedScalarFunction>());
         storage.create_aggregate_function<OverAlignedAggregateFunction>();
         REQUIRE_NOTHROW(storage.delete_aggregate_function<OverAlignedAggregateFunction>());
     }
-#endif
 
 #ifdef SQLITE_ORM_STATIC_CALL_OPERATOR_SUPPORTED
     storage.create_scalar_function<StaticCallOpFunction>();

--- a/third_party/amalgamate/config.json
+++ b/third_party/amalgamate/config.json
@@ -3,7 +3,6 @@
   "target": "include/sqlite_orm/sqlite_orm.h",
   "sources": [
     "dev/functional/start_macros.h",
-    "dev/functional/sqlite3_config.h",
     "dev/functional/config.h",
     "dev/storage.h",
     "dev/interface_definitions.h",


### PR DESCRIPTION
The most annoying thing solved are warning messages by Clang complaining about using "future" language features when compiling in specific language modes. IMO this is stupid because if the compiler tells us it supports e.g. pack indexing even in C++17 mode then it is perfectly valid to use w/o getting a stupid warning.

This PR contains:
* Ignore Clang warnings about future language features used within the library.
* `storage_base`'s copy constructor should copy arguments rather than attempting to move them.
* Get rid of unreachable code in UTs.
* Disable deprecation warnings for Clang when compiling UTs - we are still testing facilities that are marked deprecated.
* Ignore stupid MSVC warning about over-aligned structures in UTs.

Also:
* Removed factory function for the table name collector - C++17 has CTAD.