### PR TITLE
Add SAVEPOINT support

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,6 @@
 * `ATTACH`
 * blob incremental I/O https://sqlite.org/c3ref/blob_open.html
 * query static check for correct order (e.g. `GROUP BY` after `WHERE`)
-* `SAVEPOINT` https://www.sqlite.org/lang_savepoint.html
 * add `static_assert` in crud `get*` functions in case user passes `where_t` instead of id to make compilation error more clear (example https://github.com/fnc12/sqlite_orm/issues/485)
 * named constraints: constraint can have name `CREATE TABLE heroes(id INTEGER CONSTRAINT pk PRIMARY KEY)`
 * `UPDATE FROM` support https://sqlite.org/lang_update.html#upfrom

--- a/dev/savepoint.h
+++ b/dev/savepoint.h
@@ -70,7 +70,7 @@ namespace sqlite_orm::internal {
             this->rollback_to_func();
         }
 
-      protected:
+      private:
         connection_ref connection;
         std::function<void()> release_func;
         std::function<void()> rollback_to_func;

--- a/dev/savepoint.h
+++ b/dev/savepoint.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#ifndef SQLITE_ORM_IMPORT_STD_MODULE
+#include <functional>  //  std::function
+#include <utility>  //  std::move
+#endif
+
+#include "connection_holder.h"
+
+namespace sqlite_orm::internal {
+    /**
+     *  Class used as a guard for a savepoint. Calls `ROLLBACK TO` and `RELEASE` in destructor.
+     *  Has explicit `release()` and `rollback_to()` functions. After the `release()` function is fired
+     *  the guard won't do anything in its d-tor. Note that unlike a rollback of a transaction
+     *  `rollback_to()` doesn't finish the savepoint: the savepoint remains on the transaction stack,
+     *  so `rollback_to()` may be called multiple times, and the guard is still armed afterwards.
+     *  Also you can set `release_on_destroy` to true to make the guard call `RELEASE` only on destroy,
+     *  keeping the changes.
+     *
+     *  Note: The guard's destructor is explicitly marked as potentially throwing,
+     *  so exceptions that occur during release or rollback are propagated to the caller.
+     */
+    struct savepoint_t {
+        /**
+         *  This is a public lever to tell a guard what it must do in its destructor
+         *  if `gotta_fire` is true
+         */
+        bool release_on_destroy = false;
+
+        savepoint_t(connection_ref connection_,
+                    std::function<void()> release_func_,
+                    std::function<void()> rollback_to_func_) :
+            connection(std::move(connection_)), release_func(std::move(release_func_)),
+            rollback_to_func(std::move(rollback_to_func_)) {}
+
+        savepoint_t(savepoint_t&& other) :
+            release_on_destroy(other.release_on_destroy), connection(std::move(other.connection)),
+            release_func(std::move(other.release_func)), rollback_to_func(std::move(other.rollback_to_func)),
+            gotta_fire(other.gotta_fire) {
+            other.gotta_fire = false;
+        }
+
+        ~savepoint_t() noexcept(false) {
+            if (this->gotta_fire) {
+                if (!this->release_on_destroy) {
+                    this->rollback_to_func();
+                }
+                this->release_func();
+            }
+        }
+
+        savepoint_t& operator=(savepoint_t&&) = delete;
+
+        /**
+         *  Call `RELEASE` explicitly. After this call
+         *  guard will not call `ROLLBACK TO` or `RELEASE`
+         *  in its destructor.
+         */
+        void release() {
+            this->gotta_fire = false;
+            this->release_func();
+        }
+
+        /**
+         *  Call `ROLLBACK TO` explicitly. The savepoint remains on the
+         *  transaction stack, so the guard is still armed after this call:
+         *  its destructor will fire unless `release()` is called.
+         */
+        void rollback_to() {
+            this->rollback_to_func();
+        }
+
+      protected:
+        connection_ref connection;
+        std::function<void()> release_func;
+        std::function<void()> rollback_to_func;
+        bool gotta_fire = true;
+    };
+}

--- a/dev/storage_base.h
+++ b/dev/storage_base.h
@@ -280,7 +280,7 @@ namespace sqlite_orm::internal {
 
         static std::string savepoint_sql(serialize_arg_type statementPrefix, const std::string& savepointName) {
             std::stringstream ss;
-            ss << statementPrefix << streaming_identifier(savepointName) << std::flush;
+            ss << statementPrefix << streaming_identifier(savepointName);
             return ss.str();
         }
 

--- a/dev/storage_base.h
+++ b/dev/storage_base.h
@@ -23,6 +23,7 @@
 #include "pragma.h"
 #include "limit_accessor.h"
 #include "transaction_guard.h"
+#include "savepoint.h"
 #include "row_extractor.h"
 #include "connection_holder.h"
 #include "backup.h"
@@ -123,6 +124,26 @@ namespace sqlite_orm::internal {
             return {std::move(connection),
                     std::bind(&sqlite_executor::perform_void_exec, &executor, db, "COMMIT"),
                     std::bind(&sqlite_executor::perform_void_exec, &executor, db, "ROLLBACK")};
+        }
+
+        /**
+         *  Executes `SAVEPOINT savepointName` and returns a guard object.
+         *  The guard executes `ROLLBACK TO SAVEPOINT` + `RELEASE SAVEPOINT` in its destructor,
+         *  unless `release()` was called or `release_on_destroy` is set to true.
+         *  More info: https://www.sqlite.org/lang_savepoint.html
+         */
+        savepoint_t savepoint_guard(const std::string& savepointName) {
+            auto connection = this->get_connection();
+            sqlite3* db = connection.get();
+            this->executor.perform_void_exec(db, this->savepoint_sql("SAVEPOINT ", savepointName).c_str());
+            return {
+                std::move(connection),
+                [&executor = this->executor, db, sql = this->savepoint_sql("RELEASE SAVEPOINT ", savepointName)] {
+                    executor.perform_void_exec(db, sql.c_str());
+                },
+                [&executor = this->executor, db, sql = this->savepoint_sql("ROLLBACK TO SAVEPOINT ", savepointName)] {
+                    executor.perform_void_exec(db, sql.c_str());
+                }};
         }
 
         /**
@@ -257,6 +278,12 @@ namespace sqlite_orm::internal {
             this->executor.perform_void_exec(db, sql.c_str());
         }
 
+        static std::string savepoint_sql(serialize_arg_type statementPrefix, const std::string& savepointName) {
+            std::stringstream ss;
+            ss << statementPrefix << streaming_identifier(savepointName) << std::flush;
+            return ss.str();
+        }
+
         void add_generated_cols(std::vector<const table_xinfo*>& columnsToAdd,
                                 const std::vector<table_xinfo>& storageTableInfo) {
             //  iterate through storage columns
@@ -307,6 +334,20 @@ namespace sqlite_orm::internal {
             }
             auto guard = this->transaction_guard();
             return guard.commit_on_destroy = function();
+        }
+
+        /**
+         *  Executes the passed function within a savepoint.
+         *  If the function returns true the savepoint is released (keeping the changes),
+         *  otherwise (false or an exception) the changes are rolled back.
+         *  More info: https://www.sqlite.org/lang_savepoint.html
+         */
+        bool savepoint(const std::string& savepointName, const std::function<bool()>& function) {
+            if (!function) {
+                return false;
+            }
+            auto guard = this->savepoint_guard(savepointName);
+            return guard.release_on_destroy = function();
         }
 
         std::string current_time() {
@@ -686,6 +727,48 @@ namespace sqlite_orm::internal {
         void begin_exclusive_transaction() {
             sqlite3* db = this->connection->retain();
             this->executor.perform_void_exec(db, "BEGIN EXCLUSIVE TRANSACTION");
+        }
+
+        /**
+         *  Executes `SAVEPOINT savepointName`.
+         *  A savepoint started outside of a transaction behaves like `BEGIN DEFERRED TRANSACTION`.
+         *  More info: https://www.sqlite.org/lang_savepoint.html
+         */
+        void savepoint(const std::string& savepointName) {
+            sqlite3* db = this->connection->retain();
+            this->executor.perform_void_exec(db, this->savepoint_sql("SAVEPOINT ", savepointName).c_str());
+        }
+
+        /**
+         *  Executes `RELEASE SAVEPOINT savepointName`, which works like a `COMMIT` for a savepoint:
+         *  it removes all savepoints back to and including the most recent one with the matching name.
+         *  If it empties the whole transaction stack the changes are committed.
+         */
+        void release_savepoint(const std::string& savepointName) {
+            if (connection_ptr maybeConnection = *this->connection) {
+                this->executor.perform_void_exec(maybeConnection.get(),
+                                                 this->savepoint_sql("RELEASE SAVEPOINT ", savepointName).c_str());
+            }
+            // check for programming error on user's side not having called `savepoint()` before
+            else {
+                throw std::system_error{orm_error_code::no_active_transaction};
+            }
+        }
+
+        /**
+         *  Executes `ROLLBACK TO SAVEPOINT savepointName`, which reverts the database back to the state
+         *  it was in right after the matching `SAVEPOINT`. Unlike a plain `ROLLBACK` the savepoint
+         *  remains on the transaction stack, so the transaction continues.
+         */
+        void rollback_to_savepoint(const std::string& savepointName) {
+            if (connection_ptr maybeConnection = *this->connection) {
+                this->executor.perform_void_exec(maybeConnection.get(),
+                                                 this->savepoint_sql("ROLLBACK TO SAVEPOINT ", savepointName).c_str());
+            }
+            // check for programming error on user's side not having called `savepoint()` before
+            else {
+                throw std::system_error{orm_error_code::no_active_transaction};
+            }
         }
 
         void commit() {

--- a/examples/savepoint.cpp
+++ b/examples/savepoint.cpp
@@ -12,7 +12,7 @@ using std::cout;
 using std::endl;
 
 struct Order {
-    int id = 0;
+    sqlite_orm::int64 id = 0;
     std::string item;
     int quantity = 0;
 };

--- a/examples/savepoint.cpp
+++ b/examples/savepoint.cpp
@@ -1,0 +1,79 @@
+/**
+ *  Savepoints are named nested transactions: https://www.sqlite.org/lang_savepoint.html
+ *
+ *  SAVEPOINT name;                      -> storage.savepoint("name") / storage.savepoint_guard("name")
+ *  RELEASE SAVEPOINT name;              -> storage.release_savepoint("name") / guard.release()
+ *  ROLLBACK TO SAVEPOINT name;          -> storage.rollback_to_savepoint("name") / guard.rollback_to()
+ */
+#include <sqlite_orm/sqlite_orm.h>
+#include <iostream>
+
+using std::cout;
+using std::endl;
+
+struct Order {
+    int id = 0;
+    std::string item;
+    int quantity = 0;
+};
+
+int main() {
+    using namespace sqlite_orm;
+    auto storage = make_storage("savepoint.sqlite",
+                                make_table("orders",
+                                           make_column("id", &Order::id, primary_key()),
+                                           make_column("item", &Order::item),
+                                           make_column("quantity", &Order::quantity)));
+    storage.sync_schema();
+    storage.remove_all<Order>();
+
+    //  BEGIN TRANSACTION;
+    //  INSERT INTO orders (item, quantity) VALUES ('keyboard', 1);
+    //  SAVEPOINT "accessories";
+    //  INSERT INTO orders (item, quantity) VALUES ('mouse', 1);
+    //  ROLLBACK TO SAVEPOINT "accessories";     -- the mouse is out of stock
+    //  RELEASE SAVEPOINT "accessories";
+    //  COMMIT;
+    {
+        auto transactionGuard = storage.transaction_guard();
+        storage.insert(Order{0, "keyboard", 1});
+        {
+            auto savepointGuard = storage.savepoint_guard("accessories");
+            storage.insert(Order{0, "mouse", 1});
+            //  the mouse turned out to be out of stock: the guard's destructor
+            //  executes ROLLBACK TO SAVEPOINT + RELEASE SAVEPOINT, undoing only this insert
+        }
+        transactionGuard.commit();
+    }
+    cout << "after a partial rollback the keyboard is still ordered: " << storage.count<Order>() << " order(s)" << endl;
+
+    //  a savepoint outside of a transaction behaves like BEGIN DEFERRED TRANSACTION;
+    //  ROLLBACK TO SAVEPOINT keeps the savepoint on the stack, so a batch may be retried
+    {
+        auto savepointGuard = storage.savepoint_guard("bulk_order");
+        for (int attempt = 1; attempt <= 2; ++attempt) {
+            try {
+                storage.insert(Order{0, "monitor", attempt == 1 ? -1 : 2});
+                if (storage.count<Order>(where(c(&Order::quantity) < 0)) > 0) {
+                    throw std::runtime_error("negative quantity");
+                }
+                break;
+            } catch (const std::runtime_error&) {
+                cout << "attempt " << attempt << " failed, retrying" << endl;
+                savepointGuard.rollback_to();
+            }
+        }
+        savepointGuard.release();
+    }
+    cout << "orders after the retried bulk order: " << storage.count<Order>() << endl;
+
+    //  the functional style mirrors storage.transaction():
+    //  returning true releases the savepoint, false rolls it back
+    storage.savepoint("discount", [&storage] {
+        storage.insert(Order{0, "cable", 3});
+        return false;  //  changed our mind
+    });
+    cout << "orders after the declined discount purchase: " << storage.count<Order>() << endl;
+
+    return 0;
+}

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -19775,6 +19775,86 @@ namespace sqlite_orm::internal {
     };
 }
 
+// #include "savepoint.h"
+
+#ifndef SQLITE_ORM_IMPORT_STD_MODULE
+#include <functional>  //  std::function
+#include <utility>  //  std::move
+#endif
+
+// #include "connection_holder.h"
+
+namespace sqlite_orm::internal {
+    /**
+     *  Class used as a guard for a savepoint. Calls `ROLLBACK TO` and `RELEASE` in destructor.
+     *  Has explicit `release()` and `rollback_to()` functions. After the `release()` function is fired
+     *  the guard won't do anything in its d-tor. Note that unlike a rollback of a transaction
+     *  `rollback_to()` doesn't finish the savepoint: the savepoint remains on the transaction stack,
+     *  so `rollback_to()` may be called multiple times, and the guard is still armed afterwards.
+     *  Also you can set `release_on_destroy` to true to make the guard call `RELEASE` only on destroy,
+     *  keeping the changes.
+     *
+     *  Note: The guard's destructor is explicitly marked as potentially throwing,
+     *  so exceptions that occur during release or rollback are propagated to the caller.
+     */
+    struct savepoint_t {
+        /**
+         *  This is a public lever to tell a guard what it must do in its destructor
+         *  if `gotta_fire` is true
+         */
+        bool release_on_destroy = false;
+
+        savepoint_t(connection_ref connection_,
+                    std::function<void()> release_func_,
+                    std::function<void()> rollback_to_func_) :
+            connection(std::move(connection_)), release_func(std::move(release_func_)),
+            rollback_to_func(std::move(rollback_to_func_)) {}
+
+        savepoint_t(savepoint_t&& other) :
+            release_on_destroy(other.release_on_destroy), connection(std::move(other.connection)),
+            release_func(std::move(other.release_func)), rollback_to_func(std::move(other.rollback_to_func)),
+            gotta_fire(other.gotta_fire) {
+            other.gotta_fire = false;
+        }
+
+        ~savepoint_t() noexcept(false) {
+            if (this->gotta_fire) {
+                if (!this->release_on_destroy) {
+                    this->rollback_to_func();
+                }
+                this->release_func();
+            }
+        }
+
+        savepoint_t& operator=(savepoint_t&&) = delete;
+
+        /**
+         *  Call `RELEASE` explicitly. After this call
+         *  guard will not call `ROLLBACK TO` or `RELEASE`
+         *  in its destructor.
+         */
+        void release() {
+            this->gotta_fire = false;
+            this->release_func();
+        }
+
+        /**
+         *  Call `ROLLBACK TO` explicitly. The savepoint remains on the
+         *  transaction stack, so the guard is still armed after this call:
+         *  its destructor will fire unless `release()` is called.
+         */
+        void rollback_to() {
+            this->rollback_to_func();
+        }
+
+      protected:
+        connection_ref connection;
+        std::function<void()> release_func;
+        std::function<void()> rollback_to_func;
+        bool gotta_fire = true;
+    };
+}
+
 // #include "row_extractor.h"
 
 // #include "connection_holder.h"
@@ -20378,6 +20458,26 @@ namespace sqlite_orm::internal {
         }
 
         /**
+         *  Executes `SAVEPOINT savepointName` and returns a guard object.
+         *  The guard executes `ROLLBACK TO SAVEPOINT` + `RELEASE SAVEPOINT` in its destructor,
+         *  unless `release()` was called or `release_on_destroy` is set to true.
+         *  More info: https://www.sqlite.org/lang_savepoint.html
+         */
+        savepoint_t savepoint_guard(const std::string& savepointName) {
+            auto connection = this->get_connection();
+            sqlite3* db = connection.get();
+            this->executor.perform_void_exec(db, this->savepoint_sql("SAVEPOINT ", savepointName).c_str());
+            return {
+                std::move(connection),
+                [&executor = this->executor, db, sql = this->savepoint_sql("RELEASE SAVEPOINT ", savepointName)] {
+                    executor.perform_void_exec(db, sql.c_str());
+                },
+                [&executor = this->executor, db, sql = this->savepoint_sql("ROLLBACK TO SAVEPOINT ", savepointName)] {
+                    executor.perform_void_exec(db, sql.c_str());
+                }};
+        }
+
+        /**
          *  Drops index with given name. 
          *  Calls `DROP INDEX indexName`.
          *  More info: https://www.sqlite.org/lang_dropindex.html
@@ -20509,6 +20609,12 @@ namespace sqlite_orm::internal {
             this->executor.perform_void_exec(db, sql.c_str());
         }
 
+        static std::string savepoint_sql(serialize_arg_type statementPrefix, const std::string& savepointName) {
+            std::stringstream ss;
+            ss << statementPrefix << streaming_identifier(savepointName) << std::flush;
+            return ss.str();
+        }
+
         void add_generated_cols(std::vector<const table_xinfo*>& columnsToAdd,
                                 const std::vector<table_xinfo>& storageTableInfo) {
             //  iterate through storage columns
@@ -20559,6 +20665,20 @@ namespace sqlite_orm::internal {
             }
             auto guard = this->transaction_guard();
             return guard.commit_on_destroy = function();
+        }
+
+        /**
+         *  Executes the passed function within a savepoint.
+         *  If the function returns true the savepoint is released (keeping the changes),
+         *  otherwise (false or an exception) the changes are rolled back.
+         *  More info: https://www.sqlite.org/lang_savepoint.html
+         */
+        bool savepoint(const std::string& savepointName, const std::function<bool()>& function) {
+            if (!function) {
+                return false;
+            }
+            auto guard = this->savepoint_guard(savepointName);
+            return guard.release_on_destroy = function();
         }
 
         std::string current_time() {
@@ -20938,6 +21058,48 @@ namespace sqlite_orm::internal {
         void begin_exclusive_transaction() {
             sqlite3* db = this->connection->retain();
             this->executor.perform_void_exec(db, "BEGIN EXCLUSIVE TRANSACTION");
+        }
+
+        /**
+         *  Executes `SAVEPOINT savepointName`.
+         *  A savepoint started outside of a transaction behaves like `BEGIN DEFERRED TRANSACTION`.
+         *  More info: https://www.sqlite.org/lang_savepoint.html
+         */
+        void savepoint(const std::string& savepointName) {
+            sqlite3* db = this->connection->retain();
+            this->executor.perform_void_exec(db, this->savepoint_sql("SAVEPOINT ", savepointName).c_str());
+        }
+
+        /**
+         *  Executes `RELEASE SAVEPOINT savepointName`, which works like a `COMMIT` for a savepoint:
+         *  it removes all savepoints back to and including the most recent one with the matching name.
+         *  If it empties the whole transaction stack the changes are committed.
+         */
+        void release_savepoint(const std::string& savepointName) {
+            if (connection_ptr maybeConnection = *this->connection) {
+                this->executor.perform_void_exec(maybeConnection.get(),
+                                                 this->savepoint_sql("RELEASE SAVEPOINT ", savepointName).c_str());
+            }
+            // check for programming error on user's side not having called `savepoint()` before
+            else {
+                throw std::system_error{orm_error_code::no_active_transaction};
+            }
+        }
+
+        /**
+         *  Executes `ROLLBACK TO SAVEPOINT savepointName`, which reverts the database back to the state
+         *  it was in right after the matching `SAVEPOINT`. Unlike a plain `ROLLBACK` the savepoint
+         *  remains on the transaction stack, so the transaction continues.
+         */
+        void rollback_to_savepoint(const std::string& savepointName) {
+            if (connection_ptr maybeConnection = *this->connection) {
+                this->executor.perform_void_exec(maybeConnection.get(),
+                                                 this->savepoint_sql("ROLLBACK TO SAVEPOINT ", savepointName).c_str());
+            }
+            // check for programming error on user's side not having called `savepoint()` before
+            else {
+                throw std::system_error{orm_error_code::no_active_transaction};
+            }
         }
 
         void commit() {

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -19847,7 +19847,7 @@ namespace sqlite_orm::internal {
             this->rollback_to_func();
         }
 
-      protected:
+      private:
         connection_ref connection;
         std::function<void()> release_func;
         std::function<void()> rollback_to_func;
@@ -20611,7 +20611,7 @@ namespace sqlite_orm::internal {
 
         static std::string savepoint_sql(serialize_arg_type statementPrefix, const std::string& savepointName) {
             std::stringstream ss;
-            ss << statementPrefix << streaming_identifier(savepointName) << std::flush;
+            ss << statementPrefix << streaming_identifier(savepointName);
             return ss.str();
         }
 

--- a/tests/logger_tests.cpp
+++ b/tests/logger_tests.cpp
@@ -145,6 +145,68 @@ TEST_CASE("logger") {
                 pushExpected("ROLLBACK");
             }
         }
+        SECTION("savepoint_guard") {
+            auto savepointGuard = storage.savepoint_guard("first");
+            pushExpected(R"(SAVEPOINT "first")");
+            runRequire();
+
+            SECTION("nothing") {
+                SECTION("nothing") {
+                    pushExpected(R"(ROLLBACK TO SAVEPOINT "first")");
+                    pushExpected(R"(RELEASE SAVEPOINT "first")");
+                }
+                SECTION("release_on_destroy = true") {
+                    savepointGuard.release_on_destroy = true;
+                    pushExpected(R"(RELEASE SAVEPOINT "first")");
+                }
+            }
+            SECTION("release") {
+                savepointGuard.release();
+                pushExpected(R"(RELEASE SAVEPOINT "first")");
+            }
+            SECTION("rollback_to") {
+                savepointGuard.rollback_to();
+                pushExpected(R"(ROLLBACK TO SAVEPOINT "first")");
+                //  the guard is still armed after `rollback_to()`
+                pushExpected(R"(ROLLBACK TO SAVEPOINT "first")");
+                pushExpected(R"(RELEASE SAVEPOINT "first")");
+            }
+        }
+        SECTION("savepoint") {
+            storage.savepoint("first");
+            pushExpected(R"(SAVEPOINT "first")");
+
+            SECTION("release") {
+                storage.release_savepoint("first");
+                pushExpected(R"(RELEASE SAVEPOINT "first")");
+            }
+            SECTION("rollback_to") {
+                storage.rollback_to_savepoint("first");
+                pushExpected(R"(ROLLBACK TO SAVEPOINT "first")");
+                storage.release_savepoint("first");
+                pushExpected(R"(RELEASE SAVEPOINT "first")");
+            }
+            SECTION("nothing") {}
+        }
+        SECTION("savepoint function") {
+            using Savepoint = std::function<bool()>;
+
+            const auto [savepointLambda, expectedVector] = GENERATE(table<Savepoint, std::vector<std::string>>({
+                {Savepoint(), {}},
+                {Savepoint([] {
+                     return false;
+                 }),
+                 {R"(SAVEPOINT "first")", R"(ROLLBACK TO SAVEPOINT "first")", R"(RELEASE SAVEPOINT "first")"}},
+                {Savepoint([] {
+                     return true;
+                 }),
+                 {R"(SAVEPOINT "first")", R"(RELEASE SAVEPOINT "first")"}},
+            }));
+            storage.savepoint("first", savepointLambda);
+            for (auto& expected: expectedVector) {
+                pushExpected(expected);
+            }
+        }
         SECTION("drop_index") {
             storage.drop_index("user_id_index");
             pushExpected(R"(DROP INDEX "user_id_index")");

--- a/tests/transaction_tests.cpp
+++ b/tests/transaction_tests.cpp
@@ -344,3 +344,154 @@ TEST_CASE("Transaction guard") {
     }
     std::remove("guard.sqlite");
 }
+
+TEST_CASE("savepoint") {
+    auto storage = make_storage(
+        {},
+        make_table("objects", make_column("id", &Object::id, primary_key()), make_column("name", &Object::name)));
+    storage.sync_schema();
+
+    SECTION("release keeps changes") {
+        storage.savepoint("first");
+        storage.replace(Object{1, "Leony"});
+        storage.release_savepoint("first");
+        std::vector<Object> expected{{1, "Leony"}};
+        REQUIRE(storage.get_all<Object>() == expected);
+    }
+    SECTION("rollback to undoes changes") {
+        storage.savepoint("first");
+        storage.replace(Object{1, "Leony"});
+        storage.rollback_to_savepoint("first");
+        storage.release_savepoint("first");
+        REQUIRE(storage.get_all<Object>().empty());
+    }
+    SECTION("release removes savepoints back to the most recent matching name") {
+        storage.savepoint("point");
+        storage.replace(Object{1, "outer"});
+        storage.savepoint("point");
+        storage.replace(Object{2, "inner"});
+        //  releases the inner savepoint only
+        storage.release_savepoint("point");
+        REQUIRE(storage.count<Object>() == 2);
+        //  now targets the outer savepoint
+        storage.rollback_to_savepoint("point");
+        REQUIRE(storage.count<Object>() == 0);
+        storage.release_savepoint("point");
+    }
+    SECTION("unknown savepoint name") {
+        const ErrorCodeExceptionMatcher sqliteErrorMatcher(sqlite_errc(SQLITE_ERROR));
+        storage.savepoint("real");
+        REQUIRE_THROWS_MATCHES(storage.release_savepoint("unknown"), std::system_error, sqliteErrorMatcher);
+        REQUIRE_THROWS_MATCHES(storage.rollback_to_savepoint("unknown"), std::system_error, sqliteErrorMatcher);
+        storage.release_savepoint("real");
+    }
+}
+
+TEST_CASE("savepoint function") {
+    auto filename = "savepoint_function.sqlite";
+    std::remove(filename);
+    auto storage = make_storage(
+        filename,
+        make_table("objects", make_column("id", &Object::id, primary_key()), make_column("name", &Object::name)));
+    storage.sync_schema();
+
+    SECTION("returning true releases the savepoint") {
+        storage.savepoint("first", [&storage] {
+            storage.replace(Object{1, "Leony"});
+            return true;
+        });
+        REQUIRE(storage.count<Object>() == 1);
+    }
+    SECTION("returning false rolls the savepoint back") {
+        storage.savepoint("first", [&storage] {
+            storage.replace(Object{1, "Leony"});
+            return false;
+        });
+        REQUIRE(storage.count<Object>() == 0);
+    }
+    std::remove(filename);
+}
+
+TEST_CASE("savepoint guard") {
+    const ErrorCodeExceptionMatcher notFoundExceptionMatcher(orm_error_code::not_found);
+
+    std::remove("savepoint_guard.sqlite");
+    auto storage = make_storage(
+        "savepoint_guard.sqlite",
+        make_table("objects", make_column("id", &Object::id, primary_key()), make_column("name", &Object::name)));
+    storage.sync_schema();
+    storage.insert(Object{0, "Jack"});
+    auto countBefore = storage.count<Object>();
+
+    SECTION("changes are rolled back on destroy") {
+        {
+            auto savepointGuard = storage.savepoint_guard("first");
+            storage.insert(Object{0, "John"});
+        }
+        REQUIRE(storage.count<Object>() == countBefore);
+    }
+    SECTION("changes are kept with an explicit release") {
+        {
+            auto savepointGuard = storage.savepoint_guard("first");
+            storage.insert(Object{0, "John"});
+            savepointGuard.release();
+        }
+        REQUIRE(storage.count<Object>() == countBefore + 1);
+    }
+    SECTION("changes are kept with release_on_destroy") {
+        {
+            auto savepointGuard = storage.savepoint_guard("first");
+            savepointGuard.release_on_destroy = true;
+            storage.insert(Object{0, "John"});
+        }
+        REQUIRE(storage.count<Object>() == countBefore + 1);
+    }
+    SECTION("rollback_to keeps the savepoint active") {
+        {
+            auto savepointGuard = storage.savepoint_guard("first");
+            storage.insert(Object{0, "John"});
+            savepointGuard.rollback_to();
+            storage.insert(Object{0, "Jane"});
+            savepointGuard.release();
+        }
+        REQUIRE(storage.count<Object>() == countBefore + 1);
+        REQUIRE(storage.count<Object>(where(c(&Object::name) == "Jane")) == 1);
+    }
+    SECTION("an exception rolls the savepoint back") {
+        REQUIRE_THROWS_MATCHES(
+            [&storage] {
+                auto savepointGuard = storage.savepoint_guard("first");
+                storage.insert(Object{0, "John"});
+                storage.get<Object>(-1);
+            }(),
+            std::system_error,
+            notFoundExceptionMatcher);
+        REQUIRE(storage.count<Object>() == countBefore);
+    }
+    SECTION("partial rollback inside a transaction") {
+        {
+            auto transactionGuard = storage.transaction_guard();
+            storage.insert(Object{0, "kept"});
+            {
+                auto savepointGuard = storage.savepoint_guard("inner");
+                storage.insert(Object{0, "undone"});
+            }
+            transactionGuard.commit();
+        }
+        REQUIRE(storage.count<Object>() == countBefore + 1);
+        REQUIRE(storage.count<Object>(where(c(&Object::name) == "undone")) == 0);
+    }
+    SECTION("an inner release is undone by an outer rollback") {
+        {
+            auto transactionGuard = storage.transaction_guard();
+            {
+                auto savepointGuard = storage.savepoint_guard("inner");
+                storage.insert(Object{0, "John"});
+                savepointGuard.release();
+            }
+            transactionGuard.rollback();
+        }
+        REQUIRE(storage.count<Object>() == countBefore);
+    }
+    std::remove("savepoint_guard.sqlite");
+}


### PR DESCRIPTION
Implements `SAVEPOINT` / `RELEASE SAVEPOINT` / `ROLLBACK TO SAVEPOINT` (https://www.sqlite.org/lang_savepoint.html), mirroring the existing transaction API on all three levels:

- **Manual**: `storage.savepoint("name")`, `storage.release_savepoint("name")`, `storage.rollback_to_savepoint("name")` — same connection handling and `no_active_transaction` programming-error checks as `begin_transaction()`/`commit()`/`rollback()`.
- **RAII**: `storage.savepoint_guard("name")` returns a `savepoint_t` (new `dev/savepoint.h`, modeled after `transaction_guard_t`): the destructor executes `ROLLBACK TO SAVEPOINT` + `RELEASE SAVEPOINT` unless `release()` was called or `release_on_destroy` is set. `rollback_to()` is deliberately non-terminal — the savepoint stays on the transaction stack per SQLite semantics, so it can be used in retry loops.
- **Functional**: `storage.savepoint("name", lambda)` mirroring `storage.transaction(lambda)` — `true` releases, `false`/exception rolls back.

Savepoint names are quoted with `streaming_identifier`. Tests cover the manual/guard/functional APIs including nesting inside `transaction_guard`, same-name savepoint stacks (`RELEASE` pops to the most recent match), the inner-release-undone-by-outer-rollback semantics and unknown-name errors; logger tests assert the exact emitted SQL. Comes with `examples/savepoint.cpp` (partial rollback + retry loop) and removes the SAVEPOINT entry from TODO.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NopQNBFjcTmkQ9dzkakpeb