### PR TITLE
Add SQLite window functions support

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,6 @@
 * blob incremental I/O https://sqlite.org/c3ref/blob_open.html
 * CREATE VIEW and other view operations https://sqlite.org/lang_createview.html
 * query static check for correct order (e.g. `GROUP BY` after `WHERE`)
-* `WINDOW`
 * `SAVEPOINT` https://www.sqlite.org/lang_savepoint.html
 * add `static_assert` in crud `get*` functions in case user passes `where_t` instead of id to make compilation error more clear (example https://github.com/fnc12/sqlite_orm/issues/485)
 * named constraints: constraint can have name `CREATE TABLE heroes(id INTEGER CONSTRAINT pk PRIMARY KEY)`

--- a/dev/ast/rank.h
+++ b/dev/ast/rank.h
@@ -1,14 +1,25 @@
 #pragma once
 
+#ifndef SQLITE_ORM_IMPORT_STD_MODULE
+#include <utility>  //  std::forward
+#endif
+
+#include "window.h"
+
 namespace sqlite_orm::internal {
-    struct rank_t {};
+    struct rank_t {
+        template<class... OverArgs>
+        over_t<rank_t, OverArgs...> over(OverArgs... overArgs) {
+            return {*this, {std::forward<OverArgs>(overArgs)...}};
+        }
+    };
 }
 
 SQLITE_ORM_EXPORT namespace sqlite_orm {
-    /** 
-     *  [Deprecation notice] This expression factory function is deprecated and will be removed in v1.11.
+    /**
+     *  RANK() window function / FTS5 rank keyword.
+     *  https://sqlite.org/windowfunctions.html#built-in_window_functions
      */
-    [[deprecated("Use the hidden FTS5 rank column instead")]]
     inline internal::rank_t rank() {
         return {};
     }

--- a/dev/ast/window.h
+++ b/dev/ast/window.h
@@ -1,0 +1,207 @@
+#pragma once
+
+#ifndef SQLITE_ORM_IMPORT_STD_MODULE
+#include <string>  //  std::string
+#include <tuple>  //  std::tuple
+#include <type_traits>  //  std::forward, std::move
+#include <utility>  //  std::forward, std::move
+#endif
+
+#include "../functional/cxx_type_traits_polyfill.h"
+
+namespace sqlite_orm::internal {
+
+    struct unbounded_preceding_t {};
+
+    template<class E>
+    struct preceding_t {
+        E expression;
+    };
+
+    struct current_row_t {};
+
+    template<class E>
+    struct following_t {
+        E expression;
+    };
+
+    struct unbounded_following_t {};
+
+    enum class frame_type_t { rows, range, groups };
+    enum class frame_exclude_t { no_others, current_row, group, ties };
+
+    template<class Start, class End>
+    struct frame_spec_t {
+        frame_type_t type;
+        Start start;
+        End end;
+        frame_exclude_t exclude = frame_exclude_t::no_others;
+
+        frame_spec_t exclude_current_row() const {
+            auto res = *this;
+            res.exclude = frame_exclude_t::current_row;
+            return res;
+        }
+
+        frame_spec_t exclude_group() const {
+            auto res = *this;
+            res.exclude = frame_exclude_t::group;
+            return res;
+        }
+
+        frame_spec_t exclude_ties() const {
+            auto res = *this;
+            res.exclude = frame_exclude_t::ties;
+            return res;
+        }
+
+        frame_spec_t exclude_no_others() const {
+            auto res = *this;
+            res.exclude = frame_exclude_t::no_others;
+            return res;
+        }
+    };
+
+    template<class... Args>
+    struct partition_by_t {
+        using arguments_type = std::tuple<Args...>;
+        arguments_type arguments;
+    };
+
+    template<class T>
+    inline constexpr bool is_partition_by_v = polyfill::is_specialization_of_v<T, partition_by_t>;
+
+    template<class T>
+    using is_partition_by = polyfill::bool_constant<is_partition_by_v<T>>;
+
+    struct window_ref_t {
+        std::string name;
+    };
+
+    template<class F, class... Args>
+    struct over_t {
+        using function_type = F;
+        using arguments_type = std::tuple<Args...>;
+
+        function_type function;
+        arguments_type arguments;
+    };
+
+    template<class T>
+    inline constexpr bool is_over_v = polyfill::is_specialization_of_v<T, over_t>;
+
+    template<class T>
+    using is_over = polyfill::bool_constant<is_over_v<T>>;
+
+    template<class... Args>
+    struct window_defn_t {
+        std::string name;
+        using arguments_type = std::tuple<Args...>;
+        arguments_type arguments;
+    };
+
+    template<class T>
+    inline constexpr bool is_window_defn_v = polyfill::is_specialization_of_v<T, window_defn_t>;
+
+    template<class T>
+    using is_window_defn = polyfill::bool_constant<is_window_defn_v<T>>;
+}
+
+SQLITE_ORM_EXPORT namespace sqlite_orm {
+
+    /**
+     *  UNBOUNDED PRECEDING frame boundary.
+     *  https://sqlite.org/windowfunctions.html
+     */
+    inline internal::unbounded_preceding_t unbounded_preceding() {
+        return {};
+    }
+
+    /**
+     *  expr PRECEDING frame boundary.
+     *  https://sqlite.org/windowfunctions.html
+     */
+    template<class E>
+    internal::preceding_t<E> preceding(E expression) {
+        return {std::move(expression)};
+    }
+
+    /**
+     *  CURRENT ROW frame boundary.
+     *  https://sqlite.org/windowfunctions.html
+     */
+    inline internal::current_row_t current_row() {
+        return {};
+    }
+
+    /**
+     *  expr FOLLOWING frame boundary.
+     *  https://sqlite.org/windowfunctions.html
+     */
+    template<class E>
+    internal::following_t<E> following(E expression) {
+        return {std::move(expression)};
+    }
+
+    /**
+     *  UNBOUNDED FOLLOWING frame boundary.
+     *  https://sqlite.org/windowfunctions.html
+     */
+    inline internal::unbounded_following_t unbounded_following() {
+        return {};
+    }
+
+    /**
+     *  ROWS BETWEEN start AND end frame specification.
+     *  Example: rows(unbounded_preceding(), current_row())
+     */
+    template<class Start, class End>
+    internal::frame_spec_t<Start, End> rows(Start start, End end) {
+        return {internal::frame_type_t::rows, std::move(start), std::move(end)};
+    }
+
+    /**
+     *  RANGE BETWEEN start AND end frame specification.
+     *  Example: range(current_row(), unbounded_following())
+     */
+    template<class Start, class End>
+    internal::frame_spec_t<Start, End> range(Start start, End end) {
+        return {internal::frame_type_t::range, std::move(start), std::move(end)};
+    }
+
+    /**
+     *  GROUPS BETWEEN start AND end frame specification.
+     *  Example: groups(unbounded_preceding(), current_row())
+     */
+    template<class Start, class End>
+    internal::frame_spec_t<Start, End> groups(Start start, End end) {
+        return {internal::frame_type_t::groups, std::move(start), std::move(end)};
+    }
+
+    /**
+     *  PARTITION BY expression list for window functions.
+     *  Example: partition_by(&Employee::departmentId)
+     */
+    template<class... Args>
+    internal::partition_by_t<Args...> partition_by(Args... args) {
+        return {{std::forward<Args>(args)...}};
+    }
+
+    /**
+     *  Reference to a named window definition (OVER window_name).
+     *  Example: row_number().over(window_ref("win"))
+     */
+    inline internal::window_ref_t window_ref(std::string name) {
+        return {std::move(name)};
+    }
+
+    /**
+     *  Named window definition (WINDOW name AS (...)).
+     *  Passed as a condition to select().
+     *  Example: window("win", order_by(&Employee::salary))
+     */
+    template<class... Args>
+    internal::window_defn_t<Args...> window(std::string name, Args... args) {
+        return {std::move(name), {std::forward<Args>(args)...}};
+    }
+}

--- a/dev/ast_iterator.h
+++ b/dev/ast_iterator.h
@@ -31,6 +31,8 @@
 #include "ast/between.h"
 #include "ast/is_null.h"
 #include "ast/is_not_null.h"
+#include "ast/window.h"
+#include "window_functions.h"
 
 namespace sqlite_orm::internal {
     /**
@@ -766,6 +768,128 @@ namespace sqlite_orm::internal {
         template<class L>
         SQLITE_ORM_STATIC_CALLOP void operator()(const node_type& node, L& lambda) SQLITE_ORM_OR_CONST_CALLOP {
             iterate_ast(node.expression, lambda);
+        }
+    };
+
+    template<class E>
+    struct ast_iterator<preceding_t<E>, void> {
+        using node_type = preceding_t<E>;
+
+        template<class L>
+        SQLITE_ORM_STATIC_CALLOP void operator()(const node_type& node, L& lambda) SQLITE_ORM_OR_CONST_CALLOP {
+            iterate_ast(node.expression, lambda);
+        }
+    };
+
+    template<class E>
+    struct ast_iterator<following_t<E>, void> {
+        using node_type = following_t<E>;
+
+        template<class L>
+        SQLITE_ORM_STATIC_CALLOP void operator()(const node_type& node, L& lambda) SQLITE_ORM_OR_CONST_CALLOP {
+            iterate_ast(node.expression, lambda);
+        }
+    };
+
+    template<class Start, class End>
+    struct ast_iterator<frame_spec_t<Start, End>, void> {
+        using node_type = frame_spec_t<Start, End>;
+
+        template<class L>
+        SQLITE_ORM_STATIC_CALLOP void operator()(const node_type& node, L& lambda) SQLITE_ORM_OR_CONST_CALLOP {
+            iterate_ast(node.start, lambda);
+            iterate_ast(node.end, lambda);
+        }
+    };
+
+    template<class... Args>
+    struct ast_iterator<partition_by_t<Args...>, void> {
+        using node_type = partition_by_t<Args...>;
+
+        template<class L>
+        SQLITE_ORM_STATIC_CALLOP void operator()(const node_type& node, L& lambda) SQLITE_ORM_OR_CONST_CALLOP {
+            iterate_ast(node.arguments, lambda);
+        }
+    };
+
+    template<class F, class... Args>
+    struct ast_iterator<over_t<F, Args...>, void> {
+        using node_type = over_t<F, Args...>;
+
+        template<class L>
+        SQLITE_ORM_STATIC_CALLOP void operator()(const node_type& node, L& lambda) SQLITE_ORM_OR_CONST_CALLOP {
+            iterate_ast(node.function, lambda);
+            iterate_ast(node.arguments, lambda);
+        }
+    };
+
+    template<class... Args>
+    struct ast_iterator<window_defn_t<Args...>, void> {
+        using node_type = window_defn_t<Args...>;
+
+        template<class L>
+        SQLITE_ORM_STATIC_CALLOP void operator()(const node_type& node, L& lambda) SQLITE_ORM_OR_CONST_CALLOP {
+            iterate_ast(node.arguments, lambda);
+        }
+    };
+
+    template<class... Args>
+    struct ast_iterator<ntile_t<Args...>, void> {
+        using node_type = ntile_t<Args...>;
+
+        template<class L>
+        SQLITE_ORM_STATIC_CALLOP void operator()(const node_type& node, L& lambda) SQLITE_ORM_OR_CONST_CALLOP {
+            iterate_ast(node.args, lambda);
+        }
+    };
+
+    template<class... Args>
+    struct ast_iterator<lag_t<Args...>, void> {
+        using node_type = lag_t<Args...>;
+
+        template<class L>
+        SQLITE_ORM_STATIC_CALLOP void operator()(const node_type& node, L& lambda) SQLITE_ORM_OR_CONST_CALLOP {
+            iterate_ast(node.args, lambda);
+        }
+    };
+
+    template<class... Args>
+    struct ast_iterator<lead_t<Args...>, void> {
+        using node_type = lead_t<Args...>;
+
+        template<class L>
+        SQLITE_ORM_STATIC_CALLOP void operator()(const node_type& node, L& lambda) SQLITE_ORM_OR_CONST_CALLOP {
+            iterate_ast(node.args, lambda);
+        }
+    };
+
+    template<class... Args>
+    struct ast_iterator<first_value_t<Args...>, void> {
+        using node_type = first_value_t<Args...>;
+
+        template<class L>
+        SQLITE_ORM_STATIC_CALLOP void operator()(const node_type& node, L& lambda) SQLITE_ORM_OR_CONST_CALLOP {
+            iterate_ast(node.args, lambda);
+        }
+    };
+
+    template<class... Args>
+    struct ast_iterator<last_value_t<Args...>, void> {
+        using node_type = last_value_t<Args...>;
+
+        template<class L>
+        SQLITE_ORM_STATIC_CALLOP void operator()(const node_type& node, L& lambda) SQLITE_ORM_OR_CONST_CALLOP {
+            iterate_ast(node.args, lambda);
+        }
+    };
+
+    template<class... Args>
+    struct ast_iterator<nth_value_t<Args...>, void> {
+        using node_type = nth_value_t<Args...>;
+
+        template<class L>
+        SQLITE_ORM_STATIC_CALLOP void operator()(const node_type& node, L& lambda) SQLITE_ORM_OR_CONST_CALLOP {
+            iterate_ast(node.args, lambda);
         }
     };
 }

--- a/dev/column_result.h
+++ b/dev/column_result.h
@@ -31,6 +31,9 @@
 #include "ast/between.h"
 #include "ast/is_null.h"
 #include "ast/is_not_null.h"
+#include "ast/window.h"
+#include "ast/rank.h"
+#include "window_functions.h"
 
 namespace sqlite_orm::internal {
     /**
@@ -144,6 +147,67 @@ namespace sqlite_orm::internal {
 
     template<class DBOs, class T>
     struct column_result_t<DBOs, count_asterisk_t<T>, void> {
+        using type = int;
+    };
+
+    template<class DBOs, class F, class W>
+    struct column_result_t<DBOs, filtered_aggregate_function<F, W>, void> : column_result_t<DBOs, F> {};
+
+    template<class DBOs, class F, class... Args>
+    struct column_result_t<DBOs, over_t<F, Args...>, void> : column_result_t<DBOs, F> {};
+
+    template<class DBOs>
+    struct column_result_t<DBOs, row_number_t, void> {
+        using type = int;
+    };
+
+    template<class DBOs>
+    struct column_result_t<DBOs, dense_rank_t, void> {
+        using type = int;
+    };
+
+    template<class DBOs>
+    struct column_result_t<DBOs, percent_rank_t, void> {
+        using type = double;
+    };
+
+    template<class DBOs>
+    struct column_result_t<DBOs, cume_dist_t, void> {
+        using type = double;
+    };
+
+    template<class DBOs, class... Args>
+    struct column_result_t<DBOs, ntile_t<Args...>, void> {
+        using type = int;
+    };
+
+    template<class DBOs, class X, class... Rest>
+    struct column_result_t<DBOs, lag_t<X, Rest...>, void> {
+        using type = column_result_of_t<DBOs, X>;
+    };
+
+    template<class DBOs, class X, class... Rest>
+    struct column_result_t<DBOs, lead_t<X, Rest...>, void> {
+        using type = column_result_of_t<DBOs, X>;
+    };
+
+    template<class DBOs, class X, class... Rest>
+    struct column_result_t<DBOs, first_value_t<X, Rest...>, void> {
+        using type = column_result_of_t<DBOs, X>;
+    };
+
+    template<class DBOs, class X, class... Rest>
+    struct column_result_t<DBOs, last_value_t<X, Rest...>, void> {
+        using type = column_result_of_t<DBOs, X>;
+    };
+
+    template<class DBOs, class X, class... Rest>
+    struct column_result_t<DBOs, nth_value_t<X, Rest...>, void> {
+        using type = column_result_of_t<DBOs, X>;
+    };
+
+    template<class DBOs>
+    struct column_result_t<DBOs, rank_t, void> {
         using type = int;
     };
 

--- a/dev/core_functions.h
+++ b/dev/core_functions.h
@@ -19,6 +19,7 @@
 #include "field_traits.h"
 #include "alias_traits.h"
 #include "ast/into.h"
+#include "ast/window.h"
 #include "field_of.h"
 
 namespace sqlite_orm::internal {
@@ -57,6 +58,11 @@ namespace sqlite_orm::internal {
 
         function_type function;
         where_expression where;
+
+        template<class... OverArgs>
+        over_t<filtered_aggregate_function, OverArgs...> over(OverArgs... overArgs) {
+            return {*this, {std::forward<OverArgs>(overArgs)...}};
+        }
     };
 
     template<class C>
@@ -71,6 +77,11 @@ namespace sqlite_orm::internal {
         template<class W>
         filtered_aggregate_function<built_in_aggregate_function_t<R, S, Args...>, W> filter(where_t<W> wh) {
             return {*this, std::move(wh.expression)};
+        }
+
+        template<class... OverArgs>
+        over_t<built_in_aggregate_function_t, OverArgs...> over(OverArgs... overArgs) {
+            return {*this, {std::forward<OverArgs>(overArgs)...}};
         }
     };
 
@@ -293,6 +304,11 @@ namespace sqlite_orm::internal {
         template<class W>
         filtered_aggregate_function<count_asterisk_t<T>, W> filter(where_t<W> wh) {
             return {*this, std::move(wh.expression)};
+        }
+
+        template<class... OverArgs>
+        over_t<count_asterisk_t, OverArgs...> over(OverArgs... overArgs) {
+            return {*this, {std::forward<OverArgs>(overArgs)...}};
         }
     };
 

--- a/dev/node_tuple.h
+++ b/dev/node_tuple.h
@@ -29,6 +29,8 @@
 #include "ast/in.h"
 #include "ast/is_null.h"
 #include "ast/is_not_null.h"
+#include "ast/window.h"
+#include "window_functions.h"
 
 namespace sqlite_orm::internal {
     template<class T, class SFINAE = void>
@@ -271,4 +273,80 @@ namespace sqlite_orm::internal {
 
     template<class Table, class... Args>
     struct node_tuple<table_valued_expression<Table, Args...>, void> : node_tuple_for<Args...> {};
+
+    template<class E>
+    struct node_tuple<preceding_t<E>, void> : node_tuple<E> {};
+
+    template<class E>
+    struct node_tuple<following_t<E>, void> : node_tuple<E> {};
+
+    template<>
+    struct node_tuple<unbounded_preceding_t, void> {
+        using type = std::tuple<>;
+    };
+
+    template<>
+    struct node_tuple<unbounded_following_t, void> {
+        using type = std::tuple<>;
+    };
+
+    template<>
+    struct node_tuple<current_row_t, void> {
+        using type = std::tuple<>;
+    };
+
+    template<class Start, class End>
+    struct node_tuple<frame_spec_t<Start, End>, void> : node_tuple_for<Start, End> {};
+
+    template<class... Args>
+    struct node_tuple<partition_by_t<Args...>, void> : node_tuple_for<Args...> {};
+
+    template<>
+    struct node_tuple<window_ref_t, void> {
+        using type = std::tuple<>;
+    };
+
+    template<class F, class... Args>
+    struct node_tuple<over_t<F, Args...>, void> : node_tuple_for<F, Args...> {};
+
+    template<class... Args>
+    struct node_tuple<window_defn_t<Args...>, void> : node_tuple_for<Args...> {};
+
+    template<>
+    struct node_tuple<row_number_t, void> {
+        using type = std::tuple<>;
+    };
+
+    template<>
+    struct node_tuple<dense_rank_t, void> {
+        using type = std::tuple<>;
+    };
+
+    template<>
+    struct node_tuple<percent_rank_t, void> {
+        using type = std::tuple<>;
+    };
+
+    template<>
+    struct node_tuple<cume_dist_t, void> {
+        using type = std::tuple<>;
+    };
+
+    template<class... Args>
+    struct node_tuple<ntile_t<Args...>, void> : node_tuple_for<Args...> {};
+
+    template<class... Args>
+    struct node_tuple<lag_t<Args...>, void> : node_tuple_for<Args...> {};
+
+    template<class... Args>
+    struct node_tuple<lead_t<Args...>, void> : node_tuple_for<Args...> {};
+
+    template<class... Args>
+    struct node_tuple<first_value_t<Args...>, void> : node_tuple_for<Args...> {};
+
+    template<class... Args>
+    struct node_tuple<last_value_t<Args...>, void> : node_tuple_for<Args...> {};
+
+    template<class... Args>
+    struct node_tuple<nth_value_t<Args...>, void> : node_tuple_for<Args...> {};
 }

--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -36,6 +36,7 @@
 #include "ast/is_null.h"
 #include "ast/is_not_null.h"
 #include "core_functions.h"
+#include "window_functions.h"
 #include "constraints.h"
 #include "conditions.h"
 #include "indexed_column.h"
@@ -298,6 +299,313 @@ namespace sqlite_orm::internal {
             std::stringstream ss;
             ss << serialize(statement.function, context);
             ss << " FILTER (WHERE " << serialize(statement.where, context) << ")";
+            return ss.str();
+        }
+    };
+
+    template<>
+    struct statement_serializer<row_number_t, void> {
+        using statement_type = row_number_t;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP serialize_result_type operator()(const statement_type&,
+                                                                  const Ctx&) SQLITE_ORM_OR_CONST_CALLOP {
+            return "ROW_NUMBER()";
+        }
+    };
+
+    template<>
+    struct statement_serializer<dense_rank_t, void> {
+        using statement_type = dense_rank_t;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP serialize_result_type operator()(const statement_type&,
+                                                                  const Ctx&) SQLITE_ORM_OR_CONST_CALLOP {
+            return "DENSE_RANK()";
+        }
+    };
+
+    template<>
+    struct statement_serializer<percent_rank_t, void> {
+        using statement_type = percent_rank_t;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP serialize_result_type operator()(const statement_type&,
+                                                                  const Ctx&) SQLITE_ORM_OR_CONST_CALLOP {
+            return "PERCENT_RANK()";
+        }
+    };
+
+    template<>
+    struct statement_serializer<cume_dist_t, void> {
+        using statement_type = cume_dist_t;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP serialize_result_type operator()(const statement_type&,
+                                                                  const Ctx&) SQLITE_ORM_OR_CONST_CALLOP {
+            return "CUME_DIST()";
+        }
+    };
+
+    template<class... Args>
+    struct statement_serializer<ntile_t<Args...>, void> {
+        using statement_type = ntile_t<Args...>;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
+                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
+            std::stringstream ss;
+            ss << "NTILE(" << streaming_expressions_tuple(statement.args, context) << ")";
+            return ss.str();
+        }
+    };
+
+    template<class... Args>
+    struct statement_serializer<lag_t<Args...>, void> {
+        using statement_type = lag_t<Args...>;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
+                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
+            std::stringstream ss;
+            ss << "LAG(" << streaming_expressions_tuple(statement.args, context) << ")";
+            return ss.str();
+        }
+    };
+
+    template<class... Args>
+    struct statement_serializer<lead_t<Args...>, void> {
+        using statement_type = lead_t<Args...>;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
+                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
+            std::stringstream ss;
+            ss << "LEAD(" << streaming_expressions_tuple(statement.args, context) << ")";
+            return ss.str();
+        }
+    };
+
+    template<class... Args>
+    struct statement_serializer<first_value_t<Args...>, void> {
+        using statement_type = first_value_t<Args...>;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
+                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
+            std::stringstream ss;
+            ss << "FIRST_VALUE(" << streaming_expressions_tuple(statement.args, context) << ")";
+            return ss.str();
+        }
+    };
+
+    template<class... Args>
+    struct statement_serializer<last_value_t<Args...>, void> {
+        using statement_type = last_value_t<Args...>;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
+                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
+            std::stringstream ss;
+            ss << "LAST_VALUE(" << streaming_expressions_tuple(statement.args, context) << ")";
+            return ss.str();
+        }
+    };
+
+    template<class... Args>
+    struct statement_serializer<nth_value_t<Args...>, void> {
+        using statement_type = nth_value_t<Args...>;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
+                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
+            std::stringstream ss;
+            ss << "NTH_VALUE(" << streaming_expressions_tuple(statement.args, context) << ")";
+            return ss.str();
+        }
+    };
+
+    template<>
+    struct statement_serializer<unbounded_preceding_t, void> {
+        using statement_type = unbounded_preceding_t;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP serialize_result_type operator()(const statement_type&,
+                                                                  const Ctx&) SQLITE_ORM_OR_CONST_CALLOP {
+            return "UNBOUNDED PRECEDING";
+        }
+    };
+
+    template<class E>
+    struct statement_serializer<preceding_t<E>, void> {
+        using statement_type = preceding_t<E>;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
+                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
+            std::stringstream ss;
+            ss << serialize(statement.expression, context) << " PRECEDING";
+            return ss.str();
+        }
+    };
+
+    template<>
+    struct statement_serializer<current_row_t, void> {
+        using statement_type = current_row_t;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP serialize_result_type operator()(const statement_type&,
+                                                                  const Ctx&) SQLITE_ORM_OR_CONST_CALLOP {
+            return "CURRENT ROW";
+        }
+    };
+
+    template<class E>
+    struct statement_serializer<following_t<E>, void> {
+        using statement_type = following_t<E>;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
+                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
+            std::stringstream ss;
+            ss << serialize(statement.expression, context) << " FOLLOWING";
+            return ss.str();
+        }
+    };
+
+    template<>
+    struct statement_serializer<unbounded_following_t, void> {
+        using statement_type = unbounded_following_t;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP serialize_result_type operator()(const statement_type&,
+                                                                  const Ctx&) SQLITE_ORM_OR_CONST_CALLOP {
+            return "UNBOUNDED FOLLOWING";
+        }
+    };
+
+    template<class Start, class End>
+    struct statement_serializer<frame_spec_t<Start, End>, void> {
+        using statement_type = frame_spec_t<Start, End>;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
+                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
+            std::stringstream ss;
+            switch (statement.type) {
+                case frame_type_t::rows:
+                    ss << "ROWS";
+                    break;
+                case frame_type_t::range:
+                    ss << "RANGE";
+                    break;
+                case frame_type_t::groups:
+                    ss << "GROUPS";
+                    break;
+            }
+            ss << " BETWEEN " << serialize(statement.start, context) << " AND " << serialize(statement.end, context);
+            switch (statement.exclude) {
+                case frame_exclude_t::no_others:
+                    break;
+                case frame_exclude_t::current_row:
+                    ss << " EXCLUDE CURRENT ROW";
+                    break;
+                case frame_exclude_t::group:
+                    ss << " EXCLUDE GROUP";
+                    break;
+                case frame_exclude_t::ties:
+                    ss << " EXCLUDE TIES";
+                    break;
+            }
+            return ss.str();
+        }
+    };
+
+    template<class... Args>
+    struct statement_serializer<partition_by_t<Args...>, void> {
+        using statement_type = partition_by_t<Args...>;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
+                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
+            std::stringstream ss;
+            ss << "PARTITION BY " << streaming_expressions_tuple(statement.arguments, context);
+            return ss.str();
+        }
+    };
+
+    template<>
+    struct statement_serializer<window_ref_t, void> {
+        using statement_type = window_ref_t;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
+                                                        const Ctx&) SQLITE_ORM_OR_CONST_CALLOP {
+            return statement.name;
+        }
+    };
+
+    template<class Tuple, class Ctx>
+    void serialize_over_arguments(std::stringstream& ss, const Tuple& arguments, const Ctx& context) {
+        using args_tuple = std::decay_t<Tuple>;
+        constexpr bool is_named_ref = std::tuple_size<args_tuple>::value == 1 &&
+                                      std::is_same<std::tuple_element_t<0, args_tuple>, window_ref_t>::value;
+        if constexpr (is_named_ref) {
+            ss << " OVER " << std::get<0>(arguments).name;
+        } else {
+            ss << " OVER (";
+            std::string separator;
+            iterate_tuple(arguments, [&ss, &context, &separator](auto& arg) {
+                ss << separator << serialize(arg, context);
+                separator = " ";
+            });
+            ss << ")";
+        }
+    }
+
+    template<class F, class... Args>
+    struct statement_serializer<over_t<F, Args...>, void> {
+        using statement_type = over_t<F, Args...>;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
+                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
+            std::stringstream ss;
+            ss << serialize(statement.function, context);
+            serialize_over_arguments(ss, statement.arguments, context);
+            return ss.str();
+        }
+    };
+
+    template<class... Args>
+    struct statement_serializer<over_t<rank_t, Args...>, void> {
+        using statement_type = over_t<rank_t, Args...>;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
+                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
+            std::stringstream ss;
+            ss << "rank()";
+            serialize_over_arguments(ss, statement.arguments, context);
+            return ss.str();
+        }
+    };
+
+    template<class... Args>
+    struct statement_serializer<window_defn_t<Args...>, void> {
+        using statement_type = window_defn_t<Args...>;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
+                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
+            std::stringstream ss;
+            ss << "WINDOW " << statement.name << " AS (";
+            std::string separator;
+            iterate_tuple(statement.arguments, [&ss, &context, &separator](auto& arg) {
+                ss << separator << serialize(arg, context);
+                separator = " ";
+            });
+            ss << ")";
             return ss.str();
         }
     };

--- a/dev/window_functions.h
+++ b/dev/window_functions.h
@@ -1,0 +1,230 @@
+#pragma once
+
+#ifndef SQLITE_ORM_IMPORT_STD_MODULE
+#include <tuple>  //  std::tuple
+#include <utility>  //  std::forward, std::move
+#endif
+
+#include "ast/window.h"
+
+namespace sqlite_orm::internal {
+
+    struct row_number_t {
+        template<class... OverArgs>
+        over_t<row_number_t, OverArgs...> over(OverArgs... overArgs) {
+            return {*this, {std::forward<OverArgs>(overArgs)...}};
+        }
+    };
+
+    struct dense_rank_t {
+        template<class... OverArgs>
+        over_t<dense_rank_t, OverArgs...> over(OverArgs... overArgs) {
+            return {*this, {std::forward<OverArgs>(overArgs)...}};
+        }
+    };
+
+    struct percent_rank_t {
+        template<class... OverArgs>
+        over_t<percent_rank_t, OverArgs...> over(OverArgs... overArgs) {
+            return {*this, {std::forward<OverArgs>(overArgs)...}};
+        }
+    };
+
+    struct cume_dist_t {
+        template<class... OverArgs>
+        over_t<cume_dist_t, OverArgs...> over(OverArgs... overArgs) {
+            return {*this, {std::forward<OverArgs>(overArgs)...}};
+        }
+    };
+
+    template<class... Args>
+    struct ntile_t {
+        using args_type = std::tuple<Args...>;
+        args_type args;
+
+        template<class... OverArgs>
+        over_t<ntile_t, OverArgs...> over(OverArgs... overArgs) {
+            return {*this, {std::forward<OverArgs>(overArgs)...}};
+        }
+    };
+
+    template<class... Args>
+    struct lag_t {
+        using args_type = std::tuple<Args...>;
+        args_type args;
+
+        template<class... OverArgs>
+        over_t<lag_t, OverArgs...> over(OverArgs... overArgs) {
+            return {*this, {std::forward<OverArgs>(overArgs)...}};
+        }
+    };
+
+    template<class... Args>
+    struct lead_t {
+        using args_type = std::tuple<Args...>;
+        args_type args;
+
+        template<class... OverArgs>
+        over_t<lead_t, OverArgs...> over(OverArgs... overArgs) {
+            return {*this, {std::forward<OverArgs>(overArgs)...}};
+        }
+    };
+
+    template<class... Args>
+    struct first_value_t {
+        using args_type = std::tuple<Args...>;
+        args_type args;
+
+        template<class... OverArgs>
+        over_t<first_value_t, OverArgs...> over(OverArgs... overArgs) {
+            return {*this, {std::forward<OverArgs>(overArgs)...}};
+        }
+    };
+
+    template<class... Args>
+    struct last_value_t {
+        using args_type = std::tuple<Args...>;
+        args_type args;
+
+        template<class... OverArgs>
+        over_t<last_value_t, OverArgs...> over(OverArgs... overArgs) {
+            return {*this, {std::forward<OverArgs>(overArgs)...}};
+        }
+    };
+
+    template<class... Args>
+    struct nth_value_t {
+        using args_type = std::tuple<Args...>;
+        args_type args;
+
+        template<class... OverArgs>
+        over_t<nth_value_t, OverArgs...> over(OverArgs... overArgs) {
+            return {*this, {std::forward<OverArgs>(overArgs)...}};
+        }
+    };
+}
+
+SQLITE_ORM_EXPORT namespace sqlite_orm {
+
+    /**
+     *  ROW_NUMBER() window function.
+     *  https://sqlite.org/windowfunctions.html#built-in_window_functions
+     */
+    inline internal::row_number_t row_number() {
+        return {};
+    }
+
+    /**
+     *  DENSE_RANK() window function.
+     *  https://sqlite.org/windowfunctions.html#built-in_window_functions
+     */
+    inline internal::dense_rank_t dense_rank() {
+        return {};
+    }
+
+    /**
+     *  PERCENT_RANK() window function.
+     *  https://sqlite.org/windowfunctions.html#built-in_window_functions
+     */
+    inline internal::percent_rank_t percent_rank() {
+        return {};
+    }
+
+    /**
+     *  CUME_DIST() window function.
+     *  https://sqlite.org/windowfunctions.html#built-in_window_functions
+     */
+    inline internal::cume_dist_t cume_dist() {
+        return {};
+    }
+
+    /**
+     *  NTILE(N) window function.
+     *  https://sqlite.org/windowfunctions.html#built-in_window_functions
+     */
+    template<class N>
+    internal::ntile_t<N> ntile(N n) {
+        return {std::tuple<N>{std::forward<N>(n)}};
+    }
+
+    /**
+     *  LAG(expr) window function.
+     *  https://sqlite.org/windowfunctions.html#built-in_window_functions
+     */
+    template<class E>
+    internal::lag_t<E> lag(E expression) {
+        return {std::tuple<E>{std::forward<E>(expression)}};
+    }
+
+    /**
+     *  LAG(expr, offset) window function.
+     *  https://sqlite.org/windowfunctions.html#built-in_window_functions
+     */
+    template<class E, class O>
+    internal::lag_t<E, O> lag(E expression, O offset) {
+        return {{std::forward<E>(expression), std::forward<O>(offset)}};
+    }
+
+    /**
+     *  LAG(expr, offset, default) window function.
+     *  https://sqlite.org/windowfunctions.html#built-in_window_functions
+     */
+    template<class E, class O, class D>
+    internal::lag_t<E, O, D> lag(E expression, O offset, D defaultValue) {
+        return {{std::forward<E>(expression), std::forward<O>(offset), std::forward<D>(defaultValue)}};
+    }
+
+    /**
+     *  LEAD(expr) window function.
+     *  https://sqlite.org/windowfunctions.html#built-in_window_functions
+     */
+    template<class E>
+    internal::lead_t<E> lead(E expression) {
+        return {std::tuple<E>{std::forward<E>(expression)}};
+    }
+
+    /**
+     *  LEAD(expr, offset) window function.
+     *  https://sqlite.org/windowfunctions.html#built-in_window_functions
+     */
+    template<class E, class O>
+    internal::lead_t<E, O> lead(E expression, O offset) {
+        return {{std::forward<E>(expression), std::forward<O>(offset)}};
+    }
+
+    /**
+     *  LEAD(expr, offset, default) window function.
+     *  https://sqlite.org/windowfunctions.html#built-in_window_functions
+     */
+    template<class E, class O, class D>
+    internal::lead_t<E, O, D> lead(E expression, O offset, D defaultValue) {
+        return {{std::forward<E>(expression), std::forward<O>(offset), std::forward<D>(defaultValue)}};
+    }
+
+    /**
+     *  FIRST_VALUE(expr) window function.
+     *  https://sqlite.org/windowfunctions.html#built-in_window_functions
+     */
+    template<class E>
+    internal::first_value_t<E> first_value(E expression) {
+        return {std::tuple<E>{std::forward<E>(expression)}};
+    }
+
+    /**
+     *  LAST_VALUE(expr) window function.
+     *  https://sqlite.org/windowfunctions.html#built-in_window_functions
+     */
+    template<class E>
+    internal::last_value_t<E> last_value(E expression) {
+        return {std::tuple<E>{std::forward<E>(expression)}};
+    }
+
+    /**
+     *  NTH_VALUE(expr, N) window function.
+     *  https://sqlite.org/windowfunctions.html#built-in_window_functions
+     */
+    template<class E, class N>
+    internal::nth_value_t<E, N> nth_value(E expression, N n) {
+        return {{std::forward<E>(expression), std::forward<N>(n)}};
+    }
+}

--- a/examples/window_functions.cpp
+++ b/examples/window_functions.cpp
@@ -1,0 +1,208 @@
+#include <sqlite_orm/sqlite_orm.h>
+#include <iostream>
+#include <string>
+
+using std::cout;
+using std::endl;
+
+struct Employee {
+    int id = 0;
+    std::string name;
+    std::string department;
+    double salary = 0;
+};
+
+int main(int, char** argv) {
+    cout << "path = " << argv[0] << endl;
+
+    using namespace sqlite_orm;
+    auto storage = make_storage("",
+                                make_table("employees",
+                                           make_column("id", &Employee::id, primary_key().autoincrement()),
+                                           make_column("name", &Employee::name),
+                                           make_column("department", &Employee::department),
+                                           make_column("salary", &Employee::salary)));
+    storage.sync_schema();
+
+    storage.transaction([&storage] {
+        storage.insert(Employee{-1, "Alice", "Engineering", 90000});
+        storage.insert(Employee{-1, "Bob", "Engineering", 85000});
+        storage.insert(Employee{-1, "Charlie", "Engineering", 85000});
+        storage.insert(Employee{-1, "Diana", "Sales", 70000});
+        storage.insert(Employee{-1, "Eve", "Sales", 65000});
+        storage.insert(Employee{-1, "Frank", "Sales", 65000});
+        storage.insert(Employee{-1, "Grace", "HR", 75000});
+        storage.insert(Employee{-1, "Hank", "HR", 72000});
+        return true;
+    });
+
+    cout << endl;
+
+    //  SELECT name, department, salary, ROW_NUMBER() OVER (PARTITION BY department ORDER BY salary DESC)
+    //  FROM employees
+    {
+        cout << "=== ROW_NUMBER with PARTITION BY ===" << endl;
+        auto result = storage.select(
+            columns(&Employee::name,
+                    &Employee::department,
+                    &Employee::salary,
+                    row_number().over(partition_by(&Employee::department),
+                                      order_by(&Employee::salary).desc())));
+        for (auto& row: result) {
+            cout << get<0>(row) << "\t" << get<1>(row) << "\t" << get<2>(row) << "\t#" << get<3>(row) << endl;
+        }
+        cout << endl;
+    }
+
+    //  SELECT name, salary, RANK() OVER (ORDER BY salary DESC)
+    //  FROM employees
+    {
+        cout << "=== RANK ===" << endl;
+        auto result = storage.select(
+            columns(&Employee::name,
+                    &Employee::salary,
+                    rank().over(order_by(&Employee::salary).desc())));
+        for (auto& row: result) {
+            cout << get<0>(row) << "\t" << get<1>(row) << "\trank=" << get<2>(row) << endl;
+        }
+        cout << endl;
+    }
+
+    //  SELECT name, salary, DENSE_RANK() OVER (ORDER BY salary DESC)
+    //  FROM employees
+    {
+        cout << "=== DENSE_RANK ===" << endl;
+        auto result = storage.select(
+            columns(&Employee::name,
+                    &Employee::salary,
+                    dense_rank().over(order_by(&Employee::salary).desc())));
+        for (auto& row: result) {
+            cout << get<0>(row) << "\t" << get<1>(row) << "\tdense_rank=" << get<2>(row) << endl;
+        }
+        cout << endl;
+    }
+
+    //  SELECT name, salary, NTILE(3) OVER (ORDER BY salary DESC)
+    //  FROM employees
+    {
+        cout << "=== NTILE(3) ===" << endl;
+        auto result = storage.select(
+            columns(&Employee::name,
+                    &Employee::salary,
+                    ntile(3).over(order_by(&Employee::salary).desc())));
+        for (auto& row: result) {
+            cout << get<0>(row) << "\t" << get<1>(row) << "\tbucket=" << get<2>(row) << endl;
+        }
+        cout << endl;
+    }
+
+    //  SELECT name, salary,
+    //    LAG(name, 1) OVER (ORDER BY salary DESC),
+    //    LEAD(name, 1) OVER (ORDER BY salary DESC)
+    //  FROM employees
+    {
+        cout << "=== LAG / LEAD ===" << endl;
+        auto w = order_by(&Employee::salary).desc();
+        auto result = storage.select(
+            columns(&Employee::name,
+                    &Employee::salary,
+                    lag(&Employee::name, 1).over(order_by(&Employee::salary).desc()),
+                    lead(&Employee::name, 1).over(order_by(&Employee::salary).desc())));
+        for (auto& row: result) {
+            cout << get<0>(row) << "\t" << get<1>(row) << "\tprev=" << get<2>(row) << "\tnext=" << get<3>(row) << endl;
+        }
+        cout << endl;
+    }
+
+    //  SELECT name, department, salary,
+    //    FIRST_VALUE(name) OVER (PARTITION BY department ORDER BY salary DESC),
+    //    LAST_VALUE(name) OVER (PARTITION BY department ORDER BY salary DESC
+    //      RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+    //  FROM employees
+    {
+        cout << "=== FIRST_VALUE / LAST_VALUE ===" << endl;
+        auto result = storage.select(
+            columns(&Employee::name,
+                    &Employee::department,
+                    &Employee::salary,
+                    first_value(&Employee::name).over(partition_by(&Employee::department),
+                                                      order_by(&Employee::salary).desc()),
+                    last_value(&Employee::name).over(
+                        partition_by(&Employee::department),
+                        order_by(&Employee::salary).desc(),
+                        range(unbounded_preceding(), unbounded_following()))));
+        for (auto& row: result) {
+            cout << get<0>(row) << "\t" << get<1>(row) << "\t" << get<2>(row) << "\tfirst=" << get<3>(row)
+                 << "\tlast=" << get<4>(row) << endl;
+        }
+        cout << endl;
+    }
+
+    //  SELECT name, department, salary,
+    //    SUM(salary) OVER (PARTITION BY department ORDER BY salary
+    //      ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+    //  FROM employees
+    {
+        cout << "=== Running SUM with frame spec ===" << endl;
+        auto result = storage.select(
+            columns(&Employee::name,
+                    &Employee::department,
+                    &Employee::salary,
+                    sum(&Employee::salary)
+                        .over(partition_by(&Employee::department),
+                              order_by(&Employee::salary),
+                              rows(unbounded_preceding(), current_row()))));
+        for (auto& row: result) {
+            cout << get<0>(row) << "\t" << get<1>(row) << "\t" << get<2>(row) << "\trunning_sum=";
+            if (auto& v = get<3>(row)) {
+                cout << *v;
+            }
+            cout << endl;
+        }
+        cout << endl;
+    }
+
+    //  SELECT name, salary,
+    //    PERCENT_RANK() OVER (ORDER BY salary),
+    //    CUME_DIST() OVER (ORDER BY salary)
+    //  FROM employees
+    {
+        cout << "=== PERCENT_RANK / CUME_DIST ===" << endl;
+        auto result = storage.select(
+            columns(&Employee::name,
+                    &Employee::salary,
+                    percent_rank().over(order_by(&Employee::salary)),
+                    cume_dist().over(order_by(&Employee::salary))));
+        for (auto& row: result) {
+            cout << get<0>(row) << "\t" << get<1>(row) << "\tpct_rank=" << get<2>(row)
+                 << "\tcume_dist=" << get<3>(row) << endl;
+        }
+        cout << endl;
+    }
+
+    //  Named window:
+    //  SELECT name, salary,
+    //    ROW_NUMBER() OVER win,
+    //    SUM(salary) OVER win
+    //  FROM employees
+    //  WINDOW win AS (ORDER BY salary DESC)
+    {
+        cout << "=== Named window ===" << endl;
+        auto result = storage.select(
+            columns(&Employee::name,
+                    &Employee::salary,
+                    row_number().over(window_ref("win")),
+                    sum(&Employee::salary).over(window_ref("win"))),
+            window("win", order_by(&Employee::salary).desc()));
+        for (auto& row: result) {
+            cout << get<0>(row) << "\t" << get<1>(row) << "\trow#=" << get<2>(row) << "\tsum=";
+            if (auto& v = get<3>(row)) {
+                cout << *v;
+            }
+            cout << endl;
+        }
+        cout << endl;
+    }
+
+    return 0;
+}

--- a/examples/window_functions.cpp
+++ b/examples/window_functions.cpp
@@ -46,8 +46,7 @@ int main(int, char** argv) {
             columns(&Employee::name,
                     &Employee::department,
                     &Employee::salary,
-                    row_number().over(partition_by(&Employee::department),
-                                      order_by(&Employee::salary).desc())));
+                    row_number().over(partition_by(&Employee::department), order_by(&Employee::salary).desc())));
         for (auto& row: result) {
             cout << get<0>(row) << "\t" << get<1>(row) << "\t" << get<2>(row) << "\t#" << get<3>(row) << endl;
         }
@@ -59,9 +58,7 @@ int main(int, char** argv) {
     {
         cout << "=== RANK ===" << endl;
         auto result = storage.select(
-            columns(&Employee::name,
-                    &Employee::salary,
-                    rank().over(order_by(&Employee::salary).desc())));
+            columns(&Employee::name, &Employee::salary, rank().over(order_by(&Employee::salary).desc())));
         for (auto& row: result) {
             cout << get<0>(row) << "\t" << get<1>(row) << "\trank=" << get<2>(row) << endl;
         }
@@ -73,9 +70,7 @@ int main(int, char** argv) {
     {
         cout << "=== DENSE_RANK ===" << endl;
         auto result = storage.select(
-            columns(&Employee::name,
-                    &Employee::salary,
-                    dense_rank().over(order_by(&Employee::salary).desc())));
+            columns(&Employee::name, &Employee::salary, dense_rank().over(order_by(&Employee::salary).desc())));
         for (auto& row: result) {
             cout << get<0>(row) << "\t" << get<1>(row) << "\tdense_rank=" << get<2>(row) << endl;
         }
@@ -87,9 +82,7 @@ int main(int, char** argv) {
     {
         cout << "=== NTILE(3) ===" << endl;
         auto result = storage.select(
-            columns(&Employee::name,
-                    &Employee::salary,
-                    ntile(3).over(order_by(&Employee::salary).desc())));
+            columns(&Employee::name, &Employee::salary, ntile(3).over(order_by(&Employee::salary).desc())));
         for (auto& row: result) {
             cout << get<0>(row) << "\t" << get<1>(row) << "\tbucket=" << get<2>(row) << endl;
         }
@@ -103,11 +96,10 @@ int main(int, char** argv) {
     {
         cout << "=== LAG / LEAD ===" << endl;
         auto w = order_by(&Employee::salary).desc();
-        auto result = storage.select(
-            columns(&Employee::name,
-                    &Employee::salary,
-                    lag(&Employee::name, 1).over(order_by(&Employee::salary).desc()),
-                    lead(&Employee::name, 1).over(order_by(&Employee::salary).desc())));
+        auto result = storage.select(columns(&Employee::name,
+                                             &Employee::salary,
+                                             lag(&Employee::name, 1).over(order_by(&Employee::salary).desc()),
+                                             lead(&Employee::name, 1).over(order_by(&Employee::salary).desc())));
         for (auto& row: result) {
             cout << get<0>(row) << "\t" << get<1>(row) << "\tprev=" << get<2>(row) << "\tnext=" << get<3>(row) << endl;
         }
@@ -121,16 +113,15 @@ int main(int, char** argv) {
     //  FROM employees
     {
         cout << "=== FIRST_VALUE / LAST_VALUE ===" << endl;
-        auto result = storage.select(
-            columns(&Employee::name,
-                    &Employee::department,
-                    &Employee::salary,
-                    first_value(&Employee::name).over(partition_by(&Employee::department),
-                                                      order_by(&Employee::salary).desc()),
-                    last_value(&Employee::name).over(
-                        partition_by(&Employee::department),
-                        order_by(&Employee::salary).desc(),
-                        range(unbounded_preceding(), unbounded_following()))));
+        auto result = storage.select(columns(
+            &Employee::name,
+            &Employee::department,
+            &Employee::salary,
+            first_value(&Employee::name).over(partition_by(&Employee::department), order_by(&Employee::salary).desc()),
+            last_value(&Employee::name)
+                .over(partition_by(&Employee::department),
+                      order_by(&Employee::salary).desc(),
+                      range(unbounded_preceding(), unbounded_following()))));
         for (auto& row: result) {
             cout << get<0>(row) << "\t" << get<1>(row) << "\t" << get<2>(row) << "\tfirst=" << get<3>(row)
                  << "\tlast=" << get<4>(row) << endl;
@@ -144,14 +135,13 @@ int main(int, char** argv) {
     //  FROM employees
     {
         cout << "=== Running SUM with frame spec ===" << endl;
-        auto result = storage.select(
-            columns(&Employee::name,
-                    &Employee::department,
-                    &Employee::salary,
-                    sum(&Employee::salary)
-                        .over(partition_by(&Employee::department),
-                              order_by(&Employee::salary),
-                              rows(unbounded_preceding(), current_row()))));
+        auto result = storage.select(columns(&Employee::name,
+                                             &Employee::department,
+                                             &Employee::salary,
+                                             sum(&Employee::salary)
+                                                 .over(partition_by(&Employee::department),
+                                                       order_by(&Employee::salary),
+                                                       rows(unbounded_preceding(), current_row()))));
         for (auto& row: result) {
             cout << get<0>(row) << "\t" << get<1>(row) << "\t" << get<2>(row) << "\trunning_sum=";
             if (auto& v = get<3>(row)) {
@@ -168,14 +158,13 @@ int main(int, char** argv) {
     //  FROM employees
     {
         cout << "=== PERCENT_RANK / CUME_DIST ===" << endl;
-        auto result = storage.select(
-            columns(&Employee::name,
-                    &Employee::salary,
-                    percent_rank().over(order_by(&Employee::salary)),
-                    cume_dist().over(order_by(&Employee::salary))));
+        auto result = storage.select(columns(&Employee::name,
+                                             &Employee::salary,
+                                             percent_rank().over(order_by(&Employee::salary)),
+                                             cume_dist().over(order_by(&Employee::salary))));
         for (auto& row: result) {
-            cout << get<0>(row) << "\t" << get<1>(row) << "\tpct_rank=" << get<2>(row)
-                 << "\tcume_dist=" << get<3>(row) << endl;
+            cout << get<0>(row) << "\t" << get<1>(row) << "\tpct_rank=" << get<2>(row) << "\tcume_dist=" << get<3>(row)
+                 << endl;
         }
         cout << endl;
     }
@@ -188,12 +177,11 @@ int main(int, char** argv) {
     //  WINDOW win AS (ORDER BY salary DESC)
     {
         cout << "=== Named window ===" << endl;
-        auto result = storage.select(
-            columns(&Employee::name,
-                    &Employee::salary,
-                    row_number().over(window_ref("win")),
-                    sum(&Employee::salary).over(window_ref("win"))),
-            window("win", order_by(&Employee::salary).desc()));
+        auto result = storage.select(columns(&Employee::name,
+                                             &Employee::salary,
+                                             row_number().over(window_ref("win")),
+                                             sum(&Employee::salary).over(window_ref("win"))),
+                                     window("win", order_by(&Employee::salary).desc()));
         for (auto& row: result) {
             cout << get<0>(row) << "\t" << get<1>(row) << "\trow#=" << get<2>(row) << "\tsum=";
             if (auto& v = get<3>(row)) {

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -6378,6 +6378,214 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 #endif
 }
 
+// #include "ast/window.h"
+
+#ifndef SQLITE_ORM_IMPORT_STD_MODULE
+#include <string>  //  std::string
+#include <tuple>  //  std::tuple
+#include <type_traits>  //  std::forward, std::move
+#include <utility>  //  std::forward, std::move
+#endif
+
+// #include "../functional/cxx_type_traits_polyfill.h"
+
+namespace sqlite_orm::internal {
+
+    struct unbounded_preceding_t {};
+
+    template<class E>
+    struct preceding_t {
+        E expression;
+    };
+
+    struct current_row_t {};
+
+    template<class E>
+    struct following_t {
+        E expression;
+    };
+
+    struct unbounded_following_t {};
+
+    enum class frame_type_t { rows, range, groups };
+    enum class frame_exclude_t { no_others, current_row, group, ties };
+
+    template<class Start, class End>
+    struct frame_spec_t {
+        frame_type_t type;
+        Start start;
+        End end;
+        frame_exclude_t exclude = frame_exclude_t::no_others;
+
+        frame_spec_t exclude_current_row() const {
+            auto res = *this;
+            res.exclude = frame_exclude_t::current_row;
+            return res;
+        }
+
+        frame_spec_t exclude_group() const {
+            auto res = *this;
+            res.exclude = frame_exclude_t::group;
+            return res;
+        }
+
+        frame_spec_t exclude_ties() const {
+            auto res = *this;
+            res.exclude = frame_exclude_t::ties;
+            return res;
+        }
+
+        frame_spec_t exclude_no_others() const {
+            auto res = *this;
+            res.exclude = frame_exclude_t::no_others;
+            return res;
+        }
+    };
+
+    template<class... Args>
+    struct partition_by_t {
+        using arguments_type = std::tuple<Args...>;
+        arguments_type arguments;
+    };
+
+    template<class T>
+    inline constexpr bool is_partition_by_v = polyfill::is_specialization_of_v<T, partition_by_t>;
+
+    template<class T>
+    using is_partition_by = polyfill::bool_constant<is_partition_by_v<T>>;
+
+    struct window_ref_t {
+        std::string name;
+    };
+
+    template<class F, class... Args>
+    struct over_t {
+        using function_type = F;
+        using arguments_type = std::tuple<Args...>;
+
+        function_type function;
+        arguments_type arguments;
+    };
+
+    template<class T>
+    inline constexpr bool is_over_v = polyfill::is_specialization_of_v<T, over_t>;
+
+    template<class T>
+    using is_over = polyfill::bool_constant<is_over_v<T>>;
+
+    template<class... Args>
+    struct window_defn_t {
+        std::string name;
+        using arguments_type = std::tuple<Args...>;
+        arguments_type arguments;
+    };
+
+    template<class T>
+    inline constexpr bool is_window_defn_v = polyfill::is_specialization_of_v<T, window_defn_t>;
+
+    template<class T>
+    using is_window_defn = polyfill::bool_constant<is_window_defn_v<T>>;
+}
+
+SQLITE_ORM_EXPORT namespace sqlite_orm {
+
+    /**
+     *  UNBOUNDED PRECEDING frame boundary.
+     *  https://sqlite.org/windowfunctions.html
+     */
+    inline internal::unbounded_preceding_t unbounded_preceding() {
+        return {};
+    }
+
+    /**
+     *  expr PRECEDING frame boundary.
+     *  https://sqlite.org/windowfunctions.html
+     */
+    template<class E>
+    internal::preceding_t<E> preceding(E expression) {
+        return {std::move(expression)};
+    }
+
+    /**
+     *  CURRENT ROW frame boundary.
+     *  https://sqlite.org/windowfunctions.html
+     */
+    inline internal::current_row_t current_row() {
+        return {};
+    }
+
+    /**
+     *  expr FOLLOWING frame boundary.
+     *  https://sqlite.org/windowfunctions.html
+     */
+    template<class E>
+    internal::following_t<E> following(E expression) {
+        return {std::move(expression)};
+    }
+
+    /**
+     *  UNBOUNDED FOLLOWING frame boundary.
+     *  https://sqlite.org/windowfunctions.html
+     */
+    inline internal::unbounded_following_t unbounded_following() {
+        return {};
+    }
+
+    /**
+     *  ROWS BETWEEN start AND end frame specification.
+     *  Example: rows(unbounded_preceding(), current_row())
+     */
+    template<class Start, class End>
+    internal::frame_spec_t<Start, End> rows(Start start, End end) {
+        return {internal::frame_type_t::rows, std::move(start), std::move(end)};
+    }
+
+    /**
+     *  RANGE BETWEEN start AND end frame specification.
+     *  Example: range(current_row(), unbounded_following())
+     */
+    template<class Start, class End>
+    internal::frame_spec_t<Start, End> range(Start start, End end) {
+        return {internal::frame_type_t::range, std::move(start), std::move(end)};
+    }
+
+    /**
+     *  GROUPS BETWEEN start AND end frame specification.
+     *  Example: groups(unbounded_preceding(), current_row())
+     */
+    template<class Start, class End>
+    internal::frame_spec_t<Start, End> groups(Start start, End end) {
+        return {internal::frame_type_t::groups, std::move(start), std::move(end)};
+    }
+
+    /**
+     *  PARTITION BY expression list for window functions.
+     *  Example: partition_by(&Employee::departmentId)
+     */
+    template<class... Args>
+    internal::partition_by_t<Args...> partition_by(Args... args) {
+        return {{std::forward<Args>(args)...}};
+    }
+
+    /**
+     *  Reference to a named window definition (OVER window_name).
+     *  Example: row_number().over(window_ref("win"))
+     */
+    inline internal::window_ref_t window_ref(std::string name) {
+        return {std::move(name)};
+    }
+
+    /**
+     *  Named window definition (WINDOW name AS (...)).
+     *  Passed as a condition to select().
+     *  Example: window("win", order_by(&Employee::salary))
+     */
+    template<class... Args>
+    internal::window_defn_t<Args...> window(std::string name, Args... args) {
+        return {std::move(name), {std::forward<Args>(args)...}};
+    }
+}
+
 // #include "field_of.h"
 
 namespace sqlite_orm::internal {
@@ -6416,6 +6624,11 @@ namespace sqlite_orm::internal {
 
         function_type function;
         where_expression where;
+
+        template<class... OverArgs>
+        over_t<filtered_aggregate_function, OverArgs...> over(OverArgs... overArgs) {
+            return {*this, {std::forward<OverArgs>(overArgs)...}};
+        }
     };
 
     template<class C>
@@ -6430,6 +6643,11 @@ namespace sqlite_orm::internal {
         template<class W>
         filtered_aggregate_function<built_in_aggregate_function_t<R, S, Args...>, W> filter(where_t<W> wh) {
             return {*this, std::move(wh.expression)};
+        }
+
+        template<class... OverArgs>
+        over_t<built_in_aggregate_function_t, OverArgs...> over(OverArgs... overArgs) {
+            return {*this, {std::forward<OverArgs>(overArgs)...}};
         }
     };
 
@@ -6652,6 +6870,11 @@ namespace sqlite_orm::internal {
         template<class W>
         filtered_aggregate_function<count_asterisk_t<T>, W> filter(where_t<W> wh) {
             return {*this, std::move(wh.expression)};
+        }
+
+        template<class... OverArgs>
+        over_t<count_asterisk_t, OverArgs...> over(OverArgs... overArgs) {
+            return {*this, {std::forward<OverArgs>(overArgs)...}};
         }
     };
 
@@ -12119,6 +12342,266 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     }
 }
 
+// #include "ast/window.h"
+
+// #include "ast/rank.h"
+
+#ifndef SQLITE_ORM_IMPORT_STD_MODULE
+#include <utility>  //  std::forward
+#endif
+
+// #include "window.h"
+
+namespace sqlite_orm::internal {
+    struct rank_t {
+        template<class... OverArgs>
+        over_t<rank_t, OverArgs...> over(OverArgs... overArgs) {
+            return {*this, {std::forward<OverArgs>(overArgs)...}};
+        }
+    };
+}
+
+SQLITE_ORM_EXPORT namespace sqlite_orm {
+    /**
+     *  RANK() window function / FTS5 rank keyword.
+     *  https://sqlite.org/windowfunctions.html#built-in_window_functions
+     */
+    inline internal::rank_t rank() {
+        return {};
+    }
+}
+
+// #include "window_functions.h"
+
+#ifndef SQLITE_ORM_IMPORT_STD_MODULE
+#include <tuple>  //  std::tuple
+#include <utility>  //  std::forward, std::move
+#endif
+
+// #include "ast/window.h"
+
+namespace sqlite_orm::internal {
+
+    struct row_number_t {
+        template<class... OverArgs>
+        over_t<row_number_t, OverArgs...> over(OverArgs... overArgs) {
+            return {*this, {std::forward<OverArgs>(overArgs)...}};
+        }
+    };
+
+    struct dense_rank_t {
+        template<class... OverArgs>
+        over_t<dense_rank_t, OverArgs...> over(OverArgs... overArgs) {
+            return {*this, {std::forward<OverArgs>(overArgs)...}};
+        }
+    };
+
+    struct percent_rank_t {
+        template<class... OverArgs>
+        over_t<percent_rank_t, OverArgs...> over(OverArgs... overArgs) {
+            return {*this, {std::forward<OverArgs>(overArgs)...}};
+        }
+    };
+
+    struct cume_dist_t {
+        template<class... OverArgs>
+        over_t<cume_dist_t, OverArgs...> over(OverArgs... overArgs) {
+            return {*this, {std::forward<OverArgs>(overArgs)...}};
+        }
+    };
+
+    template<class... Args>
+    struct ntile_t {
+        using args_type = std::tuple<Args...>;
+        args_type args;
+
+        template<class... OverArgs>
+        over_t<ntile_t, OverArgs...> over(OverArgs... overArgs) {
+            return {*this, {std::forward<OverArgs>(overArgs)...}};
+        }
+    };
+
+    template<class... Args>
+    struct lag_t {
+        using args_type = std::tuple<Args...>;
+        args_type args;
+
+        template<class... OverArgs>
+        over_t<lag_t, OverArgs...> over(OverArgs... overArgs) {
+            return {*this, {std::forward<OverArgs>(overArgs)...}};
+        }
+    };
+
+    template<class... Args>
+    struct lead_t {
+        using args_type = std::tuple<Args...>;
+        args_type args;
+
+        template<class... OverArgs>
+        over_t<lead_t, OverArgs...> over(OverArgs... overArgs) {
+            return {*this, {std::forward<OverArgs>(overArgs)...}};
+        }
+    };
+
+    template<class... Args>
+    struct first_value_t {
+        using args_type = std::tuple<Args...>;
+        args_type args;
+
+        template<class... OverArgs>
+        over_t<first_value_t, OverArgs...> over(OverArgs... overArgs) {
+            return {*this, {std::forward<OverArgs>(overArgs)...}};
+        }
+    };
+
+    template<class... Args>
+    struct last_value_t {
+        using args_type = std::tuple<Args...>;
+        args_type args;
+
+        template<class... OverArgs>
+        over_t<last_value_t, OverArgs...> over(OverArgs... overArgs) {
+            return {*this, {std::forward<OverArgs>(overArgs)...}};
+        }
+    };
+
+    template<class... Args>
+    struct nth_value_t {
+        using args_type = std::tuple<Args...>;
+        args_type args;
+
+        template<class... OverArgs>
+        over_t<nth_value_t, OverArgs...> over(OverArgs... overArgs) {
+            return {*this, {std::forward<OverArgs>(overArgs)...}};
+        }
+    };
+}
+
+SQLITE_ORM_EXPORT namespace sqlite_orm {
+
+    /**
+     *  ROW_NUMBER() window function.
+     *  https://sqlite.org/windowfunctions.html#built-in_window_functions
+     */
+    inline internal::row_number_t row_number() {
+        return {};
+    }
+
+    /**
+     *  DENSE_RANK() window function.
+     *  https://sqlite.org/windowfunctions.html#built-in_window_functions
+     */
+    inline internal::dense_rank_t dense_rank() {
+        return {};
+    }
+
+    /**
+     *  PERCENT_RANK() window function.
+     *  https://sqlite.org/windowfunctions.html#built-in_window_functions
+     */
+    inline internal::percent_rank_t percent_rank() {
+        return {};
+    }
+
+    /**
+     *  CUME_DIST() window function.
+     *  https://sqlite.org/windowfunctions.html#built-in_window_functions
+     */
+    inline internal::cume_dist_t cume_dist() {
+        return {};
+    }
+
+    /**
+     *  NTILE(N) window function.
+     *  https://sqlite.org/windowfunctions.html#built-in_window_functions
+     */
+    template<class N>
+    internal::ntile_t<N> ntile(N n) {
+        return {std::tuple<N>{std::forward<N>(n)}};
+    }
+
+    /**
+     *  LAG(expr) window function.
+     *  https://sqlite.org/windowfunctions.html#built-in_window_functions
+     */
+    template<class E>
+    internal::lag_t<E> lag(E expression) {
+        return {std::tuple<E>{std::forward<E>(expression)}};
+    }
+
+    /**
+     *  LAG(expr, offset) window function.
+     *  https://sqlite.org/windowfunctions.html#built-in_window_functions
+     */
+    template<class E, class O>
+    internal::lag_t<E, O> lag(E expression, O offset) {
+        return {{std::forward<E>(expression), std::forward<O>(offset)}};
+    }
+
+    /**
+     *  LAG(expr, offset, default) window function.
+     *  https://sqlite.org/windowfunctions.html#built-in_window_functions
+     */
+    template<class E, class O, class D>
+    internal::lag_t<E, O, D> lag(E expression, O offset, D defaultValue) {
+        return {{std::forward<E>(expression), std::forward<O>(offset), std::forward<D>(defaultValue)}};
+    }
+
+    /**
+     *  LEAD(expr) window function.
+     *  https://sqlite.org/windowfunctions.html#built-in_window_functions
+     */
+    template<class E>
+    internal::lead_t<E> lead(E expression) {
+        return {std::tuple<E>{std::forward<E>(expression)}};
+    }
+
+    /**
+     *  LEAD(expr, offset) window function.
+     *  https://sqlite.org/windowfunctions.html#built-in_window_functions
+     */
+    template<class E, class O>
+    internal::lead_t<E, O> lead(E expression, O offset) {
+        return {{std::forward<E>(expression), std::forward<O>(offset)}};
+    }
+
+    /**
+     *  LEAD(expr, offset, default) window function.
+     *  https://sqlite.org/windowfunctions.html#built-in_window_functions
+     */
+    template<class E, class O, class D>
+    internal::lead_t<E, O, D> lead(E expression, O offset, D defaultValue) {
+        return {{std::forward<E>(expression), std::forward<O>(offset), std::forward<D>(defaultValue)}};
+    }
+
+    /**
+     *  FIRST_VALUE(expr) window function.
+     *  https://sqlite.org/windowfunctions.html#built-in_window_functions
+     */
+    template<class E>
+    internal::first_value_t<E> first_value(E expression) {
+        return {std::tuple<E>{std::forward<E>(expression)}};
+    }
+
+    /**
+     *  LAST_VALUE(expr) window function.
+     *  https://sqlite.org/windowfunctions.html#built-in_window_functions
+     */
+    template<class E>
+    internal::last_value_t<E> last_value(E expression) {
+        return {std::tuple<E>{std::forward<E>(expression)}};
+    }
+
+    /**
+     *  NTH_VALUE(expr, N) window function.
+     *  https://sqlite.org/windowfunctions.html#built-in_window_functions
+     */
+    template<class E, class N>
+    internal::nth_value_t<E, N> nth_value(E expression, N n) {
+        return {{std::forward<E>(expression), std::forward<N>(n)}};
+    }
+}
+
 namespace sqlite_orm::internal {
     /**
      *  Obtains the result type of expressions that form the columns of a select statement.
@@ -12231,6 +12714,67 @@ namespace sqlite_orm::internal {
 
     template<class DBOs, class T>
     struct column_result_t<DBOs, count_asterisk_t<T>, void> {
+        using type = int;
+    };
+
+    template<class DBOs, class F, class W>
+    struct column_result_t<DBOs, filtered_aggregate_function<F, W>, void> : column_result_t<DBOs, F> {};
+
+    template<class DBOs, class F, class... Args>
+    struct column_result_t<DBOs, over_t<F, Args...>, void> : column_result_t<DBOs, F> {};
+
+    template<class DBOs>
+    struct column_result_t<DBOs, row_number_t, void> {
+        using type = int;
+    };
+
+    template<class DBOs>
+    struct column_result_t<DBOs, dense_rank_t, void> {
+        using type = int;
+    };
+
+    template<class DBOs>
+    struct column_result_t<DBOs, percent_rank_t, void> {
+        using type = double;
+    };
+
+    template<class DBOs>
+    struct column_result_t<DBOs, cume_dist_t, void> {
+        using type = double;
+    };
+
+    template<class DBOs, class... Args>
+    struct column_result_t<DBOs, ntile_t<Args...>, void> {
+        using type = int;
+    };
+
+    template<class DBOs, class X, class... Rest>
+    struct column_result_t<DBOs, lag_t<X, Rest...>, void> {
+        using type = column_result_of_t<DBOs, X>;
+    };
+
+    template<class DBOs, class X, class... Rest>
+    struct column_result_t<DBOs, lead_t<X, Rest...>, void> {
+        using type = column_result_of_t<DBOs, X>;
+    };
+
+    template<class DBOs, class X, class... Rest>
+    struct column_result_t<DBOs, first_value_t<X, Rest...>, void> {
+        using type = column_result_of_t<DBOs, X>;
+    };
+
+    template<class DBOs, class X, class... Rest>
+    struct column_result_t<DBOs, last_value_t<X, Rest...>, void> {
+        using type = column_result_of_t<DBOs, X>;
+    };
+
+    template<class DBOs, class X, class... Rest>
+    struct column_result_t<DBOs, nth_value_t<X, Rest...>, void> {
+        using type = column_result_of_t<DBOs, X>;
+    };
+
+    template<class DBOs>
+    struct column_result_t<DBOs, rank_t, void> {
         using type = int;
     };
 
@@ -16291,6 +16835,10 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 
 // #include "ast/is_not_null.h"
 
+// #include "ast/window.h"
+
+// #include "window_functions.h"
+
 namespace sqlite_orm::internal {
     /**
      *  ast_iterator accepts any expression and a callable object
@@ -17025,6 +17573,128 @@ namespace sqlite_orm::internal {
         template<class L>
         SQLITE_ORM_STATIC_CALLOP void operator()(const node_type& node, L& lambda) SQLITE_ORM_OR_CONST_CALLOP {
             iterate_ast(node.expression, lambda);
+        }
+    };
+
+    template<class E>
+    struct ast_iterator<preceding_t<E>, void> {
+        using node_type = preceding_t<E>;
+
+        template<class L>
+        SQLITE_ORM_STATIC_CALLOP void operator()(const node_type& node, L& lambda) SQLITE_ORM_OR_CONST_CALLOP {
+            iterate_ast(node.expression, lambda);
+        }
+    };
+
+    template<class E>
+    struct ast_iterator<following_t<E>, void> {
+        using node_type = following_t<E>;
+
+        template<class L>
+        SQLITE_ORM_STATIC_CALLOP void operator()(const node_type& node, L& lambda) SQLITE_ORM_OR_CONST_CALLOP {
+            iterate_ast(node.expression, lambda);
+        }
+    };
+
+    template<class Start, class End>
+    struct ast_iterator<frame_spec_t<Start, End>, void> {
+        using node_type = frame_spec_t<Start, End>;
+
+        template<class L>
+        SQLITE_ORM_STATIC_CALLOP void operator()(const node_type& node, L& lambda) SQLITE_ORM_OR_CONST_CALLOP {
+            iterate_ast(node.start, lambda);
+            iterate_ast(node.end, lambda);
+        }
+    };
+
+    template<class... Args>
+    struct ast_iterator<partition_by_t<Args...>, void> {
+        using node_type = partition_by_t<Args...>;
+
+        template<class L>
+        SQLITE_ORM_STATIC_CALLOP void operator()(const node_type& node, L& lambda) SQLITE_ORM_OR_CONST_CALLOP {
+            iterate_ast(node.arguments, lambda);
+        }
+    };
+
+    template<class F, class... Args>
+    struct ast_iterator<over_t<F, Args...>, void> {
+        using node_type = over_t<F, Args...>;
+
+        template<class L>
+        SQLITE_ORM_STATIC_CALLOP void operator()(const node_type& node, L& lambda) SQLITE_ORM_OR_CONST_CALLOP {
+            iterate_ast(node.function, lambda);
+            iterate_ast(node.arguments, lambda);
+        }
+    };
+
+    template<class... Args>
+    struct ast_iterator<window_defn_t<Args...>, void> {
+        using node_type = window_defn_t<Args...>;
+
+        template<class L>
+        SQLITE_ORM_STATIC_CALLOP void operator()(const node_type& node, L& lambda) SQLITE_ORM_OR_CONST_CALLOP {
+            iterate_ast(node.arguments, lambda);
+        }
+    };
+
+    template<class... Args>
+    struct ast_iterator<ntile_t<Args...>, void> {
+        using node_type = ntile_t<Args...>;
+
+        template<class L>
+        SQLITE_ORM_STATIC_CALLOP void operator()(const node_type& node, L& lambda) SQLITE_ORM_OR_CONST_CALLOP {
+            iterate_ast(node.args, lambda);
+        }
+    };
+
+    template<class... Args>
+    struct ast_iterator<lag_t<Args...>, void> {
+        using node_type = lag_t<Args...>;
+
+        template<class L>
+        SQLITE_ORM_STATIC_CALLOP void operator()(const node_type& node, L& lambda) SQLITE_ORM_OR_CONST_CALLOP {
+            iterate_ast(node.args, lambda);
+        }
+    };
+
+    template<class... Args>
+    struct ast_iterator<lead_t<Args...>, void> {
+        using node_type = lead_t<Args...>;
+
+        template<class L>
+        SQLITE_ORM_STATIC_CALLOP void operator()(const node_type& node, L& lambda) SQLITE_ORM_OR_CONST_CALLOP {
+            iterate_ast(node.args, lambda);
+        }
+    };
+
+    template<class... Args>
+    struct ast_iterator<first_value_t<Args...>, void> {
+        using node_type = first_value_t<Args...>;
+
+        template<class L>
+        SQLITE_ORM_STATIC_CALLOP void operator()(const node_type& node, L& lambda) SQLITE_ORM_OR_CONST_CALLOP {
+            iterate_ast(node.args, lambda);
+        }
+    };
+
+    template<class... Args>
+    struct ast_iterator<last_value_t<Args...>, void> {
+        using node_type = last_value_t<Args...>;
+
+        template<class L>
+        SQLITE_ORM_STATIC_CALLOP void operator()(const node_type& node, L& lambda) SQLITE_ORM_OR_CONST_CALLOP {
+            iterate_ast(node.args, lambda);
+        }
+    };
+
+    template<class... Args>
+    struct ast_iterator<nth_value_t<Args...>, void> {
+        using node_type = nth_value_t<Args...>;
+
+        template<class L>
+        SQLITE_ORM_STATIC_CALLOP void operator()(const node_type& node, L& lambda) SQLITE_ORM_OR_CONST_CALLOP {
+            iterate_ast(node.args, lambda);
         }
     };
 }
@@ -20098,20 +20768,6 @@ namespace sqlite_orm::internal {
 
 // #include "ast/rank.h"
 
-namespace sqlite_orm::internal {
-    struct rank_t {};
-}
-
-SQLITE_ORM_EXPORT namespace sqlite_orm {
-    /** 
-     *  [Deprecation notice] This expression factory function is deprecated and will be removed in v1.11.
-     */
-    [[deprecated("Use the hidden FTS5 rank column instead")]]
-    inline internal::rank_t rank() {
-        return {};
-    }
-}
-
 // #include "ast/special_keywords.h"
 
 // #include "ast/limit.h"
@@ -20121,6 +20777,8 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 // #include "ast/is_not_null.h"
 
 // #include "core_functions.h"
+
+// #include "window_functions.h"
 
 // #include "constraints.h"
 
@@ -21283,6 +21941,313 @@ namespace sqlite_orm::internal {
             std::stringstream ss;
             ss << serialize(statement.function, context);
             ss << " FILTER (WHERE " << serialize(statement.where, context) << ")";
+            return ss.str();
+        }
+    };
+
+    template<>
+    struct statement_serializer<row_number_t, void> {
+        using statement_type = row_number_t;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP serialize_result_type operator()(const statement_type&,
+                                                                  const Ctx&) SQLITE_ORM_OR_CONST_CALLOP {
+            return "ROW_NUMBER()";
+        }
+    };
+
+    template<>
+    struct statement_serializer<dense_rank_t, void> {
+        using statement_type = dense_rank_t;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP serialize_result_type operator()(const statement_type&,
+                                                                  const Ctx&) SQLITE_ORM_OR_CONST_CALLOP {
+            return "DENSE_RANK()";
+        }
+    };
+
+    template<>
+    struct statement_serializer<percent_rank_t, void> {
+        using statement_type = percent_rank_t;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP serialize_result_type operator()(const statement_type&,
+                                                                  const Ctx&) SQLITE_ORM_OR_CONST_CALLOP {
+            return "PERCENT_RANK()";
+        }
+    };
+
+    template<>
+    struct statement_serializer<cume_dist_t, void> {
+        using statement_type = cume_dist_t;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP serialize_result_type operator()(const statement_type&,
+                                                                  const Ctx&) SQLITE_ORM_OR_CONST_CALLOP {
+            return "CUME_DIST()";
+        }
+    };
+
+    template<class... Args>
+    struct statement_serializer<ntile_t<Args...>, void> {
+        using statement_type = ntile_t<Args...>;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
+                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
+            std::stringstream ss;
+            ss << "NTILE(" << streaming_expressions_tuple(statement.args, context) << ")";
+            return ss.str();
+        }
+    };
+
+    template<class... Args>
+    struct statement_serializer<lag_t<Args...>, void> {
+        using statement_type = lag_t<Args...>;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
+                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
+            std::stringstream ss;
+            ss << "LAG(" << streaming_expressions_tuple(statement.args, context) << ")";
+            return ss.str();
+        }
+    };
+
+    template<class... Args>
+    struct statement_serializer<lead_t<Args...>, void> {
+        using statement_type = lead_t<Args...>;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
+                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
+            std::stringstream ss;
+            ss << "LEAD(" << streaming_expressions_tuple(statement.args, context) << ")";
+            return ss.str();
+        }
+    };
+
+    template<class... Args>
+    struct statement_serializer<first_value_t<Args...>, void> {
+        using statement_type = first_value_t<Args...>;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
+                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
+            std::stringstream ss;
+            ss << "FIRST_VALUE(" << streaming_expressions_tuple(statement.args, context) << ")";
+            return ss.str();
+        }
+    };
+
+    template<class... Args>
+    struct statement_serializer<last_value_t<Args...>, void> {
+        using statement_type = last_value_t<Args...>;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
+                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
+            std::stringstream ss;
+            ss << "LAST_VALUE(" << streaming_expressions_tuple(statement.args, context) << ")";
+            return ss.str();
+        }
+    };
+
+    template<class... Args>
+    struct statement_serializer<nth_value_t<Args...>, void> {
+        using statement_type = nth_value_t<Args...>;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
+                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
+            std::stringstream ss;
+            ss << "NTH_VALUE(" << streaming_expressions_tuple(statement.args, context) << ")";
+            return ss.str();
+        }
+    };
+
+    template<>
+    struct statement_serializer<unbounded_preceding_t, void> {
+        using statement_type = unbounded_preceding_t;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP serialize_result_type operator()(const statement_type&,
+                                                                  const Ctx&) SQLITE_ORM_OR_CONST_CALLOP {
+            return "UNBOUNDED PRECEDING";
+        }
+    };
+
+    template<class E>
+    struct statement_serializer<preceding_t<E>, void> {
+        using statement_type = preceding_t<E>;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
+                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
+            std::stringstream ss;
+            ss << serialize(statement.expression, context) << " PRECEDING";
+            return ss.str();
+        }
+    };
+
+    template<>
+    struct statement_serializer<current_row_t, void> {
+        using statement_type = current_row_t;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP serialize_result_type operator()(const statement_type&,
+                                                                  const Ctx&) SQLITE_ORM_OR_CONST_CALLOP {
+            return "CURRENT ROW";
+        }
+    };
+
+    template<class E>
+    struct statement_serializer<following_t<E>, void> {
+        using statement_type = following_t<E>;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
+                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
+            std::stringstream ss;
+            ss << serialize(statement.expression, context) << " FOLLOWING";
+            return ss.str();
+        }
+    };
+
+    template<>
+    struct statement_serializer<unbounded_following_t, void> {
+        using statement_type = unbounded_following_t;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP serialize_result_type operator()(const statement_type&,
+                                                                  const Ctx&) SQLITE_ORM_OR_CONST_CALLOP {
+            return "UNBOUNDED FOLLOWING";
+        }
+    };
+
+    template<class Start, class End>
+    struct statement_serializer<frame_spec_t<Start, End>, void> {
+        using statement_type = frame_spec_t<Start, End>;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
+                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
+            std::stringstream ss;
+            switch (statement.type) {
+                case frame_type_t::rows:
+                    ss << "ROWS";
+                    break;
+                case frame_type_t::range:
+                    ss << "RANGE";
+                    break;
+                case frame_type_t::groups:
+                    ss << "GROUPS";
+                    break;
+            }
+            ss << " BETWEEN " << serialize(statement.start, context) << " AND " << serialize(statement.end, context);
+            switch (statement.exclude) {
+                case frame_exclude_t::no_others:
+                    break;
+                case frame_exclude_t::current_row:
+                    ss << " EXCLUDE CURRENT ROW";
+                    break;
+                case frame_exclude_t::group:
+                    ss << " EXCLUDE GROUP";
+                    break;
+                case frame_exclude_t::ties:
+                    ss << " EXCLUDE TIES";
+                    break;
+            }
+            return ss.str();
+        }
+    };
+
+    template<class... Args>
+    struct statement_serializer<partition_by_t<Args...>, void> {
+        using statement_type = partition_by_t<Args...>;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
+                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
+            std::stringstream ss;
+            ss << "PARTITION BY " << streaming_expressions_tuple(statement.arguments, context);
+            return ss.str();
+        }
+    };
+
+    template<>
+    struct statement_serializer<window_ref_t, void> {
+        using statement_type = window_ref_t;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
+                                                        const Ctx&) SQLITE_ORM_OR_CONST_CALLOP {
+            return statement.name;
+        }
+    };
+
+    template<class Tuple, class Ctx>
+    void serialize_over_arguments(std::stringstream& ss, const Tuple& arguments, const Ctx& context) {
+        using args_tuple = std::decay_t<Tuple>;
+        constexpr bool is_named_ref = std::tuple_size<args_tuple>::value == 1 &&
+                                      std::is_same<std::tuple_element_t<0, args_tuple>, window_ref_t>::value;
+        if constexpr (is_named_ref) {
+            ss << " OVER " << std::get<0>(arguments).name;
+        } else {
+            ss << " OVER (";
+            std::string separator;
+            iterate_tuple(arguments, [&ss, &context, &separator](auto& arg) {
+                ss << separator << serialize(arg, context);
+                separator = " ";
+            });
+            ss << ")";
+        }
+    }
+
+    template<class F, class... Args>
+    struct statement_serializer<over_t<F, Args...>, void> {
+        using statement_type = over_t<F, Args...>;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
+                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
+            std::stringstream ss;
+            ss << serialize(statement.function, context);
+            serialize_over_arguments(ss, statement.arguments, context);
+            return ss.str();
+        }
+    };
+
+    template<class... Args>
+    struct statement_serializer<over_t<rank_t, Args...>, void> {
+        using statement_type = over_t<rank_t, Args...>;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
+                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
+            std::stringstream ss;
+            ss << "rank()";
+            serialize_over_arguments(ss, statement.arguments, context);
+            return ss.str();
+        }
+    };
+
+    template<class... Args>
+    struct statement_serializer<window_defn_t<Args...>, void> {
+        using statement_type = window_defn_t<Args...>;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
+                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
+            std::stringstream ss;
+            ss << "WINDOW " << statement.name << " AS (";
+            std::string separator;
+            iterate_tuple(statement.arguments, [&ss, &context, &separator](auto& arg) {
+                ss << separator << serialize(arg, context);
+                separator = " ";
+            });
+            ss << ")";
             return ss.str();
         }
     };
@@ -26290,6 +27255,10 @@ namespace sqlite_orm::internal {
 
 // #include "ast/is_not_null.h"
 
+// #include "ast/window.h"
+
+// #include "window_functions.h"
+
 namespace sqlite_orm::internal {
     template<class T, class SFINAE = void>
     struct node_tuple {
@@ -26531,6 +27500,82 @@ namespace sqlite_orm::internal {
 
     template<class Table, class... Args>
     struct node_tuple<table_valued_expression<Table, Args...>, void> : node_tuple_for<Args...> {};
+
+    template<class E>
+    struct node_tuple<preceding_t<E>, void> : node_tuple<E> {};
+
+    template<class E>
+    struct node_tuple<following_t<E>, void> : node_tuple<E> {};
+
+    template<>
+    struct node_tuple<unbounded_preceding_t, void> {
+        using type = std::tuple<>;
+    };
+
+    template<>
+    struct node_tuple<unbounded_following_t, void> {
+        using type = std::tuple<>;
+    };
+
+    template<>
+    struct node_tuple<current_row_t, void> {
+        using type = std::tuple<>;
+    };
+
+    template<class Start, class End>
+    struct node_tuple<frame_spec_t<Start, End>, void> : node_tuple_for<Start, End> {};
+
+    template<class... Args>
+    struct node_tuple<partition_by_t<Args...>, void> : node_tuple_for<Args...> {};
+
+    template<>
+    struct node_tuple<window_ref_t, void> {
+        using type = std::tuple<>;
+    };
+
+    template<class F, class... Args>
+    struct node_tuple<over_t<F, Args...>, void> : node_tuple_for<F, Args...> {};
+
+    template<class... Args>
+    struct node_tuple<window_defn_t<Args...>, void> : node_tuple_for<Args...> {};
+
+    template<>
+    struct node_tuple<row_number_t, void> {
+        using type = std::tuple<>;
+    };
+
+    template<>
+    struct node_tuple<dense_rank_t, void> {
+        using type = std::tuple<>;
+    };
+
+    template<>
+    struct node_tuple<percent_rank_t, void> {
+        using type = std::tuple<>;
+    };
+
+    template<>
+    struct node_tuple<cume_dist_t, void> {
+        using type = std::tuple<>;
+    };
+
+    template<class... Args>
+    struct node_tuple<ntile_t<Args...>, void> : node_tuple_for<Args...> {};
+
+    template<class... Args>
+    struct node_tuple<lag_t<Args...>, void> : node_tuple_for<Args...> {};
+
+    template<class... Args>
+    struct node_tuple<lead_t<Args...>, void> : node_tuple_for<Args...> {};
+
+    template<class... Args>
+    struct node_tuple<first_value_t<Args...>, void> : node_tuple_for<Args...> {};
+
+    template<class... Args>
+    struct node_tuple<last_value_t<Args...>, void> : node_tuple_for<Args...> {};
+
+    template<class... Args>
+    struct node_tuple<nth_value_t<Args...>, void> : node_tuple_for<Args...> {};
 }
 
 // #include "expression_object_type.h"

--- a/tests/statement_serializer_tests/window_functions.cpp
+++ b/tests/statement_serializer_tests/window_functions.cpp
@@ -1,0 +1,213 @@
+#include <sqlite_orm/sqlite_orm.h>
+#include <catch2/catch_all.hpp>
+
+using namespace sqlite_orm;
+
+TEST_CASE("statement_serializer window functions") {
+    using internal::serialize;
+
+    struct T1 {
+        int a = 0;
+        std::string b;
+        std::string c;
+    };
+    auto table = make_table("t1", make_column("a", &T1::a), make_column("b", &T1::b), make_column("c", &T1::c));
+    using db_objects_t = internal::db_objects_tuple<decltype(table)>;
+    auto dbObjects = db_objects_t{table};
+    using context_t = internal::serializer_context<db_objects_t>;
+    context_t context{dbObjects};
+
+    std::string value;
+    decltype(value) expected;
+
+    SECTION("row_number") {
+        // SQL: ROW_NUMBER() OVER (ORDER BY b)
+        auto expression = row_number().over(order_by(&T1::b));
+        value = serialize(expression, context);
+        expected = R"(ROW_NUMBER() OVER (ORDER BY "t1"."b"))";
+    }
+    SECTION("rank") {
+        // SQL: rank() OVER (ORDER BY b)
+        auto expression = rank().over(order_by(&T1::b));
+        value = serialize(expression, context);
+        expected = R"(rank() OVER (ORDER BY "t1"."b"))";
+    }
+    SECTION("dense_rank") {
+        // SQL: DENSE_RANK() OVER (ORDER BY a)
+        auto expression = dense_rank().over(order_by(&T1::a));
+        value = serialize(expression, context);
+        expected = R"(DENSE_RANK() OVER (ORDER BY "t1"."a"))";
+    }
+    SECTION("percent_rank") {
+        // SQL: PERCENT_RANK() OVER (ORDER BY a)
+        auto expression = percent_rank().over(order_by(&T1::a));
+        value = serialize(expression, context);
+        expected = R"(PERCENT_RANK() OVER (ORDER BY "t1"."a"))";
+    }
+    SECTION("cume_dist") {
+        // SQL: CUME_DIST() OVER (ORDER BY a)
+        auto expression = cume_dist().over(order_by(&T1::a));
+        value = serialize(expression, context);
+        expected = R"(CUME_DIST() OVER (ORDER BY "t1"."a"))";
+    }
+    SECTION("ntile") {
+        // SQL: NTILE(2) OVER (ORDER BY a)
+        auto expression = ntile(2).over(order_by(&T1::a));
+        value = serialize(expression, context);
+        expected = R"(NTILE(2) OVER (ORDER BY "t1"."a"))";
+    }
+    SECTION("lag") {
+        SECTION("one arg") {
+            // SQL: LAG(b) OVER (ORDER BY a)
+            auto expression = lag(&T1::b).over(order_by(&T1::a));
+            value = serialize(expression, context);
+            expected = R"(LAG("b") OVER (ORDER BY "t1"."a"))";
+        }
+        SECTION("two args") {
+            // SQL: LAG(b, 2) OVER (ORDER BY a)
+            auto expression = lag(&T1::b, 2).over(order_by(&T1::a));
+            value = serialize(expression, context);
+            expected = R"(LAG("b", 2) OVER (ORDER BY "t1"."a"))";
+        }
+        SECTION("three args") {
+            // SQL: LAG(b, 2, 'n/a') OVER (ORDER BY b)
+            auto expression = lag(&T1::b, 2, std::string("n/a")).over(order_by(&T1::b));
+            value = serialize(expression, context);
+            expected = R"(LAG("b", 2, 'n/a') OVER (ORDER BY "t1"."b"))";
+        }
+    }
+    SECTION("lead") {
+        SECTION("one arg") {
+            // SQL: LEAD(b) OVER (ORDER BY a)
+            auto expression = lead(&T1::b).over(order_by(&T1::a));
+            value = serialize(expression, context);
+            expected = R"(LEAD("b") OVER (ORDER BY "t1"."a"))";
+        }
+        SECTION("two args") {
+            // SQL: LEAD(b, 2) OVER (ORDER BY a)
+            auto expression = lead(&T1::b, 2).over(order_by(&T1::a));
+            value = serialize(expression, context);
+            expected = R"(LEAD("b", 2) OVER (ORDER BY "t1"."a"))";
+        }
+        SECTION("three args") {
+            // SQL: LEAD(b, 2, 'n/a') OVER (ORDER BY b)
+            auto expression = lead(&T1::b, 2, std::string("n/a")).over(order_by(&T1::b));
+            value = serialize(expression, context);
+            expected = R"(LEAD("b", 2, 'n/a') OVER (ORDER BY "t1"."b"))";
+        }
+    }
+    SECTION("first_value") {
+        // SQL: FIRST_VALUE(b) OVER (ORDER BY b ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+        auto expression = first_value(&T1::b).over(order_by(&T1::b), rows(unbounded_preceding(), current_row()));
+        value = serialize(expression, context);
+        expected = R"(FIRST_VALUE("b") OVER (ORDER BY "t1"."b" ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))";
+    }
+    SECTION("last_value") {
+        // SQL: LAST_VALUE(b) OVER (ORDER BY b ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+        auto expression = last_value(&T1::b).over(order_by(&T1::b), rows(unbounded_preceding(), current_row()));
+        value = serialize(expression, context);
+        expected = R"(LAST_VALUE("b") OVER (ORDER BY "t1"."b" ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))";
+    }
+    SECTION("nth_value") {
+        // SQL: NTH_VALUE(b, 3) OVER (ORDER BY b)
+        auto expression = nth_value(&T1::b, 3).over(order_by(&T1::b));
+        value = serialize(expression, context);
+        expected = R"(NTH_VALUE("b", 3) OVER (ORDER BY "t1"."b"))";
+    }
+    SECTION("partition_by") {
+        // SQL: DENSE_RANK() OVER (PARTITION BY c ORDER BY a)
+        auto expression = dense_rank().over(partition_by(&T1::c), order_by(&T1::a));
+        value = serialize(expression, context);
+        expected = R"(DENSE_RANK() OVER (PARTITION BY "c" ORDER BY "t1"."a"))";
+    }
+    SECTION("frame ROWS") {
+        // SQL: group_concat(b, '.') OVER (ORDER BY a ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+        auto expression =
+            group_concat(&T1::b, std::string(".")).over(order_by(&T1::a), rows(preceding(1), following(1)));
+        value = serialize(expression, context);
+        expected = R"(GROUP_CONCAT("b", '.') OVER (ORDER BY "t1"."a" ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING))";
+    }
+    SECTION("frame RANGE") {
+        // SQL: group_concat(b, '.') OVER (PARTITION BY c ORDER BY a RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
+        auto expression =
+            group_concat(&T1::b, std::string("."))
+                .over(partition_by(&T1::c), order_by(&T1::a), range(current_row(), unbounded_following()));
+        value = serialize(expression, context);
+        expected =
+            R"(GROUP_CONCAT("b", '.') OVER (PARTITION BY "c" ORDER BY "t1"."a" RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING))";
+    }
+    SECTION("frame GROUPS") {
+        // SQL: group_concat(b, '.') OVER (ORDER BY c GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+        auto expression =
+            group_concat(&T1::b, std::string(".")).over(order_by(&T1::c), groups(unbounded_preceding(), current_row()));
+        value = serialize(expression, context);
+        expected =
+            R"(GROUP_CONCAT("b", '.') OVER (ORDER BY "t1"."c" GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))";
+    }
+    SECTION("EXCLUDE") {
+        SECTION("EXCLUDE CURRENT ROW") {
+            // SQL: ... GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE CURRENT ROW
+            auto expression =
+                group_concat(&T1::b, std::string("."))
+                    .over(order_by(&T1::c), groups(unbounded_preceding(), current_row()).exclude_current_row());
+            value = serialize(expression, context);
+            expected =
+                R"(GROUP_CONCAT("b", '.') OVER (ORDER BY "t1"."c" GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE CURRENT ROW))";
+        }
+        SECTION("EXCLUDE GROUP") {
+            auto expression = group_concat(&T1::b, std::string("."))
+                                  .over(order_by(&T1::c), groups(unbounded_preceding(), current_row()).exclude_group());
+            value = serialize(expression, context);
+            expected =
+                R"(GROUP_CONCAT("b", '.') OVER (ORDER BY "t1"."c" GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE GROUP))";
+        }
+        SECTION("EXCLUDE TIES") {
+            auto expression = group_concat(&T1::b, std::string("."))
+                                  .over(order_by(&T1::c), groups(unbounded_preceding(), current_row()).exclude_ties());
+            value = serialize(expression, context);
+            expected =
+                R"(GROUP_CONCAT("b", '.') OVER (ORDER BY "t1"."c" GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES))";
+        }
+    }
+    SECTION("FILTER + OVER") {
+        // SQL: group_concat(b, '.') FILTER (WHERE c != 'two') OVER (ORDER BY a)
+        auto expression = group_concat(&T1::b, std::string("."))
+                              .filter(where(c(&T1::c) != std::string("two")))
+                              .over(order_by(&T1::a));
+        value = serialize(expression, context);
+        expected = R"(GROUP_CONCAT("b", '.') FILTER (WHERE "c" != 'two') OVER (ORDER BY "t1"."a"))";
+    }
+    SECTION("aggregate with OVER") {
+        SECTION("sum") {
+            // SQL: SUM(a) OVER (ORDER BY a)
+            auto expression = sum(&T1::a).over(order_by(&T1::a));
+            value = serialize(expression, context);
+            expected = R"(SUM("a") OVER (ORDER BY "t1"."a"))";
+        }
+        SECTION("count") {
+            // SQL: COUNT(a) OVER (PARTITION BY c)
+            auto expression = count(&T1::a).over(partition_by(&T1::c));
+            value = serialize(expression, context);
+            expected = R"(COUNT("a") OVER (PARTITION BY "c"))";
+        }
+        SECTION("avg") {
+            // SQL: AVG(a) OVER (ORDER BY a)
+            auto expression = avg(&T1::a).over(order_by(&T1::a));
+            value = serialize(expression, context);
+            expected = R"(AVG("a") OVER (ORDER BY "t1"."a"))";
+        }
+    }
+    SECTION("named window") {
+        // SQL: WINDOW win AS (ORDER BY b ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+        auto expression = window("win", order_by(&T1::b), rows(unbounded_preceding(), current_row()));
+        value = serialize(expression, context);
+        expected = R"(WINDOW win AS (ORDER BY "t1"."b" ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))";
+    }
+    SECTION("OVER named window reference") {
+        // SQL: ROW_NUMBER() OVER win
+        auto expression = row_number().over(window_ref("win"));
+        value = serialize(expression, context);
+        expected = R"(ROW_NUMBER() OVER win)";
+    }
+    REQUIRE(value == expected);
+}

--- a/tests/static_tests/window_function_return_types.cpp
+++ b/tests/static_tests/window_function_return_types.cpp
@@ -1,0 +1,71 @@
+#include <sqlite_orm/sqlite_orm.h>
+#include <catch2/catch_all.hpp>
+#include <type_traits>  //  std::is_same
+#include <memory>  //  std::unique_ptr
+
+using namespace sqlite_orm;
+
+template<class Type, class E>
+void do_assert() {
+    STATIC_REQUIRE(std::is_same<Type, E>::value);
+}
+
+TEST_CASE("window function return types") {
+    struct User {
+        int id = 0;
+        std::string name;
+        double salary = 0;
+    };
+
+    auto table = make_table("users",
+                            make_column("id", &User::id, primary_key()),
+                            make_column("name", &User::name),
+                            make_column("salary", &User::salary));
+    using db_objects_t = internal::db_objects_tuple<decltype(table)>;
+
+    SECTION("nullary window functions") {
+        do_assert<internal::column_result_of_t<db_objects_t, decltype(row_number().over(order_by(&User::id)))>, int>();
+        do_assert<internal::column_result_of_t<db_objects_t, decltype(rank().over(order_by(&User::id)))>, int>();
+        do_assert<internal::column_result_of_t<db_objects_t, decltype(dense_rank().over(order_by(&User::id)))>, int>();
+        do_assert<internal::column_result_of_t<db_objects_t, decltype(percent_rank().over(order_by(&User::id)))>,
+                  double>();
+        do_assert<internal::column_result_of_t<db_objects_t, decltype(cume_dist().over(order_by(&User::id)))>,
+                  double>();
+    }
+    SECTION("ntile") {
+        do_assert<internal::column_result_of_t<db_objects_t, decltype(ntile(4).over(order_by(&User::id)))>, int>();
+    }
+    SECTION("lag/lead deduce type from first arg") {
+        do_assert<internal::column_result_of_t<db_objects_t, decltype(lag(&User::name).over(order_by(&User::id)))>,
+                  std::string>();
+        do_assert<internal::column_result_of_t<db_objects_t, decltype(lag(&User::id, 2).over(order_by(&User::id)))>,
+                  int>();
+        do_assert<internal::column_result_of_t<db_objects_t, decltype(lead(&User::salary).over(order_by(&User::id)))>,
+                  double>();
+    }
+    SECTION("first_value/last_value/nth_value deduce type from first arg") {
+        do_assert<
+            internal::column_result_of_t<db_objects_t, decltype(first_value(&User::name).over(order_by(&User::id)))>,
+            std::string>();
+        do_assert<
+            internal::column_result_of_t<db_objects_t, decltype(last_value(&User::salary).over(order_by(&User::id)))>,
+            double>();
+        do_assert<
+            internal::column_result_of_t<db_objects_t, decltype(nth_value(&User::id, 3).over(order_by(&User::id)))>,
+            int>();
+    }
+    SECTION("aggregate over_t delegates to aggregate return type") {
+        do_assert<internal::column_result_of_t<db_objects_t, decltype(sum(&User::id).over(order_by(&User::id)))>,
+                  std::unique_ptr<double>>();
+        do_assert<internal::column_result_of_t<db_objects_t, decltype(avg(&User::id).over(order_by(&User::id)))>,
+                  double>();
+        do_assert<internal::column_result_of_t<db_objects_t, decltype(count(&User::id).over(order_by(&User::id)))>,
+                  int>();
+    }
+    SECTION("filtered aggregate over_t") {
+        do_assert<internal::column_result_of_t<
+                      db_objects_t,
+                      decltype(count(&User::id).filter(where(c(&User::id) > 0)).over(order_by(&User::id)))>,
+                  int>();
+    }
+}

--- a/tests/window_function_tests.cpp
+++ b/tests/window_function_tests.cpp
@@ -1,0 +1,202 @@
+#include <sqlite_orm/sqlite_orm.h>
+#include <catch2/catch_all.hpp>
+
+using namespace sqlite_orm;
+
+TEST_CASE("window functions") {
+    struct DenseRankDemo {
+        int id = 0;
+        std::string val;
+    };
+
+    struct T1 {
+        int a = 0;
+        std::string b;
+        std::string c;
+    };
+
+    struct T2 {
+        std::string a;
+        std::string b;
+    };
+
+    auto storage = make_storage(
+        "",
+        make_table("DenseRankDemo",
+                   make_column("id", &DenseRankDemo::id, primary_key().autoincrement()),
+                   make_column("Val", &DenseRankDemo::val)),
+        make_table("t1", make_column("a", &T1::a, primary_key()), make_column("b", &T1::b), make_column("c", &T1::c)),
+        make_table("t2", make_column("a", &T2::a), make_column("b", &T2::b)));
+    storage.sync_schema();
+
+    SECTION("DENSE_RANK - Issue #1478") {
+        // SQL: INSERT INTO DenseRankDemo(Val) VALUES('A'),('B'),('C'),('C'),('D'),('D'),('E');
+        storage.insert(DenseRankDemo{0, "A"});
+        storage.insert(DenseRankDemo{0, "B"});
+        storage.insert(DenseRankDemo{0, "C"});
+        storage.insert(DenseRankDemo{0, "C"});
+        storage.insert(DenseRankDemo{0, "D"});
+        storage.insert(DenseRankDemo{0, "D"});
+        storage.insert(DenseRankDemo{0, "E"});
+
+        // SQL: SELECT Val, DENSE_RANK() OVER (ORDER BY Val) ValRank FROM DenseRankDemo
+        auto rows = storage.select(columns(&DenseRankDemo::val, dense_rank().over(order_by(&DenseRankDemo::val))));
+
+        REQUIRE(rows.size() == 7);
+        // A=1, B=2, C=3, C=3, D=4, D=4, E=5
+        REQUIRE(std::get<1>(rows[0]) == 1);
+        REQUIRE(std::get<1>(rows[1]) == 2);
+        REQUIRE(std::get<1>(rows[2]) == 3);
+        REQUIRE(std::get<1>(rows[3]) == 3);
+        REQUIRE(std::get<1>(rows[4]) == 4);
+        REQUIRE(std::get<1>(rows[5]) == 4);
+        REQUIRE(std::get<1>(rows[6]) == 5);
+    }
+    SECTION("ROW_NUMBER with PARTITION BY") {
+        storage.replace(T2{"a", "one"});
+        storage.replace(T2{"a", "two"});
+        storage.replace(T2{"a", "three"});
+        storage.replace(T2{"b", "four"});
+        storage.replace(T2{"c", "five"});
+        storage.replace(T2{"c", "six"});
+
+        // SQL: SELECT a, row_number() OVER (PARTITION BY a ORDER BY b) FROM t2
+        auto rows = storage.select(columns(&T2::a, row_number().over(partition_by(&T2::a), order_by(&T2::b))));
+
+        REQUIRE(rows.size() == 6);
+        // Each partition restarts numbering
+        int maxRowNum = 0;
+        std::string lastA;
+        for (auto& [a, rn]: rows) {
+            if (a != lastA) {
+                lastA = a;
+                maxRowNum = 0;
+            }
+            REQUIRE(rn > maxRowNum);
+            maxRowNum = rn;
+        }
+    }
+    SECTION("Ranking functions") {
+        storage.replace(T2{"a", "one"});
+        storage.replace(T2{"a", "two"});
+        storage.replace(T2{"a", "three"});
+        storage.replace(T2{"b", "four"});
+        storage.replace(T2{"c", "five"});
+        storage.replace(T2{"c", "six"});
+
+        // SQL: SELECT a, row_number() OVER win, rank() OVER win, dense_rank() OVER win,
+        //             percent_rank() OVER win, cume_dist() OVER win
+        //      FROM t2 WINDOW win AS (ORDER BY a)
+        auto rows = storage.select(columns(&T2::a,
+                                           row_number().over(order_by(&T2::a)),
+                                           rank().over(order_by(&T2::a)),
+                                           dense_rank().over(order_by(&T2::a)),
+                                           percent_rank().over(order_by(&T2::a)),
+                                           cume_dist().over(order_by(&T2::a))));
+
+        REQUIRE(rows.size() == 6);
+        // row 1: a='a', row_number=1, rank=1, dense_rank=1
+        REQUIRE(std::get<1>(rows[0]) == 1);
+        REQUIRE(std::get<2>(rows[0]) == 1);
+        REQUIRE(std::get<3>(rows[0]) == 1);
+    }
+    SECTION("LAG and LEAD") {
+        storage.replace(T1{1, "A", "one"});
+        storage.replace(T1{2, "B", "two"});
+        storage.replace(T1{3, "C", "three"});
+        storage.replace(T1{4, "D", "one"});
+        storage.replace(T1{5, "E", "two"});
+
+        // SQL: SELECT b, lag(b) OVER (ORDER BY a), lead(b) OVER (ORDER BY a) FROM t1
+        auto rows =
+            storage.select(columns(&T1::b, lag(&T1::b).over(order_by(&T1::a)), lead(&T1::b).over(order_by(&T1::a))));
+
+        REQUIRE(rows.size() == 5);
+        // First row: lag is NULL (empty string for std::string), lead is "B"
+        REQUIRE(std::get<1>(rows[0]) == "");
+        REQUIRE(std::get<2>(rows[0]) == "B");
+        // Last row: lag is "D", lead is NULL (empty string)
+        REQUIRE(std::get<1>(rows[4]) == "D");
+        REQUIRE(std::get<2>(rows[4]) == "");
+    }
+    SECTION("FIRST_VALUE, LAST_VALUE, NTH_VALUE") {
+        storage.replace(T1{1, "A", "one"});
+        storage.replace(T1{2, "B", "two"});
+        storage.replace(T1{3, "C", "three"});
+        storage.replace(T1{4, "D", "one"});
+        storage.replace(T1{5, "E", "two"});
+
+        // SQL: SELECT b, first_value(b) OVER win, last_value(b) OVER win, nth_value(b, 3) OVER win
+        //      FROM t1 WINDOW win AS (ORDER BY b ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+        auto frameSpec = rows(unbounded_preceding(), current_row());
+        auto result = storage.select(columns(&T1::b,
+                                             first_value(&T1::b).over(order_by(&T1::b), frameSpec),
+                                             last_value(&T1::b).over(order_by(&T1::b), frameSpec),
+                                             nth_value(&T1::b, 3).over(order_by(&T1::b), frameSpec)));
+
+        REQUIRE(result.size() == 5);
+        for (auto& row: result) {
+            REQUIRE(std::get<1>(row) == "A");
+        }
+        REQUIRE(std::get<2>(result[0]) == "A");
+        REQUIRE(std::get<2>(result[1]) == "B");
+    }
+    SECTION("Aggregate with OVER and frame") {
+        storage.replace(T1{1, "A", "one"});
+        storage.replace(T1{2, "B", "two"});
+        storage.replace(T1{3, "C", "three"});
+        storage.replace(T1{4, "D", "one"});
+        storage.replace(T1{5, "E", "two"});
+
+        // SQL: SELECT a, sum(a) OVER (ORDER BY a ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM t1
+        auto frameSpec = rows(unbounded_preceding(), current_row());
+        auto result = storage.select(columns(&T1::a, sum(&T1::a).over(order_by(&T1::a), frameSpec)));
+
+        REQUIRE(result.size() == 5);
+        REQUIRE(*std::get<1>(result[0]) == 1);
+        REQUIRE(*std::get<1>(result[1]) == 3);
+        REQUIRE(*std::get<1>(result[2]) == 6);
+        REQUIRE(*std::get<1>(result[3]) == 10);
+        REQUIRE(*std::get<1>(result[4]) == 15);
+    }
+    SECTION("FILTER + OVER") {
+        storage.replace(T1{1, "A", "one"});
+        storage.replace(T1{2, "B", "two"});
+        storage.replace(T1{3, "C", "three"});
+        storage.replace(T1{4, "D", "one"});
+        storage.replace(T1{5, "E", "two"});
+
+        // SQL: SELECT a, count(a) FILTER (WHERE c = 'one') OVER (ORDER BY a ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM t1
+        auto frameSpec = rows(unbounded_preceding(), current_row());
+        auto result = storage.select(
+            columns(&T1::a,
+                    count(&T1::a).filter(where(c(&T1::c) == std::string("one"))).over(order_by(&T1::a), frameSpec)));
+
+        REQUIRE(result.size() == 5);
+        REQUIRE(std::get<1>(result[0]) == 1);
+        REQUIRE(std::get<1>(result[1]) == 1);
+        REQUIRE(std::get<1>(result[2]) == 1);
+        REQUIRE(std::get<1>(result[3]) == 2);
+        REQUIRE(std::get<1>(result[4]) == 2);
+    }
+    SECTION("NTILE") {
+        storage.replace(T2{"a", "one"});
+        storage.replace(T2{"a", "two"});
+        storage.replace(T2{"a", "three"});
+        storage.replace(T2{"b", "four"});
+        storage.replace(T2{"c", "five"});
+        storage.replace(T2{"c", "six"});
+
+        // SQL: SELECT a, b, ntile(2) OVER (ORDER BY a) FROM t2
+        auto rows = storage.select(columns(&T2::a, &T2::b, ntile(2).over(order_by(&T2::a))));
+
+        REQUIRE(rows.size() == 6);
+        // ntile(2) divides 6 rows into 2 groups: first 3 get 1, last 3 get 2
+        REQUIRE(std::get<2>(rows[0]) == 1);
+        REQUIRE(std::get<2>(rows[1]) == 1);
+        REQUIRE(std::get<2>(rows[2]) == 1);
+        REQUIRE(std::get<2>(rows[3]) == 2);
+        REQUIRE(std::get<2>(rows[4]) == 2);
+        REQUIRE(std::get<2>(rows[5]) == 2);
+    }
+}


### PR DESCRIPTION
Closes #1478

**Summary**
Full implementation of SQLite window functions following the static AST design of the library.

Built-in window functions (11): _ROW_NUMBER()_, _RANK()_, _DENSE_RANK()_, _PERCENT_RANK()_, _CUME_DIST()_, _NTILE(N)_, _LAG(expr [, offset [, default]])_, _LEAD(expr [, offset [, default]])_, _FIRST_VALUE(expr)_, _LAST_VALUE(expr)_, _NTH_VALUE(expr, N)_

Aggregate functions as window functions: All existing aggregate functions (SUM, COUNT, AVG, MAX, MIN, TOTAL, GROUP_CONCAT) now support _.over(...)_ including _FILTER(WHERE ...) ... OVER(...)_ combination.

**OVER clause components:**

PARTITION BY — partition_by(...)
ORDER BY within window — reuses existing order_by(...)
Frame specification — rows(start, end), range(start, end), groups(start, end) with boundaries unbounded_preceding(), preceding(N), current_row(), following(N), unbounded_following() and EXCLUDE options
Named windows — window("name", ...) + window_ref("name")

**Usage example**

```c++
// SELECT DENSE_RANK() OVER (ORDER BY salary DESC) FROM employees
storage.select(dense_rank().over(order_by(&Employee::salary).desc()));

// SELECT name, SUM(amount) OVER (PARTITION BY dept ORDER BY date
//   ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM t
storage.select(columns(&T::name,
    sum(&T::amount).over(
        partition_by(&T::dept),
        order_by(&T::date),
        rows(unbounded_preceding(), current_row()))));
```
