### PR TITLE
Add BETWEEN operator implementation and related tests

### DIFF
--- a/dev/ast/between.h
+++ b/dev/ast/between.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#ifndef SQLITE_ORM_IMPORT_STD_MODULE
+#include <utility>  //  std::move
+#endif
+#include "tags.h"
+
+namespace sqlite_orm::internal {
+    /**
+     *  BETWEEN operator object.
+     */
+    template<class A, class T>
+    struct between_t : condition_t, negatable_t {
+        using expression_type = A;
+        using lower_type = T;
+        using upper_type = T;
+
+        expression_type expression;
+        lower_type lower;
+        upper_type upper;
+
+        between_t(expression_type expression_, lower_type lower_, upper_type upper_) :
+            expression(std::move(expression_)), lower(std::move(lower_)), upper(std::move(upper_)) {}
+    };
+}
+
+SQLITE_ORM_EXPORT namespace sqlite_orm {
+    /**
+     *  X BETWEEN Y AND Z
+     *  Example: storage.select(between(&User::id, 10, 20))
+     */
+    template<class A, class T>
+    internal::between_t<A, T> between(A expression, T lower, T upper) {
+        return {std::move(expression), std::move(lower), std::move(upper)};
+    }
+}

--- a/dev/ast_iterator.h
+++ b/dev/ast_iterator.h
@@ -28,6 +28,7 @@
 #include "ast/cast.h"
 #include "ast/limit.h"
 #include "ast/in.h"
+#include "ast/between.h"
 
 namespace sqlite_orm::internal {
     /**
@@ -488,9 +489,9 @@ namespace sqlite_orm::internal {
 
         template<class L>
         SQLITE_ORM_STATIC_CALLOP void operator()(const node_type& b, L& lambda) SQLITE_ORM_OR_CONST_CALLOP {
-            iterate_ast(b.expr, lambda);
-            iterate_ast(b.b1, lambda);
-            iterate_ast(b.b2, lambda);
+            iterate_ast(b.expression, lambda);
+            iterate_ast(b.lower, lambda);
+            iterate_ast(b.upper, lambda);
         }
     };
 

--- a/dev/column_result.h
+++ b/dev/column_result.h
@@ -28,6 +28,7 @@
 #include "ast/special_keywords.h"
 #include "ast/cast.h"
 #include "ast/in.h"
+#include "ast/between.h"
 
 namespace sqlite_orm::internal {
     /**
@@ -78,6 +79,11 @@ namespace sqlite_orm::internal {
 
     template<class DBOs, class L, class... Args>
     struct column_result_t<DBOs, in_t<L, Args...>, void> {
+        using type = bool;
+    };
+
+    template<class DBOs, class A, class T>
+    struct column_result_t<DBOs, between_t<A, T>, void> {
         using type = bool;
     };
 

--- a/dev/conditions.h
+++ b/dev/conditions.h
@@ -489,29 +489,6 @@ namespace sqlite_orm::internal {
     template<class T>
     struct is_order_by : polyfill::bool_constant<is_order_by_v<T>> {};
 
-    struct between_string {
-        operator std::string() const {
-            return "BETWEEN";
-        }
-    };
-
-    /**
-     *  BETWEEN operator object.
-     */
-    template<class A, class T>
-    struct between_t : condition_t, between_string {
-        using expression_type = A;
-        using lower_type = T;
-        using upper_type = T;
-
-        expression_type expr;
-        lower_type b1;
-        upper_type b2;
-
-        between_t(expression_type expr_, lower_type b1_, upper_type b2_) :
-            expr(std::move(expr_)), b1(std::move(b1_)), b2(std::move(b2_)) {}
-    };
-
     struct like_string {
         operator std::string() const {
             return "LIKE";
@@ -1121,15 +1098,6 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     internal::dynamic_order_by_t<internal::serializer_context<typename S::db_objects_type>>
     dynamic_order_by(const S& storage) {
         return {obtain_db_objects(storage)};
-    }
-
-    /**
-     *  X BETWEEN Y AND Z
-     *  Example: storage.select(between(&User::id, 10, 20))
-     */
-    template<class A, class T>
-    internal::between_t<A, T> between(A expr, T b1, T b2) {
-        return {std::move(expr), std::move(b1), std::move(b2)};
     }
 
     /**

--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -1056,14 +1056,14 @@ namespace sqlite_orm::internal {
         using statement_type = between_t<A, T>;
 
         template<class Ctx>
-        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& c,
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
                                                         const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
             std::stringstream ss;
-            auto expr = serialize(c.expr, context);
-            ss << expr << " " << static_cast<std::string>(c) << " ";
-            ss << serialize(c.b1, context);
+            auto expr = serialize(statement.expression, context);
+            ss << expr << " BETWEEN ";
+            ss << serialize(statement.lower, context);
             ss << " AND ";
-            ss << serialize(c.b2, context);
+            ss << serialize(statement.upper, context);
             return ss.str();
         }
     };

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -5707,29 +5707,6 @@ namespace sqlite_orm::internal {
     template<class T>
     struct is_order_by : polyfill::bool_constant<is_order_by_v<T>> {};
 
-    struct between_string {
-        operator std::string() const {
-            return "BETWEEN";
-        }
-    };
-
-    /**
-     *  BETWEEN operator object.
-     */
-    template<class A, class T>
-    struct between_t : condition_t, between_string {
-        using expression_type = A;
-        using lower_type = T;
-        using upper_type = T;
-
-        expression_type expr;
-        lower_type b1;
-        upper_type b2;
-
-        between_t(expression_type expr_, lower_type b1_, upper_type b2_) :
-            expr(std::move(expr_)), b1(std::move(b1_)), b2(std::move(b2_)) {}
-    };
-
     struct like_string {
         operator std::string() const {
             return "LIKE";
@@ -6339,15 +6316,6 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     internal::dynamic_order_by_t<internal::serializer_context<typename S::db_objects_type>>
     dynamic_order_by(const S& storage) {
         return {obtain_db_objects(storage)};
-    }
-
-    /**
-     *  X BETWEEN Y AND Z
-     *  Example: storage.select(between(&User::id, 10, 20))
-     */
-    template<class A, class T>
-    internal::between_t<A, T> between(A expr, T b1, T b2) {
-        return {std::move(expr), std::move(b1), std::move(b2)};
     }
 
     /**
@@ -12090,6 +12058,42 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
         return {std::move(left), std::move(argument), true};
     }
 }
+// #include "ast/between.h"
+
+#ifndef SQLITE_ORM_IMPORT_STD_MODULE
+#include <utility>  //  std::move
+#endif
+// #include "tags.h"
+
+namespace sqlite_orm::internal {
+    /**
+     *  BETWEEN operator object.
+     */
+    template<class A, class T>
+    struct between_t : condition_t, negatable_t {
+        using expression_type = A;
+        using lower_type = T;
+        using upper_type = T;
+
+        expression_type expression;
+        lower_type lower;
+        upper_type upper;
+
+        between_t(expression_type expression_, lower_type lower_, upper_type upper_) :
+            expression(std::move(expression_)), lower(std::move(lower_)), upper(std::move(upper_)) {}
+    };
+}
+
+SQLITE_ORM_EXPORT namespace sqlite_orm {
+    /**
+     *  X BETWEEN Y AND Z
+     *  Example: storage.select(between(&User::id, 10, 20))
+     */
+    template<class A, class T>
+    internal::between_t<A, T> between(A expression, T lower, T upper) {
+        return {std::move(expression), std::move(lower), std::move(upper)};
+    }
+}
 
 namespace sqlite_orm::internal {
     /**
@@ -12140,6 +12144,11 @@ namespace sqlite_orm::internal {
 
     template<class DBOs, class L, class... Args>
     struct column_result_t<DBOs, in_t<L, Args...>, void> {
+        using type = bool;
+    };
+
+    template<class DBOs, class A, class T>
+    struct column_result_t<DBOs, between_t<A, T>, void> {
         using type = bool;
     };
 
@@ -16242,6 +16251,8 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 
 // #include "ast/in.h"
 
+// #include "ast/between.h"
+
 namespace sqlite_orm::internal {
     /**
      *  ast_iterator accepts any expression and a callable object
@@ -16701,9 +16712,9 @@ namespace sqlite_orm::internal {
 
         template<class L>
         SQLITE_ORM_STATIC_CALLOP void operator()(const node_type& b, L& lambda) SQLITE_ORM_OR_CONST_CALLOP {
-            iterate_ast(b.expr, lambda);
-            iterate_ast(b.b1, lambda);
-            iterate_ast(b.b2, lambda);
+            iterate_ast(b.expression, lambda);
+            iterate_ast(b.lower, lambda);
+            iterate_ast(b.upper, lambda);
         }
     };
 
@@ -21990,14 +22001,14 @@ namespace sqlite_orm::internal {
         using statement_type = between_t<A, T>;
 
         template<class Ctx>
-        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& c,
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
                                                         const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
             std::stringstream ss;
-            auto expr = serialize(c.expr, context);
-            ss << expr << " " << static_cast<std::string>(c) << " ";
-            ss << serialize(c.b1, context);
+            auto expr = serialize(statement.expression, context);
+            ss << expr << " BETWEEN ";
+            ss << serialize(statement.lower, context);
             ss << " AND ";
-            ss << serialize(c.b2, context);
+            ss << serialize(statement.upper, context);
             return ss.str();
         }
     };

--- a/tests/operators/between.cpp
+++ b/tests/operators/between.cpp
@@ -19,6 +19,38 @@ TEST_CASE("Between") {
     storage.insert(Object{});
 
     auto allObjects = storage.get_all<Object>();
-    auto rows = storage.select(&Object::id, where(between(&Object::id, 1, 3)));
-    REQUIRE(rows.size() == 3);
+    REQUIRE(allObjects.size() == 5);
+
+    SECTION("between in where clause") {
+        auto rows = storage.select(&Object::id, where(between(&Object::id, 1, 3)));
+        REQUIRE(rows.size() == 3);
+    }
+
+    SECTION("between as select expression") {
+        auto rows = storage.select(between(&Object::id, 2, 4));
+        REQUIRE(rows.size() == 5);
+        REQUIRE(rows[0] == false);
+        REQUIRE(rows[1] == true);
+        REQUIRE(rows[2] == true);
+        REQUIRE(rows[3] == true);
+        REQUIRE(rows[4] == false);
+    }
+
+    SECTION("negated between in where clause") {
+        auto rows = storage.select(&Object::id, where(!between(&Object::id, 2, 4)));
+        REQUIRE(rows.size() == 2);
+        REQUIRE(rows[0] == 1);
+        REQUIRE(rows[1] == 5);
+    }
+
+    SECTION("between with empty result") {
+        auto rows = storage.select(&Object::id, where(between(&Object::id, 10, 20)));
+        REQUIRE(rows.empty());
+    }
+
+    SECTION("between with single match") {
+        auto rows = storage.select(&Object::id, where(between(&Object::id, 3, 3)));
+        REQUIRE(rows.size() == 1);
+        REQUIRE(rows[0] == 3);
+    }
 }

--- a/tests/statement_serializer_tests/between.cpp
+++ b/tests/statement_serializer_tests/between.cpp
@@ -1,0 +1,66 @@
+#include <sqlite_orm/sqlite_orm.h>
+#include <catch2/catch_all.hpp>
+
+using namespace sqlite_orm;
+
+TEST_CASE("statement_serializer between") {
+    struct User {
+        int id = 0;
+        std::string name;
+        int age = 0;
+    };
+    auto table = make_table("users",
+                            make_column("id", &User::id),
+                            make_column("name", &User::name),
+                            make_column("age", &User::age));
+    using db_objects_t = internal::db_objects_tuple<decltype(table)>;
+    auto dbObjects = db_objects_t{table};
+    using context_t = internal::serializer_context<db_objects_t>;
+    context_t context{dbObjects};
+    std::string value;
+    std::string expected;
+
+    SECTION("between with column and literal values") {
+        SECTION("integer range") {
+            value = serialize(between(&User::id, 1, 10), context);
+            expected = R"("id" BETWEEN 1 AND 10)";
+        }
+        SECTION("age range") {
+            value = serialize(between(&User::age, 18, 65), context);
+            expected = R"("age" BETWEEN 18 AND 65)";
+        }
+    }
+
+    SECTION("between with cast") {
+        value = serialize(between(cast<int>(&User::name), 1, 5), context);
+        expected = R"(CAST ("name" AS INTEGER) BETWEEN 1 AND 5)";
+    }
+
+    SECTION("between with function") {
+        value = serialize(between(length(&User::name), 5, 20), context);
+        expected = R"(LENGTH("name") BETWEEN 5 AND 20)";
+    }
+
+    SECTION("between in where clause") {
+        context.use_parentheses = false;
+        value = serialize(select(object<User>(), where(between(&User::age, 18, 65))), context);
+        expected = R"(SELECT "users".* FROM "users" WHERE ("users"."age" BETWEEN 18 AND 65))";
+    }
+
+    SECTION("between with and condition") {
+        value = serialize(between(&User::id, 5, 15) and between(&User::age, 20, 30), context);
+        expected = R"("id" BETWEEN 5 AND 15 AND "age" BETWEEN 20 AND 30)";
+    }
+
+    SECTION("between with or condition") {
+        value = serialize(between(&User::id, 1, 5) or between(&User::id, 15, 20), context);
+        expected = R"("id" BETWEEN 1 AND 5 OR "id" BETWEEN 15 AND 20)";
+    }
+
+    SECTION("between with negation") {
+        value = serialize(!between(&User::age, 0, 18), context);
+        expected = R"(NOT "age" BETWEEN 0 AND 18)";
+    }
+
+    REQUIRE(value == expected);
+}


### PR DESCRIPTION
- moved `between_t` declaration to a dedicated file in `ast` folder
- added `select(between(...` support with unit tests
- added statement serialized unit tests for between
- renamed fields from shortened to full words