### PR TITLE
Legacy Compiler Hygiene

### DIFF
--- a/dev/functional/config.h
+++ b/dev/functional/config.h
@@ -41,7 +41,8 @@
 #define SQLITE_ORM_CPP_UNLIKELY
 #endif
 
-#ifdef SQLITE_ORM_CONSTEVAL_SUPPORTED
+// note: Visual Studio 2019 v16.11 supports `consteval` but not for functions returning void.
+#if defined(SQLITE_ORM_CONSTEVAL_SUPPORTED) && (!defined(SQLITE_ORM_MS_MSVC) || (_MSC_VER >= 1930))
 #define SQLITE_ORM_CONSTEVAL consteval
 #else
 #define SQLITE_ORM_CONSTEVAL constexpr

--- a/dev/functional/cxx_compiler_quirks.h
+++ b/dev/functional/cxx_compiler_quirks.h
@@ -27,6 +27,10 @@
 #define SQLITE_ORM_CLANG_MSVC
 #endif
 
+#if defined(__GNUC__) && !defined(__clang__)
+#define SQLITE_ORM_GNU_GCC
+#endif
+
 #ifdef SQLITE_ORM_MS_MSVC
 #define SQLITE_ORM_DO_PRAGMA(...) __pragma(__VA_ARGS__)
 #endif

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -1649,19 +1649,18 @@ namespace sqlite_orm::internal {
             auto processObject = [&table = this->get_table<object_type>(),
                                   bindValue = field_value_binder{stmt}](const object_type& object) mutable {
                 using table_type = polyfill::remove_cvref_t<decltype(table)>;
-                using without_rowid = typename table_type::is_without_rowid;
-                using is_pkcolumn_q =
-                    mpl::conjunction<mpl::not_<mpl::always<without_rowid>>, mpl::quote_fn<is_primary_key>>;
+                using is_pkcolumn_q = mpl::conjunction<mpl::not_<mpl::always<typename table_type::is_without_rowid>>,
+                                                       mpl::quote_fn<is_primary_key>>;
                 using is_generated_always_q = mpl::quote_fn<is_generated_always>;
 
                 table.template for_each_column_excluding<mpl::disjunction<is_pkcolumn_q, is_generated_always_q>>(
                     [&table, &bindValue, &object](auto& column) {
-                        if (!without_rowid::value &&
+                        if (!table_type::is_without_rowid::value &&
                             (is_single_table_primary_key(table, column) ||
                              (column.template is_template<default_t>() && table_primary_key_contains(table, column)))) {
                             return;
-                        } else if (without_rowid::value && (column.template is_template<default_t>() &&
-                                                            table_primary_key_contains(table, column))) {
+                        } else if (table_type::is_without_rowid::value && (column.template is_template<default_t>() &&
+                                                                           table_primary_key_contains(table, column))) {
                             return;
                         }
                         bindValue(polyfill::invoke(column.member_pointer, object));

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -175,6 +175,10 @@ using std::nullptr_t;
 #define SQLITE_ORM_CLANG_MSVC
 #endif
 
+#if defined(__GNUC__) && !defined(__clang__)
+#define SQLITE_ORM_GNU_GCC
+#endif
+
 #ifdef SQLITE_ORM_MS_MSVC
 #define SQLITE_ORM_DO_PRAGMA(...) __pragma(__VA_ARGS__)
 #endif
@@ -303,7 +307,8 @@ using std::nullptr_t;
 #define SQLITE_ORM_CPP_UNLIKELY
 #endif
 
-#ifdef SQLITE_ORM_CONSTEVAL_SUPPORTED
+// note: Visual Studio 2019 v16.11 supports `consteval` but not for functions returning void.
+#if defined(SQLITE_ORM_CONSTEVAL_SUPPORTED) && (!defined(SQLITE_ORM_MS_MSVC) || (_MSC_VER >= 1930))
 #define SQLITE_ORM_CONSTEVAL consteval
 #else
 #define SQLITE_ORM_CONSTEVAL constexpr
@@ -27039,19 +27044,18 @@ namespace sqlite_orm::internal {
             auto processObject = [&table = this->get_table<object_type>(),
                                   bindValue = field_value_binder{stmt}](const object_type& object) mutable {
                 using table_type = polyfill::remove_cvref_t<decltype(table)>;
-                using without_rowid = typename table_type::is_without_rowid;
-                using is_pkcolumn_q =
-                    mpl::conjunction<mpl::not_<mpl::always<without_rowid>>, mpl::quote_fn<is_primary_key>>;
+                using is_pkcolumn_q = mpl::conjunction<mpl::not_<mpl::always<typename table_type::is_without_rowid>>,
+                                                       mpl::quote_fn<is_primary_key>>;
                 using is_generated_always_q = mpl::quote_fn<is_generated_always>;
 
                 table.template for_each_column_excluding<mpl::disjunction<is_pkcolumn_q, is_generated_always_q>>(
                     [&table, &bindValue, &object](auto& column) {
-                        if (!without_rowid::value &&
+                        if (!table_type::is_without_rowid::value &&
                             (is_single_table_primary_key(table, column) ||
                              (column.template is_template<default_t>() && table_primary_key_contains(table, column)))) {
                             return;
-                        } else if (without_rowid::value && (column.template is_template<default_t>() &&
-                                                            table_primary_key_contains(table, column))) {
+                        } else if (table_type::is_without_rowid::value && (column.template is_template<default_t>() &&
+                                                                           table_primary_key_contains(table, column))) {
                             return;
                         }
                         bindValue(polyfill::invoke(column.member_pointer, object));

--- a/tests/static_tests/function_static_tests.cpp
+++ b/tests/static_tests/function_static_tests.cpp
@@ -345,7 +345,7 @@ TEST_CASE("function static") {
         }
 #endif
         SECTION("freestanding function") {
-#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 12)
+#if (defined(SQLITE_ORM_GNU_GCC) && (__GNUC__ < 12)) || (defined(SQLITE_ORM_MS_MSVC) && _MSC_VER < 1930)
             SKIP("GCC < 12 cannot use this function pointer as NTTP in this test.");
 #else
             constexpr auto quotedScalar = "f"_scalar.quote(clamp_int_ptr);
@@ -377,7 +377,7 @@ TEST_CASE("function static") {
 #endif
         }
         SECTION("template function") {
-#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 12)
+#if (defined(SQLITE_ORM_GNU_GCC) && (__GNUC__ < 12)) || (defined(SQLITE_ORM_MS_MSVC) && _MSC_VER < 1930)
             SKIP("GCC < 12 cannot use this function pointer as NTTP in this test.");
 #else
             constexpr auto quotedScalar =

--- a/tests/user_defined_functions.cpp
+++ b/tests/user_defined_functions.cpp
@@ -569,7 +569,7 @@ TEST_CASE("generalized scalar udf") {
     storage.sync_schema();
 
     SECTION("freestanding function") {
-#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 12)
+#if (defined(SQLITE_ORM_GNU_GCC) && (__GNUC__ < 12)) || (defined(SQLITE_ORM_MS_MSVC) && _MSC_VER < 1930)
         SKIP("GCC < 12 cannot use this function as NTTP in quoted scalar tests.");
 #else
         constexpr auto err_fatal_error_f = "ERR_FATAL_ERROR"_scalar.quote(ERR_FATAL_ERROR);
@@ -583,6 +583,9 @@ TEST_CASE("generalized scalar udf") {
 #endif
     }
     SECTION("stateless lambda") {
+#if (defined(SQLITE_ORM_MS_MSVC) && _MSC_VER < 1930)
+        SKIP("MSVC < 1930 cannot use this function as NTTP in quoted scalar tests.");
+#else
         constexpr auto is_fatal_error_f = "is_fatal_error"_scalar.quote([](unsigned long errcode) {
             return errcode != 0;
         });
@@ -593,6 +596,7 @@ TEST_CASE("generalized scalar udf") {
             REQUIRE(rows == expected);
         }
         storage.delete_scalar_function<is_fatal_error_f>();
+#endif
     }
 #ifdef SQLITE_ORM_STATIC_CALL_OPERATOR_SUPPORTED
     SECTION("stateless static lambda") {
@@ -609,6 +613,9 @@ TEST_CASE("generalized scalar udf") {
     }
 #endif
     SECTION("function object instance") {
+#if (defined(SQLITE_ORM_MS_MSVC) && _MSC_VER < 1930)
+        SKIP("MSVC < 1930 cannot use this function as NTTP in quoted scalar tests.");
+#else
         constexpr auto equal_to_int_f = "equal_to"_scalar.quote(std::equal_to<int>{});
         storage.create_scalar_function<equal_to_int_f>();
         {
@@ -617,8 +624,12 @@ TEST_CASE("generalized scalar udf") {
             REQUIRE(rows == expected);
         }
         storage.delete_scalar_function<equal_to_int_f>();
+#endif
     }
     SECTION("explicit function object type") {
+#if (defined(SQLITE_ORM_MS_MSVC) && _MSC_VER < 1930)
+        SKIP("MSVC < 1930 cannot use this function as NTTP in quoted scalar tests.");
+#else
         constexpr auto equal_to_int_f = "equal_to"_scalar.quote<std::equal_to<int>>();
         storage.create_scalar_function<equal_to_int_f>();
         {
@@ -627,8 +638,12 @@ TEST_CASE("generalized scalar udf") {
             REQUIRE(rows == expected);
         }
         storage.delete_scalar_function<equal_to_int_f>();
+#endif
     }
     SECTION("'transparent' function object instance") {
+#if (defined(SQLITE_ORM_MS_MSVC) && _MSC_VER < 1930)
+        SKIP("MSVC < 1930 cannot use this function as NTTP in quoted scalar tests.");
+#else
         constexpr auto equal_to_int_f =
             "equal_to"_scalar.quote<bool(const int&, const int&) const>(std::equal_to<void>{});
         storage.create_scalar_function<equal_to_int_f>();
@@ -638,8 +653,12 @@ TEST_CASE("generalized scalar udf") {
             REQUIRE(rows == expected);
         }
         storage.delete_scalar_function<equal_to_int_f>();
+#endif
     }
     SECTION("explicit 'transparent' function object type") {
+#if (defined(SQLITE_ORM_MS_MSVC) && _MSC_VER < 1930)
+        SKIP("MSVC < 1930 cannot use this function as NTTP in quoted scalar tests.");
+#else
         constexpr auto equal_to_int_f =
             "equal_to"_scalar.quote<bool(const int&, const int&) const, std::equal_to<void>>();
         storage.create_scalar_function<equal_to_int_f>();
@@ -649,6 +668,7 @@ TEST_CASE("generalized scalar udf") {
             REQUIRE(rows == expected);
         }
         storage.delete_scalar_function<equal_to_int_f>();
+#endif
     }
 #ifdef SQLITE_ORM_STATIC_CALL_OPERATOR_SUPPORTED
     SECTION("function object instance with static call operator") {
@@ -663,7 +683,7 @@ TEST_CASE("generalized scalar udf") {
     }
 #endif
     SECTION("specialized template function") {
-#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 12)
+#if (defined(SQLITE_ORM_GNU_GCC) && (__GNUC__ < 12)) || (defined(SQLITE_ORM_MS_MSVC) && _MSC_VER < 1930)
         SKIP("GCC < 12 cannot use std::clamp specialization as NTTP.");
 #else
         constexpr auto clamp_int_f = "clamp_int"_scalar.quote(std::clamp<int>);
@@ -677,7 +697,7 @@ TEST_CASE("generalized scalar udf") {
 #endif
     }
     SECTION("overloaded template function") {
-#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 12)
+#if (defined(SQLITE_ORM_GNU_GCC) && (__GNUC__ < 12)) || (defined(SQLITE_ORM_MS_MSVC) && _MSC_VER < 1930)
         SKIP("GCC < 12 cannot use std::clamp overload as NTTP.");
 #else
         constexpr auto clamp_int_f =
@@ -705,6 +725,9 @@ TEST_CASE("generalized scalar udf") {
         storage.delete_scalar_function<(idfunc_f)>();
     }
     SECTION("stateful function object") {
+#if (defined(SQLITE_ORM_MS_MSVC) && _MSC_VER < 1930)
+        SKIP("MSVC < 1930 cannot use this function as NTTP in quoted scalar tests.");
+#else
         constexpr auto offset0_f = "offset0"_scalar.quote(offset0);
         storage.create_scalar_function<offset0_f>();
         {
@@ -713,9 +736,10 @@ TEST_CASE("generalized scalar udf") {
             REQUIRE(rows == expected);
         }
         storage.delete_scalar_function<offset0_f>();
+#endif
     }
     SECTION("escaped function identifier") {
-#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 12)
+#if (defined(SQLITE_ORM_GNU_GCC) && (__GNUC__ < 12)) || (defined(SQLITE_ORM_MS_MSVC) && _MSC_VER < 1930)
         SKIP("GCC < 12 cannot use std::clamp specialization as NTTP.");
 #else
         constexpr auto clamp_f = R"("clamp int")"_scalar.quote(std::clamp<int>);


### PR DESCRIPTION
This PR resolves a few issues found with the MSVC 19.29 (VS 16.11) compiler.

Specifically:
* Doesn't like dependent alias templates in lambdas.
* Has problems with immediate 'consteval' functions without a return type. Note: though immediate functions with a return type work, I decided to simply default to `constexpr` for all immediate functions.
* Has problems to use quoted scalar functions.
* For completeness: Introduced a preprocessor macro when GNU GCC is used as a compiler.
