### PR TITLE
Fix advanced `from` expression

### DIFF
--- a/dev/mapped_type_proxy.h
+++ b/dev/mapped_type_proxy.h
@@ -12,6 +12,7 @@ namespace sqlite_orm::internal {
     /** 
      *  Defines the `type` typename to be:
      *  - The unqualified unwrapped table reference type if T is a table reference.
+     *  - The unqualified unwrapped table-valued expression type if T is a table-valued expression.
      *  - The unqualified aliased type if T is a recordset alias.
      *  - The enclosing data struct for eponymous virtual tables with hidden columns.
      *  - ... otherwise unqualified T.
@@ -26,6 +27,9 @@ namespace sqlite_orm::internal {
 
     template<class R>
     struct mapped_type_proxy<R, match_if<is_table_reference, R>> : R {};
+
+    template<class E>
+    struct mapped_type_proxy<E, match_if<is_table_valued_expression, E>> : E {};
 
     template<class A>
     struct mapped_type_proxy<A, match_if<is_recordset_alias, A>> : std::remove_const<type_t<A>> {};

--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -2412,12 +2412,11 @@ namespace sqlite_orm::internal {
             ss << "FROM ";
             iterate_tuple(from.table_expressions, [&context, &ss, first = true](const auto& tableExpression) mutable {
                 using expression_type = polyfill::remove_cvref_t<decltype(tableExpression)>;
-                using table_type = type_t<expression_type>;
 
                 static constexpr std::array<orm_gsl::czstring, 2> sep = {", ", ""};
                 ss << sep[std::exchange(first, false)]
-                   << streaming_identifier(lookup_table_name<mapped_type_proxy_t<table_type>>(context.db_objects),
-                                           alias_extractor<table_type>::as_alias());
+                   << streaming_identifier(lookup_table_name<mapped_type_proxy_t<expression_type>>(context.db_objects),
+                                           alias_extractor<expression_type>::as_alias());
 
                 if constexpr (is_table_valued_expression_v<expression_type>) {
                     ss << '(' << streaming_expressions_tuple(tableExpression.table_values, context) << ')';

--- a/dev/table_reference.h
+++ b/dev/table_reference.h
@@ -23,7 +23,7 @@ namespace sqlite_orm::internal {
     };
 
     template<class T>
-    inline constexpr bool is_table_valued_expression_v = polyfill::is_specialization_of_v<T, table_valued_expression>;
+    constexpr bool is_table_valued_expression_v = polyfill::is_specialization_of_v<T, table_valued_expression>;
 
     template<class T>
     using is_table_valued_expression = polyfill::bool_constant<is_table_valued_expression_v<T>>;
@@ -33,16 +33,6 @@ namespace sqlite_orm::internal {
      */
     template<class O>
     struct table_reference : polyfill::type_identity<O> {
-#ifdef SQLITE_ORM_CPP20_CONCEPTS_SUPPORTED
-        /** 
-         *  Make a table-valued function call.
-         */
-        template<class... Args>
-        constexpr SQLITE_ORM_STATIC_CALLOP table_valued_expression<O, Args...>
-        operator()(Args... arguments) SQLITE_ORM_OR_CONST_CALLOP {
-            return {{ {std::move(arguments)}... }};
-        }
-#else
         /** 
          *  Make a table-valued function call.
          */
@@ -51,7 +41,6 @@ namespace sqlite_orm::internal {
         operator()(Args... arguments) SQLITE_ORM_OR_CONST_CALLOP {
             return {{{std::move(arguments)}...}};
         }
-#endif
     };
 }
 

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -2415,7 +2415,7 @@ namespace sqlite_orm::internal {
     };
 
     template<class T>
-    inline constexpr bool is_table_valued_expression_v = polyfill::is_specialization_of_v<T, table_valued_expression>;
+    constexpr bool is_table_valued_expression_v = polyfill::is_specialization_of_v<T, table_valued_expression>;
 
     template<class T>
     using is_table_valued_expression = polyfill::bool_constant<is_table_valued_expression_v<T>>;
@@ -2425,25 +2425,14 @@ namespace sqlite_orm::internal {
      */
     template<class O>
     struct table_reference : polyfill::type_identity<O> {
-#ifdef SQLITE_ORM_CPP20_CONCEPTS_SUPPORTED
         /** 
          *  Make a table-valued function call.
          */
         template<class... Args>
         constexpr SQLITE_ORM_STATIC_CALLOP table_valued_expression<O, Args...>
         operator()(Args... arguments) SQLITE_ORM_OR_CONST_CALLOP {
-            return {{ {std::move(arguments)}... }};
+            return {{{std::move(arguments)}...}};
         }
-#else
-        /** 
-         *  Make a table-valued function call.
-         */
-        template<class... Args>
-        constexpr SQLITE_ORM_STATIC_CALLOP table_valued_expression<O, Args...>
-        operator()(Args... arguments) SQLITE_ORM_OR_CONST_CALLOP {
-            return {{ {std::move(arguments)}... }};
-        }
-#endif
     };
 }
 
@@ -11070,6 +11059,7 @@ namespace sqlite_orm::internal {
     /** 
      *  Defines the `type` typename to be:
      *  - The unqualified unwrapped table reference type if T is a table reference.
+     *  - The unqualified unwrapped table-valued expression type if T is a table-valued expression.
      *  - The unqualified aliased type if T is a recordset alias.
      *  - The enclosing data struct for eponymous virtual tables with hidden columns.
      *  - ... otherwise unqualified T.
@@ -11084,6 +11074,9 @@ namespace sqlite_orm::internal {
 
     template<class R>
     struct mapped_type_proxy<R, match_if<is_table_reference, R>> : R {};
+
+    template<class E>
+    struct mapped_type_proxy<E, match_if<is_table_valued_expression, E>> : E {};
 
     template<class A>
     struct mapped_type_proxy<A, match_if<is_recordset_alias, A>> : std::remove_const<type_t<A>> {};
@@ -24448,12 +24441,11 @@ namespace sqlite_orm::internal {
             ss << "FROM ";
             iterate_tuple(from.table_expressions, [&context, &ss, first = true](const auto& tableExpression) mutable {
                 using expression_type = polyfill::remove_cvref_t<decltype(tableExpression)>;
-                using table_type = type_t<expression_type>;
 
                 static constexpr std::array<orm_gsl::czstring, 2> sep = {", ", ""};
                 ss << sep[std::exchange(first, false)]
-                   << streaming_identifier(lookup_table_name<mapped_type_proxy_t<table_type>>(context.db_objects),
-                                           alias_extractor<table_type>::as_alias());
+                   << streaming_identifier(lookup_table_name<mapped_type_proxy_t<expression_type>>(context.db_objects),
+                                           alias_extractor<expression_type>::as_alias());
 
                 if constexpr (is_table_valued_expression_v<expression_type>) {
                     ss << '(' << streaming_expressions_tuple(tableExpression.table_values, context) << ')';

--- a/tests/statement_serializer_tests/select_constraints.cpp
+++ b/tests/statement_serializer_tests/select_constraints.cpp
@@ -71,23 +71,39 @@ TEST_CASE("statement_serializer select constraints") {
             value = serialize(expression, context);
             expected = R"(FROM "users" "u")";
         }
+        SECTION("with multiple") {
+            auto expression = from<User, alias_u<User>>();
+            value = serialize(expression, context);
+            expected = R"(FROM "users", "users" "u")";
+        }
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
         {
+            constexpr auto user = c<User>();
+            constexpr auto u = "u"_alias.for_<User>();
             SECTION("with table reference") {
-                constexpr auto user = c<User>();
                 auto expression = from<user>();
                 value = serialize(expression, context);
                 expected = R"(FROM "users")";
             }
+            SECTION("with table reference 2") {
+                auto expression = from(user);
+                value = serialize(expression, context);
+                expected = R"(FROM "users")";
+            }
             SECTION("with alias 2") {
-                auto expression = from<alias<'u'>.for_<User>()>();
+                auto expression = from<u>();
                 value = serialize(expression, context);
                 expected = R"(FROM "users" "u")";
             }
             SECTION("with alias 3") {
-                auto expression = from<"u"_alias.for_<User>()>();
+                auto expression = from(u);
                 value = serialize(expression, context);
                 expected = R"(FROM "users" "u")";
+            }
+            SECTION("with multiple 2") {
+                auto expression = from(user, u, user());
+                value = serialize(expression, context);
+                expected = R"(FROM "users", "users" "u", "users"())";
             }
         }
 #endif

--- a/tests/static_tests/column_result_t.cpp
+++ b/tests/static_tests/column_result_t.cpp
@@ -181,5 +181,6 @@ TEST_CASE("mapped type proxy") {
 #endif
 #if SQLITE_VERSION_NUMBER >= 3008012
     STATIC_REQUIRE(std::is_same<mapped_type_proxy_t<generate_series::hidden>, generate_series>::value);
+    STATIC_REQUIRE(std::is_same<mapped_type_proxy_t<decltype(generate_series())>, generate_series>::value);
 #endif
 }


### PR DESCRIPTION
PR #1461 introduced a value-based argument form of the explicit `from` expression to facilitate table-valued expression, e.g. `from(dbstat_table("main", true))`, which also accepts table references and table aliases.

However the table alias is missing from the resulting SQL string - this PR corrects this bug so that the following is possible:
```c++
constexpr orm_table_alias auto u = "u"_alias.for_<User>();
// as a template argument
from<u>()
// as well as a value argument:
from(u);
```

Additionally this PR adds serialization tests for multiple tables specified to `from`.