### PR TITLE
Fixed deprecated CMake target SQLite::SQLite3 -> SQLite3::SQLite3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,10 @@ add_library(sqlite_orm INTERFACE)
 add_library(sqlite_orm::sqlite_orm ALIAS sqlite_orm)
 
 find_package(SQLite3 REQUIRED)
-target_link_libraries(sqlite_orm INTERFACE SQLite::SQLite3)
+if(NOT TARGET SQLite3::SQLite3)
+    add_library(SQLite3::SQLite3 ALIAS SQLite::SQLite3)
+endif()
+target_link_libraries(sqlite_orm INTERFACE SQLite3::SQLite3)
 
 target_sources(sqlite_orm INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/sqlite_orm/sqlite_orm.h>)
 

--- a/cmake/SqliteOrmConfig.cmake.in
+++ b/cmake/SqliteOrmConfig.cmake.in
@@ -1,7 +1,4 @@
 include(CMakeFindDependencyMacro)
 find_dependency(SQLite3)
-if(NOT TARGET SQLite3::SQLite3) # CMake < 4.3
-    add_library(SQLite3::SQLite3 ALIAS SQLite::SQLite3)
-endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/SqliteOrmTargets.cmake)

--- a/cmake/SqliteOrmConfig.cmake.in
+++ b/cmake/SqliteOrmConfig.cmake.in
@@ -1,4 +1,7 @@
 include(CMakeFindDependencyMacro)
 find_dependency(SQLite3)
+if(NOT TARGET SQLite3::SQLite3) # CMake < 4.3
+    add_library(SQLite3::SQLite3 ALIAS SQLite::SQLite3)
+endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/SqliteOrmTargets.cmake)


### PR DESCRIPTION
CMake 4.3 deprecated the `SQLite::SQLite3` target name in favour of `SQLite3::SQLite3`, producing dev warnings on configuration:
  
    CMake Warning (dev): The library that is being linked to, SQLite::SQLite3, 
    is marked as being deprecated by the owner. Please use SQLite3::SQLite3 instead.
      
A direct rename would break CMake < 4.3, where `SQLite3::SQLite3` does not exist yet. Instead, a compatibility shim is added following the pattern recommended by CMake's own module documentation: 
If `SQLite3::SQLite3` is not yet defined, it is aliased to `SQLite::SQLite3`. This keeps the build warning-free on CMake >= 4.3 while remaining fully compatible with older versions down to the project's minimum of CMake 3.16.