### PR TITLE
Marked constraint+condition factories and related types `constexpr`

### DIFF
--- a/dev/conditions.h
+++ b/dev/conditions.h
@@ -473,13 +473,12 @@ namespace sqlite_orm::internal {
         pattern_t pattern;
         optional_container<escape_t> arg3;  //  not escape cause escape exists as a function here
 
-        like_t(arg_t arg_, pattern_t pattern_, optional_container<escape_t> escape_) :
+        constexpr like_t(arg_t arg_, pattern_t pattern_, optional_container<escape_t> escape_) :
             arg(std::move(arg_)), pattern(std::move(pattern_)), arg3(std::move(escape_)) {}
 
         template<class C>
-        like_t<A, T, C> escape(C c) const {
-            optional_container<C> newArg3{std::move(c)};
-            return {std::move(this->arg), std::move(this->pattern), std::move(newArg3)};
+        constexpr like_t<A, T, C> escape(C c) const {
+            return {std::move(this->arg), std::move(this->pattern), {std::move(c)}};
         }
     };
 
@@ -498,7 +497,7 @@ namespace sqlite_orm::internal {
         arg_t arg;
         pattern_t pattern;
 
-        glob_t(arg_t arg_, pattern_t pattern_) : arg(std::move(arg_)), pattern(std::move(pattern_)) {}
+        constexpr glob_t(arg_t arg_, pattern_t pattern_) : arg(std::move(arg_)), pattern(std::move(pattern_)) {}
     };
 
     /**
@@ -1067,17 +1066,8 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  Example: storage.select(like(&User::name, "T%"))
      */
     template<class A, class T>
-    internal::like_t<A, T, void> like(A a, T t) {
+    constexpr internal::like_t<A, T, void> like(A a, T t) {
         return {std::move(a), std::move(t), {}};
-    }
-
-    /**
-     *  X GLOB Y
-     *  Example: storage.select(glob(&User::name, "*S"))
-     */
-    template<class A, class T>
-    internal::glob_t<A, T> glob(A a, T t) {
-        return {std::move(a), std::move(t)};
     }
 
     /**
@@ -1085,7 +1075,16 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  Example: storage.select(like(&User::name, "T%", "%"))
      */
     template<class A, class T, class E>
-    internal::like_t<A, T, E> like(A a, T t, E e) {
+    constexpr internal::like_t<A, T, E> like(A a, T t, E e) {
         return {std::move(a), std::move(t), {std::move(e)}};
+    }
+
+    /**
+     *  X GLOB Y
+     *  Example: storage.select(glob(&User::name, "*S"))
+     */
+    template<class A, class T>
+    constexpr internal::glob_t<A, T> glob(A a, T t) {
+        return {std::move(a), std::move(t)};
     }
 }

--- a/dev/constraints.h
+++ b/dev/constraints.h
@@ -39,7 +39,7 @@ namespace sqlite_orm::internal {
             order_by asc_option = order_by::unspecified;
             conflict_clause_t conflict_clause = conflict_clause_t::rollback;
             bool conflict_clause_is_on = false;
-        } options;
+        } _options;
     };
 
     template<class T>
@@ -61,19 +61,19 @@ namespace sqlite_orm::internal {
         using order_by = primary_key_base::order_by;
         using columns_tuple = std::tuple<Cs...>;
 
-        columns_tuple columns;
+        columns_tuple _columns;
 
-        constexpr primary_key_t(columns_tuple columns) : columns(std::move(columns)) {}
+        constexpr primary_key_t(columns_tuple columns) : _columns(std::move(columns)) {}
 
         constexpr primary_key_t asc() const {
             auto res = *this;
-            res.options.asc_option = order_by::ascending;
+            res._options.asc_option = order_by::ascending;
             return res;
         }
 
         constexpr primary_key_t desc() const {
             auto res = *this;
-            res.options.asc_option = order_by::descending;
+            res._options.asc_option = order_by::descending;
             return res;
         }
 
@@ -83,36 +83,36 @@ namespace sqlite_orm::internal {
 
         constexpr primary_key_t on_conflict_rollback() const {
             auto res = *this;
-            res.options.conflict_clause_is_on = true;
-            res.options.conflict_clause = conflict_clause_t::rollback;
+            res._options.conflict_clause_is_on = true;
+            res._options.conflict_clause = conflict_clause_t::rollback;
             return res;
         }
 
         constexpr primary_key_t on_conflict_abort() const {
             auto res = *this;
-            res.options.conflict_clause_is_on = true;
-            res.options.conflict_clause = conflict_clause_t::abort;
+            res._options.conflict_clause_is_on = true;
+            res._options.conflict_clause = conflict_clause_t::abort;
             return res;
         }
 
         constexpr primary_key_t on_conflict_fail() const {
             auto res = *this;
-            res.options.conflict_clause_is_on = true;
-            res.options.conflict_clause = conflict_clause_t::fail;
+            res._options.conflict_clause_is_on = true;
+            res._options.conflict_clause = conflict_clause_t::fail;
             return res;
         }
 
         constexpr primary_key_t on_conflict_ignore() const {
             auto res = *this;
-            res.options.conflict_clause_is_on = true;
-            res.options.conflict_clause = conflict_clause_t::ignore;
+            res._options.conflict_clause_is_on = true;
+            res._options.conflict_clause = conflict_clause_t::ignore;
             return res;
         }
 
         constexpr primary_key_t on_conflict_replace() const {
             auto res = *this;
-            res.options.conflict_clause_is_on = true;
-            res.options.conflict_clause = conflict_clause_t::replace;
+            res._options.conflict_clause_is_on = true;
+            res._options.conflict_clause = conflict_clause_t::replace;
             return res;
         }
     };

--- a/dev/constraints.h
+++ b/dev/constraints.h
@@ -46,7 +46,7 @@ namespace sqlite_orm::internal {
     struct primary_key_with_autoincrement : T {
         using primary_key_type = T;
 
-        const primary_key_type& as_base() const {
+        constexpr const primary_key_type& as_base() const {
             return *this;
         }
     };
@@ -132,7 +132,7 @@ namespace sqlite_orm::internal {
 
         columns_tuple columns;
 
-        unique_t(columns_tuple columns_) : columns(std::move(columns_)) {}
+        constexpr unique_t(columns_tuple columns_) : columns(std::move(columns_)) {}
     };
 
     struct unindexed_t {};
@@ -254,12 +254,12 @@ namespace sqlite_orm::internal {
 
         const foreign_key_type& fk;
 
-        on_update_delete_t(decltype(fk) fk_, decltype(update) update_, foreign_key_action action_) :
+        constexpr on_update_delete_t(decltype(fk) fk_, decltype(update) update_, foreign_key_action action_) :
             on_update_delete_base{update_}, fk(fk_), _action(action_) {}
 
         foreign_key_action _action = foreign_key_action::none;
 
-        foreign_key_type no_action() const {
+        constexpr foreign_key_type no_action() const {
             auto res = this->fk;
             if (update) {
                 res.on_update._action = foreign_key_action::no_action;
@@ -269,7 +269,7 @@ namespace sqlite_orm::internal {
             return res;
         }
 
-        foreign_key_type restrict_() const {
+        constexpr foreign_key_type restrict_() const {
             auto res = this->fk;
             if (update) {
                 res.on_update._action = foreign_key_action::restrict_;
@@ -279,7 +279,7 @@ namespace sqlite_orm::internal {
             return res;
         }
 
-        foreign_key_type set_null() const {
+        constexpr foreign_key_type set_null() const {
             auto res = this->fk;
             if (update) {
                 res.on_update._action = foreign_key_action::set_null;
@@ -289,7 +289,7 @@ namespace sqlite_orm::internal {
             return res;
         }
 
-        foreign_key_type set_default() const {
+        constexpr foreign_key_type set_default() const {
             auto res = this->fk;
             if (update) {
                 res.on_update._action = foreign_key_action::set_default;
@@ -299,7 +299,7 @@ namespace sqlite_orm::internal {
             return res;
         }
 
-        foreign_key_type cascade() const {
+        constexpr foreign_key_type cascade() const {
             auto res = this->fk;
             if (update) {
                 res.on_update._action = foreign_key_action::cascade;
@@ -309,7 +309,7 @@ namespace sqlite_orm::internal {
             return res;
         }
 
-        explicit operator bool() const {
+        constexpr explicit operator bool() const {
             return _action != foreign_key_action::none;
         }
     };
@@ -345,11 +345,11 @@ namespace sqlite_orm::internal {
         static_assert(!std::is_same<source_type, void>::value, "All columns must have the same mapped type");
         static_assert(!std::is_same<target_type, void>::value, "All references must have the same mapped type");
 
-        foreign_key_t(columns_type columns_, references_type references_) :
+        constexpr foreign_key_t(columns_type columns_, references_type references_) :
             columns(std::move(columns_)), references(std::move(references_)),
             on_update(*this, true, foreign_key_action::none), on_delete(*this, false, foreign_key_action::none) {}
 
-        foreign_key_t(const foreign_key_t& other) :
+        constexpr foreign_key_t(const foreign_key_t& other) :
             columns(other.columns), references(other.references), on_update(*this, true, other.on_update._action),
             on_delete(*this, false, other.on_delete._action) {}
 
@@ -376,7 +376,7 @@ namespace sqlite_orm::internal {
          *  Specify one or more target fields, which can either be pointers to class members or column pointers.
          */
         template<class... Rs>
-        foreign_key_t<tuple_type, std::tuple<Rs...>> references(Rs... refs) {
+        constexpr foreign_key_t<tuple_type, std::tuple<Rs...>> references(Rs... refs) {
             return {std::move(_columns), {std::forward<Rs>(refs)...}};
         }
 
@@ -385,7 +385,7 @@ namespace sqlite_orm::internal {
          *  specifying the derived class as an explicit template argument.
          */
         template<class O, class... Base, class... F>
-        foreign_key_t<tuple_type, std::tuple<F O::*...>> references(F Base::*... refs) {
+        constexpr foreign_key_t<tuple_type, std::tuple<F O::*...>> references(F Base::*... refs) {
             static_assert(polyfill::conjunction<is_field_of<F Base::*, O>...>::value,
                           "Referenced fields must be from explicitly specified derived class");
             return {std::move(_columns), {refs...}};
@@ -397,7 +397,7 @@ namespace sqlite_orm::internal {
          *  specifying the derived class as an explicit template argument.
          */
         template<orm_table_reference auto table, class... Base, class... F>
-        auto references(F Base::*... refs) {
+        constexpr auto references(F Base::*... refs) {
             return this->references<auto_decay_table_ref_t<table>>(refs...);
         }
 #endif
@@ -447,14 +447,14 @@ namespace sqlite_orm::internal {
 
         expression_type expression;
 
-        generated_always_t(expression_type expression_, bool full, storage_type storage) :
+        constexpr generated_always_t(expression_type expression_, bool full, storage_type storage) :
             basic_generated_always{full, storage}, expression(std::move(expression_)) {}
 
-        generated_always_t<T> virtual_() {
+        constexpr generated_always_t<T> virtual_() {
             return {std::move(this->expression), this->full, storage_type::virtual_};
         }
 
-        generated_always_t<T> stored() {
+        constexpr generated_always_t<T> stored() {
             return {std::move(this->expression), this->full, storage_type::stored};
         }
     };
@@ -560,12 +560,12 @@ namespace sqlite_orm::internal {
 SQLITE_ORM_EXPORT namespace sqlite_orm {
 #if SQLITE_VERSION_NUMBER >= 3031000
     template<class T>
-    internal::generated_always_t<T> generated_always_as(T expression) {
+    constexpr internal::generated_always_t<T> generated_always_as(T expression) {
         return {std::move(expression), true, internal::basic_generated_always::storage_type::not_specified};
     }
 
     template<class T>
-    internal::generated_always_t<T> as(T expression) {
+    constexpr internal::generated_always_t<T> as(T expression) {
         return {std::move(expression), false, internal::basic_generated_always::storage_type::not_specified};
     }
 #endif
@@ -576,7 +576,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  Available since SQLite 3.6.19
      */
     template<class... Cs>
-    internal::foreign_key_intermediate_t<Cs...> foreign_key(Cs... columns) {
+    constexpr internal::foreign_key_intermediate_t<Cs...> foreign_key(Cs... columns) {
         return {{std::forward<Cs>(columns)...}};
     }
 
@@ -586,7 +586,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  Available since SQLite 3.6.19
      */
     template<class O, class... Base, class... F>
-    internal::foreign_key_intermediate_t<F O::*...> foreign_key(F Base::*... columns) {
+    constexpr internal::foreign_key_intermediate_t<F O::*...> foreign_key(F Base::*... columns) {
         static_assert(polyfill::conjunction<internal::is_field_of<F Base::*, O>...>::value,
                       "Fields must be from explicitly specified derived class");
         return {{columns...}};
@@ -599,7 +599,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  Available since SQLite 3.6.19
      */
     template<orm_table_reference auto table, class... Base, class... F>
-    auto foreign_key(F Base::*... columns) {
+    constexpr auto foreign_key(F Base::*... columns) {
         return foreign_key<internal::auto_decay_table_ref_t<table>>(columns...);
     }
 #endif
@@ -609,14 +609,14 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  UNIQUE table constraint builder function.
      */
     template<class... Args>
-    internal::unique_t<Args...> unique(Args... args) {
+    constexpr internal::unique_t<Args...> unique(Args... args) {
         return {{std::forward<Args>(args)...}};
     }
 
     /**
      *  UNIQUE column constraint builder function.
      */
-    inline internal::unique_t<> unique() {
+    inline constexpr internal::unique_t<> unique() {
         return {{}};
     }
 
@@ -626,7 +626,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  
      *  https://www.sqlite.org/fts5.html#the_unindexed_column_option
      */
-    inline internal::unindexed_t unindexed() {
+    inline constexpr internal::unindexed_t unindexed() {
         return {};
     }
 
@@ -636,7 +636,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  https://www.sqlite.org/fts5.html#prefix_indexes
      */
     template<class T>
-    internal::prefix_t<T> prefix(T value) {
+    constexpr internal::prefix_t<T> prefix(T value) {
         return {std::move(value)};
     }
 
@@ -646,7 +646,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  https://www.sqlite.org/fts5.html#tokenizers
      */
     template<class T>
-    internal::tokenize_t<T> tokenize(T value) {
+    constexpr internal::tokenize_t<T> tokenize(T value) {
         return {std::move(value)};
     }
 
@@ -656,7 +656,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  https://www.sqlite.org/fts5.html#contentless_tables
      */
     template<class T>
-    internal::content_t<T> content(T value) {
+    constexpr internal::content_t<T> content(T value) {
         return {std::move(value)};
     }
 
@@ -666,7 +666,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  https://www.sqlite.org/fts5.html#external_content_tables
      */
     template<class T>
-    internal::table_content_t<T> content() {
+    constexpr internal::table_content_t<T> content() {
         return {};
     }
 
@@ -674,7 +674,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     /** 
      *  Auxiliary virtual table column
      */
-    inline internal::auxiliary_t auxiliary() {
+    constexpr inline internal::auxiliary_t auxiliary() {
         return {};
     }
 #endif
@@ -686,7 +686,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  https://www.sqlite.org/fts5.html#external_content_tables
      */
     template<orm_table_reference auto table>
-    auto content() {
+    constexpr auto content() {
         return content<internal::auto_decay_table_ref_t<table>>();
     }
 #endif
@@ -730,32 +730,32 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     }
 
     template<class T>
-    internal::default_t<T> default_value(T t) {
+    constexpr internal::default_t<T> default_value(T t) {
         return {std::move(t)};
     }
 
-    inline internal::collate_constraint_t collate_nocase() {
+    inline constexpr internal::collate_constraint_t collate_nocase() {
         return {internal::collate_argument::nocase};
     }
 
-    inline internal::collate_constraint_t collate_binary() {
+    inline constexpr internal::collate_constraint_t collate_binary() {
         return {internal::collate_argument::binary};
     }
 
-    inline internal::collate_constraint_t collate_rtrim() {
+    inline constexpr internal::collate_constraint_t collate_rtrim() {
         return {internal::collate_argument::rtrim};
     }
 
     template<class T>
-    internal::check_t<T> check(T t) {
+    constexpr internal::check_t<T> check(T t) {
         return {std::move(t)};
     }
 
-    inline internal::null_t null() {
+    inline constexpr internal::null_t null() {
         return {};
     }
 
-    inline internal::not_null_t not_null() {
+    inline constexpr internal::not_null_t not_null() {
         return {};
     }
 }

--- a/dev/constraints.h
+++ b/dev/constraints.h
@@ -256,6 +256,9 @@ namespace sqlite_orm::internal {
 
         foreign_key_action _action = foreign_key_action::none;
 
+        on_update_delete_t(const on_update_delete_t&) = delete;
+        on_update_delete_t& operator=(const on_update_delete_t&) = delete;
+
         on_update_delete_t(foreign_key_type& fk_, decltype(update) update_, foreign_key_action action_) :
             on_update_delete_base{update_}, fk(fk_), _action(action_) {}
 

--- a/dev/constraints.h
+++ b/dev/constraints.h
@@ -441,8 +441,8 @@ namespace sqlite_orm::internal {
         };
 
 #if SQLITE_VERSION_NUMBER >= 3031000
-        bool full = true;
-        storage_type storage = storage_type::not_specified;
+        bool _full = true;
+        storage_type _storage = storage_type::not_specified;
 #endif
     };
 
@@ -451,17 +451,14 @@ namespace sqlite_orm::internal {
     struct generated_always_t : basic_generated_always {
         using expression_type = T;
 
-        expression_type expression;
+        expression_type _expression;
 
-        constexpr generated_always_t(expression_type expression_, bool full, storage_type storage) :
-            basic_generated_always{full, storage}, expression(std::move(expression_)) {}
-
-        constexpr generated_always_t<T> virtual_() {
-            return {std::move(this->expression), this->full, storage_type::virtual_};
+        constexpr generated_always_t<T> virtual_() && {
+            return {_full, storage_type::virtual_, std::move(_expression)};
         }
 
-        constexpr generated_always_t<T> stored() {
-            return {std::move(this->expression), this->full, storage_type::stored};
+        constexpr generated_always_t<T> stored() && {
+            return {_full, storage_type::stored, std::move(_expression)};
         }
     };
 #endif
@@ -567,12 +564,12 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 #if SQLITE_VERSION_NUMBER >= 3031000
     template<class T>
     constexpr internal::generated_always_t<T> generated_always_as(T expression) {
-        return {std::move(expression), true, internal::basic_generated_always::storage_type::not_specified};
+        return {true, internal::basic_generated_always::storage_type::not_specified, std::move(expression)};
     }
 
     template<class T>
     constexpr internal::generated_always_t<T> as(T expression) {
-        return {std::move(expression), false, internal::basic_generated_always::storage_type::not_specified};
+        return {false, internal::basic_generated_always::storage_type::not_specified, std::move(expression)};
     }
 #endif
 

--- a/dev/constraints.h
+++ b/dev/constraints.h
@@ -46,7 +46,7 @@ namespace sqlite_orm::internal {
     struct primary_key_with_autoincrement : T {
         using primary_key_type = T;
 
-        constexpr const primary_key_type& as_base() const {
+        const primary_key_type& as_base() const {
             return *this;
         }
     };

--- a/dev/constraints.h
+++ b/dev/constraints.h
@@ -334,8 +334,8 @@ namespace sqlite_orm::internal {
          */
         using source_type = same_or_void_t<table_type_of_t<Cs>...>;
 
-        columns_type columns;
-        references_type references;
+        columns_type _columns;
+        references_type _references;
 
         on_update_delete_t<foreign_key_t> on_update;
         on_update_delete_t<foreign_key_t> on_delete;
@@ -345,12 +345,12 @@ namespace sqlite_orm::internal {
         static_assert(!std::is_same<source_type, void>::value, "All columns must have the same mapped type");
         static_assert(!std::is_same<target_type, void>::value, "All references must have the same mapped type");
 
-        foreign_key_t(columns_type columns_, references_type references_) :
-            columns(std::move(columns_)), references(std::move(references_)),
+        foreign_key_t(columns_type columns, references_type references) :
+            _columns(std::move(columns)), _references(std::move(references)),
             on_update(*this, true, foreign_key_action::none), on_delete(*this, false, foreign_key_action::none) {}
 
         foreign_key_t(const foreign_key_t& other) :
-            columns(other.columns), references(other.references), on_update(*this, true, other.on_update._action),
+            _columns(other._columns), _references(other._references), on_update(*this, true, other.on_update._action),
             on_delete(*this, false, other.on_delete._action) {}
 
         foreign_key_t& operator=(const foreign_key_t&) = delete;
@@ -359,8 +359,8 @@ namespace sqlite_orm::internal {
         friend bool operator==(const foreign_key_t& lhs, const foreign_key_t& rhs) = default;
 #else
         friend bool operator==(const foreign_key_t& lhs, const foreign_key_t& rhs) {
-            return lhs.columns == rhs.columns && lhs.references == rhs.references && lhs.on_update == rhs.on_update &&
-                   lhs.on_delete == rhs.on_delete;
+            return lhs._columns == rhs._columns && lhs._references == rhs._references &&
+                   lhs.on_update == rhs.on_update && lhs.on_delete == rhs.on_delete;
         }
 #endif
     };

--- a/dev/constraints.h
+++ b/dev/constraints.h
@@ -6,6 +6,7 @@
 #include <ostream>  //  std::ostream
 #include <string>  //  std::string
 #include <tuple>  //  std::tuple
+#include <functional>  //  std::ref
 #endif
 
 #include "functional/cxx_type_traits_polyfill.h"
@@ -350,11 +351,13 @@ namespace sqlite_orm::internal {
 
         foreign_key_t(columns_type columns, references_type references) :
             _columns(std::move(columns)), _references(std::move(references)),
-            on_update(*this, true, foreign_key_action::none), on_delete(*this, false, foreign_key_action::none) {}
+            on_update(std::ref(*this), true, foreign_key_action::none),
+            on_delete(std::ref(*this), false, foreign_key_action::none) {}
 
         foreign_key_t(const foreign_key_t& other) :
-            _columns(other._columns), _references(other._references), on_update(*this, true, other.on_update._action),
-            on_delete(*this, false, other.on_delete._action) {}
+            _columns(other._columns), _references(other._references),
+            on_update(std::ref(*this), true, other.on_update._action),
+            on_delete(std::ref(*this), false, other.on_delete._action) {}
 
         foreign_key_t& operator=(const foreign_key_t&) = delete;
 

--- a/dev/constraints.h
+++ b/dev/constraints.h
@@ -354,13 +354,16 @@ namespace sqlite_orm::internal {
             on_delete(*this, false, other.on_delete._action) {}
 
         foreign_key_t& operator=(const foreign_key_t&) = delete;
-    };
 
-    template<class A, class B>
-    bool operator==(const foreign_key_t<A, B>& lhs, const foreign_key_t<A, B>& rhs) {
-        return lhs.columns == rhs.columns && lhs.references == rhs.references && lhs.on_update == rhs.on_update &&
-               lhs.on_delete == rhs.on_delete;
-    }
+#ifdef SQLITE_ORM_DEFAULT_COMPARISONS_SUPPORTED
+        friend bool operator==(const foreign_key_t& lhs, const foreign_key_t& rhs) = default;
+#else
+        friend bool operator==(const foreign_key_t& lhs, const foreign_key_t& rhs) {
+            return lhs.columns == rhs.columns && lhs.references == rhs.references && lhs.on_update == rhs.on_update &&
+                   lhs.on_delete == rhs.on_delete;
+        }
+#endif
+    };
 
     /**
      *  Cs can be a class member pointer or column pointer

--- a/dev/constraints.h
+++ b/dev/constraints.h
@@ -578,7 +578,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 
 #if SQLITE_VERSION_NUMBER >= 3006019
     /**
-     *  FOREIGN KEY constraint builder function taking one or more fields, which can either be pointers to class members or column pointers.
+     *  FOREIGN KEY constraint factory function taking one or more fields, which can either be pointers to class members or column pointers.
      *  Available since SQLite 3.6.19
      */
     template<class... Cs>
@@ -587,7 +587,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     }
 
     /**
-     *  FOREIGN KEY constraint builder function taking one or more fields that are member pointers of base classes,
+     *  FOREIGN KEY constraint factory function taking one or more fields that are member pointers of base classes,
      *  specifying the derived class as an explicit template argument.
      *  Available since SQLite 3.6.19
      */
@@ -600,7 +600,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
     /**
-     *  FOREIGN KEY constraint builder function taking one or more fields that are member pointers of base classes,
+     *  FOREIGN KEY constraint factory function taking one or more fields that are member pointers of base classes,
      *  specifying the derived class as an explicit template argument.
      *  Available since SQLite 3.6.19
      */
@@ -612,7 +612,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 #endif
 
     /**
-     *  UNIQUE table constraint builder function.
+     *  UNIQUE table constraint factory function.
      */
     template<class... Args>
     constexpr internal::unique_t<Args...> unique(Args... args) {
@@ -620,24 +620,24 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     }
 
     /**
-     *  UNIQUE column constraint builder function.
+     *  UNIQUE column constraint factory function.
      */
-    inline constexpr internal::unique_t<> unique() {
+    constexpr internal::unique_t<> unique() {
         return {{}};
     }
 
 #if SQLITE_VERSION_NUMBER >= 3009000 || defined(SQLITE_ORM_ENABLE_FTS5)
     /**
-     *  UNINDEXED column constraint builder function. Used in FTS virtual tables.
+     *  UNINDEXED column constraint factory function. Used in FTS virtual tables.
      *  
      *  https://www.sqlite.org/fts5.html#the_unindexed_column_option
      */
-    inline constexpr internal::unindexed_t unindexed() {
+    constexpr internal::unindexed_t unindexed() {
         return {};
     }
 
     /**
-     *  prefix=N table constraint builder function. Used in FTS virtual tables.
+     *  prefix=N table constraint factory function. Used in FTS virtual tables.
      *  
      *  https://www.sqlite.org/fts5.html#prefix_indexes
      */
@@ -647,7 +647,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     }
 
     /**
-     *  tokenize='...'' table constraint builder function. Used in FTS virtual tables.
+     *  tokenize='...'' table constraint factory function. Used in FTS virtual tables.
      *  
      *  https://www.sqlite.org/fts5.html#tokenizers
      */
@@ -657,7 +657,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     }
 
     /**
-     *  content='' table constraint builder function. Used in FTS virtual tables.
+     *  content='' table constraint factory function. Used in FTS virtual tables.
      *  
      *  https://www.sqlite.org/fts5.html#contentless_tables
      */
@@ -667,7 +667,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     }
 
     /**
-     *  content='table' table constraint builder function. Used in FTS virtual tables.
+     *  content='table' table constraint factory function. Used in FTS virtual tables.
      *  
      *  https://www.sqlite.org/fts5.html#external_content_tables
      */
@@ -687,7 +687,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
     /**
-     *  content='table' table constraint builder function. Used in FTS virtual tables.
+     *  content='table' table constraint factory function. Used in FTS virtual tables.
      *  
      *  https://www.sqlite.org/fts5.html#external_content_tables
      */
@@ -699,7 +699,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 #endif
 
     /**
-     *  PRIMARY KEY constraint builder function taking one or more fields, which can either be pointers to class members or column pointers.
+     *  PRIMARY KEY constraint factory function taking one or more fields, which can either be pointers to class members or column pointers.
      */
     template<class... Cs>
     constexpr internal::primary_key_t<Cs...> primary_key(Cs... cs) {
@@ -707,7 +707,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     }
 
     /**
-     *  PRIMARY KEY constraint builder function taking one or more fields that are member pointers of base classes,
+     *  PRIMARY KEY constraint factory function taking one or more fields that are member pointers of base classes,
      *  specifying the derived class as an explicit template argument.
      */
     template<class O, class... Base, class... F>
@@ -719,7 +719,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
     /**
-     *  PRIMARY KEY constraint builder function taking one or more fields that are member pointers of base classes,
+     *  PRIMARY KEY constraint factory function taking one or more fields that are member pointers of base classes,
      *  specifying the derived class as an explicit template argument.
      */
     template<orm_table_reference auto table, class... Base, class... F>
@@ -729,9 +729,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 #endif
 
     /**
-     *  PRIMARY KEY column constraint builder function (used at a single column).
+     *  PRIMARY KEY column constraint factory function (used at a single column).
      */
-    inline constexpr internal::primary_key_t<> primary_key() {
+    constexpr internal::primary_key_t<> primary_key() {
         return {{}};
     }
 
@@ -740,15 +740,15 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
         return {std::move(t)};
     }
 
-    inline constexpr internal::collate_constraint_t collate_nocase() {
+    constexpr internal::collate_constraint_t collate_nocase() {
         return {internal::collate_argument::nocase};
     }
 
-    inline constexpr internal::collate_constraint_t collate_binary() {
+    constexpr internal::collate_constraint_t collate_binary() {
         return {internal::collate_argument::binary};
     }
 
-    inline constexpr internal::collate_constraint_t collate_rtrim() {
+    constexpr internal::collate_constraint_t collate_rtrim() {
         return {internal::collate_argument::rtrim};
     }
 
@@ -757,11 +757,11 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
         return {std::move(t)};
     }
 
-    inline constexpr internal::null_t null() {
+    constexpr internal::null_t null() {
         return {};
     }
 
-    inline constexpr internal::not_null_t not_null() {
+    constexpr internal::not_null_t not_null() {
         return {};
     }
 }

--- a/dev/constraints.h
+++ b/dev/constraints.h
@@ -254,12 +254,12 @@ namespace sqlite_orm::internal {
 
         const foreign_key_type& fk;
 
-        constexpr on_update_delete_t(decltype(fk) fk_, decltype(update) update_, foreign_key_action action_) :
-            on_update_delete_base{update_}, fk(fk_), _action(action_) {}
-
         foreign_key_action _action = foreign_key_action::none;
 
-        constexpr foreign_key_type no_action() const {
+        on_update_delete_t(foreign_key_type& fk_, decltype(update) update_, foreign_key_action action_) :
+            on_update_delete_base{update_}, fk(fk_), _action(action_) {}
+
+        foreign_key_type no_action() const {
             auto res = this->fk;
             if (update) {
                 res.on_update._action = foreign_key_action::no_action;
@@ -269,7 +269,7 @@ namespace sqlite_orm::internal {
             return res;
         }
 
-        constexpr foreign_key_type restrict_() const {
+        foreign_key_type restrict_() const {
             auto res = this->fk;
             if (update) {
                 res.on_update._action = foreign_key_action::restrict_;
@@ -279,7 +279,7 @@ namespace sqlite_orm::internal {
             return res;
         }
 
-        constexpr foreign_key_type set_null() const {
+        foreign_key_type set_null() const {
             auto res = this->fk;
             if (update) {
                 res.on_update._action = foreign_key_action::set_null;
@@ -289,7 +289,7 @@ namespace sqlite_orm::internal {
             return res;
         }
 
-        constexpr foreign_key_type set_default() const {
+        foreign_key_type set_default() const {
             auto res = this->fk;
             if (update) {
                 res.on_update._action = foreign_key_action::set_default;
@@ -299,7 +299,7 @@ namespace sqlite_orm::internal {
             return res;
         }
 
-        constexpr foreign_key_type cascade() const {
+        foreign_key_type cascade() const {
             auto res = this->fk;
             if (update) {
                 res.on_update._action = foreign_key_action::cascade;
@@ -309,7 +309,7 @@ namespace sqlite_orm::internal {
             return res;
         }
 
-        constexpr explicit operator bool() const {
+        explicit operator bool() const {
             return _action != foreign_key_action::none;
         }
     };
@@ -345,11 +345,11 @@ namespace sqlite_orm::internal {
         static_assert(!std::is_same<source_type, void>::value, "All columns must have the same mapped type");
         static_assert(!std::is_same<target_type, void>::value, "All references must have the same mapped type");
 
-        constexpr foreign_key_t(columns_type columns_, references_type references_) :
+        foreign_key_t(columns_type columns_, references_type references_) :
             columns(std::move(columns_)), references(std::move(references_)),
             on_update(*this, true, foreign_key_action::none), on_delete(*this, false, foreign_key_action::none) {}
 
-        constexpr foreign_key_t(const foreign_key_t& other) :
+        foreign_key_t(const foreign_key_t& other) :
             columns(other.columns), references(other.references), on_update(*this, true, other.on_update._action),
             on_delete(*this, false, other.on_delete._action) {}
 
@@ -379,7 +379,7 @@ namespace sqlite_orm::internal {
          *  Specify one or more target fields, which can either be pointers to class members or column pointers.
          */
         template<class... Rs>
-        constexpr foreign_key_t<tuple_type, std::tuple<Rs...>> references(Rs... refs) {
+        foreign_key_t<tuple_type, std::tuple<Rs...>> references(Rs... refs) {
             return {std::move(_columns), {std::forward<Rs>(refs)...}};
         }
 
@@ -388,7 +388,7 @@ namespace sqlite_orm::internal {
          *  specifying the derived class as an explicit template argument.
          */
         template<class O, class... Base, class... F>
-        constexpr foreign_key_t<tuple_type, std::tuple<F O::*...>> references(F Base::*... refs) {
+        foreign_key_t<tuple_type, std::tuple<F O::*...>> references(F Base::*... refs) {
             static_assert(polyfill::conjunction<is_field_of<F Base::*, O>...>::value,
                           "Referenced fields must be from explicitly specified derived class");
             return {std::move(_columns), {refs...}};
@@ -400,7 +400,7 @@ namespace sqlite_orm::internal {
          *  specifying the derived class as an explicit template argument.
          */
         template<orm_table_reference auto table, class... Base, class... F>
-        constexpr auto references(F Base::*... refs) {
+        auto references(F Base::*... refs) {
             return this->references<auto_decay_table_ref_t<table>>(refs...);
         }
 #endif

--- a/dev/constraints.h
+++ b/dev/constraints.h
@@ -680,7 +680,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     /** 
      *  Auxiliary virtual table column
      */
-    constexpr inline internal::auxiliary_t auxiliary() {
+    constexpr internal::auxiliary_t auxiliary() {
         return {};
     }
 #endif

--- a/dev/core_functions.h
+++ b/dev/core_functions.h
@@ -42,7 +42,7 @@ namespace sqlite_orm::internal {
 
         args_type args;
 
-        built_in_function_t(args_type&& args_) : args(std::move(args_)) {}
+        constexpr built_in_function_t(args_type&& args_) : args(std::move(args_)) {}
     };
 
     template<class T>
@@ -655,7 +655,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::acos(&Triangle::cornerA));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::acos_string, X> acos(X x) {
+    constexpr internal::built_in_function_t<double, internal::acos_string, X> acos(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -671,7 +671,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::acos<std::optional<double>>(&Triangle::cornerA));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::acos_string, X> acos(X x) {
+    constexpr internal::built_in_function_t<R, internal::acos_string, X> acos(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -683,7 +683,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::acosh(&Triangle::cornerA));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::acosh_string, X> acosh(X x) {
+    constexpr internal::built_in_function_t<double, internal::acosh_string, X> acosh(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -699,7 +699,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::acosh<std::optional<double>>(&Triangle::cornerA));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::acosh_string, X> acosh(X x) {
+    constexpr internal::built_in_function_t<R, internal::acosh_string, X> acosh(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -711,7 +711,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::asin(&Triangle::cornerA));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::asin_string, X> asin(X x) {
+    constexpr internal::built_in_function_t<double, internal::asin_string, X> asin(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -727,7 +727,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::asin<std::optional<double>>(&Triangle::cornerA));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::asin_string, X> asin(X x) {
+    constexpr internal::built_in_function_t<R, internal::asin_string, X> asin(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -739,7 +739,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::asinh(&Triangle::cornerA));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::asinh_string, X> asinh(X x) {
+    constexpr internal::built_in_function_t<double, internal::asinh_string, X> asinh(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -755,7 +755,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::asinh<std::optional<double>>(&Triangle::cornerA));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::asinh_string, X> asinh(X x) {
+    constexpr internal::built_in_function_t<R, internal::asinh_string, X> asinh(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -767,7 +767,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::atan(1));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::atan_string, X> atan(X x) {
+    constexpr internal::built_in_function_t<double, internal::atan_string, X> atan(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -783,7 +783,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::atan<std::optional<double>>(1));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::atan_string, X> atan(X x) {
+    constexpr internal::built_in_function_t<R, internal::atan_string, X> atan(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -795,7 +795,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::atan2(1, 3));   //  decltype(rows) is std::vector<double>
      */
     template<class X, class Y>
-    internal::built_in_function_t<double, internal::atan2_string, X, Y> atan2(X x, Y y) {
+    constexpr internal::built_in_function_t<double, internal::atan2_string, X, Y> atan2(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
@@ -811,7 +811,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::atan2<std::optional<double>>(1, 3));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X, class Y>
-    internal::built_in_function_t<R, internal::atan2_string, X, Y> atan2(X x, Y y) {
+    constexpr internal::built_in_function_t<R, internal::atan2_string, X, Y> atan2(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
@@ -823,7 +823,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::atanh(1));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::atanh_string, X> atanh(X x) {
+    constexpr internal::built_in_function_t<double, internal::atanh_string, X> atanh(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -839,7 +839,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::atanh<std::optional<double>>(1));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::atanh_string, X> atanh(X x) {
+    constexpr internal::built_in_function_t<R, internal::atanh_string, X> atanh(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -851,7 +851,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::ceil(&User::rating));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::ceil_string, X> ceil(X x) {
+    constexpr internal::built_in_function_t<double, internal::ceil_string, X> ceil(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -867,7 +867,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::ceil<std::optional<double>>(&User::rating));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::ceil_string, X> ceil(X x) {
+    constexpr internal::built_in_function_t<R, internal::ceil_string, X> ceil(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -879,7 +879,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::ceiling(&User::rating));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::ceiling_string, X> ceiling(X x) {
+    constexpr internal::built_in_function_t<double, internal::ceiling_string, X> ceiling(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -895,7 +895,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::ceiling<std::optional<double>>(&User::rating));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::ceiling_string, X> ceiling(X x) {
+    constexpr internal::built_in_function_t<R, internal::ceiling_string, X> ceiling(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -907,7 +907,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::cos(&Triangle::cornerB));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::cos_string, X> cos(X x) {
+    constexpr internal::built_in_function_t<double, internal::cos_string, X> cos(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -923,7 +923,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::cos<std::optional<double>>(&User::rating));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::cos_string, X> cos(X x) {
+    constexpr internal::built_in_function_t<R, internal::cos_string, X> cos(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -935,7 +935,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::cosh(&Triangle::cornerB));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::cosh_string, X> cosh(X x) {
+    constexpr internal::built_in_function_t<double, internal::cosh_string, X> cosh(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -951,7 +951,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::cosh<std::optional<double>>(&User::rating));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::cosh_string, X> cosh(X x) {
+    constexpr internal::built_in_function_t<R, internal::cosh_string, X> cosh(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -963,7 +963,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::degrees(&Triangle::cornerB));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::degrees_string, X> degrees(X x) {
+    constexpr internal::built_in_function_t<double, internal::degrees_string, X> degrees(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -979,7 +979,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::degrees<std::optional<double>>(&User::rating));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::degrees_string, X> degrees(X x) {
+    constexpr internal::built_in_function_t<R, internal::degrees_string, X> degrees(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -991,7 +991,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::exp(&Triangle::cornerB));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::exp_string, X> exp(X x) {
+    constexpr internal::built_in_function_t<double, internal::exp_string, X> exp(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1007,7 +1007,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::exp<std::optional<double>>(&User::rating));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::exp_string, X> exp(X x) {
+    constexpr internal::built_in_function_t<R, internal::exp_string, X> exp(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1019,7 +1019,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::floor(&User::rating));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::floor_string, X> floor(X x) {
+    constexpr internal::built_in_function_t<double, internal::floor_string, X> floor(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1035,7 +1035,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::floor<std::optional<double>>(&User::rating));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::floor_string, X> floor(X x) {
+    constexpr internal::built_in_function_t<R, internal::floor_string, X> floor(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1047,7 +1047,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::ln(200));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::ln_string, X> ln(X x) {
+    constexpr internal::built_in_function_t<double, internal::ln_string, X> ln(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1063,7 +1063,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::ln<std::optional<double>>(200));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::ln_string, X> ln(X x) {
+    constexpr internal::built_in_function_t<R, internal::ln_string, X> ln(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1075,7 +1075,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::log(100));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::log_string, X> log(X x) {
+    constexpr internal::built_in_function_t<double, internal::log_string, X> log(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1091,7 +1091,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::log<std::optional<double>>(100));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::log_string, X> log(X x) {
+    constexpr internal::built_in_function_t<R, internal::log_string, X> log(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1103,7 +1103,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::log10(100));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::log10_string, X> log10(X x) {
+    constexpr internal::built_in_function_t<double, internal::log10_string, X> log10(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1119,7 +1119,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::log10<std::optional<double>>(100));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::log10_string, X> log10(X x) {
+    constexpr internal::built_in_function_t<R, internal::log10_string, X> log10(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1131,7 +1131,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::log(10, 100));   //  decltype(rows) is std::vector<double>
      */
     template<class B, class X>
-    internal::built_in_function_t<double, internal::log_string, B, X> log(B b, X x) {
+    constexpr internal::built_in_function_t<double, internal::log_string, B, X> log(B b, X x) {
         return {std::tuple<B, X>{std::forward<B>(b), std::forward<X>(x)}};
     }
 
@@ -1147,7 +1147,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::log<std::optional<double>>(10, 100));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class B, class X>
-    internal::built_in_function_t<R, internal::log_string, B, X> log(B b, X x) {
+    constexpr internal::built_in_function_t<R, internal::log_string, B, X> log(B b, X x) {
         return {std::tuple<B, X>{std::forward<B>(b), std::forward<X>(x)}};
     }
 
@@ -1159,7 +1159,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::log2(64));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::log2_string, X> log2(X x) {
+    constexpr internal::built_in_function_t<double, internal::log2_string, X> log2(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1175,7 +1175,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::log2<std::optional<double>>(64));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::log2_string, X> log2(X x) {
+    constexpr internal::built_in_function_t<R, internal::log2_string, X> log2(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1187,7 +1187,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::mod_f(6, 5));   //  decltype(rows) is std::vector<double>
      */
     template<class X, class Y>
-    internal::built_in_function_t<double, internal::mod_string, X, Y> mod_f(X x, Y y) {
+    constexpr internal::built_in_function_t<double, internal::mod_string, X, Y> mod_f(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
@@ -1203,7 +1203,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::mod_f<std::optional<double>>(6, 5));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X, class Y>
-    internal::built_in_function_t<R, internal::mod_string, X, Y> mod_f(X x, Y y) {
+    constexpr internal::built_in_function_t<R, internal::mod_string, X, Y> mod_f(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
@@ -1214,7 +1214,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *
      *  auto rows = storage.select(sqlite_orm::pi());   //  decltype(rows) is std::vector<double>
      */
-    inline internal::built_in_function_t<double, internal::pi_string> pi() {
+    constexpr internal::built_in_function_t<double, internal::pi_string> pi() {
         return {{}};
     }
 
@@ -1230,7 +1230,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::pi<float>());   //  decltype(rows) is std::vector<float>
      */
     template<class R>
-    internal::built_in_function_t<R, internal::pi_string> pi() {
+    constexpr internal::built_in_function_t<R, internal::pi_string> pi() {
         return {{}};
     }
 
@@ -1242,7 +1242,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::pow(2, 5));   //  decltype(rows) is std::vector<double>
      */
     template<class X, class Y>
-    internal::built_in_function_t<double, internal::pow_string, X, Y> pow(X x, Y y) {
+    constexpr internal::built_in_function_t<double, internal::pow_string, X, Y> pow(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
@@ -1258,7 +1258,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::pow<std::optional<double>>(2, 5));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X, class Y>
-    internal::built_in_function_t<R, internal::pow_string, X, Y> pow(X x, Y y) {
+    constexpr internal::built_in_function_t<R, internal::pow_string, X, Y> pow(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
@@ -1270,7 +1270,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::power(2, 5));   //  decltype(rows) is std::vector<double>
      */
     template<class X, class Y>
-    internal::built_in_function_t<double, internal::power_string, X, Y> power(X x, Y y) {
+    constexpr internal::built_in_function_t<double, internal::power_string, X, Y> power(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
@@ -1286,7 +1286,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::power<std::optional<double>>(2, 5));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X, class Y>
-    internal::built_in_function_t<R, internal::power_string, X, Y> power(X x, Y y) {
+    constexpr internal::built_in_function_t<R, internal::power_string, X, Y> power(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
@@ -1298,7 +1298,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::radians(&Triangle::cornerAInDegrees));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::radians_string, X> radians(X x) {
+    constexpr internal::built_in_function_t<double, internal::radians_string, X> radians(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1314,7 +1314,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::radians<std::optional<double>>(&Triangle::cornerAInDegrees));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::radians_string, X> radians(X x) {
+    constexpr internal::built_in_function_t<R, internal::radians_string, X> radians(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1326,7 +1326,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::sin(&Triangle::cornerA));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::sin_string, X> sin(X x) {
+    constexpr internal::built_in_function_t<double, internal::sin_string, X> sin(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1342,7 +1342,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::sin<std::optional<double>>(&Triangle::cornerA));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::sin_string, X> sin(X x) {
+    constexpr internal::built_in_function_t<R, internal::sin_string, X> sin(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1354,7 +1354,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::sinh(&Triangle::cornerA));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::sinh_string, X> sinh(X x) {
+    constexpr internal::built_in_function_t<double, internal::sinh_string, X> sinh(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1370,7 +1370,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::sinh<std::optional<double>>(&Triangle::cornerA));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::sinh_string, X> sinh(X x) {
+    constexpr internal::built_in_function_t<R, internal::sinh_string, X> sinh(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1382,7 +1382,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::sqrt(25));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::sqrt_string, X> sqrt(X x) {
+    constexpr internal::built_in_function_t<double, internal::sqrt_string, X> sqrt(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1398,7 +1398,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::sqrt<int>(25));   //  decltype(rows) is std::vector<int>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::sqrt_string, X> sqrt(X x) {
+    constexpr internal::built_in_function_t<R, internal::sqrt_string, X> sqrt(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1410,7 +1410,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::tan(&Triangle::cornerC));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::tan_string, X> tan(X x) {
+    constexpr internal::built_in_function_t<double, internal::tan_string, X> tan(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1426,7 +1426,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::tan<float>(&Triangle::cornerC));   //  decltype(rows) is std::vector<float>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::tan_string, X> tan(X x) {
+    constexpr internal::built_in_function_t<R, internal::tan_string, X> tan(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1438,7 +1438,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::tanh(&Triangle::cornerC));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::tanh_string, X> tanh(X x) {
+    constexpr internal::built_in_function_t<double, internal::tanh_string, X> tanh(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1454,7 +1454,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::tanh<float>(&Triangle::cornerC));   //  decltype(rows) is std::vector<float>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::tanh_string, X> tanh(X x) {
+    constexpr internal::built_in_function_t<R, internal::tanh_string, X> tanh(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1466,7 +1466,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::trunc(5.5));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::trunc_string, X> trunc(X x) {
+    constexpr internal::built_in_function_t<double, internal::trunc_string, X> trunc(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1482,15 +1482,16 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::trunc<float>(5.5));   //  decltype(rows) is std::vector<float>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::trunc_string, X> trunc(X x) {
+    constexpr internal::built_in_function_t<R, internal::trunc_string, X> trunc(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 #endif  //  SQLITE_ENABLE_MATH_FUNCTIONS
+
     /**
      *  TYPEOF(x) function https://sqlite.org/lang_corefunc.html#typeof
      */
     template<class T>
-    internal::built_in_function_t<std::string, internal::typeof_string, T> typeof_(T t) {
+    constexpr internal::built_in_function_t<std::string, internal::typeof_string, T> typeof_(T t) {
         return {std::tuple<T>{std::forward<T>(t)}};
     }
 
@@ -1498,7 +1499,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  UNICODE(x) function https://sqlite.org/lang_corefunc.html#unicode
      */
     template<class T>
-    internal::built_in_function_t<int, internal::unicode_string, T> unicode(T t) {
+    constexpr internal::built_in_function_t<int, internal::unicode_string, T> unicode(T t) {
         return {std::tuple<T>{std::forward<T>(t)}};
     }
 
@@ -1506,7 +1507,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  LENGTH(x) function https://sqlite.org/lang_corefunc.html#length
      */
     template<class T>
-    internal::built_in_function_t<int, internal::length_string, T> length(T t) {
+    constexpr internal::built_in_function_t<int, internal::length_string, T> length(T t) {
         return {std::tuple<T>{std::forward<T>(t)}};
     }
 
@@ -1514,7 +1515,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  ABS(x) function https://sqlite.org/lang_corefunc.html#abs
      */
     template<class T>
-    internal::built_in_function_t<std::unique_ptr<double>, internal::abs_string, T> abs(T t) {
+    constexpr internal::built_in_function_t<std::unique_ptr<double>, internal::abs_string, T> abs(T t) {
         return {std::tuple<T>{std::forward<T>(t)}};
     }
 
@@ -1522,7 +1523,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  LOWER(x) function https://sqlite.org/lang_corefunc.html#lower
      */
     template<class T>
-    internal::built_in_function_t<std::string, internal::lower_string, T> lower(T t) {
+    constexpr internal::built_in_function_t<std::string, internal::lower_string, T> lower(T t) {
         return {std::tuple<T>{std::forward<T>(t)}};
     }
 
@@ -1530,28 +1531,28 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  UPPER(x) function https://sqlite.org/lang_corefunc.html#upper
      */
     template<class T>
-    internal::built_in_function_t<std::string, internal::upper_string, T> upper(T t) {
+    constexpr internal::built_in_function_t<std::string, internal::upper_string, T> upper(T t) {
         return {std::tuple<T>{std::forward<T>(t)}};
     }
 
     /**
      *  LAST_INSERT_ROWID(x) function https://www.sqlite.org/lang_corefunc.html#last_insert_rowid
      */
-    inline internal::built_in_function_t<int64, internal::last_insert_rowid_string> last_insert_rowid() {
+    constexpr internal::built_in_function_t<int64, internal::last_insert_rowid_string> last_insert_rowid() {
         return {{}};
     }
 
     /**
      *  TOTAL_CHANGES() function https://sqlite.org/lang_corefunc.html#total_changes
      */
-    inline internal::built_in_function_t<int, internal::total_changes_string> total_changes() {
+    constexpr internal::built_in_function_t<int, internal::total_changes_string> total_changes() {
         return {{}};
     }
 
     /**
      *  CHANGES() function https://sqlite.org/lang_corefunc.html#changes
      */
-    inline internal::built_in_function_t<int, internal::changes_string> changes() {
+    constexpr internal::built_in_function_t<int, internal::changes_string> changes() {
         return {{}};
     }
 
@@ -1559,7 +1560,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  TRIM(X) function https://sqlite.org/lang_corefunc.html#trim
      */
     template<class T>
-    internal::built_in_function_t<std::string, internal::trim_string, T> trim(T t) {
+    constexpr internal::built_in_function_t<std::string, internal::trim_string, T> trim(T t) {
         return {std::tuple<T>{std::forward<T>(t)}};
     }
 
@@ -1567,7 +1568,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  TRIM(X,Y) function https://sqlite.org/lang_corefunc.html#trim
      */
     template<class X, class Y>
-    internal::built_in_function_t<std::string, internal::trim_string, X, Y> trim(X x, Y y) {
+    constexpr internal::built_in_function_t<std::string, internal::trim_string, X, Y> trim(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
@@ -1575,7 +1576,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  LTRIM(X) function https://sqlite.org/lang_corefunc.html#ltrim
      */
     template<class X>
-    internal::built_in_function_t<std::string, internal::ltrim_string, X> ltrim(X x) {
+    constexpr internal::built_in_function_t<std::string, internal::ltrim_string, X> ltrim(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1583,7 +1584,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  LTRIM(X,Y) function https://sqlite.org/lang_corefunc.html#ltrim
      */
     template<class X, class Y>
-    internal::built_in_function_t<std::string, internal::ltrim_string, X, Y> ltrim(X x, Y y) {
+    constexpr internal::built_in_function_t<std::string, internal::ltrim_string, X, Y> ltrim(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
@@ -1591,7 +1592,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  RTRIM(X) function https://sqlite.org/lang_corefunc.html#rtrim
      */
     template<class X>
-    internal::built_in_function_t<std::string, internal::rtrim_string, X> rtrim(X x) {
+    constexpr internal::built_in_function_t<std::string, internal::rtrim_string, X> rtrim(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1599,7 +1600,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  RTRIM(X,Y) function https://sqlite.org/lang_corefunc.html#rtrim
      */
     template<class X, class Y>
-    internal::built_in_function_t<std::string, internal::rtrim_string, X, Y> rtrim(X x, Y y) {
+    constexpr internal::built_in_function_t<std::string, internal::rtrim_string, X, Y> rtrim(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
@@ -1607,7 +1608,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  HEX(X) function https://sqlite.org/lang_corefunc.html#hex
      */
     template<class X>
-    internal::built_in_function_t<std::string, internal::hex_string, X> hex(X x) {
+    constexpr internal::built_in_function_t<std::string, internal::hex_string, X> hex(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1615,7 +1616,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  QUOTE(X) function https://sqlite.org/lang_corefunc.html#quote
      */
     template<class X>
-    internal::built_in_function_t<std::string, internal::quote_string, X> quote(X x) {
+    constexpr internal::built_in_function_t<std::string, internal::quote_string, X> quote(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1623,7 +1624,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  RANDOMBLOB(X) function https://sqlite.org/lang_corefunc.html#randomblob
      */
     template<class X>
-    internal::built_in_function_t<std::vector<char>, internal::randomblob_string, X> randomblob(X x) {
+    constexpr internal::built_in_function_t<std::vector<char>, internal::randomblob_string, X> randomblob(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1631,7 +1632,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  INSTR(X) function https://sqlite.org/lang_corefunc.html#instr
      */
     template<class X, class Y>
-    internal::built_in_function_t<int, internal::instr_string, X, Y> instr(X x, Y y) {
+    constexpr internal::built_in_function_t<int, internal::instr_string, X, Y> instr(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
@@ -1642,7 +1643,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
              class Y,
              class Z,
              std::enable_if_t<internal::count_tuple<std::tuple<X, Y, Z>, internal::is_into>::value == 0, bool> = true>
-    internal::built_in_function_t<std::string, internal::replace_string, X, Y, Z> replace(X x, Y y, Z z) {
+    constexpr internal::built_in_function_t<std::string, internal::replace_string, X, Y, Z> replace(X x, Y y, Z z) {
         return {std::tuple<X, Y, Z>{std::forward<X>(x), std::forward<Y>(y), std::forward<Z>(z)}};
     }
 
@@ -1650,7 +1651,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  ROUND(X) function https://sqlite.org/lang_corefunc.html#round
      */
     template<class X>
-    internal::built_in_function_t<double, internal::round_string, X> round(X x) {
+    constexpr internal::built_in_function_t<double, internal::round_string, X> round(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1658,7 +1659,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  ROUND(X, Y) function https://sqlite.org/lang_corefunc.html#round
      */
     template<class X, class Y>
-    internal::built_in_function_t<double, internal::round_string, X, Y> round(X x, Y y) {
+    constexpr internal::built_in_function_t<double, internal::round_string, X, Y> round(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
@@ -1667,14 +1668,14 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  CHAR(X1,X2,...,XN) function https://sqlite.org/lang_corefunc.html#char
      */
     template<class... Args>
-    internal::built_in_function_t<std::string, internal::char_string, Args...> char_(Args... args) {
+    constexpr internal::built_in_function_t<std::string, internal::char_string, Args...> char_(Args... args) {
         return {std::make_tuple(std::forward<Args>(args)...)};
     }
 
     /**
      *  RANDOM() function https://www.sqlite.org/lang_corefunc.html#random
      */
-    inline internal::built_in_function_t<int, internal::random_string> random() {
+    constexpr internal::built_in_function_t<int, internal::random_string> random() {
         return {{}};
     }
 #endif
@@ -1683,7 +1684,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  COALESCE(X,Y,...) function https://www.sqlite.org/lang_corefunc.html#coalesce
      */
     template<class R = void, class... Args>
-    auto coalesce(Args... args)
+    constexpr auto coalesce(Args... args)
         -> internal::built_in_function_t<typename mpl::conditional_t<  //  choose R or common type
                                              std::is_void<R>::value,
                                              std::common_type<internal::field_type_or_type_t<Args>...>,
@@ -1697,7 +1698,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  IFNULL(X,Y) function https://www.sqlite.org/lang_corefunc.html#ifnull
      */
     template<class R = void, class X, class Y>
-    auto ifnull(X x, Y y) -> internal::built_in_function_t<
+    constexpr auto ifnull(X x, Y y) -> internal::built_in_function_t<
         typename mpl::conditional_t<  //  choose R or common type
             std::is_void<R>::value,
             std::common_type<internal::field_type_or_type_t<X>, internal::field_type_or_type_t<Y>>,
@@ -1723,7 +1724,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
                                                                             internal::field_type_or_type_t<X>,
                                                                             internal::field_type_or_type_t<Y>>>,
                               bool> = true>
-    auto nullif(X x, Y y) {
+    constexpr auto nullif(X x, Y y) {
         if constexpr (std::is_void<R>::value) {
             using F = internal::built_in_function_t<
                 std::optional<std::common_type_t<internal::field_type_or_type_t<X>, internal::field_type_or_type_t<Y>>>,
@@ -1740,7 +1741,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     }
 #else
     template<class R, class X, class Y>
-    internal::built_in_function_t<R, internal::nullif_string, X, Y> nullif(X x, Y y) {
+    constexpr internal::built_in_function_t<R, internal::nullif_string, X, Y> nullif(X x, Y y) {
         return {std::make_tuple(std::move(x), std::move(y))};
     }
 #endif
@@ -1749,7 +1750,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  DATE(timestring, modifier, modifier, ...) function https://www.sqlite.org/lang_datefunc.html
      */
     template<class... Args>
-    internal::built_in_function_t<std::string, internal::date_string, Args...> date(Args... args) {
+    constexpr internal::built_in_function_t<std::string, internal::date_string, Args...> date(Args... args) {
         return {std::tuple<Args...>{std::forward<Args>(args)...}};
     }
 
@@ -1757,7 +1758,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  TIME(timestring, modifier, modifier, ...) function https://www.sqlite.org/lang_datefunc.html
      */
     template<class... Args>
-    internal::built_in_function_t<std::string, internal::time_string, Args...> time(Args... args) {
+    constexpr internal::built_in_function_t<std::string, internal::time_string, Args...> time(Args... args) {
         return {std::tuple<Args...>{std::forward<Args>(args)...}};
     }
 
@@ -1765,7 +1766,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  DATETIME(timestring, modifier, modifier, ...) function https://www.sqlite.org/lang_datefunc.html
      */
     template<class... Args>
-    internal::built_in_function_t<std::string, internal::datetime_string, Args...> datetime(Args... args) {
+    constexpr internal::built_in_function_t<std::string, internal::datetime_string, Args...> datetime(Args... args) {
         return {std::tuple<Args...>{std::forward<Args>(args)...}};
     }
 
@@ -1773,7 +1774,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  JULIANDAY(timestring, modifier, modifier, ...) function https://www.sqlite.org/lang_datefunc.html
      */
     template<class... Args>
-    internal::built_in_function_t<double, internal::julianday_string, Args...> julianday(Args... args) {
+    constexpr internal::built_in_function_t<double, internal::julianday_string, Args...> julianday(Args... args) {
         return {std::tuple<Args...>{std::forward<Args>(args)...}};
     }
 
@@ -1781,7 +1782,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  STRFTIME(timestring, modifier, modifier, ...) function https://www.sqlite.org/lang_datefunc.html
      */
     template<class... Args>
-    internal::built_in_function_t<std::string, internal::strftime_string, Args...> strftime(Args... args) {
+    constexpr internal::built_in_function_t<std::string, internal::strftime_string, Args...> strftime(Args... args) {
         return {std::tuple<Args...>{std::forward<Args>(args)...}};
     }
 
@@ -1789,7 +1790,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  ZEROBLOB(N) function https://www.sqlite.org/lang_corefunc.html#zeroblob
      */
     template<class N>
-    internal::built_in_function_t<std::vector<char>, internal::zeroblob_string, N> zeroblob(N n) {
+    constexpr internal::built_in_function_t<std::vector<char>, internal::zeroblob_string, N> zeroblob(N n) {
         return {std::tuple<N>{std::forward<N>(n)}};
     }
 
@@ -1797,7 +1798,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  SUBSTR(X,Y) function https://www.sqlite.org/lang_corefunc.html#substr
      */
     template<class X, class Y>
-    internal::built_in_function_t<std::string, internal::substr_string, X, Y> substr(X x, Y y) {
+    constexpr internal::built_in_function_t<std::string, internal::substr_string, X, Y> substr(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
@@ -1805,7 +1806,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  SUBSTR(X,Y,Z) function https://www.sqlite.org/lang_corefunc.html#substr
      */
     template<class X, class Y, class Z>
-    internal::built_in_function_t<std::string, internal::substr_string, X, Y, Z> substr(X x, Y y, Z z) {
+    constexpr internal::built_in_function_t<std::string, internal::substr_string, X, Y, Z> substr(X x, Y y, Z z) {
         return {std::tuple<X, Y, Z>{std::forward<X>(x), std::forward<Y>(y), std::forward<Z>(z)}};
     }
 
@@ -1814,7 +1815,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  SOUNDEX(X) function https://www.sqlite.org/lang_corefunc.html#soundex
      */
     template<class X>
-    internal::built_in_function_t<std::string, internal::soundex_string, X> soundex(X x) {
+    constexpr internal::built_in_function_t<std::string, internal::soundex_string, X> soundex(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 #endif
@@ -1823,7 +1824,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  TOTAL(X) aggregate function.
      */
     template<class X>
-    internal::built_in_aggregate_function_t<double, internal::total_string, X> total(X x) {
+    constexpr internal::built_in_aggregate_function_t<double, internal::total_string, X> total(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1831,7 +1832,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  SUM(X) aggregate function.
      */
     template<class X>
-    internal::built_in_aggregate_function_t<std::unique_ptr<double>, internal::sum_string, X> sum(X x) {
+    constexpr internal::built_in_aggregate_function_t<std::unique_ptr<double>, internal::sum_string, X> sum(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1846,7 +1847,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     /**
      *  COUNT(*) without FROM function.
      */
-    inline internal::count_asterisk_without_type count() {
+    constexpr internal::count_asterisk_without_type count() {
         return {};
     }
 
@@ -1855,7 +1856,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  a from argument.
      */
     template<class T>
-    internal::count_asterisk_t<T> count() {
+    constexpr internal::count_asterisk_t<T> count() {
         return {};
     }
 
@@ -1865,7 +1866,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  a from argument.
      */
     template<orm_refers_to_recordset auto mapped>
-    auto count() {
+    constexpr auto count() {
         return count<internal::auto_decay_table_ref_t<mapped>>();
     }
 #endif
@@ -1874,7 +1875,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  AVG(X) aggregate function.
      */
     template<class X>
-    internal::built_in_aggregate_function_t<double, internal::avg_string, X> avg(X x) {
+    constexpr internal::built_in_aggregate_function_t<double, internal::avg_string, X> avg(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1882,7 +1883,8 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  MAX(X) aggregate function.
      */
     template<class X>
-    internal::built_in_aggregate_function_t<internal::unique_ptr_result_of<X>, internal::max_string, X> max(X x) {
+    constexpr internal::built_in_aggregate_function_t<internal::unique_ptr_result_of<X>, internal::max_string, X>
+    max(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1890,7 +1892,8 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  MIN(X) aggregate function.
      */
     template<class X>
-    internal::built_in_aggregate_function_t<internal::unique_ptr_result_of<X>, internal::min_string, X> min(X x) {
+    constexpr internal::built_in_aggregate_function_t<internal::unique_ptr_result_of<X>, internal::min_string, X>
+    min(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1899,7 +1902,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  The return type is the type of the first argument.
      */
     template<class X, class Y, class... Rest>
-    internal::built_in_function_t<internal::unique_ptr_result_of<X>, internal::max_string, X, Y, Rest...>
+    constexpr internal::built_in_function_t<internal::unique_ptr_result_of<X>, internal::max_string, X, Y, Rest...>
     max(X x, Y y, Rest... rest) {
         return {std::tuple<X, Y, Rest...>{std::forward<X>(x), std::forward<Y>(y), std::forward<Rest>(rest)...}};
     }
@@ -1909,7 +1912,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  The return type is the type of the first argument.
      */
     template<class X, class Y, class... Rest>
-    internal::built_in_function_t<internal::unique_ptr_result_of<X>, internal::min_string, X, Y, Rest...>
+    constexpr internal::built_in_function_t<internal::unique_ptr_result_of<X>, internal::min_string, X, Y, Rest...>
     min(X x, Y y, Rest... rest) {
         return {std::tuple<X, Y, Rest...>{std::forward<X>(x), std::forward<Y>(y), std::forward<Rest>(rest)...}};
     }
@@ -1918,7 +1921,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  GROUP_CONCAT(X) aggregate function.
      */
     template<class X>
-    internal::built_in_aggregate_function_t<std::string, internal::group_concat_string, X> group_concat(X x) {
+    constexpr internal::built_in_aggregate_function_t<std::string, internal::group_concat_string, X> group_concat(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -1926,32 +1929,34 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  GROUP_CONCAT(X, Y) aggregate function.
      */
     template<class X, class Y>
-    internal::built_in_aggregate_function_t<std::string, internal::group_concat_string, X, Y> group_concat(X x, Y y) {
+    constexpr internal::built_in_aggregate_function_t<std::string, internal::group_concat_string, X, Y>
+    group_concat(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 #ifdef SQLITE_ENABLE_JSON1
     template<class X>
-    internal::built_in_function_t<std::string, internal::json_string, X> json(X x) {
+    constexpr internal::built_in_function_t<std::string, internal::json_string, X> json(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
     template<class... Args>
-    internal::built_in_function_t<std::string, internal::json_array_string, Args...> json_array(Args... args) {
+    constexpr internal::built_in_function_t<std::string, internal::json_array_string, Args...>
+    json_array(Args... args) {
         return {std::tuple<Args...>{std::forward<Args>(args)...}};
     }
 
     template<class X>
-    internal::built_in_function_t<int, internal::json_array_length_string, X> json_array_length(X x) {
+    constexpr internal::built_in_function_t<int, internal::json_array_length_string, X> json_array_length(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
     template<class R, class X>
-    internal::built_in_function_t<R, internal::json_array_length_string, X> json_array_length(X x) {
+    constexpr internal::built_in_function_t<R, internal::json_array_length_string, X> json_array_length(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
     template<class X, class Y>
-    internal::built_in_function_t<int, internal::json_array_length_string, X, Y> json_array_length(X x, Y y) {
+    constexpr internal::built_in_function_t<int, internal::json_array_length_string, X, Y> json_array_length(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
@@ -1961,93 +1966,98 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     }
 
     template<class R, class X, class... Args>
-    internal::built_in_function_t<R, internal::json_extract_string, X, Args...> json_extract(X x, Args... args) {
+    constexpr internal::built_in_function_t<R, internal::json_extract_string, X, Args...> json_extract(X x,
+                                                                                                       Args... args) {
         return {std::tuple<X, Args...>{std::forward<X>(x), std::forward<Args>(args)...}};
     }
 
     template<class X, class... Args>
-    internal::built_in_function_t<std::string, internal::json_insert_string, X, Args...> json_insert(X x,
-                                                                                                     Args... args) {
+    constexpr internal::built_in_function_t<std::string, internal::json_insert_string, X, Args...>
+    json_insert(X x, Args... args) {
         static_assert(std::tuple_size<std::tuple<Args...>>::value % 2 == 0,
                       "number of arguments in json_insert must be odd");
         return {std::tuple<X, Args...>{std::forward<X>(x), std::forward<Args>(args)...}};
     }
 
     template<class X, class... Args>
-    internal::built_in_function_t<std::string, internal::json_replace_string, X, Args...> json_replace(X x,
-                                                                                                       Args... args) {
+    constexpr internal::built_in_function_t<std::string, internal::json_replace_string, X, Args...>
+    json_replace(X x, Args... args) {
         static_assert(std::tuple_size<std::tuple<Args...>>::value % 2 == 0,
                       "number of arguments in json_replace must be odd");
         return {std::tuple<X, Args...>{std::forward<X>(x), std::forward<Args>(args)...}};
     }
 
     template<class X, class... Args>
-    internal::built_in_function_t<std::string, internal::json_set_string, X, Args...> json_set(X x, Args... args) {
+    constexpr internal::built_in_function_t<std::string, internal::json_set_string, X, Args...> json_set(X x,
+                                                                                                         Args... args) {
         static_assert(std::tuple_size<std::tuple<Args...>>::value % 2 == 0,
                       "number of arguments in json_set must be odd");
         return {std::tuple<X, Args...>{std::forward<X>(x), std::forward<Args>(args)...}};
     }
 
     template<class... Args>
-    internal::built_in_function_t<std::string, internal::json_object_string, Args...> json_object(Args... args) {
+    constexpr internal::built_in_function_t<std::string, internal::json_object_string, Args...>
+    json_object(Args... args) {
         static_assert(std::tuple_size<std::tuple<Args...>>::value % 2 == 0,
                       "number of arguments in json_object must be even");
         return {std::tuple<Args...>{std::forward<Args>(args)...}};
     }
 
     template<class X, class Y>
-    internal::built_in_function_t<std::string, internal::json_patch_string, X, Y> json_patch(X x, Y y) {
+    constexpr internal::built_in_function_t<std::string, internal::json_patch_string, X, Y> json_patch(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
     template<class X, class... Args>
-    internal::built_in_function_t<std::string, internal::json_remove_string, X, Args...> json_remove(X x,
-                                                                                                     Args... args) {
+    constexpr internal::built_in_function_t<std::string, internal::json_remove_string, X, Args...>
+    json_remove(X x, Args... args) {
         return {std::tuple<X, Args...>{std::forward<X>(x), std::forward<Args>(args)...}};
     }
 
     template<class R, class X, class... Args>
-    internal::built_in_function_t<R, internal::json_remove_string, X, Args...> json_remove(X x, Args... args) {
+    constexpr internal::built_in_function_t<R, internal::json_remove_string, X, Args...> json_remove(X x,
+                                                                                                     Args... args) {
         return {std::tuple<X, Args...>{std::forward<X>(x), std::forward<Args>(args)...}};
     }
 
     template<class X>
-    internal::built_in_function_t<std::string, internal::json_type_string, X> json_type(X x) {
+    constexpr internal::built_in_function_t<std::string, internal::json_type_string, X> json_type(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
     template<class R, class X>
-    internal::built_in_function_t<R, internal::json_type_string, X> json_type(X x) {
+    constexpr internal::built_in_function_t<R, internal::json_type_string, X> json_type(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
     template<class X, class Y>
-    internal::built_in_function_t<std::string, internal::json_type_string, X, Y> json_type(X x, Y y) {
+    constexpr internal::built_in_function_t<std::string, internal::json_type_string, X, Y> json_type(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
     template<class R, class X, class Y>
-    internal::built_in_function_t<R, internal::json_type_string, X, Y> json_type(X x, Y y) {
+    constexpr internal::built_in_function_t<R, internal::json_type_string, X, Y> json_type(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
     template<class X>
-    internal::built_in_function_t<bool, internal::json_valid_string, X> json_valid(X x) {
+    constexpr internal::built_in_function_t<bool, internal::json_valid_string, X> json_valid(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
     template<class R, class X>
-    internal::built_in_function_t<R, internal::json_quote_string, X> json_quote(X x) {
+    constexpr internal::built_in_function_t<R, internal::json_quote_string, X> json_quote(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
     template<class X>
-    internal::built_in_function_t<std::string, internal::json_group_array_string, X> json_group_array(X x) {
+    constexpr internal::built_in_function_t<std::string, internal::json_group_array_string, X> json_group_array(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
     template<class X, class Y>
-    internal::built_in_function_t<std::string, internal::json_group_object_string, X, Y> json_group_object(X x, Y y) {
+    constexpr internal::built_in_function_t<std::string, internal::json_group_object_string, X, Y>
+    json_group_object(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 #endif  //  SQLITE_ENABLE_JSON1

--- a/dev/indexed_column.h
+++ b/dev/indexed_column.h
@@ -16,19 +16,19 @@ namespace sqlite_orm::internal {
         std::string _collation_name;
         int _order = 0;  //  -1 = desc, 1 = asc, 0 = unspecified
 
-        indexed_column_t<column_type> collate(std::string name) {
+        indexed_column_t<column_type> collate(std::string name) && {
             auto res = std::move(*this);
             res._collation_name = std::move(name);
             return res;
         }
 
-        indexed_column_t<column_type> asc() {
+        indexed_column_t<column_type> asc() && {
             auto res = std::move(*this);
             res._order = 1;
             return res;
         }
 
-        indexed_column_t<column_type> desc() {
+        indexed_column_t<column_type> desc() && {
             auto res = std::move(*this);
             res._order = -1;
             return res;

--- a/dev/schema/table.h
+++ b/dev/schema/table.h
@@ -52,7 +52,7 @@ namespace sqlite_orm::internal {
                     using generated_op_index_sequence =
                         filter_tuple_sequence_t<std::remove_const_t<decltype(column.constraints)>, is_generated_always>;
                     constexpr size_t opIndex = index_sequence_value_at<0>(generated_op_index_sequence{});
-                    result = &std::get<opIndex>(column.constraints).storage;
+                    result = &std::get<opIndex>(column.constraints)._storage;
                 });
 #endif
             return result;

--- a/dev/schema/table_base.h
+++ b/dev/schema/table_base.h
@@ -160,13 +160,13 @@ namespace sqlite_orm::internal {
                               lambda(column.member_pointer);
                           }));
             this->visit_table_primary_key([&lambda](auto& primaryKey) {
-                iterate_tuple(primaryKey.columns, lambda);
+                iterate_tuple(primaryKey._columns, lambda);
             });
         }
 
         template<class... Args>
         std::vector<std::string> table_key_columns_names(const primary_key_t<Args...>& primaryKey) const {
-            return create_from_tuple<std::vector<std::string>>(primaryKey.columns,
+            return create_from_tuple<std::vector<std::string>>(primaryKey._columns,
                                                                [this, empty = std::string{}](auto& memberPointer) {
                                                                    if (const std::string* columnName =
                                                                            this->find_column_name(memberPointer)) {
@@ -186,12 +186,12 @@ namespace sqlite_orm::internal {
         if constexpr (/*bool hasNoColumnPK =*/!insertable_table_definition<Cs...>::template count_of_columns_with<
                       is_primary_key>()) {
             definition.visit_table_primary_key([&column, &res](auto& primaryKey) {
-                using colrefs_tuple = decltype(primaryKey.columns);
+                using colrefs_tuple = decltype(primaryKey._columns);
                 using same_type_index_sequence =
                     filter_tuple_sequence_t<colrefs_tuple,
                                             check_if_is_type<member_field_type_t<G>>::template fn,
                                             member_field_type_t>;
-                iterate_tuple(primaryKey.columns, same_type_index_sequence{}, [&res, &column](auto& memberPointer) {
+                iterate_tuple(primaryKey._columns, same_type_index_sequence{}, [&res, &column](auto& memberPointer) {
                     if (compare_fields(memberPointer, column.member_pointer) ||
                         compare_fields(memberPointer, column.setter)) {
                         res = true;
@@ -213,7 +213,7 @@ namespace sqlite_orm::internal {
                 // note: use `decltype(primaryKey)` instead of `decltype(primaryKey.columns)` otherwise msvc 141 chokes on the `if constexpr` below
                 using colrefs_tuple = columns_tuple_t<polyfill::remove_cvref_t<decltype(primaryKey)>>;
                 if constexpr (std::tuple_size<colrefs_tuple>::value == 1) {
-                    auto& memberPointer = std::get<0>(primaryKey.columns);
+                    auto& memberPointer = std::get<0>(primaryKey._columns);
                     if (compare_fields(memberPointer, column.member_pointer) ||
                         compare_fields(memberPointer, column.setter)) {
                         res = true;

--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -1597,7 +1597,7 @@ namespace sqlite_orm::internal {
         SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& fk,
                                                         const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
             std::stringstream ss;
-            ss << "FOREIGN KEY(" << streaming_mapped_columns_expressions(fk.columns, context) << ") REFERENCES ";
+            ss << "FOREIGN KEY(" << streaming_mapped_columns_expressions(fk._columns, context) << ") REFERENCES ";
             {
                 using references_type_t = typename statement_type::references_type;
                 using first_reference_t = std::tuple_element_t<0, references_type_t>;
@@ -1605,7 +1605,7 @@ namespace sqlite_orm::internal {
                 auto refTableName = lookup_table_name<first_reference_mapped_type>(context.db_objects);
                 ss << streaming_identifier(refTableName);
             }
-            ss << "(" << streaming_mapped_columns_expressions(fk.references, context) << ")";
+            ss << "(" << streaming_mapped_columns_expressions(fk._references, context) << ")";
             if (fk.on_update) {
                 ss << ' ' << static_cast<std::string>(fk.on_update) << " " << fk.on_update._action;
             }

--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -1638,12 +1638,12 @@ namespace sqlite_orm::internal {
         SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
                                                         const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
             std::stringstream ss;
-            if (statement.full) {
+            if (statement._full) {
                 ss << "GENERATED ALWAYS ";
             }
             ss << "AS (";
-            ss << serialize(statement.expression, context) << ")";
-            switch (statement.storage) {
+            ss << serialize(statement._expression, context) << ")";
+            switch (statement._storage) {
                 case basic_generated_always::storage_type::not_specified:
                     //..
                     break;

--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -1457,7 +1457,7 @@ namespace sqlite_orm::internal {
                                                         const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
             std::stringstream ss;
             ss << "PRIMARY KEY";
-            switch (statement.options.asc_option) {
+            switch (statement._options.asc_option) {
                 case statement_type::order_by::ascending:
                     ss << " ASC";
                     break;
@@ -1467,13 +1467,13 @@ namespace sqlite_orm::internal {
                 default:
                     break;
             }
-            if (statement.options.conflict_clause_is_on) {
-                ss << " ON CONFLICT " << serialize(statement.options.conflict_clause, context);
+            if (statement._options.conflict_clause_is_on) {
+                ss << " ON CONFLICT " << serialize(statement._options.conflict_clause, context);
             }
             using columns_tuple = typename statement_type::columns_tuple;
             constexpr size_t columnsCount = std::tuple_size<columns_tuple>::value;
             if constexpr (columnsCount > 0) {
-                ss << "(" << streaming_mapped_columns_expressions(statement.columns, context) << ")";
+                ss << "(" << streaming_mapped_columns_expressions(statement._columns, context) << ")";
             }
             return ss.str();
         }

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -3796,8 +3796,8 @@ namespace sqlite_orm::internal {
          */
         using source_type = same_or_void_t<table_type_of_t<Cs>...>;
 
-        columns_type columns;
-        references_type references;
+        columns_type _columns;
+        references_type _references;
 
         on_update_delete_t<foreign_key_t> on_update;
         on_update_delete_t<foreign_key_t> on_delete;
@@ -3807,12 +3807,12 @@ namespace sqlite_orm::internal {
         static_assert(!std::is_same<source_type, void>::value, "All columns must have the same mapped type");
         static_assert(!std::is_same<target_type, void>::value, "All references must have the same mapped type");
 
-        foreign_key_t(columns_type columns_, references_type references_) :
-            columns(std::move(columns_)), references(std::move(references_)),
+        foreign_key_t(columns_type columns, references_type references) :
+            _columns(std::move(columns)), _references(std::move(references)),
             on_update(*this, true, foreign_key_action::none), on_delete(*this, false, foreign_key_action::none) {}
 
         foreign_key_t(const foreign_key_t& other) :
-            columns(other.columns), references(other.references), on_update(*this, true, other.on_update._action),
+            _columns(other._columns), _references(other._references), on_update(*this, true, other.on_update._action),
             on_delete(*this, false, other.on_delete._action) {}
 
         foreign_key_t& operator=(const foreign_key_t&) = delete;
@@ -3821,8 +3821,8 @@ namespace sqlite_orm::internal {
         friend bool operator==(const foreign_key_t& lhs, const foreign_key_t& rhs) = default;
 #else
         friend bool operator==(const foreign_key_t& lhs, const foreign_key_t& rhs) {
-            return lhs.columns == rhs.columns && lhs.references == rhs.references && lhs.on_update == rhs.on_update &&
-                   lhs.on_delete == rhs.on_delete;
+            return lhs._columns == rhs._columns && lhs._references == rhs._references &&
+                   lhs.on_update == rhs.on_update && lhs.on_delete == rhs.on_delete;
         }
 #endif
     };
@@ -23646,7 +23646,7 @@ namespace sqlite_orm::internal {
         SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& fk,
                                                         const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
             std::stringstream ss;
-            ss << "FOREIGN KEY(" << streaming_mapped_columns_expressions(fk.columns, context) << ") REFERENCES ";
+            ss << "FOREIGN KEY(" << streaming_mapped_columns_expressions(fk._columns, context) << ") REFERENCES ";
             {
                 using references_type_t = typename statement_type::references_type;
                 using first_reference_t = std::tuple_element_t<0, references_type_t>;
@@ -23654,7 +23654,7 @@ namespace sqlite_orm::internal {
                 auto refTableName = lookup_table_name<first_reference_mapped_type>(context.db_objects);
                 ss << streaming_identifier(refTableName);
             }
-            ss << "(" << streaming_mapped_columns_expressions(fk.references, context) << ")";
+            ss << "(" << streaming_mapped_columns_expressions(fk._references, context) << ")";
             if (fk.on_update) {
                 ss << ' ' << static_cast<std::string>(fk.on_update) << " " << fk.on_update._action;
             }

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -3501,7 +3501,7 @@ namespace sqlite_orm::internal {
             order_by asc_option = order_by::unspecified;
             conflict_clause_t conflict_clause = conflict_clause_t::rollback;
             bool conflict_clause_is_on = false;
-        } options;
+        } _options;
     };
 
     template<class T>
@@ -3523,19 +3523,19 @@ namespace sqlite_orm::internal {
         using order_by = primary_key_base::order_by;
         using columns_tuple = std::tuple<Cs...>;
 
-        columns_tuple columns;
+        columns_tuple _columns;
 
-        constexpr primary_key_t(columns_tuple columns) : columns(std::move(columns)) {}
+        constexpr primary_key_t(columns_tuple columns) : _columns(std::move(columns)) {}
 
         constexpr primary_key_t asc() const {
             auto res = *this;
-            res.options.asc_option = order_by::ascending;
+            res._options.asc_option = order_by::ascending;
             return res;
         }
 
         constexpr primary_key_t desc() const {
             auto res = *this;
-            res.options.asc_option = order_by::descending;
+            res._options.asc_option = order_by::descending;
             return res;
         }
 
@@ -3545,36 +3545,36 @@ namespace sqlite_orm::internal {
 
         constexpr primary_key_t on_conflict_rollback() const {
             auto res = *this;
-            res.options.conflict_clause_is_on = true;
-            res.options.conflict_clause = conflict_clause_t::rollback;
+            res._options.conflict_clause_is_on = true;
+            res._options.conflict_clause = conflict_clause_t::rollback;
             return res;
         }
 
         constexpr primary_key_t on_conflict_abort() const {
             auto res = *this;
-            res.options.conflict_clause_is_on = true;
-            res.options.conflict_clause = conflict_clause_t::abort;
+            res._options.conflict_clause_is_on = true;
+            res._options.conflict_clause = conflict_clause_t::abort;
             return res;
         }
 
         constexpr primary_key_t on_conflict_fail() const {
             auto res = *this;
-            res.options.conflict_clause_is_on = true;
-            res.options.conflict_clause = conflict_clause_t::fail;
+            res._options.conflict_clause_is_on = true;
+            res._options.conflict_clause = conflict_clause_t::fail;
             return res;
         }
 
         constexpr primary_key_t on_conflict_ignore() const {
             auto res = *this;
-            res.options.conflict_clause_is_on = true;
-            res.options.conflict_clause = conflict_clause_t::ignore;
+            res._options.conflict_clause_is_on = true;
+            res._options.conflict_clause = conflict_clause_t::ignore;
             return res;
         }
 
         constexpr primary_key_t on_conflict_replace() const {
             auto res = *this;
-            res.options.conflict_clause_is_on = true;
-            res.options.conflict_clause = conflict_clause_t::replace;
+            res._options.conflict_clause_is_on = true;
+            res._options.conflict_clause = conflict_clause_t::replace;
             return res;
         }
     };
@@ -13410,13 +13410,13 @@ namespace sqlite_orm::internal {
                               lambda(column.member_pointer);
                           }));
             this->visit_table_primary_key([&lambda](auto& primaryKey) {
-                iterate_tuple(primaryKey.columns, lambda);
+                iterate_tuple(primaryKey._columns, lambda);
             });
         }
 
         template<class... Args>
         std::vector<std::string> table_key_columns_names(const primary_key_t<Args...>& primaryKey) const {
-            return create_from_tuple<std::vector<std::string>>(primaryKey.columns,
+            return create_from_tuple<std::vector<std::string>>(primaryKey._columns,
                                                                [this, empty = std::string{}](auto& memberPointer) {
                                                                    if (const std::string* columnName =
                                                                            this->find_column_name(memberPointer)) {
@@ -13436,12 +13436,12 @@ namespace sqlite_orm::internal {
         if constexpr (/*bool hasNoColumnPK =*/!insertable_table_definition<Cs...>::template count_of_columns_with<
                       is_primary_key>()) {
             definition.visit_table_primary_key([&column, &res](auto& primaryKey) {
-                using colrefs_tuple = decltype(primaryKey.columns);
+                using colrefs_tuple = decltype(primaryKey._columns);
                 using same_type_index_sequence =
                     filter_tuple_sequence_t<colrefs_tuple,
                                             check_if_is_type<member_field_type_t<G>>::template fn,
                                             member_field_type_t>;
-                iterate_tuple(primaryKey.columns, same_type_index_sequence{}, [&res, &column](auto& memberPointer) {
+                iterate_tuple(primaryKey._columns, same_type_index_sequence{}, [&res, &column](auto& memberPointer) {
                     if (compare_fields(memberPointer, column.member_pointer) ||
                         compare_fields(memberPointer, column.setter)) {
                         res = true;
@@ -13463,7 +13463,7 @@ namespace sqlite_orm::internal {
                 // note: use `decltype(primaryKey)` instead of `decltype(primaryKey.columns)` otherwise msvc 141 chokes on the `if constexpr` below
                 using colrefs_tuple = columns_tuple_t<polyfill::remove_cvref_t<decltype(primaryKey)>>;
                 if constexpr (std::tuple_size<colrefs_tuple>::value == 1) {
-                    auto& memberPointer = std::get<0>(primaryKey.columns);
+                    auto& memberPointer = std::get<0>(primaryKey._columns);
                     if (compare_fields(memberPointer, column.member_pointer) ||
                         compare_fields(memberPointer, column.setter)) {
                         res = true;
@@ -23509,7 +23509,7 @@ namespace sqlite_orm::internal {
                                                         const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
             std::stringstream ss;
             ss << "PRIMARY KEY";
-            switch (statement.options.asc_option) {
+            switch (statement._options.asc_option) {
                 case statement_type::order_by::ascending:
                     ss << " ASC";
                     break;
@@ -23519,13 +23519,13 @@ namespace sqlite_orm::internal {
                 default:
                     break;
             }
-            if (statement.options.conflict_clause_is_on) {
-                ss << " ON CONFLICT " << serialize(statement.options.conflict_clause, context);
+            if (statement._options.conflict_clause_is_on) {
+                ss << " ON CONFLICT " << serialize(statement._options.conflict_clause, context);
             }
             using columns_tuple = typename statement_type::columns_tuple;
             constexpr size_t columnsCount = std::tuple_size<columns_tuple>::value;
             if constexpr (columnsCount > 0) {
-                ss << "(" << streaming_mapped_columns_expressions(statement.columns, context) << ")";
+                ss << "(" << streaming_mapped_columns_expressions(statement._columns, context) << ")";
             }
             return ss.str();
         }

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -3718,6 +3718,9 @@ namespace sqlite_orm::internal {
 
         foreign_key_action _action = foreign_key_action::none;
 
+        on_update_delete_t(const on_update_delete_t&) = delete;
+        on_update_delete_t& operator=(const on_update_delete_t&) = delete;
+
         on_update_delete_t(foreign_key_type& fk_, decltype(update) update_, foreign_key_action action_) :
             on_update_delete_base{update_}, fk(fk_), _action(action_) {}
 

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -3508,7 +3508,7 @@ namespace sqlite_orm::internal {
     struct primary_key_with_autoincrement : T {
         using primary_key_type = T;
 
-        const primary_key_type& as_base() const {
+        constexpr const primary_key_type& as_base() const {
             return *this;
         }
     };
@@ -3594,7 +3594,7 @@ namespace sqlite_orm::internal {
 
         columns_tuple columns;
 
-        unique_t(columns_tuple columns_) : columns(std::move(columns_)) {}
+        constexpr unique_t(columns_tuple columns_) : columns(std::move(columns_)) {}
     };
 
     struct unindexed_t {};
@@ -3716,12 +3716,12 @@ namespace sqlite_orm::internal {
 
         const foreign_key_type& fk;
 
-        on_update_delete_t(decltype(fk) fk_, decltype(update) update_, foreign_key_action action_) :
+        constexpr on_update_delete_t(decltype(fk) fk_, decltype(update) update_, foreign_key_action action_) :
             on_update_delete_base{update_}, fk(fk_), _action(action_) {}
 
         foreign_key_action _action = foreign_key_action::none;
 
-        foreign_key_type no_action() const {
+        constexpr foreign_key_type no_action() const {
             auto res = this->fk;
             if (update) {
                 res.on_update._action = foreign_key_action::no_action;
@@ -3731,7 +3731,7 @@ namespace sqlite_orm::internal {
             return res;
         }
 
-        foreign_key_type restrict_() const {
+        constexpr foreign_key_type restrict_() const {
             auto res = this->fk;
             if (update) {
                 res.on_update._action = foreign_key_action::restrict_;
@@ -3741,7 +3741,7 @@ namespace sqlite_orm::internal {
             return res;
         }
 
-        foreign_key_type set_null() const {
+        constexpr foreign_key_type set_null() const {
             auto res = this->fk;
             if (update) {
                 res.on_update._action = foreign_key_action::set_null;
@@ -3751,7 +3751,7 @@ namespace sqlite_orm::internal {
             return res;
         }
 
-        foreign_key_type set_default() const {
+        constexpr foreign_key_type set_default() const {
             auto res = this->fk;
             if (update) {
                 res.on_update._action = foreign_key_action::set_default;
@@ -3761,7 +3761,7 @@ namespace sqlite_orm::internal {
             return res;
         }
 
-        foreign_key_type cascade() const {
+        constexpr foreign_key_type cascade() const {
             auto res = this->fk;
             if (update) {
                 res.on_update._action = foreign_key_action::cascade;
@@ -3771,7 +3771,7 @@ namespace sqlite_orm::internal {
             return res;
         }
 
-        explicit operator bool() const {
+        constexpr explicit operator bool() const {
             return _action != foreign_key_action::none;
         }
     };
@@ -3807,11 +3807,11 @@ namespace sqlite_orm::internal {
         static_assert(!std::is_same<source_type, void>::value, "All columns must have the same mapped type");
         static_assert(!std::is_same<target_type, void>::value, "All references must have the same mapped type");
 
-        foreign_key_t(columns_type columns_, references_type references_) :
+        constexpr foreign_key_t(columns_type columns_, references_type references_) :
             columns(std::move(columns_)), references(std::move(references_)),
             on_update(*this, true, foreign_key_action::none), on_delete(*this, false, foreign_key_action::none) {}
 
-        foreign_key_t(const foreign_key_t& other) :
+        constexpr foreign_key_t(const foreign_key_t& other) :
             columns(other.columns), references(other.references), on_update(*this, true, other.on_update._action),
             on_delete(*this, false, other.on_delete._action) {}
 
@@ -3838,7 +3838,7 @@ namespace sqlite_orm::internal {
          *  Specify one or more target fields, which can either be pointers to class members or column pointers.
          */
         template<class... Rs>
-        foreign_key_t<tuple_type, std::tuple<Rs...>> references(Rs... refs) {
+        constexpr foreign_key_t<tuple_type, std::tuple<Rs...>> references(Rs... refs) {
             return {std::move(_columns), {std::forward<Rs>(refs)...}};
         }
 
@@ -3847,7 +3847,7 @@ namespace sqlite_orm::internal {
          *  specifying the derived class as an explicit template argument.
          */
         template<class O, class... Base, class... F>
-        foreign_key_t<tuple_type, std::tuple<F O::*...>> references(F Base::*... refs) {
+        constexpr foreign_key_t<tuple_type, std::tuple<F O::*...>> references(F Base::*... refs) {
             static_assert(polyfill::conjunction<is_field_of<F Base::*, O>...>::value,
                           "Referenced fields must be from explicitly specified derived class");
             return {std::move(_columns), {refs...}};
@@ -3859,7 +3859,7 @@ namespace sqlite_orm::internal {
          *  specifying the derived class as an explicit template argument.
          */
         template<orm_table_reference auto table, class... Base, class... F>
-        auto references(F Base::*... refs) {
+        constexpr auto references(F Base::*... refs) {
             return this->references<auto_decay_table_ref_t<table>>(refs...);
         }
 #endif
@@ -3909,14 +3909,14 @@ namespace sqlite_orm::internal {
 
         expression_type expression;
 
-        generated_always_t(expression_type expression_, bool full, storage_type storage) :
+        constexpr generated_always_t(expression_type expression_, bool full, storage_type storage) :
             basic_generated_always{full, storage}, expression(std::move(expression_)) {}
 
-        generated_always_t<T> virtual_() {
+        constexpr generated_always_t<T> virtual_() {
             return {std::move(this->expression), this->full, storage_type::virtual_};
         }
 
-        generated_always_t<T> stored() {
+        constexpr generated_always_t<T> stored() {
             return {std::move(this->expression), this->full, storage_type::stored};
         }
     };
@@ -4022,12 +4022,12 @@ namespace sqlite_orm::internal {
 SQLITE_ORM_EXPORT namespace sqlite_orm {
 #if SQLITE_VERSION_NUMBER >= 3031000
     template<class T>
-    internal::generated_always_t<T> generated_always_as(T expression) {
+    constexpr internal::generated_always_t<T> generated_always_as(T expression) {
         return {std::move(expression), true, internal::basic_generated_always::storage_type::not_specified};
     }
 
     template<class T>
-    internal::generated_always_t<T> as(T expression) {
+    constexpr internal::generated_always_t<T> as(T expression) {
         return {std::move(expression), false, internal::basic_generated_always::storage_type::not_specified};
     }
 #endif
@@ -4038,7 +4038,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  Available since SQLite 3.6.19
      */
     template<class... Cs>
-    internal::foreign_key_intermediate_t<Cs...> foreign_key(Cs... columns) {
+    constexpr internal::foreign_key_intermediate_t<Cs...> foreign_key(Cs... columns) {
         return {{std::forward<Cs>(columns)...}};
     }
 
@@ -4048,7 +4048,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  Available since SQLite 3.6.19
      */
     template<class O, class... Base, class... F>
-    internal::foreign_key_intermediate_t<F O::*...> foreign_key(F Base::*... columns) {
+    constexpr internal::foreign_key_intermediate_t<F O::*...> foreign_key(F Base::*... columns) {
         static_assert(polyfill::conjunction<internal::is_field_of<F Base::*, O>...>::value,
                       "Fields must be from explicitly specified derived class");
         return {{columns...}};
@@ -4061,7 +4061,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  Available since SQLite 3.6.19
      */
     template<orm_table_reference auto table, class... Base, class... F>
-    auto foreign_key(F Base::*... columns) {
+    constexpr auto foreign_key(F Base::*... columns) {
         return foreign_key<internal::auto_decay_table_ref_t<table>>(columns...);
     }
 #endif
@@ -4071,14 +4071,14 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  UNIQUE table constraint builder function.
      */
     template<class... Args>
-    internal::unique_t<Args...> unique(Args... args) {
+    constexpr internal::unique_t<Args...> unique(Args... args) {
         return {{std::forward<Args>(args)...}};
     }
 
     /**
      *  UNIQUE column constraint builder function.
      */
-    inline internal::unique_t<> unique() {
+    inline constexpr internal::unique_t<> unique() {
         return {{}};
     }
 
@@ -4088,7 +4088,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  
      *  https://www.sqlite.org/fts5.html#the_unindexed_column_option
      */
-    inline internal::unindexed_t unindexed() {
+    inline constexpr internal::unindexed_t unindexed() {
         return {};
     }
 
@@ -4098,7 +4098,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  https://www.sqlite.org/fts5.html#prefix_indexes
      */
     template<class T>
-    internal::prefix_t<T> prefix(T value) {
+    constexpr internal::prefix_t<T> prefix(T value) {
         return {std::move(value)};
     }
 
@@ -4108,7 +4108,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  https://www.sqlite.org/fts5.html#tokenizers
      */
     template<class T>
-    internal::tokenize_t<T> tokenize(T value) {
+    constexpr internal::tokenize_t<T> tokenize(T value) {
         return {std::move(value)};
     }
 
@@ -4118,7 +4118,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  https://www.sqlite.org/fts5.html#contentless_tables
      */
     template<class T>
-    internal::content_t<T> content(T value) {
+    constexpr internal::content_t<T> content(T value) {
         return {std::move(value)};
     }
 
@@ -4128,7 +4128,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  https://www.sqlite.org/fts5.html#external_content_tables
      */
     template<class T>
-    internal::table_content_t<T> content() {
+    constexpr internal::table_content_t<T> content() {
         return {};
     }
 
@@ -4136,7 +4136,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     /** 
      *  Auxiliary virtual table column
      */
-    inline internal::auxiliary_t auxiliary() {
+    constexpr inline internal::auxiliary_t auxiliary() {
         return {};
     }
 #endif
@@ -4148,7 +4148,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  https://www.sqlite.org/fts5.html#external_content_tables
      */
     template<orm_table_reference auto table>
-    auto content() {
+    constexpr auto content() {
         return content<internal::auto_decay_table_ref_t<table>>();
     }
 #endif
@@ -4192,32 +4192,32 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     }
 
     template<class T>
-    internal::default_t<T> default_value(T t) {
+    constexpr internal::default_t<T> default_value(T t) {
         return {std::move(t)};
     }
 
-    inline internal::collate_constraint_t collate_nocase() {
+    inline constexpr internal::collate_constraint_t collate_nocase() {
         return {internal::collate_argument::nocase};
     }
 
-    inline internal::collate_constraint_t collate_binary() {
+    inline constexpr internal::collate_constraint_t collate_binary() {
         return {internal::collate_argument::binary};
     }
 
-    inline internal::collate_constraint_t collate_rtrim() {
+    inline constexpr internal::collate_constraint_t collate_rtrim() {
         return {internal::collate_argument::rtrim};
     }
 
     template<class T>
-    internal::check_t<T> check(T t) {
+    constexpr internal::check_t<T> check(T t) {
         return {std::move(t)};
     }
 
-    inline internal::null_t null() {
+    inline constexpr internal::null_t null() {
         return {};
     }
 
-    inline internal::not_null_t not_null() {
+    inline constexpr internal::not_null_t not_null() {
         return {};
     }
 }

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -13552,19 +13552,19 @@ namespace sqlite_orm::internal {
         std::string _collation_name;
         int _order = 0;  //  -1 = desc, 1 = asc, 0 = unspecified
 
-        indexed_column_t<column_type> collate(std::string name) {
+        indexed_column_t<column_type> collate(std::string name) && {
             auto res = std::move(*this);
             res._collation_name = std::move(name);
             return res;
         }
 
-        indexed_column_t<column_type> asc() {
+        indexed_column_t<column_type> asc() && {
             auto res = std::move(*this);
             res._order = 1;
             return res;
         }
 
-        indexed_column_t<column_type> desc() {
+        indexed_column_t<column_type> desc() && {
             auto res = std::move(*this);
             res._order = -1;
             return res;

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -4136,7 +4136,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     /** 
      *  Auxiliary virtual table column
      */
-    constexpr inline internal::auxiliary_t auxiliary() {
+    constexpr internal::auxiliary_t auxiliary() {
         return {};
     }
 #endif

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -3816,13 +3816,16 @@ namespace sqlite_orm::internal {
             on_delete(*this, false, other.on_delete._action) {}
 
         foreign_key_t& operator=(const foreign_key_t&) = delete;
-    };
 
-    template<class A, class B>
-    bool operator==(const foreign_key_t<A, B>& lhs, const foreign_key_t<A, B>& rhs) {
-        return lhs.columns == rhs.columns && lhs.references == rhs.references && lhs.on_update == rhs.on_update &&
-               lhs.on_delete == rhs.on_delete;
-    }
+#ifdef SQLITE_ORM_DEFAULT_COMPARISONS_SUPPORTED
+        friend bool operator==(const foreign_key_t& lhs, const foreign_key_t& rhs) = default;
+#else
+        friend bool operator==(const foreign_key_t& lhs, const foreign_key_t& rhs) {
+            return lhs.columns == rhs.columns && lhs.references == rhs.references && lhs.on_update == rhs.on_update &&
+                   lhs.on_delete == rhs.on_delete;
+        }
+#endif
+    };
 
     /**
      *  Cs can be a class member pointer or column pointer

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -3271,6 +3271,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 #include <ostream>  //  std::ostream
 #include <string>  //  std::string
 #include <tuple>  //  std::tuple
+#include <functional>  //  std::ref
 #endif
 
 // #include "functional/cxx_type_traits_polyfill.h"
@@ -3806,11 +3807,13 @@ namespace sqlite_orm::internal {
 
         foreign_key_t(columns_type columns, references_type references) :
             _columns(std::move(columns)), _references(std::move(references)),
-            on_update(*this, true, foreign_key_action::none), on_delete(*this, false, foreign_key_action::none) {}
+            on_update(std::ref(*this), true, foreign_key_action::none),
+            on_delete(std::ref(*this), false, foreign_key_action::none) {}
 
         foreign_key_t(const foreign_key_t& other) :
-            _columns(other._columns), _references(other._references), on_update(*this, true, other.on_update._action),
-            on_delete(*this, false, other.on_delete._action) {}
+            _columns(other._columns), _references(other._references),
+            on_update(std::ref(*this), true, other.on_update._action),
+            on_delete(std::ref(*this), false, other.on_delete._action) {}
 
         foreign_key_t& operator=(const foreign_key_t&) = delete;
 

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -3716,12 +3716,12 @@ namespace sqlite_orm::internal {
 
         const foreign_key_type& fk;
 
-        constexpr on_update_delete_t(decltype(fk) fk_, decltype(update) update_, foreign_key_action action_) :
-            on_update_delete_base{update_}, fk(fk_), _action(action_) {}
-
         foreign_key_action _action = foreign_key_action::none;
 
-        constexpr foreign_key_type no_action() const {
+        on_update_delete_t(foreign_key_type& fk_, decltype(update) update_, foreign_key_action action_) :
+            on_update_delete_base{update_}, fk(fk_), _action(action_) {}
+
+        foreign_key_type no_action() const {
             auto res = this->fk;
             if (update) {
                 res.on_update._action = foreign_key_action::no_action;
@@ -3731,7 +3731,7 @@ namespace sqlite_orm::internal {
             return res;
         }
 
-        constexpr foreign_key_type restrict_() const {
+        foreign_key_type restrict_() const {
             auto res = this->fk;
             if (update) {
                 res.on_update._action = foreign_key_action::restrict_;
@@ -3741,7 +3741,7 @@ namespace sqlite_orm::internal {
             return res;
         }
 
-        constexpr foreign_key_type set_null() const {
+        foreign_key_type set_null() const {
             auto res = this->fk;
             if (update) {
                 res.on_update._action = foreign_key_action::set_null;
@@ -3751,7 +3751,7 @@ namespace sqlite_orm::internal {
             return res;
         }
 
-        constexpr foreign_key_type set_default() const {
+        foreign_key_type set_default() const {
             auto res = this->fk;
             if (update) {
                 res.on_update._action = foreign_key_action::set_default;
@@ -3761,7 +3761,7 @@ namespace sqlite_orm::internal {
             return res;
         }
 
-        constexpr foreign_key_type cascade() const {
+        foreign_key_type cascade() const {
             auto res = this->fk;
             if (update) {
                 res.on_update._action = foreign_key_action::cascade;
@@ -3771,7 +3771,7 @@ namespace sqlite_orm::internal {
             return res;
         }
 
-        constexpr explicit operator bool() const {
+        explicit operator bool() const {
             return _action != foreign_key_action::none;
         }
     };
@@ -3807,11 +3807,11 @@ namespace sqlite_orm::internal {
         static_assert(!std::is_same<source_type, void>::value, "All columns must have the same mapped type");
         static_assert(!std::is_same<target_type, void>::value, "All references must have the same mapped type");
 
-        constexpr foreign_key_t(columns_type columns_, references_type references_) :
+        foreign_key_t(columns_type columns_, references_type references_) :
             columns(std::move(columns_)), references(std::move(references_)),
             on_update(*this, true, foreign_key_action::none), on_delete(*this, false, foreign_key_action::none) {}
 
-        constexpr foreign_key_t(const foreign_key_t& other) :
+        foreign_key_t(const foreign_key_t& other) :
             columns(other.columns), references(other.references), on_update(*this, true, other.on_update._action),
             on_delete(*this, false, other.on_delete._action) {}
 
@@ -3841,7 +3841,7 @@ namespace sqlite_orm::internal {
          *  Specify one or more target fields, which can either be pointers to class members or column pointers.
          */
         template<class... Rs>
-        constexpr foreign_key_t<tuple_type, std::tuple<Rs...>> references(Rs... refs) {
+        foreign_key_t<tuple_type, std::tuple<Rs...>> references(Rs... refs) {
             return {std::move(_columns), {std::forward<Rs>(refs)...}};
         }
 
@@ -3850,7 +3850,7 @@ namespace sqlite_orm::internal {
          *  specifying the derived class as an explicit template argument.
          */
         template<class O, class... Base, class... F>
-        constexpr foreign_key_t<tuple_type, std::tuple<F O::*...>> references(F Base::*... refs) {
+        foreign_key_t<tuple_type, std::tuple<F O::*...>> references(F Base::*... refs) {
             static_assert(polyfill::conjunction<is_field_of<F Base::*, O>...>::value,
                           "Referenced fields must be from explicitly specified derived class");
             return {std::move(_columns), {refs...}};
@@ -3862,7 +3862,7 @@ namespace sqlite_orm::internal {
          *  specifying the derived class as an explicit template argument.
          */
         template<orm_table_reference auto table, class... Base, class... F>
-        constexpr auto references(F Base::*... refs) {
+        auto references(F Base::*... refs) {
             return this->references<auto_decay_table_ref_t<table>>(refs...);
         }
 #endif
@@ -5907,13 +5907,12 @@ namespace sqlite_orm::internal {
         pattern_t pattern;
         optional_container<escape_t> arg3;  //  not escape cause escape exists as a function here
 
-        like_t(arg_t arg_, pattern_t pattern_, optional_container<escape_t> escape_) :
+        constexpr like_t(arg_t arg_, pattern_t pattern_, optional_container<escape_t> escape_) :
             arg(std::move(arg_)), pattern(std::move(pattern_)), arg3(std::move(escape_)) {}
 
         template<class C>
-        like_t<A, T, C> escape(C c) const {
-            optional_container<C> newArg3{std::move(c)};
-            return {std::move(this->arg), std::move(this->pattern), std::move(newArg3)};
+        constexpr like_t<A, T, C> escape(C c) const {
+            return {std::move(this->arg), std::move(this->pattern), {std::move(c)}};
         }
     };
 
@@ -5932,7 +5931,7 @@ namespace sqlite_orm::internal {
         arg_t arg;
         pattern_t pattern;
 
-        glob_t(arg_t arg_, pattern_t pattern_) : arg(std::move(arg_)), pattern(std::move(pattern_)) {}
+        constexpr glob_t(arg_t arg_, pattern_t pattern_) : arg(std::move(arg_)), pattern(std::move(pattern_)) {}
     };
 
     /**
@@ -6501,17 +6500,8 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  Example: storage.select(like(&User::name, "T%"))
      */
     template<class A, class T>
-    internal::like_t<A, T, void> like(A a, T t) {
+    constexpr internal::like_t<A, T, void> like(A a, T t) {
         return {std::move(a), std::move(t), {}};
-    }
-
-    /**
-     *  X GLOB Y
-     *  Example: storage.select(glob(&User::name, "*S"))
-     */
-    template<class A, class T>
-    internal::glob_t<A, T> glob(A a, T t) {
-        return {std::move(a), std::move(t)};
     }
 
     /**
@@ -6519,8 +6509,17 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  Example: storage.select(like(&User::name, "T%", "%"))
      */
     template<class A, class T, class E>
-    internal::like_t<A, T, E> like(A a, T t, E e) {
+    constexpr internal::like_t<A, T, E> like(A a, T t, E e) {
         return {std::move(a), std::move(t), {std::move(e)}};
+    }
+
+    /**
+     *  X GLOB Y
+     *  Example: storage.select(glob(&User::name, "*S"))
+     */
+    template<class A, class T>
+    constexpr internal::glob_t<A, T> glob(A a, T t) {
+        return {std::move(a), std::move(t)};
     }
 }
 
@@ -6626,7 +6625,7 @@ namespace sqlite_orm::internal {
 
         args_type args;
 
-        built_in_function_t(args_type&& args_) : args(std::move(args_)) {}
+        constexpr built_in_function_t(args_type&& args_) : args(std::move(args_)) {}
     };
 
     template<class T>
@@ -7239,7 +7238,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::acos(&Triangle::cornerA));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::acos_string, X> acos(X x) {
+    constexpr internal::built_in_function_t<double, internal::acos_string, X> acos(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7255,7 +7254,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::acos<std::optional<double>>(&Triangle::cornerA));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::acos_string, X> acos(X x) {
+    constexpr internal::built_in_function_t<R, internal::acos_string, X> acos(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7267,7 +7266,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::acosh(&Triangle::cornerA));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::acosh_string, X> acosh(X x) {
+    constexpr internal::built_in_function_t<double, internal::acosh_string, X> acosh(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7283,7 +7282,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::acosh<std::optional<double>>(&Triangle::cornerA));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::acosh_string, X> acosh(X x) {
+    constexpr internal::built_in_function_t<R, internal::acosh_string, X> acosh(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7295,7 +7294,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::asin(&Triangle::cornerA));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::asin_string, X> asin(X x) {
+    constexpr internal::built_in_function_t<double, internal::asin_string, X> asin(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7311,7 +7310,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::asin<std::optional<double>>(&Triangle::cornerA));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::asin_string, X> asin(X x) {
+    constexpr internal::built_in_function_t<R, internal::asin_string, X> asin(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7323,7 +7322,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::asinh(&Triangle::cornerA));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::asinh_string, X> asinh(X x) {
+    constexpr internal::built_in_function_t<double, internal::asinh_string, X> asinh(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7339,7 +7338,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::asinh<std::optional<double>>(&Triangle::cornerA));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::asinh_string, X> asinh(X x) {
+    constexpr internal::built_in_function_t<R, internal::asinh_string, X> asinh(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7351,7 +7350,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::atan(1));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::atan_string, X> atan(X x) {
+    constexpr internal::built_in_function_t<double, internal::atan_string, X> atan(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7367,7 +7366,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::atan<std::optional<double>>(1));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::atan_string, X> atan(X x) {
+    constexpr internal::built_in_function_t<R, internal::atan_string, X> atan(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7379,7 +7378,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::atan2(1, 3));   //  decltype(rows) is std::vector<double>
      */
     template<class X, class Y>
-    internal::built_in_function_t<double, internal::atan2_string, X, Y> atan2(X x, Y y) {
+    constexpr internal::built_in_function_t<double, internal::atan2_string, X, Y> atan2(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
@@ -7395,7 +7394,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::atan2<std::optional<double>>(1, 3));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X, class Y>
-    internal::built_in_function_t<R, internal::atan2_string, X, Y> atan2(X x, Y y) {
+    constexpr internal::built_in_function_t<R, internal::atan2_string, X, Y> atan2(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
@@ -7407,7 +7406,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::atanh(1));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::atanh_string, X> atanh(X x) {
+    constexpr internal::built_in_function_t<double, internal::atanh_string, X> atanh(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7423,7 +7422,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::atanh<std::optional<double>>(1));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::atanh_string, X> atanh(X x) {
+    constexpr internal::built_in_function_t<R, internal::atanh_string, X> atanh(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7435,7 +7434,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::ceil(&User::rating));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::ceil_string, X> ceil(X x) {
+    constexpr internal::built_in_function_t<double, internal::ceil_string, X> ceil(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7451,7 +7450,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::ceil<std::optional<double>>(&User::rating));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::ceil_string, X> ceil(X x) {
+    constexpr internal::built_in_function_t<R, internal::ceil_string, X> ceil(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7463,7 +7462,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::ceiling(&User::rating));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::ceiling_string, X> ceiling(X x) {
+    constexpr internal::built_in_function_t<double, internal::ceiling_string, X> ceiling(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7479,7 +7478,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::ceiling<std::optional<double>>(&User::rating));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::ceiling_string, X> ceiling(X x) {
+    constexpr internal::built_in_function_t<R, internal::ceiling_string, X> ceiling(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7491,7 +7490,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::cos(&Triangle::cornerB));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::cos_string, X> cos(X x) {
+    constexpr internal::built_in_function_t<double, internal::cos_string, X> cos(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7507,7 +7506,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::cos<std::optional<double>>(&User::rating));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::cos_string, X> cos(X x) {
+    constexpr internal::built_in_function_t<R, internal::cos_string, X> cos(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7519,7 +7518,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::cosh(&Triangle::cornerB));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::cosh_string, X> cosh(X x) {
+    constexpr internal::built_in_function_t<double, internal::cosh_string, X> cosh(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7535,7 +7534,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::cosh<std::optional<double>>(&User::rating));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::cosh_string, X> cosh(X x) {
+    constexpr internal::built_in_function_t<R, internal::cosh_string, X> cosh(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7547,7 +7546,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::degrees(&Triangle::cornerB));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::degrees_string, X> degrees(X x) {
+    constexpr internal::built_in_function_t<double, internal::degrees_string, X> degrees(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7563,7 +7562,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::degrees<std::optional<double>>(&User::rating));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::degrees_string, X> degrees(X x) {
+    constexpr internal::built_in_function_t<R, internal::degrees_string, X> degrees(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7575,7 +7574,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::exp(&Triangle::cornerB));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::exp_string, X> exp(X x) {
+    constexpr internal::built_in_function_t<double, internal::exp_string, X> exp(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7591,7 +7590,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::exp<std::optional<double>>(&User::rating));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::exp_string, X> exp(X x) {
+    constexpr internal::built_in_function_t<R, internal::exp_string, X> exp(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7603,7 +7602,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::floor(&User::rating));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::floor_string, X> floor(X x) {
+    constexpr internal::built_in_function_t<double, internal::floor_string, X> floor(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7619,7 +7618,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::floor<std::optional<double>>(&User::rating));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::floor_string, X> floor(X x) {
+    constexpr internal::built_in_function_t<R, internal::floor_string, X> floor(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7631,7 +7630,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::ln(200));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::ln_string, X> ln(X x) {
+    constexpr internal::built_in_function_t<double, internal::ln_string, X> ln(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7647,7 +7646,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::ln<std::optional<double>>(200));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::ln_string, X> ln(X x) {
+    constexpr internal::built_in_function_t<R, internal::ln_string, X> ln(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7659,7 +7658,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::log(100));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::log_string, X> log(X x) {
+    constexpr internal::built_in_function_t<double, internal::log_string, X> log(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7675,7 +7674,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::log<std::optional<double>>(100));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::log_string, X> log(X x) {
+    constexpr internal::built_in_function_t<R, internal::log_string, X> log(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7687,7 +7686,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::log10(100));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::log10_string, X> log10(X x) {
+    constexpr internal::built_in_function_t<double, internal::log10_string, X> log10(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7703,7 +7702,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::log10<std::optional<double>>(100));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::log10_string, X> log10(X x) {
+    constexpr internal::built_in_function_t<R, internal::log10_string, X> log10(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7715,7 +7714,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::log(10, 100));   //  decltype(rows) is std::vector<double>
      */
     template<class B, class X>
-    internal::built_in_function_t<double, internal::log_string, B, X> log(B b, X x) {
+    constexpr internal::built_in_function_t<double, internal::log_string, B, X> log(B b, X x) {
         return {std::tuple<B, X>{std::forward<B>(b), std::forward<X>(x)}};
     }
 
@@ -7731,7 +7730,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::log<std::optional<double>>(10, 100));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class B, class X>
-    internal::built_in_function_t<R, internal::log_string, B, X> log(B b, X x) {
+    constexpr internal::built_in_function_t<R, internal::log_string, B, X> log(B b, X x) {
         return {std::tuple<B, X>{std::forward<B>(b), std::forward<X>(x)}};
     }
 
@@ -7743,7 +7742,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::log2(64));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::log2_string, X> log2(X x) {
+    constexpr internal::built_in_function_t<double, internal::log2_string, X> log2(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7759,7 +7758,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::log2<std::optional<double>>(64));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::log2_string, X> log2(X x) {
+    constexpr internal::built_in_function_t<R, internal::log2_string, X> log2(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7771,7 +7770,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::mod_f(6, 5));   //  decltype(rows) is std::vector<double>
      */
     template<class X, class Y>
-    internal::built_in_function_t<double, internal::mod_string, X, Y> mod_f(X x, Y y) {
+    constexpr internal::built_in_function_t<double, internal::mod_string, X, Y> mod_f(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
@@ -7787,7 +7786,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::mod_f<std::optional<double>>(6, 5));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X, class Y>
-    internal::built_in_function_t<R, internal::mod_string, X, Y> mod_f(X x, Y y) {
+    constexpr internal::built_in_function_t<R, internal::mod_string, X, Y> mod_f(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
@@ -7798,7 +7797,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *
      *  auto rows = storage.select(sqlite_orm::pi());   //  decltype(rows) is std::vector<double>
      */
-    inline internal::built_in_function_t<double, internal::pi_string> pi() {
+    constexpr internal::built_in_function_t<double, internal::pi_string> pi() {
         return {{}};
     }
 
@@ -7814,7 +7813,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::pi<float>());   //  decltype(rows) is std::vector<float>
      */
     template<class R>
-    internal::built_in_function_t<R, internal::pi_string> pi() {
+    constexpr internal::built_in_function_t<R, internal::pi_string> pi() {
         return {{}};
     }
 
@@ -7826,7 +7825,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::pow(2, 5));   //  decltype(rows) is std::vector<double>
      */
     template<class X, class Y>
-    internal::built_in_function_t<double, internal::pow_string, X, Y> pow(X x, Y y) {
+    constexpr internal::built_in_function_t<double, internal::pow_string, X, Y> pow(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
@@ -7842,7 +7841,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::pow<std::optional<double>>(2, 5));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X, class Y>
-    internal::built_in_function_t<R, internal::pow_string, X, Y> pow(X x, Y y) {
+    constexpr internal::built_in_function_t<R, internal::pow_string, X, Y> pow(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
@@ -7854,7 +7853,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::power(2, 5));   //  decltype(rows) is std::vector<double>
      */
     template<class X, class Y>
-    internal::built_in_function_t<double, internal::power_string, X, Y> power(X x, Y y) {
+    constexpr internal::built_in_function_t<double, internal::power_string, X, Y> power(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
@@ -7870,7 +7869,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::power<std::optional<double>>(2, 5));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X, class Y>
-    internal::built_in_function_t<R, internal::power_string, X, Y> power(X x, Y y) {
+    constexpr internal::built_in_function_t<R, internal::power_string, X, Y> power(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
@@ -7882,7 +7881,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::radians(&Triangle::cornerAInDegrees));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::radians_string, X> radians(X x) {
+    constexpr internal::built_in_function_t<double, internal::radians_string, X> radians(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7898,7 +7897,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::radians<std::optional<double>>(&Triangle::cornerAInDegrees));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::radians_string, X> radians(X x) {
+    constexpr internal::built_in_function_t<R, internal::radians_string, X> radians(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7910,7 +7909,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::sin(&Triangle::cornerA));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::sin_string, X> sin(X x) {
+    constexpr internal::built_in_function_t<double, internal::sin_string, X> sin(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7926,7 +7925,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::sin<std::optional<double>>(&Triangle::cornerA));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::sin_string, X> sin(X x) {
+    constexpr internal::built_in_function_t<R, internal::sin_string, X> sin(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7938,7 +7937,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::sinh(&Triangle::cornerA));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::sinh_string, X> sinh(X x) {
+    constexpr internal::built_in_function_t<double, internal::sinh_string, X> sinh(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7954,7 +7953,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::sinh<std::optional<double>>(&Triangle::cornerA));   //  decltype(rows) is std::vector<std::optional<double>>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::sinh_string, X> sinh(X x) {
+    constexpr internal::built_in_function_t<R, internal::sinh_string, X> sinh(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7966,7 +7965,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::sqrt(25));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::sqrt_string, X> sqrt(X x) {
+    constexpr internal::built_in_function_t<double, internal::sqrt_string, X> sqrt(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7982,7 +7981,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::sqrt<int>(25));   //  decltype(rows) is std::vector<int>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::sqrt_string, X> sqrt(X x) {
+    constexpr internal::built_in_function_t<R, internal::sqrt_string, X> sqrt(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -7994,7 +7993,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::tan(&Triangle::cornerC));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::tan_string, X> tan(X x) {
+    constexpr internal::built_in_function_t<double, internal::tan_string, X> tan(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -8010,7 +8009,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::tan<float>(&Triangle::cornerC));   //  decltype(rows) is std::vector<float>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::tan_string, X> tan(X x) {
+    constexpr internal::built_in_function_t<R, internal::tan_string, X> tan(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -8022,7 +8021,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::tanh(&Triangle::cornerC));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::tanh_string, X> tanh(X x) {
+    constexpr internal::built_in_function_t<double, internal::tanh_string, X> tanh(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -8038,7 +8037,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::tanh<float>(&Triangle::cornerC));   //  decltype(rows) is std::vector<float>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::tanh_string, X> tanh(X x) {
+    constexpr internal::built_in_function_t<R, internal::tanh_string, X> tanh(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -8050,7 +8049,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::trunc(5.5));   //  decltype(rows) is std::vector<double>
      */
     template<class X>
-    internal::built_in_function_t<double, internal::trunc_string, X> trunc(X x) {
+    constexpr internal::built_in_function_t<double, internal::trunc_string, X> trunc(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -8066,15 +8065,16 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  auto rows = storage.select(sqlite_orm::trunc<float>(5.5));   //  decltype(rows) is std::vector<float>
      */
     template<class R, class X>
-    internal::built_in_function_t<R, internal::trunc_string, X> trunc(X x) {
+    constexpr internal::built_in_function_t<R, internal::trunc_string, X> trunc(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 #endif  //  SQLITE_ENABLE_MATH_FUNCTIONS
+
     /**
      *  TYPEOF(x) function https://sqlite.org/lang_corefunc.html#typeof
      */
     template<class T>
-    internal::built_in_function_t<std::string, internal::typeof_string, T> typeof_(T t) {
+    constexpr internal::built_in_function_t<std::string, internal::typeof_string, T> typeof_(T t) {
         return {std::tuple<T>{std::forward<T>(t)}};
     }
 
@@ -8082,7 +8082,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  UNICODE(x) function https://sqlite.org/lang_corefunc.html#unicode
      */
     template<class T>
-    internal::built_in_function_t<int, internal::unicode_string, T> unicode(T t) {
+    constexpr internal::built_in_function_t<int, internal::unicode_string, T> unicode(T t) {
         return {std::tuple<T>{std::forward<T>(t)}};
     }
 
@@ -8090,7 +8090,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  LENGTH(x) function https://sqlite.org/lang_corefunc.html#length
      */
     template<class T>
-    internal::built_in_function_t<int, internal::length_string, T> length(T t) {
+    constexpr internal::built_in_function_t<int, internal::length_string, T> length(T t) {
         return {std::tuple<T>{std::forward<T>(t)}};
     }
 
@@ -8098,7 +8098,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  ABS(x) function https://sqlite.org/lang_corefunc.html#abs
      */
     template<class T>
-    internal::built_in_function_t<std::unique_ptr<double>, internal::abs_string, T> abs(T t) {
+    constexpr internal::built_in_function_t<std::unique_ptr<double>, internal::abs_string, T> abs(T t) {
         return {std::tuple<T>{std::forward<T>(t)}};
     }
 
@@ -8106,7 +8106,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  LOWER(x) function https://sqlite.org/lang_corefunc.html#lower
      */
     template<class T>
-    internal::built_in_function_t<std::string, internal::lower_string, T> lower(T t) {
+    constexpr internal::built_in_function_t<std::string, internal::lower_string, T> lower(T t) {
         return {std::tuple<T>{std::forward<T>(t)}};
     }
 
@@ -8114,28 +8114,28 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  UPPER(x) function https://sqlite.org/lang_corefunc.html#upper
      */
     template<class T>
-    internal::built_in_function_t<std::string, internal::upper_string, T> upper(T t) {
+    constexpr internal::built_in_function_t<std::string, internal::upper_string, T> upper(T t) {
         return {std::tuple<T>{std::forward<T>(t)}};
     }
 
     /**
      *  LAST_INSERT_ROWID(x) function https://www.sqlite.org/lang_corefunc.html#last_insert_rowid
      */
-    inline internal::built_in_function_t<int64, internal::last_insert_rowid_string> last_insert_rowid() {
+    constexpr internal::built_in_function_t<int64, internal::last_insert_rowid_string> last_insert_rowid() {
         return {{}};
     }
 
     /**
      *  TOTAL_CHANGES() function https://sqlite.org/lang_corefunc.html#total_changes
      */
-    inline internal::built_in_function_t<int, internal::total_changes_string> total_changes() {
+    constexpr internal::built_in_function_t<int, internal::total_changes_string> total_changes() {
         return {{}};
     }
 
     /**
      *  CHANGES() function https://sqlite.org/lang_corefunc.html#changes
      */
-    inline internal::built_in_function_t<int, internal::changes_string> changes() {
+    constexpr internal::built_in_function_t<int, internal::changes_string> changes() {
         return {{}};
     }
 
@@ -8143,7 +8143,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  TRIM(X) function https://sqlite.org/lang_corefunc.html#trim
      */
     template<class T>
-    internal::built_in_function_t<std::string, internal::trim_string, T> trim(T t) {
+    constexpr internal::built_in_function_t<std::string, internal::trim_string, T> trim(T t) {
         return {std::tuple<T>{std::forward<T>(t)}};
     }
 
@@ -8151,7 +8151,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  TRIM(X,Y) function https://sqlite.org/lang_corefunc.html#trim
      */
     template<class X, class Y>
-    internal::built_in_function_t<std::string, internal::trim_string, X, Y> trim(X x, Y y) {
+    constexpr internal::built_in_function_t<std::string, internal::trim_string, X, Y> trim(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
@@ -8159,7 +8159,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  LTRIM(X) function https://sqlite.org/lang_corefunc.html#ltrim
      */
     template<class X>
-    internal::built_in_function_t<std::string, internal::ltrim_string, X> ltrim(X x) {
+    constexpr internal::built_in_function_t<std::string, internal::ltrim_string, X> ltrim(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -8167,7 +8167,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  LTRIM(X,Y) function https://sqlite.org/lang_corefunc.html#ltrim
      */
     template<class X, class Y>
-    internal::built_in_function_t<std::string, internal::ltrim_string, X, Y> ltrim(X x, Y y) {
+    constexpr internal::built_in_function_t<std::string, internal::ltrim_string, X, Y> ltrim(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
@@ -8175,7 +8175,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  RTRIM(X) function https://sqlite.org/lang_corefunc.html#rtrim
      */
     template<class X>
-    internal::built_in_function_t<std::string, internal::rtrim_string, X> rtrim(X x) {
+    constexpr internal::built_in_function_t<std::string, internal::rtrim_string, X> rtrim(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -8183,7 +8183,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  RTRIM(X,Y) function https://sqlite.org/lang_corefunc.html#rtrim
      */
     template<class X, class Y>
-    internal::built_in_function_t<std::string, internal::rtrim_string, X, Y> rtrim(X x, Y y) {
+    constexpr internal::built_in_function_t<std::string, internal::rtrim_string, X, Y> rtrim(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
@@ -8191,7 +8191,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  HEX(X) function https://sqlite.org/lang_corefunc.html#hex
      */
     template<class X>
-    internal::built_in_function_t<std::string, internal::hex_string, X> hex(X x) {
+    constexpr internal::built_in_function_t<std::string, internal::hex_string, X> hex(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -8199,7 +8199,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  QUOTE(X) function https://sqlite.org/lang_corefunc.html#quote
      */
     template<class X>
-    internal::built_in_function_t<std::string, internal::quote_string, X> quote(X x) {
+    constexpr internal::built_in_function_t<std::string, internal::quote_string, X> quote(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -8207,7 +8207,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  RANDOMBLOB(X) function https://sqlite.org/lang_corefunc.html#randomblob
      */
     template<class X>
-    internal::built_in_function_t<std::vector<char>, internal::randomblob_string, X> randomblob(X x) {
+    constexpr internal::built_in_function_t<std::vector<char>, internal::randomblob_string, X> randomblob(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -8215,7 +8215,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  INSTR(X) function https://sqlite.org/lang_corefunc.html#instr
      */
     template<class X, class Y>
-    internal::built_in_function_t<int, internal::instr_string, X, Y> instr(X x, Y y) {
+    constexpr internal::built_in_function_t<int, internal::instr_string, X, Y> instr(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
@@ -8226,7 +8226,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
              class Y,
              class Z,
              std::enable_if_t<internal::count_tuple<std::tuple<X, Y, Z>, internal::is_into>::value == 0, bool> = true>
-    internal::built_in_function_t<std::string, internal::replace_string, X, Y, Z> replace(X x, Y y, Z z) {
+    constexpr internal::built_in_function_t<std::string, internal::replace_string, X, Y, Z> replace(X x, Y y, Z z) {
         return {std::tuple<X, Y, Z>{std::forward<X>(x), std::forward<Y>(y), std::forward<Z>(z)}};
     }
 
@@ -8234,7 +8234,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  ROUND(X) function https://sqlite.org/lang_corefunc.html#round
      */
     template<class X>
-    internal::built_in_function_t<double, internal::round_string, X> round(X x) {
+    constexpr internal::built_in_function_t<double, internal::round_string, X> round(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -8242,7 +8242,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  ROUND(X, Y) function https://sqlite.org/lang_corefunc.html#round
      */
     template<class X, class Y>
-    internal::built_in_function_t<double, internal::round_string, X, Y> round(X x, Y y) {
+    constexpr internal::built_in_function_t<double, internal::round_string, X, Y> round(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
@@ -8251,14 +8251,14 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  CHAR(X1,X2,...,XN) function https://sqlite.org/lang_corefunc.html#char
      */
     template<class... Args>
-    internal::built_in_function_t<std::string, internal::char_string, Args...> char_(Args... args) {
+    constexpr internal::built_in_function_t<std::string, internal::char_string, Args...> char_(Args... args) {
         return {std::make_tuple(std::forward<Args>(args)...)};
     }
 
     /**
      *  RANDOM() function https://www.sqlite.org/lang_corefunc.html#random
      */
-    inline internal::built_in_function_t<int, internal::random_string> random() {
+    constexpr internal::built_in_function_t<int, internal::random_string> random() {
         return {{}};
     }
 #endif
@@ -8267,7 +8267,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  COALESCE(X,Y,...) function https://www.sqlite.org/lang_corefunc.html#coalesce
      */
     template<class R = void, class... Args>
-    auto coalesce(Args... args)
+    constexpr auto coalesce(Args... args)
         -> internal::built_in_function_t<typename mpl::conditional_t<  //  choose R or common type
                                              std::is_void<R>::value,
                                              std::common_type<internal::field_type_or_type_t<Args>...>,
@@ -8281,7 +8281,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  IFNULL(X,Y) function https://www.sqlite.org/lang_corefunc.html#ifnull
      */
     template<class R = void, class X, class Y>
-    auto ifnull(X x, Y y) -> internal::built_in_function_t<
+    constexpr auto ifnull(X x, Y y) -> internal::built_in_function_t<
         typename mpl::conditional_t<  //  choose R or common type
             std::is_void<R>::value,
             std::common_type<internal::field_type_or_type_t<X>, internal::field_type_or_type_t<Y>>,
@@ -8307,7 +8307,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
                                                                             internal::field_type_or_type_t<X>,
                                                                             internal::field_type_or_type_t<Y>>>,
                               bool> = true>
-    auto nullif(X x, Y y) {
+    constexpr auto nullif(X x, Y y) {
         if constexpr (std::is_void<R>::value) {
             using F = internal::built_in_function_t<
                 std::optional<std::common_type_t<internal::field_type_or_type_t<X>, internal::field_type_or_type_t<Y>>>,
@@ -8324,7 +8324,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     }
 #else
     template<class R, class X, class Y>
-    internal::built_in_function_t<R, internal::nullif_string, X, Y> nullif(X x, Y y) {
+    constexpr internal::built_in_function_t<R, internal::nullif_string, X, Y> nullif(X x, Y y) {
         return {std::make_tuple(std::move(x), std::move(y))};
     }
 #endif
@@ -8333,7 +8333,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  DATE(timestring, modifier, modifier, ...) function https://www.sqlite.org/lang_datefunc.html
      */
     template<class... Args>
-    internal::built_in_function_t<std::string, internal::date_string, Args...> date(Args... args) {
+    constexpr internal::built_in_function_t<std::string, internal::date_string, Args...> date(Args... args) {
         return {std::tuple<Args...>{std::forward<Args>(args)...}};
     }
 
@@ -8341,7 +8341,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  TIME(timestring, modifier, modifier, ...) function https://www.sqlite.org/lang_datefunc.html
      */
     template<class... Args>
-    internal::built_in_function_t<std::string, internal::time_string, Args...> time(Args... args) {
+    constexpr internal::built_in_function_t<std::string, internal::time_string, Args...> time(Args... args) {
         return {std::tuple<Args...>{std::forward<Args>(args)...}};
     }
 
@@ -8349,7 +8349,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  DATETIME(timestring, modifier, modifier, ...) function https://www.sqlite.org/lang_datefunc.html
      */
     template<class... Args>
-    internal::built_in_function_t<std::string, internal::datetime_string, Args...> datetime(Args... args) {
+    constexpr internal::built_in_function_t<std::string, internal::datetime_string, Args...> datetime(Args... args) {
         return {std::tuple<Args...>{std::forward<Args>(args)...}};
     }
 
@@ -8357,7 +8357,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  JULIANDAY(timestring, modifier, modifier, ...) function https://www.sqlite.org/lang_datefunc.html
      */
     template<class... Args>
-    internal::built_in_function_t<double, internal::julianday_string, Args...> julianday(Args... args) {
+    constexpr internal::built_in_function_t<double, internal::julianday_string, Args...> julianday(Args... args) {
         return {std::tuple<Args...>{std::forward<Args>(args)...}};
     }
 
@@ -8365,7 +8365,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  STRFTIME(timestring, modifier, modifier, ...) function https://www.sqlite.org/lang_datefunc.html
      */
     template<class... Args>
-    internal::built_in_function_t<std::string, internal::strftime_string, Args...> strftime(Args... args) {
+    constexpr internal::built_in_function_t<std::string, internal::strftime_string, Args...> strftime(Args... args) {
         return {std::tuple<Args...>{std::forward<Args>(args)...}};
     }
 
@@ -8373,7 +8373,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  ZEROBLOB(N) function https://www.sqlite.org/lang_corefunc.html#zeroblob
      */
     template<class N>
-    internal::built_in_function_t<std::vector<char>, internal::zeroblob_string, N> zeroblob(N n) {
+    constexpr internal::built_in_function_t<std::vector<char>, internal::zeroblob_string, N> zeroblob(N n) {
         return {std::tuple<N>{std::forward<N>(n)}};
     }
 
@@ -8381,7 +8381,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  SUBSTR(X,Y) function https://www.sqlite.org/lang_corefunc.html#substr
      */
     template<class X, class Y>
-    internal::built_in_function_t<std::string, internal::substr_string, X, Y> substr(X x, Y y) {
+    constexpr internal::built_in_function_t<std::string, internal::substr_string, X, Y> substr(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
@@ -8389,7 +8389,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  SUBSTR(X,Y,Z) function https://www.sqlite.org/lang_corefunc.html#substr
      */
     template<class X, class Y, class Z>
-    internal::built_in_function_t<std::string, internal::substr_string, X, Y, Z> substr(X x, Y y, Z z) {
+    constexpr internal::built_in_function_t<std::string, internal::substr_string, X, Y, Z> substr(X x, Y y, Z z) {
         return {std::tuple<X, Y, Z>{std::forward<X>(x), std::forward<Y>(y), std::forward<Z>(z)}};
     }
 
@@ -8398,7 +8398,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  SOUNDEX(X) function https://www.sqlite.org/lang_corefunc.html#soundex
      */
     template<class X>
-    internal::built_in_function_t<std::string, internal::soundex_string, X> soundex(X x) {
+    constexpr internal::built_in_function_t<std::string, internal::soundex_string, X> soundex(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 #endif
@@ -8407,7 +8407,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  TOTAL(X) aggregate function.
      */
     template<class X>
-    internal::built_in_aggregate_function_t<double, internal::total_string, X> total(X x) {
+    constexpr internal::built_in_aggregate_function_t<double, internal::total_string, X> total(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -8415,7 +8415,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  SUM(X) aggregate function.
      */
     template<class X>
-    internal::built_in_aggregate_function_t<std::unique_ptr<double>, internal::sum_string, X> sum(X x) {
+    constexpr internal::built_in_aggregate_function_t<std::unique_ptr<double>, internal::sum_string, X> sum(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -8430,7 +8430,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     /**
      *  COUNT(*) without FROM function.
      */
-    inline internal::count_asterisk_without_type count() {
+    constexpr internal::count_asterisk_without_type count() {
         return {};
     }
 
@@ -8439,7 +8439,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  a from argument.
      */
     template<class T>
-    internal::count_asterisk_t<T> count() {
+    constexpr internal::count_asterisk_t<T> count() {
         return {};
     }
 
@@ -8449,7 +8449,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  a from argument.
      */
     template<orm_refers_to_recordset auto mapped>
-    auto count() {
+    constexpr auto count() {
         return count<internal::auto_decay_table_ref_t<mapped>>();
     }
 #endif
@@ -8458,7 +8458,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  AVG(X) aggregate function.
      */
     template<class X>
-    internal::built_in_aggregate_function_t<double, internal::avg_string, X> avg(X x) {
+    constexpr internal::built_in_aggregate_function_t<double, internal::avg_string, X> avg(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -8466,7 +8466,8 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  MAX(X) aggregate function.
      */
     template<class X>
-    internal::built_in_aggregate_function_t<internal::unique_ptr_result_of<X>, internal::max_string, X> max(X x) {
+    constexpr internal::built_in_aggregate_function_t<internal::unique_ptr_result_of<X>, internal::max_string, X>
+    max(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -8474,7 +8475,8 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  MIN(X) aggregate function.
      */
     template<class X>
-    internal::built_in_aggregate_function_t<internal::unique_ptr_result_of<X>, internal::min_string, X> min(X x) {
+    constexpr internal::built_in_aggregate_function_t<internal::unique_ptr_result_of<X>, internal::min_string, X>
+    min(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -8483,7 +8485,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  The return type is the type of the first argument.
      */
     template<class X, class Y, class... Rest>
-    internal::built_in_function_t<internal::unique_ptr_result_of<X>, internal::max_string, X, Y, Rest...>
+    constexpr internal::built_in_function_t<internal::unique_ptr_result_of<X>, internal::max_string, X, Y, Rest...>
     max(X x, Y y, Rest... rest) {
         return {std::tuple<X, Y, Rest...>{std::forward<X>(x), std::forward<Y>(y), std::forward<Rest>(rest)...}};
     }
@@ -8493,7 +8495,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  The return type is the type of the first argument.
      */
     template<class X, class Y, class... Rest>
-    internal::built_in_function_t<internal::unique_ptr_result_of<X>, internal::min_string, X, Y, Rest...>
+    constexpr internal::built_in_function_t<internal::unique_ptr_result_of<X>, internal::min_string, X, Y, Rest...>
     min(X x, Y y, Rest... rest) {
         return {std::tuple<X, Y, Rest...>{std::forward<X>(x), std::forward<Y>(y), std::forward<Rest>(rest)...}};
     }
@@ -8502,7 +8504,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  GROUP_CONCAT(X) aggregate function.
      */
     template<class X>
-    internal::built_in_aggregate_function_t<std::string, internal::group_concat_string, X> group_concat(X x) {
+    constexpr internal::built_in_aggregate_function_t<std::string, internal::group_concat_string, X> group_concat(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
@@ -8510,32 +8512,34 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  GROUP_CONCAT(X, Y) aggregate function.
      */
     template<class X, class Y>
-    internal::built_in_aggregate_function_t<std::string, internal::group_concat_string, X, Y> group_concat(X x, Y y) {
+    constexpr internal::built_in_aggregate_function_t<std::string, internal::group_concat_string, X, Y>
+    group_concat(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 #ifdef SQLITE_ENABLE_JSON1
     template<class X>
-    internal::built_in_function_t<std::string, internal::json_string, X> json(X x) {
+    constexpr internal::built_in_function_t<std::string, internal::json_string, X> json(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
     template<class... Args>
-    internal::built_in_function_t<std::string, internal::json_array_string, Args...> json_array(Args... args) {
+    constexpr internal::built_in_function_t<std::string, internal::json_array_string, Args...>
+    json_array(Args... args) {
         return {std::tuple<Args...>{std::forward<Args>(args)...}};
     }
 
     template<class X>
-    internal::built_in_function_t<int, internal::json_array_length_string, X> json_array_length(X x) {
+    constexpr internal::built_in_function_t<int, internal::json_array_length_string, X> json_array_length(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
     template<class R, class X>
-    internal::built_in_function_t<R, internal::json_array_length_string, X> json_array_length(X x) {
+    constexpr internal::built_in_function_t<R, internal::json_array_length_string, X> json_array_length(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
     template<class X, class Y>
-    internal::built_in_function_t<int, internal::json_array_length_string, X, Y> json_array_length(X x, Y y) {
+    constexpr internal::built_in_function_t<int, internal::json_array_length_string, X, Y> json_array_length(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
@@ -8545,93 +8549,98 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     }
 
     template<class R, class X, class... Args>
-    internal::built_in_function_t<R, internal::json_extract_string, X, Args...> json_extract(X x, Args... args) {
+    constexpr internal::built_in_function_t<R, internal::json_extract_string, X, Args...> json_extract(X x,
+                                                                                                       Args... args) {
         return {std::tuple<X, Args...>{std::forward<X>(x), std::forward<Args>(args)...}};
     }
 
     template<class X, class... Args>
-    internal::built_in_function_t<std::string, internal::json_insert_string, X, Args...> json_insert(X x,
-                                                                                                     Args... args) {
+    constexpr internal::built_in_function_t<std::string, internal::json_insert_string, X, Args...>
+    json_insert(X x, Args... args) {
         static_assert(std::tuple_size<std::tuple<Args...>>::value % 2 == 0,
                       "number of arguments in json_insert must be odd");
         return {std::tuple<X, Args...>{std::forward<X>(x), std::forward<Args>(args)...}};
     }
 
     template<class X, class... Args>
-    internal::built_in_function_t<std::string, internal::json_replace_string, X, Args...> json_replace(X x,
-                                                                                                       Args... args) {
+    constexpr internal::built_in_function_t<std::string, internal::json_replace_string, X, Args...>
+    json_replace(X x, Args... args) {
         static_assert(std::tuple_size<std::tuple<Args...>>::value % 2 == 0,
                       "number of arguments in json_replace must be odd");
         return {std::tuple<X, Args...>{std::forward<X>(x), std::forward<Args>(args)...}};
     }
 
     template<class X, class... Args>
-    internal::built_in_function_t<std::string, internal::json_set_string, X, Args...> json_set(X x, Args... args) {
+    constexpr internal::built_in_function_t<std::string, internal::json_set_string, X, Args...> json_set(X x,
+                                                                                                         Args... args) {
         static_assert(std::tuple_size<std::tuple<Args...>>::value % 2 == 0,
                       "number of arguments in json_set must be odd");
         return {std::tuple<X, Args...>{std::forward<X>(x), std::forward<Args>(args)...}};
     }
 
     template<class... Args>
-    internal::built_in_function_t<std::string, internal::json_object_string, Args...> json_object(Args... args) {
+    constexpr internal::built_in_function_t<std::string, internal::json_object_string, Args...>
+    json_object(Args... args) {
         static_assert(std::tuple_size<std::tuple<Args...>>::value % 2 == 0,
                       "number of arguments in json_object must be even");
         return {std::tuple<Args...>{std::forward<Args>(args)...}};
     }
 
     template<class X, class Y>
-    internal::built_in_function_t<std::string, internal::json_patch_string, X, Y> json_patch(X x, Y y) {
+    constexpr internal::built_in_function_t<std::string, internal::json_patch_string, X, Y> json_patch(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
     template<class X, class... Args>
-    internal::built_in_function_t<std::string, internal::json_remove_string, X, Args...> json_remove(X x,
-                                                                                                     Args... args) {
+    constexpr internal::built_in_function_t<std::string, internal::json_remove_string, X, Args...>
+    json_remove(X x, Args... args) {
         return {std::tuple<X, Args...>{std::forward<X>(x), std::forward<Args>(args)...}};
     }
 
     template<class R, class X, class... Args>
-    internal::built_in_function_t<R, internal::json_remove_string, X, Args...> json_remove(X x, Args... args) {
+    constexpr internal::built_in_function_t<R, internal::json_remove_string, X, Args...> json_remove(X x,
+                                                                                                     Args... args) {
         return {std::tuple<X, Args...>{std::forward<X>(x), std::forward<Args>(args)...}};
     }
 
     template<class X>
-    internal::built_in_function_t<std::string, internal::json_type_string, X> json_type(X x) {
+    constexpr internal::built_in_function_t<std::string, internal::json_type_string, X> json_type(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
     template<class R, class X>
-    internal::built_in_function_t<R, internal::json_type_string, X> json_type(X x) {
+    constexpr internal::built_in_function_t<R, internal::json_type_string, X> json_type(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
     template<class X, class Y>
-    internal::built_in_function_t<std::string, internal::json_type_string, X, Y> json_type(X x, Y y) {
+    constexpr internal::built_in_function_t<std::string, internal::json_type_string, X, Y> json_type(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
     template<class R, class X, class Y>
-    internal::built_in_function_t<R, internal::json_type_string, X, Y> json_type(X x, Y y) {
+    constexpr internal::built_in_function_t<R, internal::json_type_string, X, Y> json_type(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
     template<class X>
-    internal::built_in_function_t<bool, internal::json_valid_string, X> json_valid(X x) {
+    constexpr internal::built_in_function_t<bool, internal::json_valid_string, X> json_valid(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
     template<class R, class X>
-    internal::built_in_function_t<R, internal::json_quote_string, X> json_quote(X x) {
+    constexpr internal::built_in_function_t<R, internal::json_quote_string, X> json_quote(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
     template<class X>
-    internal::built_in_function_t<std::string, internal::json_group_array_string, X> json_group_array(X x) {
+    constexpr internal::built_in_function_t<std::string, internal::json_group_array_string, X> json_group_array(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
     template<class X, class Y>
-    internal::built_in_function_t<std::string, internal::json_group_object_string, X, Y> json_group_object(X x, Y y) {
+    constexpr internal::built_in_function_t<std::string, internal::json_group_object_string, X, Y>
+    json_group_object(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 #endif  //  SQLITE_ENABLE_JSON1

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -4040,7 +4040,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 
 #if SQLITE_VERSION_NUMBER >= 3006019
     /**
-     *  FOREIGN KEY constraint builder function taking one or more fields, which can either be pointers to class members or column pointers.
+     *  FOREIGN KEY constraint factory function taking one or more fields, which can either be pointers to class members or column pointers.
      *  Available since SQLite 3.6.19
      */
     template<class... Cs>
@@ -4049,7 +4049,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     }
 
     /**
-     *  FOREIGN KEY constraint builder function taking one or more fields that are member pointers of base classes,
+     *  FOREIGN KEY constraint factory function taking one or more fields that are member pointers of base classes,
      *  specifying the derived class as an explicit template argument.
      *  Available since SQLite 3.6.19
      */
@@ -4062,7 +4062,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
     /**
-     *  FOREIGN KEY constraint builder function taking one or more fields that are member pointers of base classes,
+     *  FOREIGN KEY constraint factory function taking one or more fields that are member pointers of base classes,
      *  specifying the derived class as an explicit template argument.
      *  Available since SQLite 3.6.19
      */
@@ -4074,7 +4074,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 #endif
 
     /**
-     *  UNIQUE table constraint builder function.
+     *  UNIQUE table constraint factory function.
      */
     template<class... Args>
     constexpr internal::unique_t<Args...> unique(Args... args) {
@@ -4082,24 +4082,24 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     }
 
     /**
-     *  UNIQUE column constraint builder function.
+     *  UNIQUE column constraint factory function.
      */
-    inline constexpr internal::unique_t<> unique() {
+    constexpr internal::unique_t<> unique() {
         return {{}};
     }
 
 #if SQLITE_VERSION_NUMBER >= 3009000 || defined(SQLITE_ORM_ENABLE_FTS5)
     /**
-     *  UNINDEXED column constraint builder function. Used in FTS virtual tables.
+     *  UNINDEXED column constraint factory function. Used in FTS virtual tables.
      *  
      *  https://www.sqlite.org/fts5.html#the_unindexed_column_option
      */
-    inline constexpr internal::unindexed_t unindexed() {
+    constexpr internal::unindexed_t unindexed() {
         return {};
     }
 
     /**
-     *  prefix=N table constraint builder function. Used in FTS virtual tables.
+     *  prefix=N table constraint factory function. Used in FTS virtual tables.
      *  
      *  https://www.sqlite.org/fts5.html#prefix_indexes
      */
@@ -4109,7 +4109,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     }
 
     /**
-     *  tokenize='...'' table constraint builder function. Used in FTS virtual tables.
+     *  tokenize='...'' table constraint factory function. Used in FTS virtual tables.
      *  
      *  https://www.sqlite.org/fts5.html#tokenizers
      */
@@ -4119,7 +4119,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     }
 
     /**
-     *  content='' table constraint builder function. Used in FTS virtual tables.
+     *  content='' table constraint factory function. Used in FTS virtual tables.
      *  
      *  https://www.sqlite.org/fts5.html#contentless_tables
      */
@@ -4129,7 +4129,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     }
 
     /**
-     *  content='table' table constraint builder function. Used in FTS virtual tables.
+     *  content='table' table constraint factory function. Used in FTS virtual tables.
      *  
      *  https://www.sqlite.org/fts5.html#external_content_tables
      */
@@ -4149,7 +4149,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
     /**
-     *  content='table' table constraint builder function. Used in FTS virtual tables.
+     *  content='table' table constraint factory function. Used in FTS virtual tables.
      *  
      *  https://www.sqlite.org/fts5.html#external_content_tables
      */
@@ -4161,7 +4161,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 #endif
 
     /**
-     *  PRIMARY KEY constraint builder function taking one or more fields, which can either be pointers to class members or column pointers.
+     *  PRIMARY KEY constraint factory function taking one or more fields, which can either be pointers to class members or column pointers.
      */
     template<class... Cs>
     constexpr internal::primary_key_t<Cs...> primary_key(Cs... cs) {
@@ -4169,7 +4169,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     }
 
     /**
-     *  PRIMARY KEY constraint builder function taking one or more fields that are member pointers of base classes,
+     *  PRIMARY KEY constraint factory function taking one or more fields that are member pointers of base classes,
      *  specifying the derived class as an explicit template argument.
      */
     template<class O, class... Base, class... F>
@@ -4181,7 +4181,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 
 #ifdef SQLITE_ORM_WITH_CPP20_ALIASES
     /**
-     *  PRIMARY KEY constraint builder function taking one or more fields that are member pointers of base classes,
+     *  PRIMARY KEY constraint factory function taking one or more fields that are member pointers of base classes,
      *  specifying the derived class as an explicit template argument.
      */
     template<orm_table_reference auto table, class... Base, class... F>
@@ -4191,9 +4191,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 #endif
 
     /**
-     *  PRIMARY KEY column constraint builder function (used at a single column).
+     *  PRIMARY KEY column constraint factory function (used at a single column).
      */
-    inline constexpr internal::primary_key_t<> primary_key() {
+    constexpr internal::primary_key_t<> primary_key() {
         return {{}};
     }
 
@@ -4202,15 +4202,15 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
         return {std::move(t)};
     }
 
-    inline constexpr internal::collate_constraint_t collate_nocase() {
+    constexpr internal::collate_constraint_t collate_nocase() {
         return {internal::collate_argument::nocase};
     }
 
-    inline constexpr internal::collate_constraint_t collate_binary() {
+    constexpr internal::collate_constraint_t collate_binary() {
         return {internal::collate_argument::binary};
     }
 
-    inline constexpr internal::collate_constraint_t collate_rtrim() {
+    constexpr internal::collate_constraint_t collate_rtrim() {
         return {internal::collate_argument::rtrim};
     }
 
@@ -4219,11 +4219,11 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
         return {std::move(t)};
     }
 
-    inline constexpr internal::null_t null() {
+    constexpr internal::null_t null() {
         return {};
     }
 
-    inline constexpr internal::not_null_t not_null() {
+    constexpr internal::not_null_t not_null() {
         return {};
     }
 }

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -3508,7 +3508,7 @@ namespace sqlite_orm::internal {
     struct primary_key_with_autoincrement : T {
         using primary_key_type = T;
 
-        constexpr const primary_key_type& as_base() const {
+        const primary_key_type& as_base() const {
             return *this;
         }
     };

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -3903,8 +3903,8 @@ namespace sqlite_orm::internal {
         };
 
 #if SQLITE_VERSION_NUMBER >= 3031000
-        bool full = true;
-        storage_type storage = storage_type::not_specified;
+        bool _full = true;
+        storage_type _storage = storage_type::not_specified;
 #endif
     };
 
@@ -3913,17 +3913,14 @@ namespace sqlite_orm::internal {
     struct generated_always_t : basic_generated_always {
         using expression_type = T;
 
-        expression_type expression;
+        expression_type _expression;
 
-        constexpr generated_always_t(expression_type expression_, bool full, storage_type storage) :
-            basic_generated_always{full, storage}, expression(std::move(expression_)) {}
-
-        constexpr generated_always_t<T> virtual_() {
-            return {std::move(this->expression), this->full, storage_type::virtual_};
+        constexpr generated_always_t<T> virtual_() && {
+            return {_full, storage_type::virtual_, std::move(_expression)};
         }
 
-        constexpr generated_always_t<T> stored() {
-            return {std::move(this->expression), this->full, storage_type::stored};
+        constexpr generated_always_t<T> stored() && {
+            return {_full, storage_type::stored, std::move(_expression)};
         }
     };
 #endif
@@ -4029,12 +4026,12 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 #if SQLITE_VERSION_NUMBER >= 3031000
     template<class T>
     constexpr internal::generated_always_t<T> generated_always_as(T expression) {
-        return {std::move(expression), true, internal::basic_generated_always::storage_type::not_specified};
+        return {true, internal::basic_generated_always::storage_type::not_specified, std::move(expression)};
     }
 
     template<class T>
     constexpr internal::generated_always_t<T> as(T expression) {
-        return {std::move(expression), false, internal::basic_generated_always::storage_type::not_specified};
+        return {false, internal::basic_generated_always::storage_type::not_specified, std::move(expression)};
     }
 #endif
 
@@ -13683,7 +13680,7 @@ namespace sqlite_orm::internal {
                     using generated_op_index_sequence =
                         filter_tuple_sequence_t<std::remove_const_t<decltype(column.constraints)>, is_generated_always>;
                     constexpr size_t opIndex = index_sequence_value_at<0>(generated_op_index_sequence{});
-                    result = &std::get<opIndex>(column.constraints).storage;
+                    result = &std::get<opIndex>(column.constraints)._storage;
                 });
 #endif
             return result;
@@ -23690,12 +23687,12 @@ namespace sqlite_orm::internal {
         SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
                                                         const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
             std::stringstream ss;
-            if (statement.full) {
+            if (statement._full) {
                 ss << "GENERATED ALWAYS ";
             }
             ss << "AS (";
-            ss << serialize(statement.expression, context) << ")";
-            switch (statement.storage) {
+            ss << serialize(statement._expression, context) << ")";
+            switch (statement._storage) {
                 case basic_generated_always::storage_type::not_specified:
                     //..
                     break;

--- a/tests/statement_serializer_tests/collate.cpp
+++ b/tests/statement_serializer_tests/collate.cpp
@@ -9,17 +9,17 @@ TEST_CASE("statement_serializer collate") {
     std::string value;
     std::string expected;
     SECTION("COLLATE NOCASE") {
-        auto col = collate_nocase();
+        constexpr auto col = collate_nocase();
         value = serialize(col, context);
         expected = "COLLATE NOCASE";
     }
     SECTION("COLLATE BINARY") {
-        auto col = collate_binary();
+        constexpr auto col = collate_binary();
         value = serialize(col, context);
         expected = "COLLATE BINARY";
     }
     SECTION("COLLATE RTRIM") {
-        auto col = collate_rtrim();
+        constexpr auto col = collate_rtrim();
         value = serialize(col, context);
         expected = "COLLATE RTRIM";
     }

--- a/tests/statement_serializer_tests/column_constraints/check.cpp
+++ b/tests/statement_serializer_tests/column_constraints/check.cpp
@@ -44,7 +44,7 @@ TEST_CASE("statement_serializer check") {
             std::string pubName;
             int price = 0;
         };
-        auto ch = check(less_than(0, &Book::price));
+        constexpr auto ch = check(less_than(0, &Book::price));
         auto table = make_table("BOOK",
                                 make_column("Book_id", &Book::id, primary_key()),
                                 make_column("Book_name", &Book::name),

--- a/tests/statement_serializer_tests/column_constraints/default.cpp
+++ b/tests/statement_serializer_tests/column_constraints/default.cpp
@@ -9,17 +9,17 @@ TEST_CASE("statement_serializer default") {
     std::string value;
     decltype(value) expected;
     SECTION("int literal") {
-        auto def = default_value(1);
+        constexpr auto def = default_value(1);
         value = serialize(def, context);
         expected = "DEFAULT (1)";
     }
     SECTION("string literal") {
-        auto def = default_value("hi");
+        constexpr auto def = default_value("hi");
         value = serialize(def, context);
         expected = "DEFAULT ('hi')";
     }
     SECTION("func") {
-        auto def = default_value(datetime("now"));
+        constexpr auto def = default_value(datetime("now"));
         SECTION("use_parentheses") {
             context.use_parentheses = true;
             expected = "DEFAULT (DATETIME('now'))";

--- a/tests/statement_serializer_tests/column_constraints/generated.cpp
+++ b/tests/statement_serializer_tests/column_constraints/generated.cpp
@@ -42,7 +42,7 @@ TEST_CASE("statement_serializer generated") {
     std::string value;
     decltype(value) expected;
     SECTION("full") {
-        auto constraint = generated_always_as(&Type::a * sqlite_orm::abs(&Type::b));
+        constexpr auto constraint = generated_always_as(&Type::a * sqlite_orm::abs(&Type::b));
         value = serialize(constraint, context);
         expected = R"(GENERATED ALWAYS AS ("a" * ABS("b")))";
     }
@@ -52,27 +52,27 @@ TEST_CASE("statement_serializer generated") {
         expected = R"(GENERATED ALWAYS AS ("a" * ABS("b")) VIRTUAL)";
     }
     SECTION("full stored") {
-        auto constraint = generated_always_as(&Type::a * sqlite_orm::abs(&Type::b)).stored();
+        constexpr auto constraint = generated_always_as(&Type::a * sqlite_orm::abs(&Type::b)).stored();
         value = serialize(constraint, context);
         expected = R"(GENERATED ALWAYS AS ("a" * ABS("b")) STORED)";
     }
     SECTION("not full") {
-        auto constraint = as(&Type::a * sqlite_orm::abs(&Type::b));
+        constexpr auto constraint = as(&Type::a * sqlite_orm::abs(&Type::b));
         value = serialize(constraint, context);
         expected = R"(AS ("a" * ABS("b")))";
     }
     SECTION("not full virtual") {
-        auto constraint = as(&Type::a * sqlite_orm::abs(&Type::b)).virtual_();
+        constexpr auto constraint = as(&Type::a * sqlite_orm::abs(&Type::b)).virtual_();
         value = serialize(constraint, context);
         expected = R"(AS ("a" * ABS("b")) VIRTUAL)";
     }
     SECTION("not full stored") {
-        auto constraint = as(&Type::a * sqlite_orm::abs(&Type::b)).stored();
+        constexpr auto constraint = as(&Type::a * sqlite_orm::abs(&Type::b)).stored();
         value = serialize(constraint, context);
         expected = R"(AS ("a" * ABS("b")) STORED)";
     }
     SECTION("length") {
-        auto constraint = generated_always_as(length(&Type::a));
+        constexpr auto constraint = generated_always_as(length(&Type::a));
         value = serialize(constraint, context);
         expected = R"(GENERATED ALWAYS AS (LENGTH("a")))";
     }

--- a/tests/statement_serializer_tests/column_constraints/not_null.cpp
+++ b/tests/statement_serializer_tests/column_constraints/not_null.cpp
@@ -6,7 +6,7 @@ using namespace sqlite_orm;
 TEST_CASE("statement_serializer not null") {
     internal::db_objects_tuple<> storage;
     internal::serializer_context<internal::db_objects_tuple<>> context{storage};
-    auto statement = not_null();
+    constexpr auto statement = not_null();
     auto value = serialize(statement, context);
     REQUIRE(value == "NOT NULL");
 }

--- a/tests/statement_serializer_tests/column_constraints/null.cpp
+++ b/tests/statement_serializer_tests/column_constraints/null.cpp
@@ -6,7 +6,7 @@ using namespace sqlite_orm;
 TEST_CASE("statement_serializer null") {
     internal::db_objects_tuple<> storage;
     internal::serializer_context<internal::db_objects_tuple<>> context{storage};
-    auto statement = null();
+    constexpr auto statement = null();
     auto value = serialize(statement, context);
     REQUIRE(value == "NULL");
 }

--- a/tests/statement_serializer_tests/column_constraints/unindexed.cpp
+++ b/tests/statement_serializer_tests/column_constraints/unindexed.cpp
@@ -7,7 +7,7 @@ using namespace sqlite_orm;
 TEST_CASE("statement_serializer unindexed") {
     internal::db_objects_tuple<> storage;
     internal::serializer_context<internal::db_objects_tuple<>> context{storage};
-    auto node = unindexed();
+    constexpr auto node = unindexed();
     auto value = serialize(node, context);
     REQUIRE(value == "UNINDEXED");
 }

--- a/tests/statement_serializer_tests/column_constraints/unique.cpp
+++ b/tests/statement_serializer_tests/column_constraints/unique.cpp
@@ -6,7 +6,7 @@ using namespace sqlite_orm;
 TEST_CASE("statement_serializer unique") {
     internal::db_objects_tuple<> storage;
     internal::serializer_context<internal::db_objects_tuple<>> context{storage};
-    auto un = unique();
-    auto value = serialize(un, context);
+    constexpr auto node = unique();
+    auto value = serialize(node, context);
     REQUIRE(value == "UNIQUE");
 }

--- a/tests/statement_serializer_tests/core_functions.cpp
+++ b/tests/statement_serializer_tests/core_functions.cpp
@@ -9,19 +9,19 @@ TEST_CASE("statement_serializer core functions") {
     std::string value;
     decltype(value) expected;
     SECTION("MAX(X,Y)") {
-        auto expression = max(3, 4);
+        constexpr auto expression = max(3, 4);
         context.use_parentheses = false;
         expected = "MAX(3, 4)";
         value = serialize(expression, context);
     }
     SECTION("MIN(X,Y)") {
-        auto expression = min(3, 4);
+        constexpr auto expression = min(3, 4);
         context.use_parentheses = false;
         expected = "MIN(3, 4)";
         value = serialize(expression, context);
     }
     SECTION("LENGTH") {
-        auto expression = length("hi");
+        constexpr auto expression = length("hi");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
             expected = "LENGTH('hi')";
@@ -33,7 +33,7 @@ TEST_CASE("statement_serializer core functions") {
         value = serialize(expression, context);
     }
     SECTION("ABS") {
-        auto expression = sqlite_orm::abs(-100);
+        constexpr auto expression = sqlite_orm::abs(-100);
         SECTION("use_parentheses") {
             context.use_parentheses = true;
             expected = "ABS(-100)";
@@ -45,7 +45,7 @@ TEST_CASE("statement_serializer core functions") {
         value = serialize(expression, context);
     }
     SECTION("LOWER") {
-        auto expression = lower("dancefloor");
+        constexpr auto expression = lower("dancefloor");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
             expected = "LOWER('dancefloor')";
@@ -57,7 +57,7 @@ TEST_CASE("statement_serializer core functions") {
         value = serialize(expression, context);
     }
     SECTION("UPPER") {
-        auto expression = upper("call");
+        constexpr auto expression = upper("call");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
             expected = "UPPER('call')";
@@ -69,7 +69,7 @@ TEST_CASE("statement_serializer core functions") {
         value = serialize(expression, context);
     }
     SECTION("TOTAL_CHANGES") {
-        auto expression = total_changes();
+        constexpr auto expression = total_changes();
         SECTION("use_parentheses") {
             context.use_parentheses = true;
             expected = "TOTAL_CHANGES()";
@@ -81,7 +81,7 @@ TEST_CASE("statement_serializer core functions") {
         value = serialize(expression, context);
     }
     SECTION("CHANGES") {
-        auto expression = changes();
+        constexpr auto expression = changes();
         SECTION("use_parentheses") {
             context.use_parentheses = true;
             expected = "CHANGES()";
@@ -93,7 +93,7 @@ TEST_CASE("statement_serializer core functions") {
         value = serialize(expression, context);
     }
     SECTION("TRIM(X)") {
-        auto expression = trim("hey");
+        constexpr auto expression = trim("hey");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
             expected = "TRIM('hey')";
@@ -105,7 +105,7 @@ TEST_CASE("statement_serializer core functions") {
         value = serialize(expression, context);
     }
     SECTION("TRIM(X,Y)") {
-        auto expression = trim("hey", "h");
+        constexpr auto expression = trim("hey", "h");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
             expected = "TRIM('hey', 'h')";
@@ -117,7 +117,7 @@ TEST_CASE("statement_serializer core functions") {
         value = serialize(expression, context);
     }
     SECTION("LTRIM(X)") {
-        auto expression = ltrim("hey");
+        constexpr auto expression = ltrim("hey");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
             expected = "LTRIM('hey')";
@@ -129,7 +129,7 @@ TEST_CASE("statement_serializer core functions") {
         value = serialize(expression, context);
     }
     SECTION("LTRIM(X,Y)") {
-        auto expression = ltrim("hey", "h");
+        constexpr auto expression = ltrim("hey", "h");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
             expected = "LTRIM('hey', 'h')";
@@ -141,7 +141,7 @@ TEST_CASE("statement_serializer core functions") {
         value = serialize(expression, context);
     }
     SECTION("RTRIM(X)") {
-        auto expression = rtrim("hey");
+        constexpr auto expression = rtrim("hey");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
             expected = "RTRIM('hey')";
@@ -153,7 +153,7 @@ TEST_CASE("statement_serializer core functions") {
         value = serialize(expression, context);
     }
     SECTION("RTRIM(X,Y)") {
-        auto expression = rtrim("hey", "h");
+        constexpr auto expression = rtrim("hey", "h");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
             expected = "RTRIM('hey', 'h')";
@@ -165,7 +165,7 @@ TEST_CASE("statement_serializer core functions") {
         value = serialize(expression, context);
     }
     SECTION("HEX") {
-        auto expression = hex("love");
+        constexpr auto expression = hex("love");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
             expected = "HEX('love')";
@@ -177,7 +177,7 @@ TEST_CASE("statement_serializer core functions") {
         value = serialize(expression, context);
     }
     SECTION("QUOTE") {
-        auto expression = quote("one");
+        constexpr auto expression = quote("one");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
             expected = "QUOTE('one')";
@@ -189,7 +189,7 @@ TEST_CASE("statement_serializer core functions") {
         value = serialize(expression, context);
     }
     SECTION("RANDOMBLOB") {
-        auto expression = randomblob(5);
+        constexpr auto expression = randomblob(5);
         SECTION("use_parentheses") {
             context.use_parentheses = true;
             expected = "RANDOMBLOB(5)";
@@ -201,7 +201,7 @@ TEST_CASE("statement_serializer core functions") {
         value = serialize(expression, context);
     }
     SECTION("INSTR") {
-        auto expression = instr("hi", "i");
+        constexpr auto expression = instr("hi", "i");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
             expected = "INSTR('hi', 'i')";
@@ -213,7 +213,7 @@ TEST_CASE("statement_serializer core functions") {
         value = serialize(expression, context);
     }
     SECTION("REPLACE") {
-        auto expression = replace("contigo", "o", "a");
+        constexpr auto expression = replace("contigo", "o", "a");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
             expected = "REPLACE('contigo', 'o', 'a')";
@@ -225,7 +225,7 @@ TEST_CASE("statement_serializer core functions") {
         value = serialize(expression, context);
     }
     SECTION("ROUND(X)") {
-        auto expression = sqlite_orm::round(10.5);
+        constexpr auto expression = sqlite_orm::round(10.5);
         SECTION("use_parentheses") {
             context.use_parentheses = true;
             expected = "ROUND(10.5)";
@@ -237,7 +237,7 @@ TEST_CASE("statement_serializer core functions") {
         value = serialize(expression, context);
     }
     SECTION("ROUND(X,Y)") {
-        auto expression = sqlite_orm::round(10.5, 0.5);
+        constexpr auto expression = sqlite_orm::round(10.5, 0.5);
         SECTION("use_parentheses") {
             context.use_parentheses = true;
             expected = "ROUND(10.5, 0.5)";
@@ -250,7 +250,7 @@ TEST_CASE("statement_serializer core functions") {
     }
 #if SQLITE_VERSION_NUMBER >= 3007016
     SECTION("CHAR") {
-        auto expression = char_(40, 45);
+        constexpr auto expression = char_(40, 45);
         SECTION("use_parentheses") {
             context.use_parentheses = true;
             expected = "CHAR(40, 45)";
@@ -262,7 +262,7 @@ TEST_CASE("statement_serializer core functions") {
         value = serialize(expression, context);
     }
     SECTION("RANDOM") {
-        auto expression = sqlite_orm::random();
+        constexpr auto expression = sqlite_orm::random();
         SECTION("use_parentheses") {
             context.use_parentheses = true;
             expected = "RANDOM()";
@@ -275,7 +275,7 @@ TEST_CASE("statement_serializer core functions") {
     }
 #endif
     SECTION("COALESCE") {
-        auto expression = coalesce<std::string>(10, 15);
+        constexpr auto expression = coalesce<std::string>(10, 15);
         SECTION("use_parentheses") {
             context.use_parentheses = true;
             expected = "COALESCE(10, 15)";
@@ -287,7 +287,7 @@ TEST_CASE("statement_serializer core functions") {
         value = serialize(expression, context);
     }
     SECTION("DATE") {
-        auto expression = date("now");
+        constexpr auto expression = date("now");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
             expected = "DATE('now')";
@@ -299,7 +299,7 @@ TEST_CASE("statement_serializer core functions") {
         value = serialize(expression, context);
     }
     SECTION("TIME") {
-        auto expression = time("12:00", "localtime");
+        constexpr auto expression = time("12:00", "localtime");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
             expected = "TIME('12:00', 'localtime')";
@@ -311,7 +311,7 @@ TEST_CASE("statement_serializer core functions") {
         value = serialize(expression, context);
     }
     SECTION("DATETIME") {
-        auto expression = datetime("now");
+        constexpr auto expression = datetime("now");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
             expected = "DATETIME('now')";
@@ -323,7 +323,7 @@ TEST_CASE("statement_serializer core functions") {
         value = serialize(expression, context);
     }
     SECTION("JULIANDAY") {
-        auto expression = julianday("now");
+        constexpr auto expression = julianday("now");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
             expected = "JULIANDAY('now')";
@@ -335,7 +335,7 @@ TEST_CASE("statement_serializer core functions") {
         value = serialize(expression, context);
     }
     SECTION("STRFTIME") {
-        auto expression = strftime("%s", "2014-10-07 02:34:56");
+        constexpr auto expression = strftime("%s", "2014-10-07 02:34:56");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
             expected = "STRFTIME('%s', '2014-10-07 02:34:56')";
@@ -347,7 +347,7 @@ TEST_CASE("statement_serializer core functions") {
         value = serialize(expression, context);
     }
     SECTION("ZEROBLOB") {
-        auto expression = zeroblob(5);
+        constexpr auto expression = zeroblob(5);
         SECTION("use_parentheses") {
             context.use_parentheses = true;
             expected = "ZEROBLOB(5)";
@@ -359,7 +359,7 @@ TEST_CASE("statement_serializer core functions") {
         value = serialize(expression, context);
     }
     SECTION("SUBSTR(X,Y)") {
-        auto expression = substr("Zara", 2);
+        constexpr auto expression = substr("Zara", 2);
         SECTION("use_parentheses") {
             context.use_parentheses = true;
             expected = "SUBSTR('Zara', 2)";
@@ -371,7 +371,7 @@ TEST_CASE("statement_serializer core functions") {
         value = serialize(expression, context);
     }
     SECTION("SUBSTR(X,Y,Z)") {
-        auto expression = substr("Natasha", 3, 2);
+        constexpr auto expression = substr("Natasha", 3, 2);
         SECTION("use_parentheses") {
             context.use_parentheses = true;
             expected = "SUBSTR('Natasha', 3, 2)";
@@ -384,7 +384,7 @@ TEST_CASE("statement_serializer core functions") {
     }
     SECTION("SOUNDEX") {
 #ifdef SQLITE_SOUNDEX
-        auto expression = soundex("Vaso");
+        constexpr auto expression = soundex("Vaso");
         SECTION("use_parentheses") {
             context.use_parentheses = true;
             expected = "SOUNDEX('Vaso')";

--- a/tests/statement_serializer_tests/table_constraints/content.cpp
+++ b/tests/statement_serializer_tests/table_constraints/content.cpp
@@ -9,7 +9,7 @@ TEST_CASE("statement_serializer content") {
     std::string value;
     std::string expected;
     SECTION("empty") {
-        auto node = content("");
+        constexpr auto node = content("");
         value = serialize(node, context);
         expected = "content=''";
     }
@@ -27,7 +27,7 @@ TEST_CASE("statement_serializer table_content") {
     using context_t = internal::serializer_context<db_objects_t>;
     context_t context{dbObjects};
 
-    auto node = content<User>();
+    constexpr auto node = content<User>();
     auto value = internal::serialize(node, context);
     REQUIRE(value == R"(content="users")");
 }

--- a/tests/statement_serializer_tests/table_constraints/foreign_key.cpp
+++ b/tests/statement_serializer_tests/table_constraints/foreign_key.cpp
@@ -28,7 +28,7 @@ TEST_CASE("statement_serializer foreign key") {
                                      make_column("name", &User::name));
 
         SECTION("simple") {
-            auto fk = foreign_key(&Visit::userId).references(&User::id);
+            const auto fk = foreign_key(&Visit::userId).references(&User::id);
 
             using ForeignKey = decltype(fk);
             STATIC_REQUIRE(std::is_same<ForeignKey::target_type, User>::value);
@@ -52,7 +52,7 @@ TEST_CASE("statement_serializer foreign key") {
         }
         SECTION("on update") {
             SECTION("no_action") {
-                auto fk = foreign_key(&Visit::userId).references(&User::id).on_update.no_action();
+                const auto fk = foreign_key(&Visit::userId).references(&User::id).on_update.no_action();
 
                 using ForeignKey = decltype(fk);
                 STATIC_REQUIRE(std::is_same<ForeignKey::target_type, User>::value);
@@ -75,7 +75,7 @@ TEST_CASE("statement_serializer foreign key") {
                 REQUIRE(value == R"(FOREIGN KEY("user_id") REFERENCES "users"("id") ON UPDATE NO ACTION)");
             }
             SECTION("restrict_") {
-                auto fk = foreign_key(&Visit::userId).references(&User::id).on_update.restrict_();
+                const auto fk = foreign_key(&Visit::userId).references(&User::id).on_update.restrict_();
 
                 using ForeignKey = decltype(fk);
                 STATIC_REQUIRE(std::is_same<ForeignKey::target_type, User>::value);
@@ -98,7 +98,7 @@ TEST_CASE("statement_serializer foreign key") {
                 REQUIRE(value == R"(FOREIGN KEY("user_id") REFERENCES "users"("id") ON UPDATE RESTRICT)");
             }
             SECTION("set_null") {
-                auto fk = foreign_key(&Visit::userId).references(&User::id).on_update.set_null();
+                const auto fk = foreign_key(&Visit::userId).references(&User::id).on_update.set_null();
 
                 using ForeignKey = decltype(fk);
                 STATIC_REQUIRE(std::is_same<ForeignKey::target_type, User>::value);
@@ -121,7 +121,7 @@ TEST_CASE("statement_serializer foreign key") {
                 REQUIRE(value == R"(FOREIGN KEY("user_id") REFERENCES "users"("id") ON UPDATE SET NULL)");
             }
             SECTION("set_default") {
-                auto fk = foreign_key(&Visit::userId).references(&User::id).on_update.set_default();
+                const auto fk = foreign_key(&Visit::userId).references(&User::id).on_update.set_default();
 
                 using ForeignKey = decltype(fk);
                 STATIC_REQUIRE(std::is_same<ForeignKey::target_type, User>::value);
@@ -144,7 +144,7 @@ TEST_CASE("statement_serializer foreign key") {
                 REQUIRE(value == R"(FOREIGN KEY("user_id") REFERENCES "users"("id") ON UPDATE SET DEFAULT)");
             }
             SECTION("cascade") {
-                auto fk = foreign_key(&Visit::userId).references(&User::id).on_update.cascade();
+                const auto fk = foreign_key(&Visit::userId).references(&User::id).on_update.cascade();
 
                 using ForeignKey = decltype(fk);
                 STATIC_REQUIRE(std::is_same<ForeignKey::target_type, User>::value);
@@ -192,7 +192,7 @@ TEST_CASE("statement_serializer foreign key") {
                 REQUIRE(value == R"(FOREIGN KEY("user_id") REFERENCES "users"("id") ON DELETE NO ACTION)");
             }
             SECTION("restrict_") {
-                auto fk = foreign_key(&Visit::userId).references(&User::id).on_delete.restrict_();
+                const auto fk = foreign_key(&Visit::userId).references(&User::id).on_delete.restrict_();
 
                 using ForeignKey = decltype(fk);
                 STATIC_REQUIRE(std::is_same<ForeignKey::target_type, User>::value);
@@ -215,7 +215,7 @@ TEST_CASE("statement_serializer foreign key") {
                 REQUIRE(value == R"(FOREIGN KEY("user_id") REFERENCES "users"("id") ON DELETE RESTRICT)");
             }
             SECTION("set_null") {
-                auto fk = foreign_key(&Visit::userId).references(&User::id).on_delete.set_null();
+                const auto fk = foreign_key(&Visit::userId).references(&User::id).on_delete.set_null();
 
                 using ForeignKey = decltype(fk);
                 STATIC_REQUIRE(std::is_same<ForeignKey::target_type, User>::value);
@@ -238,7 +238,7 @@ TEST_CASE("statement_serializer foreign key") {
                 REQUIRE(value == R"(FOREIGN KEY("user_id") REFERENCES "users"("id") ON DELETE SET NULL)");
             }
             SECTION("set_default") {
-                auto fk = foreign_key(&Visit::userId).references(&User::id).on_delete.set_default();
+                const auto fk = foreign_key(&Visit::userId).references(&User::id).on_delete.set_default();
 
                 using ForeignKey = decltype(fk);
                 STATIC_REQUIRE(std::is_same<ForeignKey::target_type, User>::value);
@@ -261,7 +261,7 @@ TEST_CASE("statement_serializer foreign key") {
                 REQUIRE(value == R"(FOREIGN KEY("user_id") REFERENCES "users"("id") ON DELETE SET DEFAULT)");
             }
             SECTION("cascade") {
-                auto fk = foreign_key(&Visit::userId).references(&User::id).on_delete.cascade();
+                const auto fk = foreign_key(&Visit::userId).references(&User::id).on_delete.cascade();
 
                 using ForeignKey = decltype(fk);
                 STATIC_REQUIRE(std::is_same<ForeignKey::target_type, User>::value);
@@ -303,7 +303,7 @@ TEST_CASE("statement_serializer foreign key") {
             Token(decltype(id) id_, decltype(token) token_, decltype(usedId) usedId_) :
                 Object{id_}, token(std::move(token_)), usedId(usedId_) {}
         };
-        auto fk = foreign_key(&Token::usedId).references(column<User>(&User::id));
+        const auto fk = foreign_key(&Token::usedId).references(column<User>(&User::id));
 
         using ForeignKey = decltype(fk);
         STATIC_REQUIRE(std::is_same<ForeignKey::target_type, User>::value);
@@ -342,7 +342,8 @@ TEST_CASE("statement_serializer foreign key") {
             std::time_t time = 0;
         };
 
-        auto fk = foreign_key(&UserVisit::userId, &UserVisit::userFirstName).references(&User::id, &User::firstName);
+        const auto fk =
+            foreign_key(&UserVisit::userId, &UserVisit::userFirstName).references(&User::id, &User::firstName);
 
         using ForeignKey = decltype(fk);
         STATIC_REQUIRE(std::is_same<ForeignKey::target_type, User>::value);

--- a/tests/statement_serializer_tests/table_constraints/prefix.cpp
+++ b/tests/statement_serializer_tests/table_constraints/prefix.cpp
@@ -10,17 +10,17 @@ TEST_CASE("statement_serializer prefix") {
     std::string value;
     std::string expected;
     SECTION("2") {
-        auto node = prefix(2);
+        constexpr auto node = prefix(2);
         value = serialize(node, context);
         expected = "prefix=2";
     }
     SECTION("3") {
-        auto node = prefix(3);
+        constexpr auto node = prefix(3);
         value = serialize(node, context);
         expected = "prefix=3";
     }
     SECTION("2 3") {
-        auto node = prefix("2 3");
+        constexpr auto node = prefix("2 3");
         value = serialize(node, context);
         expected = "prefix='2 3'";
     }

--- a/tests/statement_serializer_tests/table_constraints/tokenize.cpp
+++ b/tests/statement_serializer_tests/table_constraints/tokenize.cpp
@@ -9,12 +9,12 @@ TEST_CASE("statement_serializer tokenize") {
     std::string value;
     std::string expected;
     SECTION("porter ascii") {
-        auto node = tokenize("porter ascii");
+        constexpr auto node = tokenize("porter ascii");
         value = serialize(node, context);
         expected = "tokenize = 'porter ascii'";
     }
     SECTION("unicode61 remove_diacritics 1") {
-        auto node = tokenize("unicode61 remove_diacritics 1");
+        constexpr auto node = tokenize("unicode61 remove_diacritics 1");
         value = serialize(node, context);
         expected = "tokenize = 'unicode61 remove_diacritics 1'";
     }

--- a/tests/static_tests/foreign_key.cpp
+++ b/tests/static_tests/foreign_key.cpp
@@ -55,27 +55,27 @@ TEST_CASE("foreign key static") {
     constexpr orm_table_reference auto derived = c<Derived>();
 #endif
 
-    auto cppInclusionIncluderPathFk = foreign_key(&CppInclusion::includer_path).references(&File::path);
+    const auto cppInclusionIncluderPathFk = foreign_key(&CppInclusion::includer_path).references(&File::path);
     STATIC_REQUIRE(std::is_same<decltype(cppInclusionIncluderPathFk)::target_type, File>::value);
     STATIC_REQUIRE(std::is_same<decltype(cppInclusionIncluderPathFk)::source_type, CppInclusion>::value);
 
-    auto cppInclusionIncludeePathFk = foreign_key(&CppInclusion::includee_path).references(&File::path);
+    const auto cppInclusionIncludeePathFk = foreign_key(&CppInclusion::includee_path).references(&File::path);
     STATIC_REQUIRE(std::is_same<decltype(cppInclusionIncludeePathFk)::target_type, File>::value);
     STATIC_REQUIRE(std::is_same<decltype(cppInclusionIncludeePathFk)::source_type, CppInclusion>::value);
 
-    auto functionDeclFilePathFk = foreign_key(&FunctionDecl::file_path).references(&File::path);
+    const auto functionDeclFilePathFk = foreign_key(&FunctionDecl::file_path).references(&File::path);
     STATIC_REQUIRE(std::is_same<decltype(functionDeclFilePathFk)::target_type, File>::value);
     STATIC_REQUIRE(std::is_same<decltype(functionDeclFilePathFk)::source_type, FunctionDecl>::value);
 
-    auto varDeclFilePathFk = foreign_key(&VarDecl::file_path).references(&File::path);
+    const auto varDeclFilePathFk = foreign_key(&VarDecl::file_path).references(&File::path);
     STATIC_REQUIRE(std::is_same<decltype(varDeclFilePathFk)::target_type, File>::value);
     STATIC_REQUIRE(std::is_same<decltype(varDeclFilePathFk)::source_type, VarDecl>::value);
 
-    auto functionDefFilePathFk = foreign_key(&FunctionDef::file_path).references(&File::path);
+    const auto functionDefFilePathFk = foreign_key(&FunctionDef::file_path).references(&File::path);
     STATIC_REQUIRE(std::is_same<decltype(functionDefFilePathFk)::target_type, File>::value);
     STATIC_REQUIRE(std::is_same<decltype(functionDefFilePathFk)::source_type, FunctionDef>::value);
 
-    auto functionCallParentFunctionName =
+    const auto functionCallParentFunctionName =
         foreign_key(&FunctionCall::parent_function_name).references(&FunctionDef::function_name);
     STATIC_REQUIRE(std::is_same<decltype(functionCallParentFunctionName)::target_type, FunctionDef>::value);
     STATIC_REQUIRE(std::is_same<decltype(functionCallParentFunctionName)::source_type, FunctionCall>::value);

--- a/tests/sync_schema_tests.cpp
+++ b/tests/sync_schema_tests.cpp
@@ -580,14 +580,14 @@ TEST_CASE("sync_schema with generated columns") {
         std::vector<User> allUsers;
         decltype(allUsers) expectedUsers;
         SECTION("virtual") {
-            generatedAlwaysConstraint = generatedAlwaysConstraint.virtual_();
+            generatedAlwaysConstraint = std::move(generatedAlwaysConstraint).virtual_();
             expectedUsers.push_back({5, 9});
         }
         SECTION("not specified") {
             expectedUsers.push_back({5, 9});
         }
         SECTION("stored") {
-            generatedAlwaysConstraint = generatedAlwaysConstraint.stored();
+            generatedAlwaysConstraint = std::move(generatedAlwaysConstraint).stored();
             // with preserve == false nothing is preserved since this kind of generated column requires dropping the table
             // thus we don't expect any users to be preserved!
         }
@@ -607,11 +607,11 @@ TEST_CASE("sync_schema with generated columns") {
             expectedUsers.push_back({5, 9});
         }
         SECTION("virtual") {
-            generatedAlwaysConstraint = generatedAlwaysConstraint.virtual_();
+            generatedAlwaysConstraint = std::move(generatedAlwaysConstraint).virtual_();
             expectedUsers.push_back({5, 9});
         }
         SECTION("stored") {
-            generatedAlwaysConstraint = generatedAlwaysConstraint.stored();
+            generatedAlwaysConstraint = std::move(generatedAlwaysConstraint).stored();
             expectedUsers.push_back({5, 9});
         }
         auto storage2 = make_storage(storagePath,


### PR DESCRIPTION
Enables their use as C++ annotation values for the upcoming C++ reflection-based `make_table` overload, and aligns with the broader push to widen what is available at constant evaluation time.