### PR TITLE
Add missing built-in function wrappers (printf, iif, concat, unixepoch, percentile family, ...)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -203,10 +203,10 @@ jobs:
             sqlite_dir: sqlite-amalgamation-3350500
             sqlite_defines: "-DSQLITE_ENABLE_FTS5 -DSQLITE_ENABLE_RTREE -DSQLITE_ENABLE_JSON1 -DSQLITE_ENABLE_DBSTAT_VTAB -DSQLITE_ENABLE_MATH_FUNCTIONS -DSQLITE_SOUNDEX"
 
-          - sqlite_version: "3.50.4"  # a recent pinned version
-            sqlite_url: "https://www.sqlite.org/2025/sqlite-amalgamation-3500400.zip"
-            sqlite_dir: sqlite-amalgamation-3500400
-            sqlite_defines: "-DSQLITE_ENABLE_FTS5 -DSQLITE_ENABLE_RTREE -DSQLITE_ENABLE_JSON1 -DSQLITE_ENABLE_DBSTAT_VTAB -DSQLITE_ENABLE_MATH_FUNCTIONS -DSQLITE_SOUNDEX"
+          - sqlite_version: "3.51.0"  # a recent pinned version, incl. the percentile family
+            sqlite_url: "https://www.sqlite.org/2025/sqlite-amalgamation-3510000.zip"
+            sqlite_dir: sqlite-amalgamation-3510000
+            sqlite_defines: "-DSQLITE_ENABLE_FTS5 -DSQLITE_ENABLE_RTREE -DSQLITE_ENABLE_JSON1 -DSQLITE_ENABLE_DBSTAT_VTAB -DSQLITE_ENABLE_MATH_FUNCTIONS -DSQLITE_ENABLE_PERCENTILE -DSQLITE_SOUNDEX"
 
     name: Linux - SQLite ${{ matrix.sqlite_version }}, C++17
 

--- a/TODO.md
+++ b/TODO.md
@@ -10,9 +10,7 @@
 * `SAVEPOINT` https://www.sqlite.org/lang_savepoint.html
 * add `static_assert` in crud `get*` functions in case user passes `where_t` instead of id to make compilation error more clear (example https://github.com/fnc12/sqlite_orm/issues/485)
 * named constraints: constraint can have name `CREATE TABLE heroes(id INTEGER CONSTRAINT pk PRIMARY KEY)`
-* scalar math functions https://sqlite.org/lang_mathfunc.html
 * `UPDATE FROM` support https://sqlite.org/lang_update.html#upfrom
-* `iif()` function https://sqlite.org/lang_corefunc.html#iif
 * strict tables https://sqlite.org/stricttables.html
 * static assert when UPDATE is called with no PKs
 * `json_each` and `json_tree` functions for JSON1 extension

--- a/dev/core_functions.h
+++ b/dev/core_functions.h
@@ -357,6 +357,134 @@ namespace sqlite_orm::internal {
             return "GROUP_CONCAT";
         }
     };
+
+#if SQLITE_VERSION_NUMBER >= 3008003
+    struct printf_string {
+        serialize_result_type serialize() const {
+            return "PRINTF";
+        }
+    };
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3032000
+    struct iif_string {
+        serialize_result_type serialize() const {
+            return "IIF";
+        }
+    };
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3035000
+    struct sign_string {
+        serialize_result_type serialize() const {
+            return "SIGN";
+        }
+    };
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3038000
+    struct format_string {
+        serialize_result_type serialize() const {
+            return "FORMAT";
+        }
+    };
+
+    struct unixepoch_string {
+        serialize_result_type serialize() const {
+            return "UNIXEPOCH";
+        }
+    };
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3041000
+    struct unhex_string {
+        serialize_result_type serialize() const {
+            return "UNHEX";
+        }
+    };
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3043000
+    struct octet_length_string {
+        serialize_result_type serialize() const {
+            return "OCTET_LENGTH";
+        }
+    };
+
+    struct timediff_string {
+        serialize_result_type serialize() const {
+            return "TIMEDIFF";
+        }
+    };
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3044000
+    struct concat_string {
+        serialize_result_type serialize() const {
+            return "CONCAT";
+        }
+    };
+
+    struct concat_ws_string {
+        serialize_result_type serialize() const {
+            return "CONCAT_WS";
+        }
+    };
+
+    struct string_agg_string {
+        serialize_result_type serialize() const {
+            return "STRING_AGG";
+        }
+    };
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3048000
+    struct if_string {
+        serialize_result_type serialize() const {
+            return "IF";
+        }
+    };
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3050000
+    struct unistr_string {
+        serialize_result_type serialize() const {
+            return "UNISTR";
+        }
+    };
+
+    struct unistr_quote_string {
+        serialize_result_type serialize() const {
+            return "UNISTR_QUOTE";
+        }
+    };
+#endif
+
+#ifdef SQLITE_ENABLE_PERCENTILE
+    struct median_string {
+        serialize_result_type serialize() const {
+            return "MEDIAN";
+        }
+    };
+
+    struct percentile_string {
+        serialize_result_type serialize() const {
+            return "PERCENTILE";
+        }
+    };
+
+    struct percentile_cont_string {
+        serialize_result_type serialize() const {
+            return "PERCENTILE_CONT";
+        }
+    };
+
+    struct percentile_disc_string {
+        serialize_result_type serialize() const {
+            return "PERCENTILE_DISC";
+        }
+    };
+#endif
 #ifdef SQLITE_ENABLE_MATH_FUNCTIONS
     struct acos_string {
         serialize_result_type serialize() const {
@@ -1933,6 +2061,218 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     group_concat(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
+
+#if SQLITE_VERSION_NUMBER >= 3008003
+    /**
+     *  PRINTF(FORMAT,...) function https://www.sqlite.org/lang_corefunc.html#printf
+     */
+    template<class... Args>
+    constexpr internal::built_in_function_t<std::string, internal::printf_string, Args...> printf(Args... args) {
+        return {std::tuple<Args...>{std::forward<Args>(args)...}};
+    }
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3032000
+    /**
+     *  IIF(X,Y,Z) function https://www.sqlite.org/lang_corefunc.html#iif
+     *
+     *  The return type is the common type of Y and Z, unless it is explicitly specified as a template argument.
+     *
+     *  Example:
+     *
+     *  auto rows = storage.select(iif(c(&User::age) > 18, "adult", "minor"));
+     */
+    template<class R = void, class X, class Y, class Z>
+    constexpr auto iif(X x, Y y, Z z) -> internal::built_in_function_t<
+        typename mpl::conditional_t<  //  choose R or common type
+            std::is_void<R>::value,
+            std::common_type<internal::field_type_or_type_t<Y>, internal::field_type_or_type_t<Z>>,
+            polyfill::type_identity<R>>::type,
+        internal::iif_string,
+        X,
+        Y,
+        Z> {
+        return {std::make_tuple(std::move(x), std::move(y), std::move(z))};
+    }
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3035000
+    /**
+     *  SIGN(X) function https://www.sqlite.org/lang_corefunc.html#sign
+     */
+    template<class X>
+    constexpr internal::built_in_function_t<int, internal::sign_string, X> sign(X x) {
+        return {std::tuple<X>{std::forward<X>(x)}};
+    }
+
+    /**
+     *  SIGN(X) function https://www.sqlite.org/lang_corefunc.html#sign
+     *
+     *  Difference with the previous function is that previous override has `int` as return type but this
+     *  override accepts return type from you as a template argument. You can use any bindable type:
+     *  `std::optional<int>` etc. This override is handy when you expect `null` as result for a non-numeric argument.
+     */
+    template<class R, class X>
+    constexpr internal::built_in_function_t<R, internal::sign_string, X> sign(X x) {
+        return {std::tuple<X>{std::forward<X>(x)}};
+    }
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3038000
+    /**
+     *  FORMAT(FORMAT,...) function https://www.sqlite.org/lang_corefunc.html#format
+     */
+    template<class... Args>
+    constexpr internal::built_in_function_t<std::string, internal::format_string, Args...> format(Args... args) {
+        return {std::tuple<Args...>{std::forward<Args>(args)...}};
+    }
+
+    /**
+     *  UNIXEPOCH(timestring, modifier, ...) function https://www.sqlite.org/lang_datefunc.html
+     */
+    template<class... Args>
+    constexpr internal::built_in_function_t<int64, internal::unixepoch_string, Args...> unixepoch(Args... args) {
+        return {std::tuple<Args...>{std::forward<Args>(args)...}};
+    }
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3041000
+    /**
+     *  UNHEX(X) function https://www.sqlite.org/lang_corefunc.html#unhex
+     */
+    template<class X>
+    constexpr internal::built_in_function_t<std::vector<char>, internal::unhex_string, X> unhex(X x) {
+        return {std::tuple<X>{std::forward<X>(x)}};
+    }
+
+    /**
+     *  UNHEX(X,Y) function https://www.sqlite.org/lang_corefunc.html#unhex
+     */
+    template<class X, class Y>
+    constexpr internal::built_in_function_t<std::vector<char>, internal::unhex_string, X, Y> unhex(X x, Y y) {
+        return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
+    }
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3043000
+    /**
+     *  OCTET_LENGTH(X) function https://www.sqlite.org/lang_corefunc.html#octet_length
+     */
+    template<class X>
+    constexpr internal::built_in_function_t<int, internal::octet_length_string, X> octet_length(X x) {
+        return {std::tuple<X>{std::forward<X>(x)}};
+    }
+
+    /**
+     *  TIMEDIFF(A,B) function https://www.sqlite.org/lang_datefunc.html#tmdiff
+     */
+    template<class X, class Y>
+    constexpr internal::built_in_function_t<std::string, internal::timediff_string, X, Y> timediff(X x, Y y) {
+        return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
+    }
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3044000
+    /**
+     *  CONCAT(X,...) function https://www.sqlite.org/lang_corefunc.html#concat
+     */
+    template<class... Args>
+    constexpr internal::built_in_function_t<std::string, internal::concat_string, Args...> concat(Args... args) {
+        return {std::tuple<Args...>{std::forward<Args>(args)...}};
+    }
+
+    /**
+     *  CONCAT_WS(SEP,X,...) function https://www.sqlite.org/lang_corefunc.html#concat_ws
+     */
+    template<class... Args>
+    constexpr internal::built_in_function_t<std::string, internal::concat_ws_string, Args...> concat_ws(Args... args) {
+        return {std::tuple<Args...>{std::forward<Args>(args)...}};
+    }
+
+    /**
+     *  STRING_AGG(X,SEP) aggregate function https://www.sqlite.org/lang_aggfunc.html#string_agg
+     */
+    template<class X, class Y>
+    constexpr internal::built_in_aggregate_function_t<std::string, internal::string_agg_string, X, Y> string_agg(X x,
+                                                                                                                 Y y) {
+        return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
+    }
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3048000
+    /**
+     *  IF(X,Y,Z) function, an alias for IIF() https://www.sqlite.org/lang_corefunc.html#iif
+     *
+     *  The return type is the common type of Y and Z, unless it is explicitly specified as a template argument.
+     */
+    template<class R = void, class X, class Y, class Z>
+    constexpr auto if_(X x, Y y, Z z) -> internal::built_in_function_t<
+        typename mpl::conditional_t<  //  choose R or common type
+            std::is_void<R>::value,
+            std::common_type<internal::field_type_or_type_t<Y>, internal::field_type_or_type_t<Z>>,
+            polyfill::type_identity<R>>::type,
+        internal::if_string,
+        X,
+        Y,
+        Z> {
+        return {std::make_tuple(std::move(x), std::move(y), std::move(z))};
+    }
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3050000
+    /**
+     *  UNISTR(X) function https://www.sqlite.org/lang_corefunc.html#unistr
+     */
+    template<class X>
+    constexpr internal::built_in_function_t<std::string, internal::unistr_string, X> unistr(X x) {
+        return {std::tuple<X>{std::forward<X>(x)}};
+    }
+
+    /**
+     *  UNISTR_QUOTE(X) function https://www.sqlite.org/lang_corefunc.html#unistr_quote
+     */
+    template<class X>
+    constexpr internal::built_in_function_t<std::string, internal::unistr_quote_string, X> unistr_quote(X x) {
+        return {std::tuple<X>{std::forward<X>(x)}};
+    }
+#endif
+
+#ifdef SQLITE_ENABLE_PERCENTILE
+    /**
+     *  MEDIAN(X) aggregate function https://www.sqlite.org/lang_aggfunc.html#percentile
+     */
+    template<class X>
+    constexpr internal::built_in_aggregate_function_t<std::unique_ptr<double>, internal::median_string, X> median(X x) {
+        return {std::tuple<X>{std::forward<X>(x)}};
+    }
+
+    /**
+     *  PERCENTILE(Y,P) aggregate function https://www.sqlite.org/lang_aggfunc.html#percentile
+     */
+    template<class X, class Y>
+    constexpr internal::built_in_aggregate_function_t<std::unique_ptr<double>, internal::percentile_string, X, Y>
+    percentile(X x, Y y) {
+        return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
+    }
+
+    /**
+     *  PERCENTILE_CONT(Y,P) aggregate function https://www.sqlite.org/lang_aggfunc.html#percentile
+     */
+    template<class X, class Y>
+    constexpr internal::built_in_aggregate_function_t<std::unique_ptr<double>, internal::percentile_cont_string, X, Y>
+    percentile_cont(X x, Y y) {
+        return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
+    }
+
+    /**
+     *  PERCENTILE_DISC(Y,P) aggregate function https://www.sqlite.org/lang_aggfunc.html#percentile
+     */
+    template<class X, class Y>
+    constexpr internal::built_in_aggregate_function_t<std::unique_ptr<double>, internal::percentile_disc_string, X, Y>
+    percentile_disc(X x, Y y) {
+        return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
+    }
+#endif
 #ifdef SQLITE_ENABLE_JSON1
     template<class X>
     constexpr internal::built_in_function_t<std::string, internal::json_string, X> json(X x) {

--- a/dev/core_functions.h
+++ b/dev/core_functions.h
@@ -2077,22 +2077,36 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  IIF(X,Y,Z) function https://www.sqlite.org/lang_corefunc.html#iif
      *
      *  The return type is the common type of Y and Z, unless it is explicitly specified as a template argument.
+     *  The function is only enabled if a common type of Y and Z can be determined or the return type is explicit.
      *
      *  Example:
      *
-     *  auto rows = storage.select(iif(c(&User::age) > 18, "adult", "minor"));
+     *  auto rows = storage.select(iif<std::string>(c(&User::age) > 18, "adult", "minor"));
      */
-    template<class R = void, class X, class Y, class Z>
-    constexpr auto iif(X x, Y y, Z z) -> internal::built_in_function_t<
-        typename mpl::conditional_t<  //  choose R or common type
-            std::is_void<R>::value,
-            std::common_type<internal::field_type_or_type_t<Y>, internal::field_type_or_type_t<Z>>,
-            polyfill::type_identity<R>>::type,
-        internal::iif_string,
-        X,
-        Y,
-        Z> {
-        return {std::make_tuple(std::move(x), std::move(y), std::move(z))};
+    template<class R = void,
+             class X,
+             class Y,
+             class Z,
+             std::enable_if_t<polyfill::disjunction_v<polyfill::negation<std::is_void<R>>,
+                                                      polyfill::is_detected<std::common_type_t,
+                                                                            internal::field_type_or_type_t<Y>,
+                                                                            internal::field_type_or_type_t<Z>>>,
+                              bool> = true>
+    constexpr auto iif(X x, Y y, Z z) {
+        if constexpr (std::is_void<R>::value) {
+            using F = internal::built_in_function_t<
+                std::common_type_t<internal::field_type_or_type_t<Y>, internal::field_type_or_type_t<Z>>,
+                internal::iif_string,
+                X,
+                Y,
+                Z>;
+
+            return F{std::make_tuple(std::move(x), std::move(y), std::move(z))};
+        } else {
+            using F = internal::built_in_function_t<R, internal::iif_string, X, Y, Z>;
+
+            return F{std::make_tuple(std::move(x), std::move(y), std::move(z))};
+        }
     }
 #endif
 
@@ -2204,18 +2218,32 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  IF(X,Y,Z) function, an alias for IIF() https://www.sqlite.org/lang_corefunc.html#iif
      *
      *  The return type is the common type of Y and Z, unless it is explicitly specified as a template argument.
+     *  The function is only enabled if a common type of Y and Z can be determined or the return type is explicit.
      */
-    template<class R = void, class X, class Y, class Z>
-    constexpr auto if_(X x, Y y, Z z) -> internal::built_in_function_t<
-        typename mpl::conditional_t<  //  choose R or common type
-            std::is_void<R>::value,
-            std::common_type<internal::field_type_or_type_t<Y>, internal::field_type_or_type_t<Z>>,
-            polyfill::type_identity<R>>::type,
-        internal::if_string,
-        X,
-        Y,
-        Z> {
-        return {std::make_tuple(std::move(x), std::move(y), std::move(z))};
+    template<class R = void,
+             class X,
+             class Y,
+             class Z,
+             std::enable_if_t<polyfill::disjunction_v<polyfill::negation<std::is_void<R>>,
+                                                      polyfill::is_detected<std::common_type_t,
+                                                                            internal::field_type_or_type_t<Y>,
+                                                                            internal::field_type_or_type_t<Z>>>,
+                              bool> = true>
+    constexpr auto if_(X x, Y y, Z z) {
+        if constexpr (std::is_void<R>::value) {
+            using F = internal::built_in_function_t<
+                std::common_type_t<internal::field_type_or_type_t<Y>, internal::field_type_or_type_t<Z>>,
+                internal::if_string,
+                X,
+                Y,
+                Z>;
+
+            return F{std::make_tuple(std::move(x), std::move(y), std::move(z))};
+        } else {
+            using F = internal::built_in_function_t<R, internal::if_string, X, Y, Z>;
+
+            return F{std::make_tuple(std::move(x), std::move(y), std::move(z))};
+        }
     }
 #endif
 

--- a/dev/core_functions.h
+++ b/dev/core_functions.h
@@ -2240,36 +2240,47 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 #ifdef SQLITE_ENABLE_PERCENTILE
     /**
      *  MEDIAN(X) aggregate function https://www.sqlite.org/lang_aggfunc.html#percentile
+     *
+     *  The return type defaults to `std::unique_ptr<double>` (the result is NULL for an empty group);
+     *  any other bindable type such as `std::optional<double>` can be specified as a template argument.
      */
-    template<class X>
-    constexpr internal::built_in_aggregate_function_t<std::unique_ptr<double>, internal::median_string, X> median(X x) {
+    template<class R = std::unique_ptr<double>, class X>
+    constexpr internal::built_in_aggregate_function_t<R, internal::median_string, X> median(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
     /**
      *  PERCENTILE(Y,P) aggregate function https://www.sqlite.org/lang_aggfunc.html#percentile
+     *
+     *  The return type defaults to `std::unique_ptr<double>` (the result is NULL for an empty group);
+     *  any other bindable type such as `std::optional<double>` can be specified as a template argument.
      */
-    template<class X, class Y>
-    constexpr internal::built_in_aggregate_function_t<std::unique_ptr<double>, internal::percentile_string, X, Y>
-    percentile(X x, Y y) {
+    template<class R = std::unique_ptr<double>, class X, class Y>
+    constexpr internal::built_in_aggregate_function_t<R, internal::percentile_string, X, Y> percentile(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
     /**
      *  PERCENTILE_CONT(Y,P) aggregate function https://www.sqlite.org/lang_aggfunc.html#percentile
+     *
+     *  The return type defaults to `std::unique_ptr<double>` (the result is NULL for an empty group);
+     *  any other bindable type such as `std::optional<double>` can be specified as a template argument.
      */
-    template<class X, class Y>
-    constexpr internal::built_in_aggregate_function_t<std::unique_ptr<double>, internal::percentile_cont_string, X, Y>
-    percentile_cont(X x, Y y) {
+    template<class R = std::unique_ptr<double>, class X, class Y>
+    constexpr internal::built_in_aggregate_function_t<R, internal::percentile_cont_string, X, Y> percentile_cont(X x,
+                                                                                                                 Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
     /**
      *  PERCENTILE_DISC(Y,P) aggregate function https://www.sqlite.org/lang_aggfunc.html#percentile
+     *
+     *  The return type defaults to `std::unique_ptr<double>` (the result is NULL for an empty group);
+     *  any other bindable type such as `std::optional<double>` can be specified as a template argument.
      */
-    template<class X, class Y>
-    constexpr internal::built_in_aggregate_function_t<std::unique_ptr<double>, internal::percentile_disc_string, X, Y>
-    percentile_disc(X x, Y y) {
+    template<class R = std::unique_ptr<double>, class X, class Y>
+    constexpr internal::built_in_aggregate_function_t<R, internal::percentile_disc_string, X, Y> percentile_disc(X x,
+                                                                                                                 Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 #endif

--- a/examples/core_functions.cpp
+++ b/examples/core_functions.cpp
@@ -1186,6 +1186,97 @@ int main(int, char** argv) {
         cout << endl;
     }
 
+#if SQLITE_VERSION_NUMBER >= 3008003
+    //  SELECT printf('%s scores %d points', name, points)
+    //  FROM marvel
+    {
+        cout << endl;
+        auto rows = storage.select(sqlite_orm::printf("%s scores %d points", &MarvelHero::name, &MarvelHero::points));
+        for (auto& row: rows) {
+            cout << row << endl;
+        }
+        cout << endl;
+    }
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3032000
+    //  SELECT name, IIF(points >= 0, 'happy', 'grumpy')
+    //  FROM marvel
+    {
+        auto rows = storage.select(
+            columns(&MarvelHero::name, iif<std::string>(c(&MarvelHero::points) >= 0, "happy", "grumpy")));
+        for (auto& row: rows) {
+            cout << get<0>(row) << " is " << get<1>(row) << endl;
+        }
+        cout << endl;
+    }
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3035000
+    //  SELECT sign(-42), sign(0.5)
+    cout << "SELECT sign(-42) = " << storage.select(sign(-42)).front() << endl;
+    cout << "SELECT sign(0.5) = " << storage.select(sign(0.5)).front() << endl;
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3038000
+    //  SELECT format('%d heroes in total', count(*)) FROM marvel
+    cout << storage.select(format("%d heroes in total", count<MarvelHero>())).front() << endl;
+
+    //  SELECT unixepoch('2004-01-01 02:34:56')
+    cout << "SELECT unixepoch('2004-01-01 02:34:56') = " << storage.select(unixepoch("2004-01-01 02:34:56")).front()
+         << endl;
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3041000
+    //  SELECT unhex('53514C697465') -- the blob 'SQLite'
+    {
+        auto blob = storage.select(unhex("53514C697465")).front();
+        cout << "SELECT unhex('53514C697465') = '" << std::string(blob.begin(), blob.end()) << "'" << endl;
+    }
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3043000
+    //  SELECT length('ä'), octet_length('ä') -- 1 character, 2 bytes in UTF-8
+    cout << "SELECT length('ä') = " << storage.select(length("ä")).front()
+         << ", octet_length('ä') = " << storage.select(octet_length("ä")).front() << endl;
+
+    //  SELECT timediff('2023-03-15', '2023-02-15')
+    cout << "SELECT timediff('2023-03-15', '2023-02-15') = "
+         << storage.select(timediff("2023-03-15", "2023-02-15")).front() << endl;
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3044000
+    //  SELECT concat_ws(', ', lastname, firstname) FROM customers
+    {
+        cout << endl;
+        auto rows = storage.select(concat_ws(", ", &Customer::lastName, &Customer::firstName));
+        for (auto& row: rows) {
+            cout << row << endl;
+        }
+        cout << endl;
+    }
+
+    //  SELECT string_agg(name, ', ') FROM marvel WHERE points > 0
+    cout << "positive heroes: "
+         << storage.select(string_agg(&MarvelHero::name, ", "), where(c(&MarvelHero::points) > 0)).front() << endl;
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3050000
+    //  SELECT unistr('ä') -- unicode escapes decoded at runtime
+    cout << "SELECT unistr('\\u00e4') = " << storage.select(unistr("\\u00e4")).front() << endl;
+#endif
+
+#if defined(SQLITE_ENABLE_PERCENTILE) && defined(SQLITE_ORM_OPTIONAL_SUPPORTED)
+    //  SELECT median(points), percentile(points, 90) FROM marvel
+    {
+        auto medianPoints = storage.select(median<std::optional<double>>(&MarvelHero::points)).front();
+        auto topPoints = storage.select(percentile<std::optional<double>>(&MarvelHero::points, 90)).front();
+        if (medianPoints && topPoints) {
+            cout << "median(points) = " << *medianPoints << ", percentile(points, 90) = " << *topPoints << endl;
+        }
+    }
+#endif
+
     storage.update_all(
         set(c(&Contact::phone) = select(&Customer::phone, from<Customer>(), where(c(&Customer::id) == 1))));
     return 0;

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -6622,6 +6622,134 @@ namespace sqlite_orm::internal {
             return "GROUP_CONCAT";
         }
     };
+
+#if SQLITE_VERSION_NUMBER >= 3008003
+    struct printf_string {
+        serialize_result_type serialize() const {
+            return "PRINTF";
+        }
+    };
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3032000
+    struct iif_string {
+        serialize_result_type serialize() const {
+            return "IIF";
+        }
+    };
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3035000
+    struct sign_string {
+        serialize_result_type serialize() const {
+            return "SIGN";
+        }
+    };
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3038000
+    struct format_string {
+        serialize_result_type serialize() const {
+            return "FORMAT";
+        }
+    };
+
+    struct unixepoch_string {
+        serialize_result_type serialize() const {
+            return "UNIXEPOCH";
+        }
+    };
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3041000
+    struct unhex_string {
+        serialize_result_type serialize() const {
+            return "UNHEX";
+        }
+    };
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3043000
+    struct octet_length_string {
+        serialize_result_type serialize() const {
+            return "OCTET_LENGTH";
+        }
+    };
+
+    struct timediff_string {
+        serialize_result_type serialize() const {
+            return "TIMEDIFF";
+        }
+    };
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3044000
+    struct concat_string {
+        serialize_result_type serialize() const {
+            return "CONCAT";
+        }
+    };
+
+    struct concat_ws_string {
+        serialize_result_type serialize() const {
+            return "CONCAT_WS";
+        }
+    };
+
+    struct string_agg_string {
+        serialize_result_type serialize() const {
+            return "STRING_AGG";
+        }
+    };
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3048000
+    struct if_string {
+        serialize_result_type serialize() const {
+            return "IF";
+        }
+    };
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3050000
+    struct unistr_string {
+        serialize_result_type serialize() const {
+            return "UNISTR";
+        }
+    };
+
+    struct unistr_quote_string {
+        serialize_result_type serialize() const {
+            return "UNISTR_QUOTE";
+        }
+    };
+#endif
+
+#ifdef SQLITE_ENABLE_PERCENTILE
+    struct median_string {
+        serialize_result_type serialize() const {
+            return "MEDIAN";
+        }
+    };
+
+    struct percentile_string {
+        serialize_result_type serialize() const {
+            return "PERCENTILE";
+        }
+    };
+
+    struct percentile_cont_string {
+        serialize_result_type serialize() const {
+            return "PERCENTILE_CONT";
+        }
+    };
+
+    struct percentile_disc_string {
+        serialize_result_type serialize() const {
+            return "PERCENTILE_DISC";
+        }
+    };
+#endif
 #ifdef SQLITE_ENABLE_MATH_FUNCTIONS
     struct acos_string {
         serialize_result_type serialize() const {
@@ -8198,6 +8326,218 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     group_concat(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
+
+#if SQLITE_VERSION_NUMBER >= 3008003
+    /**
+     *  PRINTF(FORMAT,...) function https://www.sqlite.org/lang_corefunc.html#printf
+     */
+    template<class... Args>
+    constexpr internal::built_in_function_t<std::string, internal::printf_string, Args...> printf(Args... args) {
+        return {std::tuple<Args...>{std::forward<Args>(args)...}};
+    }
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3032000
+    /**
+     *  IIF(X,Y,Z) function https://www.sqlite.org/lang_corefunc.html#iif
+     *
+     *  The return type is the common type of Y and Z, unless it is explicitly specified as a template argument.
+     *
+     *  Example:
+     *
+     *  auto rows = storage.select(iif(c(&User::age) > 18, "adult", "minor"));
+     */
+    template<class R = void, class X, class Y, class Z>
+    constexpr auto iif(X x, Y y, Z z) -> internal::built_in_function_t<
+        typename mpl::conditional_t<  //  choose R or common type
+            std::is_void<R>::value,
+            std::common_type<internal::field_type_or_type_t<Y>, internal::field_type_or_type_t<Z>>,
+            polyfill::type_identity<R>>::type,
+        internal::iif_string,
+        X,
+        Y,
+        Z> {
+        return {std::make_tuple(std::move(x), std::move(y), std::move(z))};
+    }
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3035000
+    /**
+     *  SIGN(X) function https://www.sqlite.org/lang_corefunc.html#sign
+     */
+    template<class X>
+    constexpr internal::built_in_function_t<int, internal::sign_string, X> sign(X x) {
+        return {std::tuple<X>{std::forward<X>(x)}};
+    }
+
+    /**
+     *  SIGN(X) function https://www.sqlite.org/lang_corefunc.html#sign
+     *
+     *  Difference with the previous function is that previous override has `int` as return type but this
+     *  override accepts return type from you as a template argument. You can use any bindable type:
+     *  `std::optional<int>` etc. This override is handy when you expect `null` as result for a non-numeric argument.
+     */
+    template<class R, class X>
+    constexpr internal::built_in_function_t<R, internal::sign_string, X> sign(X x) {
+        return {std::tuple<X>{std::forward<X>(x)}};
+    }
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3038000
+    /**
+     *  FORMAT(FORMAT,...) function https://www.sqlite.org/lang_corefunc.html#format
+     */
+    template<class... Args>
+    constexpr internal::built_in_function_t<std::string, internal::format_string, Args...> format(Args... args) {
+        return {std::tuple<Args...>{std::forward<Args>(args)...}};
+    }
+
+    /**
+     *  UNIXEPOCH(timestring, modifier, ...) function https://www.sqlite.org/lang_datefunc.html
+     */
+    template<class... Args>
+    constexpr internal::built_in_function_t<int64, internal::unixepoch_string, Args...> unixepoch(Args... args) {
+        return {std::tuple<Args...>{std::forward<Args>(args)...}};
+    }
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3041000
+    /**
+     *  UNHEX(X) function https://www.sqlite.org/lang_corefunc.html#unhex
+     */
+    template<class X>
+    constexpr internal::built_in_function_t<std::vector<char>, internal::unhex_string, X> unhex(X x) {
+        return {std::tuple<X>{std::forward<X>(x)}};
+    }
+
+    /**
+     *  UNHEX(X,Y) function https://www.sqlite.org/lang_corefunc.html#unhex
+     */
+    template<class X, class Y>
+    constexpr internal::built_in_function_t<std::vector<char>, internal::unhex_string, X, Y> unhex(X x, Y y) {
+        return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
+    }
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3043000
+    /**
+     *  OCTET_LENGTH(X) function https://www.sqlite.org/lang_corefunc.html#octet_length
+     */
+    template<class X>
+    constexpr internal::built_in_function_t<int, internal::octet_length_string, X> octet_length(X x) {
+        return {std::tuple<X>{std::forward<X>(x)}};
+    }
+
+    /**
+     *  TIMEDIFF(A,B) function https://www.sqlite.org/lang_datefunc.html#tmdiff
+     */
+    template<class X, class Y>
+    constexpr internal::built_in_function_t<std::string, internal::timediff_string, X, Y> timediff(X x, Y y) {
+        return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
+    }
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3044000
+    /**
+     *  CONCAT(X,...) function https://www.sqlite.org/lang_corefunc.html#concat
+     */
+    template<class... Args>
+    constexpr internal::built_in_function_t<std::string, internal::concat_string, Args...> concat(Args... args) {
+        return {std::tuple<Args...>{std::forward<Args>(args)...}};
+    }
+
+    /**
+     *  CONCAT_WS(SEP,X,...) function https://www.sqlite.org/lang_corefunc.html#concat_ws
+     */
+    template<class... Args>
+    constexpr internal::built_in_function_t<std::string, internal::concat_ws_string, Args...> concat_ws(Args... args) {
+        return {std::tuple<Args...>{std::forward<Args>(args)...}};
+    }
+
+    /**
+     *  STRING_AGG(X,SEP) aggregate function https://www.sqlite.org/lang_aggfunc.html#string_agg
+     */
+    template<class X, class Y>
+    constexpr internal::built_in_aggregate_function_t<std::string, internal::string_agg_string, X, Y> string_agg(X x,
+                                                                                                                 Y y) {
+        return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
+    }
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3048000
+    /**
+     *  IF(X,Y,Z) function, an alias for IIF() https://www.sqlite.org/lang_corefunc.html#iif
+     *
+     *  The return type is the common type of Y and Z, unless it is explicitly specified as a template argument.
+     */
+    template<class R = void, class X, class Y, class Z>
+    constexpr auto if_(X x, Y y, Z z) -> internal::built_in_function_t<
+        typename mpl::conditional_t<  //  choose R or common type
+            std::is_void<R>::value,
+            std::common_type<internal::field_type_or_type_t<Y>, internal::field_type_or_type_t<Z>>,
+            polyfill::type_identity<R>>::type,
+        internal::if_string,
+        X,
+        Y,
+        Z> {
+        return {std::make_tuple(std::move(x), std::move(y), std::move(z))};
+    }
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3050000
+    /**
+     *  UNISTR(X) function https://www.sqlite.org/lang_corefunc.html#unistr
+     */
+    template<class X>
+    constexpr internal::built_in_function_t<std::string, internal::unistr_string, X> unistr(X x) {
+        return {std::tuple<X>{std::forward<X>(x)}};
+    }
+
+    /**
+     *  UNISTR_QUOTE(X) function https://www.sqlite.org/lang_corefunc.html#unistr_quote
+     */
+    template<class X>
+    constexpr internal::built_in_function_t<std::string, internal::unistr_quote_string, X> unistr_quote(X x) {
+        return {std::tuple<X>{std::forward<X>(x)}};
+    }
+#endif
+
+#ifdef SQLITE_ENABLE_PERCENTILE
+    /**
+     *  MEDIAN(X) aggregate function https://www.sqlite.org/lang_aggfunc.html#percentile
+     */
+    template<class X>
+    constexpr internal::built_in_aggregate_function_t<std::unique_ptr<double>, internal::median_string, X> median(X x) {
+        return {std::tuple<X>{std::forward<X>(x)}};
+    }
+
+    /**
+     *  PERCENTILE(Y,P) aggregate function https://www.sqlite.org/lang_aggfunc.html#percentile
+     */
+    template<class X, class Y>
+    constexpr internal::built_in_aggregate_function_t<std::unique_ptr<double>, internal::percentile_string, X, Y>
+    percentile(X x, Y y) {
+        return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
+    }
+
+    /**
+     *  PERCENTILE_CONT(Y,P) aggregate function https://www.sqlite.org/lang_aggfunc.html#percentile
+     */
+    template<class X, class Y>
+    constexpr internal::built_in_aggregate_function_t<std::unique_ptr<double>, internal::percentile_cont_string, X, Y>
+    percentile_cont(X x, Y y) {
+        return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
+    }
+
+    /**
+     *  PERCENTILE_DISC(Y,P) aggregate function https://www.sqlite.org/lang_aggfunc.html#percentile
+     */
+    template<class X, class Y>
+    constexpr internal::built_in_aggregate_function_t<std::unique_ptr<double>, internal::percentile_disc_string, X, Y>
+    percentile_disc(X x, Y y) {
+        return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
+    }
+#endif
 #ifdef SQLITE_ENABLE_JSON1
     template<class X>
     constexpr internal::built_in_function_t<std::string, internal::json_string, X> json(X x) {

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -8342,22 +8342,36 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  IIF(X,Y,Z) function https://www.sqlite.org/lang_corefunc.html#iif
      *
      *  The return type is the common type of Y and Z, unless it is explicitly specified as a template argument.
+     *  The function is only enabled if a common type of Y and Z can be determined or the return type is explicit.
      *
      *  Example:
      *
-     *  auto rows = storage.select(iif(c(&User::age) > 18, "adult", "minor"));
+     *  auto rows = storage.select(iif<std::string>(c(&User::age) > 18, "adult", "minor"));
      */
-    template<class R = void, class X, class Y, class Z>
-    constexpr auto iif(X x, Y y, Z z) -> internal::built_in_function_t<
-        typename mpl::conditional_t<  //  choose R or common type
-            std::is_void<R>::value,
-            std::common_type<internal::field_type_or_type_t<Y>, internal::field_type_or_type_t<Z>>,
-            polyfill::type_identity<R>>::type,
-        internal::iif_string,
-        X,
-        Y,
-        Z> {
-        return {std::make_tuple(std::move(x), std::move(y), std::move(z))};
+    template<class R = void,
+             class X,
+             class Y,
+             class Z,
+             std::enable_if_t<polyfill::disjunction_v<polyfill::negation<std::is_void<R>>,
+                                                      polyfill::is_detected<std::common_type_t,
+                                                                            internal::field_type_or_type_t<Y>,
+                                                                            internal::field_type_or_type_t<Z>>>,
+                              bool> = true>
+    constexpr auto iif(X x, Y y, Z z) {
+        if constexpr (std::is_void<R>::value) {
+            using F = internal::built_in_function_t<
+                std::common_type_t<internal::field_type_or_type_t<Y>, internal::field_type_or_type_t<Z>>,
+                internal::iif_string,
+                X,
+                Y,
+                Z>;
+
+            return F{std::make_tuple(std::move(x), std::move(y), std::move(z))};
+        } else {
+            using F = internal::built_in_function_t<R, internal::iif_string, X, Y, Z>;
+
+            return F{std::make_tuple(std::move(x), std::move(y), std::move(z))};
+        }
     }
 #endif
 
@@ -8469,18 +8483,32 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  IF(X,Y,Z) function, an alias for IIF() https://www.sqlite.org/lang_corefunc.html#iif
      *
      *  The return type is the common type of Y and Z, unless it is explicitly specified as a template argument.
+     *  The function is only enabled if a common type of Y and Z can be determined or the return type is explicit.
      */
-    template<class R = void, class X, class Y, class Z>
-    constexpr auto if_(X x, Y y, Z z) -> internal::built_in_function_t<
-        typename mpl::conditional_t<  //  choose R or common type
-            std::is_void<R>::value,
-            std::common_type<internal::field_type_or_type_t<Y>, internal::field_type_or_type_t<Z>>,
-            polyfill::type_identity<R>>::type,
-        internal::if_string,
-        X,
-        Y,
-        Z> {
-        return {std::make_tuple(std::move(x), std::move(y), std::move(z))};
+    template<class R = void,
+             class X,
+             class Y,
+             class Z,
+             std::enable_if_t<polyfill::disjunction_v<polyfill::negation<std::is_void<R>>,
+                                                      polyfill::is_detected<std::common_type_t,
+                                                                            internal::field_type_or_type_t<Y>,
+                                                                            internal::field_type_or_type_t<Z>>>,
+                              bool> = true>
+    constexpr auto if_(X x, Y y, Z z) {
+        if constexpr (std::is_void<R>::value) {
+            using F = internal::built_in_function_t<
+                std::common_type_t<internal::field_type_or_type_t<Y>, internal::field_type_or_type_t<Z>>,
+                internal::if_string,
+                X,
+                Y,
+                Z>;
+
+            return F{std::make_tuple(std::move(x), std::move(y), std::move(z))};
+        } else {
+            using F = internal::built_in_function_t<R, internal::if_string, X, Y, Z>;
+
+            return F{std::make_tuple(std::move(x), std::move(y), std::move(z))};
+        }
     }
 #endif
 

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -8505,36 +8505,47 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 #ifdef SQLITE_ENABLE_PERCENTILE
     /**
      *  MEDIAN(X) aggregate function https://www.sqlite.org/lang_aggfunc.html#percentile
+     *
+     *  The return type defaults to `std::unique_ptr<double>` (the result is NULL for an empty group);
+     *  any other bindable type such as `std::optional<double>` can be specified as a template argument.
      */
-    template<class X>
-    constexpr internal::built_in_aggregate_function_t<std::unique_ptr<double>, internal::median_string, X> median(X x) {
+    template<class R = std::unique_ptr<double>, class X>
+    constexpr internal::built_in_aggregate_function_t<R, internal::median_string, X> median(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 
     /**
      *  PERCENTILE(Y,P) aggregate function https://www.sqlite.org/lang_aggfunc.html#percentile
+     *
+     *  The return type defaults to `std::unique_ptr<double>` (the result is NULL for an empty group);
+     *  any other bindable type such as `std::optional<double>` can be specified as a template argument.
      */
-    template<class X, class Y>
-    constexpr internal::built_in_aggregate_function_t<std::unique_ptr<double>, internal::percentile_string, X, Y>
-    percentile(X x, Y y) {
+    template<class R = std::unique_ptr<double>, class X, class Y>
+    constexpr internal::built_in_aggregate_function_t<R, internal::percentile_string, X, Y> percentile(X x, Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
     /**
      *  PERCENTILE_CONT(Y,P) aggregate function https://www.sqlite.org/lang_aggfunc.html#percentile
+     *
+     *  The return type defaults to `std::unique_ptr<double>` (the result is NULL for an empty group);
+     *  any other bindable type such as `std::optional<double>` can be specified as a template argument.
      */
-    template<class X, class Y>
-    constexpr internal::built_in_aggregate_function_t<std::unique_ptr<double>, internal::percentile_cont_string, X, Y>
-    percentile_cont(X x, Y y) {
+    template<class R = std::unique_ptr<double>, class X, class Y>
+    constexpr internal::built_in_aggregate_function_t<R, internal::percentile_cont_string, X, Y> percentile_cont(X x,
+                                                                                                                 Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
     /**
      *  PERCENTILE_DISC(Y,P) aggregate function https://www.sqlite.org/lang_aggfunc.html#percentile
+     *
+     *  The return type defaults to `std::unique_ptr<double>` (the result is NULL for an empty group);
+     *  any other bindable type such as `std::optional<double>` can be specified as a template argument.
      */
-    template<class X, class Y>
-    constexpr internal::built_in_aggregate_function_t<std::unique_ptr<double>, internal::percentile_disc_string, X, Y>
-    percentile_disc(X x, Y y) {
+    template<class R = std::unique_ptr<double>, class X, class Y>
+    constexpr internal::built_in_aggregate_function_t<R, internal::percentile_disc_string, X, Y> percentile_disc(X x,
+                                                                                                                 Y y) {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 #endif

--- a/tests/built_in_functions_tests/core_functions_tests.cpp
+++ b/tests/built_in_functions_tests/core_functions_tests.cpp
@@ -1358,23 +1358,23 @@ TEST_CASE("ifnull") {
 TEST_CASE("printf") {
     auto storage = make_storage({});
     auto rows = storage.select(sqlite_orm::printf("%d/%s", 1, "one"));
-    REQUIRE(rows.size() == 1);
-    REQUIRE(rows.front() == "1/one");
+    decltype(rows) expected{"1/one"};
+    REQUIRE(rows == expected);
 }
 #endif
 
 #if SQLITE_VERSION_NUMBER >= 3032000
 TEST_CASE("iif") {
     auto storage = make_storage({});
-    {
+    SECTION("common type") {
         auto rows = storage.select(iif<std::string>(c(2) > 1, "greater", "less"));
-        REQUIRE(rows.size() == 1);
-        REQUIRE(rows.front() == "greater");
+        decltype(rows) expected{"greater"};
+        REQUIRE(rows == expected);
     }
-    {
+    SECTION("explicit type") {
         auto rows = storage.select(iif<int>(c(1) > 2, 10, 20));
-        REQUIRE(rows.size() == 1);
-        REQUIRE(rows.front() == 20);
+        decltype(rows) expected{20};
+        REQUIRE(rows == expected);
     }
 }
 #endif
@@ -1382,21 +1382,21 @@ TEST_CASE("iif") {
 #if SQLITE_VERSION_NUMBER >= 3035000
 TEST_CASE("sign") {
     auto storage = make_storage({});
-    {
+    SECTION("negative integer") {
         auto rows = storage.select(sign(-42));
-        REQUIRE(rows.size() == 1);
-        REQUIRE(rows.front() == -1);
+        decltype(rows) expected{-1};
+        REQUIRE(rows == expected);
     }
-    {
+    SECTION("positive real") {
         auto rows = storage.select(sign(3.5));
-        REQUIRE(rows.size() == 1);
-        REQUIRE(rows.front() == 1);
+        decltype(rows) expected{1};
+        REQUIRE(rows == expected);
     }
 #ifdef SQLITE_ORM_OPTIONAL_SUPPORTED
-    {
+    SECTION("null for a non-numeric argument") {
         auto rows = storage.select(sign<std::optional<int>>("ototo"));
-        REQUIRE(rows.size() == 1);
-        REQUIRE_FALSE(rows.front().has_value());
+        decltype(rows) expected{std::nullopt};
+        REQUIRE(rows == expected);
     }
 #endif
 }
@@ -1406,15 +1406,15 @@ TEST_CASE("sign") {
 TEST_CASE("format") {
     auto storage = make_storage({});
     auto rows = storage.select(format("%d/%s", 2, "two"));
-    REQUIRE(rows.size() == 1);
-    REQUIRE(rows.front() == "2/two");
+    decltype(rows) expected{"2/two"};
+    REQUIRE(rows == expected);
 }
 
 TEST_CASE("unixepoch") {
     auto storage = make_storage({});
     auto rows = storage.select(unixepoch("1970-01-02"));
-    REQUIRE(rows.size() == 1);
-    REQUIRE(rows.front() == 86400);
+    decltype(rows) expected{86400};
+    REQUIRE(rows == expected);
 }
 #endif
 
@@ -1422,8 +1422,8 @@ TEST_CASE("unixepoch") {
 TEST_CASE("unhex") {
     auto storage = make_storage({});
     auto rows = storage.select(unhex("3637"));
-    REQUIRE(rows.size() == 1);
-    REQUIRE(rows.front() == std::vector<char>{'6', '7'});
+    decltype(rows) expected{std::vector<char>{'6', '7'}};
+    REQUIRE(rows == expected);
 }
 #endif
 
@@ -1431,30 +1431,30 @@ TEST_CASE("unhex") {
 TEST_CASE("octet_length") {
     auto storage = make_storage({});
     auto rows = storage.select(octet_length("ä"));
-    REQUIRE(rows.size() == 1);
-    REQUIRE(rows.front() == 2);
+    decltype(rows) expected{2};
+    REQUIRE(rows == expected);
 }
 
 TEST_CASE("timediff") {
     auto storage = make_storage({});
     auto rows = storage.select(timediff("2026-08-08", "2026-08-07"));
-    REQUIRE(rows.size() == 1);
-    REQUIRE(rows.front() == "+0000-00-01 00:00:00.000");
+    decltype(rows) expected{"+0000-00-01 00:00:00.000"};
+    REQUIRE(rows == expected);
 }
 #endif
 
 #if SQLITE_VERSION_NUMBER >= 3044000
 TEST_CASE("concat") {
     auto storage = make_storage({});
-    {
+    SECTION("concat") {
         auto rows = storage.select(concat("one", 2, "three"));
-        REQUIRE(rows.size() == 1);
-        REQUIRE(rows.front() == "one2three");
+        decltype(rows) expected{"one2three"};
+        REQUIRE(rows == expected);
     }
-    {
+    SECTION("concat_ws") {
         auto rows = storage.select(concat_ws("-", "one", "two"));
-        REQUIRE(rows.size() == 1);
-        REQUIRE(rows.front() == "one-two");
+        decltype(rows) expected{"one-two"};
+        REQUIRE(rows == expected);
     }
 }
 
@@ -1470,8 +1470,8 @@ TEST_CASE("string_agg") {
     storage.replace(User{1, "Alex"});
     storage.replace(User{2, "Michael"});
     auto rows = storage.select(string_agg(&User::name, ", "), order_by(&User::id));
-    REQUIRE(rows.size() == 1);
-    REQUIRE(rows.front() == "Alex, Michael");
+    decltype(rows) expected{"Alex, Michael"};
+    REQUIRE(rows == expected);
 }
 #endif
 
@@ -1479,8 +1479,8 @@ TEST_CASE("string_agg") {
 TEST_CASE("if_") {
     auto storage = make_storage({});
     auto rows = storage.select(if_<std::string>(c(2) > 1, "greater", "less"));
-    REQUIRE(rows.size() == 1);
-    REQUIRE(rows.front() == "greater");
+    decltype(rows) expected{"greater"};
+    REQUIRE(rows == expected);
 }
 #endif
 
@@ -1488,8 +1488,8 @@ TEST_CASE("if_") {
 TEST_CASE("unistr") {
     auto storage = make_storage({});
     auto rows = storage.select(unistr("a\\u0062c"));
-    REQUIRE(rows.size() == 1);
-    REQUIRE(rows.front() == "abc");
+    decltype(rows) expected{"abc"};
+    REQUIRE(rows == expected);
 }
 #endif
 
@@ -1506,29 +1506,27 @@ TEST_CASE("median and percentile") {
     storage.replace(Score{1, 1.0});
     storage.replace(Score{2, 2.0});
     storage.replace(Score{3, 3.0});
-    {
-        auto rows = storage.select(median(&Score::value));
-        REQUIRE(rows.size() == 1);
-        REQUIRE(rows.front());
-        REQUIRE(*rows.front() == 2.0);
+#ifdef SQLITE_ORM_OPTIONAL_SUPPORTED
+    SECTION("median") {
+        auto rows = storage.select(median<std::optional<double>>(&Score::value));
+        decltype(rows) expected{2.0};
+        REQUIRE(rows == expected);
     }
-    {
-        auto rows = storage.select(percentile(&Score::value, 50));
-        REQUIRE(rows.size() == 1);
-        REQUIRE(rows.front());
-        REQUIRE(*rows.front() == 2.0);
+    SECTION("percentile") {
+        auto rows = storage.select(percentile<std::optional<double>>(&Score::value, 50));
+        decltype(rows) expected{2.0};
+        REQUIRE(rows == expected);
     }
-    {
-        auto rows = storage.select(percentile_cont(&Score::value, 0.5));
-        REQUIRE(rows.size() == 1);
-        REQUIRE(rows.front());
-        REQUIRE(*rows.front() == 2.0);
+    SECTION("percentile_cont") {
+        auto rows = storage.select(percentile_cont<std::optional<double>>(&Score::value, 0.5));
+        decltype(rows) expected{2.0};
+        REQUIRE(rows == expected);
     }
-    {
-        auto rows = storage.select(percentile_disc(&Score::value, 0.5));
-        REQUIRE(rows.size() == 1);
-        REQUIRE(rows.front());
-        REQUIRE(*rows.front() == 2.0);
+    SECTION("percentile_disc") {
+        auto rows = storage.select(percentile_disc<std::optional<double>>(&Score::value, 0.5));
+        decltype(rows) expected{2.0};
+        REQUIRE(rows == expected);
     }
+#endif
 }
 #endif

--- a/tests/built_in_functions_tests/core_functions_tests.cpp
+++ b/tests/built_in_functions_tests/core_functions_tests.cpp
@@ -1353,3 +1353,182 @@ TEST_CASE("ifnull") {
     expected.push_back({"Wyatt", "Girard", "Call:+33 05 56 96 96 96"});
     REQUIRE_THAT(rows, UnorderedEquals(expected));
 }
+
+#if SQLITE_VERSION_NUMBER >= 3008003
+TEST_CASE("printf") {
+    auto storage = make_storage({});
+    auto rows = storage.select(sqlite_orm::printf("%d/%s", 1, "one"));
+    REQUIRE(rows.size() == 1);
+    REQUIRE(rows.front() == "1/one");
+}
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3032000
+TEST_CASE("iif") {
+    auto storage = make_storage({});
+    {
+        auto rows = storage.select(iif<std::string>(c(2) > 1, "greater", "less"));
+        REQUIRE(rows.size() == 1);
+        REQUIRE(rows.front() == "greater");
+    }
+    {
+        auto rows = storage.select(iif<int>(c(1) > 2, 10, 20));
+        REQUIRE(rows.size() == 1);
+        REQUIRE(rows.front() == 20);
+    }
+}
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3035000
+TEST_CASE("sign") {
+    auto storage = make_storage({});
+    {
+        auto rows = storage.select(sign(-42));
+        REQUIRE(rows.size() == 1);
+        REQUIRE(rows.front() == -1);
+    }
+    {
+        auto rows = storage.select(sign(3.5));
+        REQUIRE(rows.size() == 1);
+        REQUIRE(rows.front() == 1);
+    }
+#ifdef SQLITE_ORM_OPTIONAL_SUPPORTED
+    {
+        auto rows = storage.select(sign<std::optional<int>>("ototo"));
+        REQUIRE(rows.size() == 1);
+        REQUIRE_FALSE(rows.front().has_value());
+    }
+#endif
+}
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3038000
+TEST_CASE("format") {
+    auto storage = make_storage({});
+    auto rows = storage.select(format("%d/%s", 2, "two"));
+    REQUIRE(rows.size() == 1);
+    REQUIRE(rows.front() == "2/two");
+}
+
+TEST_CASE("unixepoch") {
+    auto storage = make_storage({});
+    auto rows = storage.select(unixepoch("1970-01-02"));
+    REQUIRE(rows.size() == 1);
+    REQUIRE(rows.front() == 86400);
+}
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3041000
+TEST_CASE("unhex") {
+    auto storage = make_storage({});
+    auto rows = storage.select(unhex("3637"));
+    REQUIRE(rows.size() == 1);
+    REQUIRE(rows.front() == std::vector<char>{'6', '7'});
+}
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3043000
+TEST_CASE("octet_length") {
+    auto storage = make_storage({});
+    auto rows = storage.select(octet_length("ä"));
+    REQUIRE(rows.size() == 1);
+    REQUIRE(rows.front() == 2);
+}
+
+TEST_CASE("timediff") {
+    auto storage = make_storage({});
+    auto rows = storage.select(timediff("2026-08-08", "2026-08-07"));
+    REQUIRE(rows.size() == 1);
+    REQUIRE(rows.front() == "+0000-00-01 00:00:00.000");
+}
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3044000
+TEST_CASE("concat") {
+    auto storage = make_storage({});
+    {
+        auto rows = storage.select(concat("one", 2, "three"));
+        REQUIRE(rows.size() == 1);
+        REQUIRE(rows.front() == "one2three");
+    }
+    {
+        auto rows = storage.select(concat_ws("-", "one", "two"));
+        REQUIRE(rows.size() == 1);
+        REQUIRE(rows.front() == "one-two");
+    }
+}
+
+TEST_CASE("string_agg") {
+    struct User {
+        int id = 0;
+        std::string name;
+    };
+    auto storage = make_storage(
+        {},
+        make_table("users", make_column("id", &User::id, primary_key()), make_column("name", &User::name)));
+    storage.sync_schema();
+    storage.replace(User{1, "Alex"});
+    storage.replace(User{2, "Michael"});
+    auto rows = storage.select(string_agg(&User::name, ", "), order_by(&User::id));
+    REQUIRE(rows.size() == 1);
+    REQUIRE(rows.front() == "Alex, Michael");
+}
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3048000
+TEST_CASE("if_") {
+    auto storage = make_storage({});
+    auto rows = storage.select(if_<std::string>(c(2) > 1, "greater", "less"));
+    REQUIRE(rows.size() == 1);
+    REQUIRE(rows.front() == "greater");
+}
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3050000
+TEST_CASE("unistr") {
+    auto storage = make_storage({});
+    auto rows = storage.select(unistr("a\\u0062c"));
+    REQUIRE(rows.size() == 1);
+    REQUIRE(rows.front() == "abc");
+}
+#endif
+
+#ifdef SQLITE_ENABLE_PERCENTILE
+TEST_CASE("median and percentile") {
+    struct Score {
+        int id = 0;
+        double value = 0;
+    };
+    auto storage = make_storage(
+        {},
+        make_table("scores", make_column("id", &Score::id, primary_key()), make_column("value", &Score::value)));
+    storage.sync_schema();
+    storage.replace(Score{1, 1.0});
+    storage.replace(Score{2, 2.0});
+    storage.replace(Score{3, 3.0});
+    {
+        auto rows = storage.select(median(&Score::value));
+        REQUIRE(rows.size() == 1);
+        REQUIRE(rows.front());
+        REQUIRE(*rows.front() == 2.0);
+    }
+    {
+        auto rows = storage.select(percentile(&Score::value, 50));
+        REQUIRE(rows.size() == 1);
+        REQUIRE(rows.front());
+        REQUIRE(*rows.front() == 2.0);
+    }
+    {
+        auto rows = storage.select(percentile_cont(&Score::value, 0.5));
+        REQUIRE(rows.size() == 1);
+        REQUIRE(rows.front());
+        REQUIRE(*rows.front() == 2.0);
+    }
+    {
+        auto rows = storage.select(percentile_disc(&Score::value, 0.5));
+        REQUIRE(rows.size() == 1);
+        REQUIRE(rows.front());
+        REQUIRE(*rows.front() == 2.0);
+    }
+}
+#endif

--- a/tests/statement_serializer_tests/core_functions.cpp
+++ b/tests/statement_serializer_tests/core_functions.cpp
@@ -398,3 +398,122 @@ TEST_CASE("statement_serializer core functions") {
     }
     REQUIRE(value == expected);
 }
+
+TEST_CASE("statement_serializer newer core functions") {
+    internal::db_objects_tuple<> storage;
+    internal::serializer_context<internal::db_objects_tuple<>> context{storage};
+    context.use_parentheses = false;
+    std::string value;
+    decltype(value) expected;
+#if SQLITE_VERSION_NUMBER >= 3008003
+    SECTION("PRINTF") {
+        auto expression = sqlite_orm::printf("%d", 1);
+        expected = "PRINTF('%d', 1)";
+        value = serialize(expression, context);
+    }
+#endif
+#if SQLITE_VERSION_NUMBER >= 3032000
+    SECTION("IIF") {
+        auto expression = iif(c(2) > 1, "greater", "less");
+        expected = "IIF(2 > 1, 'greater', 'less')";
+        value = serialize(expression, context);
+    }
+#endif
+#if SQLITE_VERSION_NUMBER >= 3035000
+    SECTION("SIGN") {
+        auto expression = sign(-3);
+        expected = "SIGN(-3)";
+        value = serialize(expression, context);
+    }
+#endif
+#if SQLITE_VERSION_NUMBER >= 3038000
+    SECTION("FORMAT") {
+        auto expression = format("%d", 1);
+        expected = "FORMAT('%d', 1)";
+        value = serialize(expression, context);
+    }
+    SECTION("UNIXEPOCH") {
+        auto expression = unixepoch("now");
+        expected = "UNIXEPOCH('now')";
+        value = serialize(expression, context);
+    }
+#endif
+#if SQLITE_VERSION_NUMBER >= 3041000
+    SECTION("UNHEX") {
+        auto expression = unhex("3637");
+        expected = "UNHEX('3637')";
+        value = serialize(expression, context);
+    }
+#endif
+#if SQLITE_VERSION_NUMBER >= 3043000
+    SECTION("OCTET_LENGTH") {
+        auto expression = octet_length("hi");
+        expected = "OCTET_LENGTH('hi')";
+        value = serialize(expression, context);
+    }
+    SECTION("TIMEDIFF") {
+        auto expression = timediff("2026-08-08", "2026-08-07");
+        expected = "TIMEDIFF('2026-08-08', '2026-08-07')";
+        value = serialize(expression, context);
+    }
+#endif
+#if SQLITE_VERSION_NUMBER >= 3044000
+    SECTION("CONCAT") {
+        auto expression = concat("one", 2);
+        expected = "CONCAT('one', 2)";
+        value = serialize(expression, context);
+    }
+    SECTION("CONCAT_WS") {
+        auto expression = concat_ws("-", "one", "two");
+        expected = "CONCAT_WS('-', 'one', 'two')";
+        value = serialize(expression, context);
+    }
+    SECTION("STRING_AGG") {
+        auto expression = string_agg("x", ",");
+        expected = "STRING_AGG('x', ',')";
+        value = serialize(expression, context);
+    }
+#endif
+#if SQLITE_VERSION_NUMBER >= 3048000
+    SECTION("IF") {
+        auto expression = if_(c(2) > 1, "greater", "less");
+        expected = "IF(2 > 1, 'greater', 'less')";
+        value = serialize(expression, context);
+    }
+#endif
+#if SQLITE_VERSION_NUMBER >= 3050000
+    SECTION("UNISTR") {
+        auto expression = unistr("a\\u0062c");
+        expected = "UNISTR('a\\u0062c')";
+        value = serialize(expression, context);
+    }
+    SECTION("UNISTR_QUOTE") {
+        auto expression = unistr_quote("abc");
+        expected = "UNISTR_QUOTE('abc')";
+        value = serialize(expression, context);
+    }
+#endif
+#ifdef SQLITE_ENABLE_PERCENTILE
+    SECTION("MEDIAN") {
+        auto expression = median(1);
+        expected = "MEDIAN(1)";
+        value = serialize(expression, context);
+    }
+    SECTION("PERCENTILE") {
+        auto expression = percentile(1, 50);
+        expected = "PERCENTILE(1, 50)";
+        value = serialize(expression, context);
+    }
+    SECTION("PERCENTILE_CONT") {
+        auto expression = percentile_cont(1, 0.5);
+        expected = "PERCENTILE_CONT(1, 0.5)";
+        value = serialize(expression, context);
+    }
+    SECTION("PERCENTILE_DISC") {
+        auto expression = percentile_disc(1, 0.5);
+        expected = "PERCENTILE_DISC(1, 0.5)";
+        value = serialize(expression, context);
+    }
+#endif
+    REQUIRE(value == expected);
+}


### PR DESCRIPTION
Adds wrappers for built-in SQLite functions that were missing from `core_functions.h`:

- **Scalar**: `printf` (3.8.3), `iif` (3.32), `sign` (3.35), `format`, `unixepoch` (3.38), `unhex` (3.41), `octet_length`, `timediff` (3.43), `concat`, `concat_ws` (3.44), `if_` (3.48), `unistr`, `unistr_quote` (3.50)
- **Aggregate**: `string_agg` (3.44), `median`, `percentile`, `percentile_cont`, `percentile_disc` (3.51)

Each wrapper is gated by the `SQLITE_VERSION_NUMBER` it appeared in. The percentile family is gated by `SQLITE_ENABLE_PERCENTILE` (following the math-functions precedent — the amalgamation only compiles it in with that define). `iif`/`if_` compute the result type as the common type of the branch arguments, overridable via a template argument like `coalesce`.

Runtime tests + statement serializer tests for every function; verified locally against SQLite 3.31.1, 3.51.0 (with percentile) and the system SQLite. The recent-version CI job is bumped from 3.50.4 to 3.51.0 with `SQLITE_ENABLE_PERCENTILE`. Completed `iif()` and scalar math functions entries are removed from TODO.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)