### PR TITLE
Add IS NULL and IS NOT NULL operator implementations

### DIFF
--- a/dev/ast/is_not_null.h
+++ b/dev/ast/is_not_null.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#ifndef SQLITE_ORM_IMPORT_STD_MODULE
+#include <utility>  //  std::move
+#endif
+
+#include "../tags.h"
+#include "../functional/config.h"
+
+namespace sqlite_orm::internal {
+    /**
+     *  IS NOT NULL operator object.
+     */
+    template<class T>
+    struct is_not_null_t : condition_t, negatable_t {
+        using argument_type = T;
+        using self = is_not_null_t<argument_type>;
+
+        argument_type argument;
+
+        is_not_null_t(argument_type argument_) : argument(std::move(argument_)) {}
+    };
+}
+
+SQLITE_ORM_EXPORT namespace sqlite_orm {
+
+    /**
+     *  IS NOT NULL operator.
+     */
+    template<class T>
+    internal::is_not_null_t<T> is_not_null(T t) {
+        return {std::move(t)};
+    }
+}

--- a/dev/ast/is_null.h
+++ b/dev/ast/is_null.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#ifndef SQLITE_ORM_IMPORT_STD_MODULE
+#include <utility>  //  std::move
+#endif
+
+#include "../tags.h"
+#include "../functional/config.h"
+
+namespace sqlite_orm::internal {
+    /**
+     *  IS NULL operator object.
+     */
+    template<class T>
+    struct is_null_t : condition_t, negatable_t {
+        using argument_type = T;
+        using self = is_null_t<argument_type>;
+
+        argument_type argument;
+
+        is_null_t(argument_type argument_) : argument(std::move(argument_)) {}
+    };
+}
+
+SQLITE_ORM_EXPORT namespace sqlite_orm {
+
+    /**
+     *  IS NULL operator.
+     */
+    template<class T>
+    internal::is_null_t<T> is_null(T t) {
+        return {std::move(t)};
+    }
+}

--- a/dev/ast_iterator.h
+++ b/dev/ast_iterator.h
@@ -520,8 +520,8 @@ namespace sqlite_orm::internal {
         using node_type = is_null_t<T>;
 
         template<class L>
-        SQLITE_ORM_STATIC_CALLOP void operator()(const node_type& i, L& lambda) SQLITE_ORM_OR_CONST_CALLOP {
-            iterate_ast(i.t, lambda);
+        SQLITE_ORM_STATIC_CALLOP void operator()(const node_type& node, L& lambda) SQLITE_ORM_OR_CONST_CALLOP {
+            iterate_ast(node.argument, lambda);
         }
     };
 

--- a/dev/ast_iterator.h
+++ b/dev/ast_iterator.h
@@ -29,6 +29,8 @@
 #include "ast/limit.h"
 #include "ast/in.h"
 #include "ast/between.h"
+#include "ast/is_null.h"
+#include "ast/is_not_null.h"
 
 namespace sqlite_orm::internal {
     /**
@@ -530,8 +532,8 @@ namespace sqlite_orm::internal {
         using node_type = is_not_null_t<T>;
 
         template<class L>
-        SQLITE_ORM_STATIC_CALLOP void operator()(const node_type& i, L& lambda) SQLITE_ORM_OR_CONST_CALLOP {
-            iterate_ast(i.t, lambda);
+        SQLITE_ORM_STATIC_CALLOP void operator()(const node_type& node, L& lambda) SQLITE_ORM_OR_CONST_CALLOP {
+            iterate_ast(node.argument, lambda);
         }
     };
 

--- a/dev/column_result.h
+++ b/dev/column_result.h
@@ -29,6 +29,7 @@
 #include "ast/cast.h"
 #include "ast/in.h"
 #include "ast/between.h"
+#include "ast/is_null.h"
 
 namespace sqlite_orm::internal {
     /**
@@ -84,6 +85,16 @@ namespace sqlite_orm::internal {
 
     template<class DBOs, class A, class T>
     struct column_result_t<DBOs, between_t<A, T>, void> {
+        using type = bool;
+    };
+
+    template<class DBOs, class T>
+    struct column_result_t<DBOs, is_null_t<T>, void> {
+        using type = bool;
+    };
+
+    template<class DBOs, class T>
+    struct column_result_t<DBOs, is_not_null_t<T>, void> {
         using type = bool;
     };
 

--- a/dev/column_result.h
+++ b/dev/column_result.h
@@ -30,6 +30,7 @@
 #include "ast/in.h"
 #include "ast/between.h"
 #include "ast/is_null.h"
+#include "ast/is_not_null.h"
 
 namespace sqlite_orm::internal {
     /**

--- a/dev/conditions.h
+++ b/dev/conditions.h
@@ -322,24 +322,6 @@ namespace sqlite_orm::internal {
         }
     };
 
-    struct is_null_string {
-        operator std::string() const {
-            return "IS NULL";
-        }
-    };
-
-    /**
-     *  IS NULL operator object.
-     */
-    template<class T>
-    struct is_null_t : is_null_string, negatable_t {
-        using self = is_null_t<T>;
-
-        T t;
-
-        is_null_t(T t_) : t(std::move(t_)) {}
-    };
-
     struct is_not_null_string {
         operator std::string() const {
             return "IS NOT NULL";
@@ -350,7 +332,7 @@ namespace sqlite_orm::internal {
      *  IS NOT NULL operator object.
      */
     template<class T>
-    struct is_not_null_t : is_not_null_string, negatable_t {
+    struct is_not_null_t : condition_t, is_not_null_string, negatable_t {
         using self = is_not_null_t<T>;
 
         T t;
@@ -954,11 +936,6 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 
     template<class T>
     internal::is_not_null_t<T> is_not_null(T t) {
-        return {std::move(t)};
-    }
-
-    template<class T>
-    internal::is_null_t<T> is_null(T t) {
         return {std::move(t)};
     }
 

--- a/dev/conditions.h
+++ b/dev/conditions.h
@@ -322,24 +322,6 @@ namespace sqlite_orm::internal {
         }
     };
 
-    struct is_not_null_string {
-        operator std::string() const {
-            return "IS NOT NULL";
-        }
-    };
-
-    /**
-     *  IS NOT NULL operator object.
-     */
-    template<class T>
-    struct is_not_null_t : condition_t, is_not_null_string, negatable_t {
-        using self = is_not_null_t<T>;
-
-        T t;
-
-        is_not_null_t(T t_) : t(std::move(t_)) {}
-    };
-
     struct order_by_base {
         std::string _collate_argument;
         int _order = 0;  //  -1 = desc, 1 = asc, 0 = unspecified
@@ -932,11 +914,6 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
         using namespace ::sqlite_orm::internal;
         return or_condition_t<unwrap_expression_t<L>, unwrap_expression_t<R>>{get_from_expression(std::forward<L>(l)),
                                                                               get_from_expression(std::forward<R>(r))};
-    }
-
-    template<class T>
-    internal::is_not_null_t<T> is_not_null(T t) {
-        return {std::move(t)};
     }
 
     template<class L, class R>

--- a/dev/node_tuple.h
+++ b/dev/node_tuple.h
@@ -27,6 +27,8 @@
 #include "ast/cast.h"
 #include "ast/limit.h"
 #include "ast/in.h"
+#include "ast/is_null.h"
+#include "ast/is_not_null.h"
 
 namespace sqlite_orm::internal {
     template<class T, class SFINAE = void>

--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -33,6 +33,8 @@
 #include "ast/rank.h"
 #include "ast/special_keywords.h"
 #include "ast/limit.h"
+#include "ast/is_null.h"
+#include "ast/is_not_null.h"
 #include "core_functions.h"
 #include "constraints.h"
 #include "conditions.h"
@@ -803,10 +805,10 @@ namespace sqlite_orm::internal {
         using statement_type = is_not_null_t<T>;
 
         template<class Ctx>
-        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& c,
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
                                                         const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
             std::stringstream ss;
-            ss << serialize(c.t, context) << " " << static_cast<std::string>(c);
+            ss << serialize(statement.argument, context) << " IS NOT NULL";
             return ss.str();
         }
     };

--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -790,10 +790,10 @@ namespace sqlite_orm::internal {
         using statement_type = is_null_t<T>;
 
         template<class Ctx>
-        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& c,
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
                                                         const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
             std::stringstream ss;
-            ss << serialize(c.t, context) << " " << static_cast<std::string>(c);
+            ss << serialize(statement.argument, context) << " IS NULL";
             return ss.str();
         }
     };

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -5540,24 +5540,6 @@ namespace sqlite_orm::internal {
         }
     };
 
-    struct is_null_string {
-        operator std::string() const {
-            return "IS NULL";
-        }
-    };
-
-    /**
-     *  IS NULL operator object.
-     */
-    template<class T>
-    struct is_null_t : is_null_string, negatable_t {
-        using self = is_null_t<T>;
-
-        T t;
-
-        is_null_t(T t_) : t(std::move(t_)) {}
-    };
-
     struct is_not_null_string {
         operator std::string() const {
             return "IS NOT NULL";
@@ -5568,7 +5550,7 @@ namespace sqlite_orm::internal {
      *  IS NOT NULL operator object.
      */
     template<class T>
-    struct is_not_null_t : is_not_null_string, negatable_t {
+    struct is_not_null_t : condition_t, is_not_null_string, negatable_t {
         using self = is_not_null_t<T>;
 
         T t;
@@ -6172,11 +6154,6 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 
     template<class T>
     internal::is_not_null_t<T> is_not_null(T t) {
-        return {std::move(t)};
-    }
-
-    template<class T>
-    internal::is_null_t<T> is_null(T t) {
         return {std::move(t)};
     }
 
@@ -12094,6 +12071,41 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
         return {std::move(expression), std::move(lower), std::move(upper)};
     }
 }
+// #include "ast/is_null.h"
+
+#ifndef SQLITE_ORM_IMPORT_STD_MODULE
+#include <utility>  //  std::move
+#endif
+
+// #include "../tags.h"
+
+// #include "../functional/config.h"
+
+namespace sqlite_orm::internal {
+    /**
+     *  IS NULL operator object.
+     */
+    template<class T>
+    struct is_null_t : condition_t, negatable_t {
+        using argument_type = T;
+        using self = is_null_t<argument_type>;
+
+        argument_type argument;
+
+        is_null_t(argument_type argument_) : argument(std::move(argument_)) {}
+    };
+}
+
+SQLITE_ORM_EXPORT namespace sqlite_orm {
+
+    /**
+     *  IS NULL operator.
+     */
+    template<class T>
+    internal::is_null_t<T> is_null(T t) {
+        return {std::move(t)};
+    }
+}
 
 namespace sqlite_orm::internal {
     /**
@@ -12149,6 +12161,16 @@ namespace sqlite_orm::internal {
 
     template<class DBOs, class A, class T>
     struct column_result_t<DBOs, between_t<A, T>, void> {
+        using type = bool;
+    };
+
+    template<class DBOs, class T>
+    struct column_result_t<DBOs, is_null_t<T>, void> {
+        using type = bool;
+    };
+
+    template<class DBOs, class T>
+    struct column_result_t<DBOs, is_not_null_t<T>, void> {
         using type = bool;
     };
 
@@ -16743,8 +16765,8 @@ namespace sqlite_orm::internal {
         using node_type = is_null_t<T>;
 
         template<class L>
-        SQLITE_ORM_STATIC_CALLOP void operator()(const node_type& i, L& lambda) SQLITE_ORM_OR_CONST_CALLOP {
-            iterate_ast(i.t, lambda);
+        SQLITE_ORM_STATIC_CALLOP void operator()(const node_type& node, L& lambda) SQLITE_ORM_OR_CONST_CALLOP {
+            iterate_ast(node.argument, lambda);
         }
     };
 
@@ -21735,10 +21757,10 @@ namespace sqlite_orm::internal {
         using statement_type = is_null_t<T>;
 
         template<class Ctx>
-        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& c,
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
                                                         const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
             std::stringstream ss;
-            ss << serialize(c.t, context) << " " << static_cast<std::string>(c);
+            ss << serialize(statement.argument, context) << " IS NULL";
             return ss.str();
         }
     };

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -5540,24 +5540,6 @@ namespace sqlite_orm::internal {
         }
     };
 
-    struct is_not_null_string {
-        operator std::string() const {
-            return "IS NOT NULL";
-        }
-    };
-
-    /**
-     *  IS NOT NULL operator object.
-     */
-    template<class T>
-    struct is_not_null_t : condition_t, is_not_null_string, negatable_t {
-        using self = is_not_null_t<T>;
-
-        T t;
-
-        is_not_null_t(T t_) : t(std::move(t_)) {}
-    };
-
     struct order_by_base {
         std::string _collate_argument;
         int _order = 0;  //  -1 = desc, 1 = asc, 0 = unspecified
@@ -6150,11 +6132,6 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
         using namespace ::sqlite_orm::internal;
         return or_condition_t<unwrap_expression_t<L>, unwrap_expression_t<R>>{get_from_expression(std::forward<L>(l)),
                                                                               get_from_expression(std::forward<R>(r))};
-    }
-
-    template<class T>
-    internal::is_not_null_t<T> is_not_null(T t) {
-        return {std::move(t)};
     }
 
     template<class L, class R>
@@ -12106,6 +12083,41 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
         return {std::move(t)};
     }
 }
+// #include "ast/is_not_null.h"
+
+#ifndef SQLITE_ORM_IMPORT_STD_MODULE
+#include <utility>  //  std::move
+#endif
+
+// #include "../tags.h"
+
+// #include "../functional/config.h"
+
+namespace sqlite_orm::internal {
+    /**
+     *  IS NOT NULL operator object.
+     */
+    template<class T>
+    struct is_not_null_t : condition_t, negatable_t {
+        using argument_type = T;
+        using self = is_not_null_t<argument_type>;
+
+        argument_type argument;
+
+        is_not_null_t(argument_type argument_) : argument(std::move(argument_)) {}
+    };
+}
+
+SQLITE_ORM_EXPORT namespace sqlite_orm {
+
+    /**
+     *  IS NOT NULL operator.
+     */
+    template<class T>
+    internal::is_not_null_t<T> is_not_null(T t) {
+        return {std::move(t)};
+    }
+}
 
 namespace sqlite_orm::internal {
     /**
@@ -16275,6 +16287,10 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 
 // #include "ast/between.h"
 
+// #include "ast/is_null.h"
+
+// #include "ast/is_not_null.h"
+
 namespace sqlite_orm::internal {
     /**
      *  ast_iterator accepts any expression and a callable object
@@ -16775,8 +16791,8 @@ namespace sqlite_orm::internal {
         using node_type = is_not_null_t<T>;
 
         template<class L>
-        SQLITE_ORM_STATIC_CALLOP void operator()(const node_type& i, L& lambda) SQLITE_ORM_OR_CONST_CALLOP {
-            iterate_ast(i.t, lambda);
+        SQLITE_ORM_STATIC_CALLOP void operator()(const node_type& node, L& lambda) SQLITE_ORM_OR_CONST_CALLOP {
+            iterate_ast(node.argument, lambda);
         }
     };
 
@@ -20100,6 +20116,10 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 
 // #include "ast/limit.h"
 
+// #include "ast/is_null.h"
+
+// #include "ast/is_not_null.h"
+
 // #include "core_functions.h"
 
 // #include "constraints.h"
@@ -21770,10 +21790,10 @@ namespace sqlite_orm::internal {
         using statement_type = is_not_null_t<T>;
 
         template<class Ctx>
-        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& c,
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
                                                         const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
             std::stringstream ss;
-            ss << serialize(c.t, context) << " " << static_cast<std::string>(c);
+            ss << serialize(statement.argument, context) << " IS NOT NULL";
             return ss.str();
         }
     };
@@ -26265,6 +26285,10 @@ namespace sqlite_orm::internal {
 // #include "ast/limit.h"
 
 // #include "ast/in.h"
+
+// #include "ast/is_null.h"
+
+// #include "ast/is_not_null.h"
 
 namespace sqlite_orm::internal {
     template<class T, class SFINAE = void>

--- a/tests/operators/is_null.cpp
+++ b/tests/operators/is_null.cpp
@@ -15,11 +15,44 @@ TEST_CASE("Is null") {
 
     REQUIRE(storage.count<User>() == 0);
     storage.replace(User{1, std::make_unique<std::string>("Sheldon")});
-    REQUIRE(storage.count<User>() == 1);
     storage.replace(User{2});
-    REQUIRE(storage.count<User>() == 2);
     storage.replace(User{3, std::make_unique<std::string>("Leonard")});
     REQUIRE(storage.count<User>() == 3);
-    REQUIRE(storage.count<User>(where(is_null(&User::name))) == 1);
-    REQUIRE(storage.count<User>(where(is_not_null(&User::name))) == 2);
+
+    SECTION("is_null in where clause") {
+        REQUIRE(storage.count<User>(where(is_null(&User::name))) == 1);
+    }
+
+    SECTION("is_not_null in where clause") {
+        REQUIRE(storage.count<User>(where(is_not_null(&User::name))) == 2);
+    }
+
+    SECTION("select is_null as expression") {
+        auto rows = storage.select(is_null(&User::name));
+        REQUIRE(rows.size() == 3);
+        REQUIRE(rows[0] == false);
+        REQUIRE(rows[1] == true);
+        REQUIRE(rows[2] == false);
+    }
+
+    SECTION("select is_not_null as expression") {
+        auto rows = storage.select(is_not_null(&User::name));
+        REQUIRE(rows.size() == 3);
+        REQUIRE(rows[0] == true);
+        REQUIRE(rows[1] == false);
+        REQUIRE(rows[2] == true);
+    }
+
+    SECTION("negated is_null in where clause") {
+        auto rows = storage.select(&User::id, where(!is_null(&User::name)));
+        REQUIRE(rows.size() == 2);
+        REQUIRE(rows[0] == 1);
+        REQUIRE(rows[1] == 3);
+    }
+
+    SECTION("negated is_not_null in where clause") {
+        auto rows = storage.select(&User::id, where(!is_not_null(&User::name)));
+        REQUIRE(rows.size() == 1);
+        REQUIRE(rows[0] == 2);
+    }
 }

--- a/tests/statement_serializer_tests/is_null.cpp
+++ b/tests/statement_serializer_tests/is_null.cpp
@@ -1,0 +1,62 @@
+#include <sqlite_orm/sqlite_orm.h>
+#include <catch2/catch_all.hpp>
+
+using namespace sqlite_orm;
+
+TEST_CASE("statement_serializer is_null") {
+    struct User {
+        int id = 0;
+        std::string name;
+    };
+    auto table = make_table("users", make_column("id", &User::id), make_column("name", &User::name));
+    using db_objects_t = internal::db_objects_tuple<decltype(table)>;
+    auto dbObjects = db_objects_t{table};
+    using context_t = internal::serializer_context<db_objects_t>;
+    context_t context{dbObjects};
+    std::string value;
+    std::string expected;
+
+    SECTION("is_null with column") {
+        value = serialize(is_null(&User::name), context);
+        expected = R"("name" IS NULL)";
+    }
+
+    SECTION("is_not_null with column") {
+        value = serialize(is_not_null(&User::name), context);
+        expected = R"("name" IS NOT NULL)";
+    }
+
+    SECTION("is_null with negation") {
+        value = serialize(!is_null(&User::name), context);
+        expected = R"(NOT "name" IS NULL)";
+    }
+
+    SECTION("is_not_null with negation") {
+        value = serialize(!is_not_null(&User::name), context);
+        expected = R"(NOT "name" IS NOT NULL)";
+    }
+
+    SECTION("is_null in where clause") {
+        context.use_parentheses = false;
+        value = serialize(select(&User::id, where(is_null(&User::name))), context);
+        expected = R"(SELECT "users"."id" FROM "users" WHERE ("users"."name" IS NULL))";
+    }
+
+    SECTION("is_not_null in where clause") {
+        context.use_parentheses = false;
+        value = serialize(select(&User::id, where(is_not_null(&User::name))), context);
+        expected = R"(SELECT "users"."id" FROM "users" WHERE ("users"."name" IS NOT NULL))";
+    }
+
+    SECTION("is_null with and condition") {
+        value = serialize(is_null(&User::name) and is_null(&User::id), context);
+        expected = R"("name" IS NULL AND "id" IS NULL)";
+    }
+
+    SECTION("is_null with or condition") {
+        value = serialize(is_null(&User::name) or is_not_null(&User::id), context);
+        expected = R"("name" IS NULL OR "id" IS NOT NULL)";
+    }
+
+    REQUIRE(value == expected);
+}


### PR DESCRIPTION
- Introduced `is_null_t` and `is_not_null_t` operator objects in `ast/is_null.h`.
- Updated existing files to integrate the new operators, including changes to `ast_iterator.h`, `column_result.h`, `conditions.h`, and `statement_serializer.h`.
- Added tests for the new operators in `tests/operators/is_null.cpp` and `tests/statement_serializer_tests/is_null.cpp` to ensure correct functionality and serialization in queries.