### PR TITLE
Add static_assert to get*, remove to reject non-pk arguments at compile time  

### DIFF
--- a/dev/storage.h
+++ b/dev/storage.h
@@ -392,6 +392,7 @@ namespace sqlite_orm::internal {
          */
         template<class O, class... Ids>
         void remove(Ids... ids) {
+            static_assert((internal::is_bindable_v<Ids> && ...), "Only primary key values are accepted as Ids");
             this->assert_mapped_type<O>();
             auto statement = this->prepare(sqlite_orm::remove<O>(std::forward<Ids>(ids)...));
             this->execute(statement);
@@ -535,6 +536,7 @@ namespace sqlite_orm::internal {
          */
         template<class O, class... Ids>
         O get(Ids... ids) {
+            static_assert((internal::is_bindable_v<Ids> && ...), "Only primary key values are accepted as Ids");
             this->assert_mapped_type<O>();
             this->assert_primary_key_type<O>();
             auto statement = this->prepare(sqlite_orm::get<O>(std::forward<Ids>(ids)...));
@@ -554,6 +556,7 @@ namespace sqlite_orm::internal {
          */
         template<class O, class... Ids>
         std::unique_ptr<O> get_pointer(Ids... ids) {
+            static_assert((internal::is_bindable_v<Ids> && ...), "Only primary key values are accepted as Ids");
             this->assert_mapped_type<O>();
             this->assert_primary_key_type<O>();
             auto statement = this->prepare(sqlite_orm::get_pointer<O>(std::forward<Ids>(ids)...));
@@ -592,6 +595,7 @@ namespace sqlite_orm::internal {
          */
         template<class O, class... Ids>
         std::optional<O> get_optional(Ids... ids) {
+            static_assert((internal::is_bindable_v<Ids> && ...), "Only primary key values are accepted as Ids");
             this->assert_mapped_type<O>();
             this->assert_primary_key_type<O>();
             auto statement = this->prepare(sqlite_orm::get_optional<O>(std::forward<Ids>(ids)...));

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -25388,6 +25388,7 @@ namespace sqlite_orm::internal {
          */
         template<class O, class... Ids>
         void remove(Ids... ids) {
+            static_assert((internal::is_bindable_v<Ids> && ...), "Only primary key values are accepted as Ids");
             this->assert_mapped_type<O>();
             auto statement = this->prepare(sqlite_orm::remove<O>(std::forward<Ids>(ids)...));
             this->execute(statement);
@@ -25531,6 +25532,7 @@ namespace sqlite_orm::internal {
          */
         template<class O, class... Ids>
         O get(Ids... ids) {
+            static_assert((internal::is_bindable_v<Ids> && ...), "Only primary key values are accepted as Ids");
             this->assert_mapped_type<O>();
             this->assert_primary_key_type<O>();
             auto statement = this->prepare(sqlite_orm::get<O>(std::forward<Ids>(ids)...));
@@ -25550,6 +25552,7 @@ namespace sqlite_orm::internal {
          */
         template<class O, class... Ids>
         std::unique_ptr<O> get_pointer(Ids... ids) {
+            static_assert((internal::is_bindable_v<Ids> && ...), "Only primary key values are accepted as Ids");
             this->assert_mapped_type<O>();
             this->assert_primary_key_type<O>();
             auto statement = this->prepare(sqlite_orm::get_pointer<O>(std::forward<Ids>(ids)...));
@@ -25588,6 +25591,7 @@ namespace sqlite_orm::internal {
          */
         template<class O, class... Ids>
         std::optional<O> get_optional(Ids... ids) {
+            static_assert((internal::is_bindable_v<Ids> && ...), "Only primary key values are accepted as Ids");
             this->assert_mapped_type<O>();
             this->assert_primary_key_type<O>();
             auto statement = this->prepare(sqlite_orm::get_optional<O>(std::forward<Ids>(ids)...));

--- a/tests/static_tests/get_pk_ids.cpp
+++ b/tests/static_tests/get_pk_ids.cpp
@@ -1,0 +1,37 @@
+#include <sqlite_orm/sqlite_orm.h>
+#include <catch2/catch_all.hpp>
+
+#include <type_traits>  //  std::is_same
+#include <memory>  //  std::unique_ptr, std::shared_ptr
+#include <string>  //  std::string
+#ifdef SQLITE_ORM_OPTIONAL_SUPPORTED
+#include <optional>  //  std::optional
+#endif
+
+using namespace sqlite_orm;
+
+TEST_CASE("get* and remove accept bindable pk types") {
+    struct User {
+        int id = 0;
+        std::string name;
+    };
+
+    using Storage = decltype(make_storage(
+        "",
+        make_table("users", make_column("id", &User::id, primary_key()), make_column("name", &User::name))));
+
+    STATIC_REQUIRE(std::is_same_v<decltype(std::declval<Storage>().get<User>(std::declval<int>())), User>);
+
+    STATIC_REQUIRE(std::is_same_v<decltype(std::declval<Storage>().get_pointer<User>(std::declval<int>())),
+                                  std::unique_ptr<User>>);
+
+    STATIC_REQUIRE(std::is_same_v<decltype(std::declval<Storage>().get_no_throw<User>(std::declval<int>())),
+                                  std::shared_ptr<User>>);
+
+#ifdef SQLITE_ORM_OPTIONAL_SUPPORTED
+    STATIC_REQUIRE(
+        std::is_same_v<decltype(std::declval<Storage>().get_optional<User>(std::declval<int>())), std::optional<User>>);
+#endif
+
+    STATIC_REQUIRE(std::is_same_v<decltype(std::declval<Storage>().remove<User>(std::declval<int>())), void>);
+}


### PR DESCRIPTION
## What

`get()`, `get_pointer()`, `get_optional()`, `get_no_throw()` and `remove()` silently accepted any `Ids...`, including query expressions like `where(...)`. This compiled fine but crashed at runtime with a cryptic `std::system_error`.

Now passing a non-bindable type produces a clear compile-time error:

    error: static assertion failed: Only primary key values are accepted as Ids

## How

Added `static_assert((is_bindable_v<Ids> && ...), ...)` to `get`, `get_pointer`, `get_optional` and `remove`. `get_no_throw` is not checked directly — it delegates to `get_pointer`, which already has the assert.

## Tests

Extended tests with `tests/static_tests/get_pk_ids.cpp` that validates all five functions with `STATIC_REQUIRE` (positive cases only)

Closes #1485 