### PR TITLE
Gate the named expression factories on valid operands (DSL strictness, phase 2)

### DIFF
--- a/dev/ast/between.h
+++ b/dev/ast/between.h
@@ -4,6 +4,7 @@
 #include <utility>  //  std::move
 #endif
 #include "tags.h"
+#include "../vocabulary/algorithms/operand_predicates.h"
 
 namespace sqlite_orm::internal {
     /**
@@ -31,6 +32,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class A, class T>
     internal::between_t<A, T> between(A expression, T lower, T upper) {
+        static_assert(internal::is_operand_or_bindable<A>::value,
+                      "the tested expression must be a bindable value or one of sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(expression), std::move(lower), std::move(upper)};
     }
 }

--- a/dev/ast/between.h
+++ b/dev/ast/between.h
@@ -3,8 +3,9 @@
 #ifndef SQLITE_ORM_IMPORT_STD_MODULE
 #include <utility>  //  std::move
 #endif
-#include "tags.h"
-#include "../vocabulary/algorithms/operand_predicates.h"
+
+#include "../tags.h"
+#include "../vocabulary/node_algorithms.h"  // is_operand_or_bindable
 
 namespace sqlite_orm::internal {
     /**

--- a/dev/ast/cast.h
+++ b/dev/ast/cast.h
@@ -2,6 +2,7 @@
 
 #ifndef SQLITE_ORM_IMPORT_STD_MODULE
 #include <utility>  // std::move
+#include "../vocabulary/traits/operand_traits_fwd.h"  // Included to specialize traits
 #endif  //  SQLITE_ORM_IMPORT_STD_MODULE
 
 namespace sqlite_orm::internal {
@@ -18,6 +19,9 @@ namespace sqlite_orm::internal {
 
         expression_type expression;
     };
+
+    template<class T>
+    constexpr bool is_operator_argument_v<T, std::enable_if_t<polyfill::is_specialization_of<T, cast_t>::value>> = true;
 }
 
 SQLITE_ORM_EXPORT namespace sqlite_orm {

--- a/dev/ast/excluded.h
+++ b/dev/ast/excluded.h
@@ -2,6 +2,8 @@
 
 #ifndef SQLITE_ORM_IMPORT_STD_MODULE
 #include <utility>  //  std::move
+#include "../vocabulary/traits/operand_traits_fwd.h"  // Included to specialize traits
+#include "../functional/cxx_type_traits_polyfill.h"
 #endif
 
 namespace sqlite_orm::internal {
@@ -11,6 +13,10 @@ namespace sqlite_orm::internal {
 
         expression_type expression;
     };
+
+    template<class T>
+    constexpr bool is_operator_argument_v<T, std::enable_if_t<polyfill::is_specialization_of<T, excluded_t>::value>> =
+        true;
 }
 
 SQLITE_ORM_EXPORT namespace sqlite_orm {

--- a/dev/ast/excluded.h
+++ b/dev/ast/excluded.h
@@ -2,9 +2,10 @@
 
 #ifndef SQLITE_ORM_IMPORT_STD_MODULE
 #include <utility>  //  std::move
-#include "../vocabulary/traits/operand_traits_fwd.h"  // Included to specialize traits
-#include "../functional/cxx_type_traits_polyfill.h"
 #endif
+
+#include "../functional/cxx_type_traits_polyfill.h"
+#include "../vocabulary/traits/operand_traits_fwd.h"  // Included to specialize traits
 
 namespace sqlite_orm::internal {
     template<class T>

--- a/dev/ast/exists.h
+++ b/dev/ast/exists.h
@@ -4,9 +4,9 @@
 #include <utility>  //  std::move
 #endif
 
-#include "../tags.h"
 #include "../functional/cxx_type_traits_polyfill.h"
-#include "../vocabulary/traits/grammar_traits_fwd.h"
+#include "../tags.h"
+#include "../vocabulary/node_traits.h"
 
 namespace sqlite_orm::internal {
     template<class T>

--- a/dev/ast/exists.h
+++ b/dev/ast/exists.h
@@ -12,7 +12,6 @@ namespace sqlite_orm::internal {
     template<class T>
     struct exists_t : condition_t, negatable_t {
         using expression_type = T;
-        using self = exists_t<expression_type>;
 
         expression_type expression;
 

--- a/dev/ast/exists.h
+++ b/dev/ast/exists.h
@@ -5,6 +5,8 @@
 #endif
 
 #include "../tags.h"
+#include "../functional/cxx_type_traits_polyfill.h"
+#include "../vocabulary/traits/grammar_traits_fwd.h"
 
 namespace sqlite_orm::internal {
     template<class T>
@@ -29,6 +31,8 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class T>
     internal::exists_t<T> exists(T expression) {
+        static_assert(polyfill::disjunction<internal::is_select<T>, internal::is_compound_operator<T>>::value,
+                      "exists() requires a select statement");
         return {std::move(expression)};
     }
 }

--- a/dev/ast/in.h
+++ b/dev/ast/in.h
@@ -8,6 +8,7 @@
 #endif
 
 #include "../tags.h"
+#include "../vocabulary/algorithms/operand_predicates.h"
 
 namespace sqlite_orm::internal {
 
@@ -50,6 +51,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class L, class E>
     internal::dynamic_in_t<L, std::vector<E>> in(L left, std::vector<E> values) {
+        static_assert(internal::is_operand_or_bindable<L>::value,
+                      "the tested expression must be a bindable value or one of sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(left), std::move(values), false};
     }
 
@@ -62,6 +66,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class L, class E>
     internal::dynamic_in_t<L, std::vector<E>> in(L left, std::initializer_list<E> values) {
+        static_assert(internal::is_operand_or_bindable<L>::value,
+                      "the tested expression must be a bindable value or one of sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(left), std::move(values), false};
     }
 
@@ -74,6 +81,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class L, class A>
     internal::dynamic_in_t<L, A> in(L left, A argument) {
+        static_assert(internal::is_operand_or_bindable<L>::value,
+                      "the tested expression must be a bindable value or one of sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(left), std::move(argument), false};
     }
 
@@ -86,6 +96,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class L, class E>
     internal::dynamic_in_t<L, std::vector<E>> not_in(L left, std::vector<E> values) {
+        static_assert(internal::is_operand_or_bindable<L>::value,
+                      "the tested expression must be a bindable value or one of sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(left), std::move(values), true};
     }
 
@@ -98,6 +111,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class L, class E>
     internal::dynamic_in_t<L, std::vector<E>> not_in(L left, std::initializer_list<E> values) {
+        static_assert(internal::is_operand_or_bindable<L>::value,
+                      "the tested expression must be a bindable value or one of sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(left), std::move(values), true};
     }
 
@@ -110,6 +126,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class L, class A>
     internal::dynamic_in_t<L, A> not_in(L left, A argument) {
+        static_assert(internal::is_operand_or_bindable<L>::value,
+                      "the tested expression must be a bindable value or one of sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(left), std::move(argument), true};
     }
 }

--- a/dev/ast/in.h
+++ b/dev/ast/in.h
@@ -8,7 +8,7 @@
 #endif
 
 #include "../tags.h"
-#include "../vocabulary/algorithms/operand_predicates.h"
+#include "../vocabulary/node_algorithms.h"  // is_operand_or_bindable
 
 namespace sqlite_orm::internal {
 

--- a/dev/ast/in.h
+++ b/dev/ast/in.h
@@ -21,8 +21,6 @@ namespace sqlite_orm::internal {
      */
     template<class L, class A>
     struct dynamic_in_t : condition_t, in_base, negatable_t {
-        using self = dynamic_in_t<L, A>;
-
         L left;  //  left expression
         A argument;  //  in arg
 

--- a/dev/ast/is_not_null.h
+++ b/dev/ast/is_not_null.h
@@ -29,10 +29,10 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  IS NOT NULL operator.
      */
     template<class T>
-    internal::is_not_null_t<T> is_not_null(T t) {
+    internal::is_not_null_t<T> is_not_null(T expression) {
         static_assert(internal::is_operand_or_bindable<T>::value,
                       "the tested expression must be a bindable value or one of sqlite_orm-recognized operands: member "
                       "pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(t)};
+        return {std::move(expression)};
     }
 }

--- a/dev/ast/is_not_null.h
+++ b/dev/ast/is_not_null.h
@@ -6,6 +6,7 @@
 
 #include "../tags.h"
 #include "../functional/config.h"
+#include "../vocabulary/algorithms/operand_predicates.h"
 
 namespace sqlite_orm::internal {
     /**
@@ -29,6 +30,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class T>
     internal::is_not_null_t<T> is_not_null(T t) {
+        static_assert(internal::is_operand_or_bindable<T>::value,
+                      "the tested expression must be a bindable value or one of sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(t)};
     }
 }

--- a/dev/ast/is_not_null.h
+++ b/dev/ast/is_not_null.h
@@ -5,8 +5,7 @@
 #endif
 
 #include "../tags.h"
-#include "../functional/config.h"
-#include "../vocabulary/algorithms/operand_predicates.h"
+#include "../vocabulary/node_algorithms.h"
 
 namespace sqlite_orm::internal {
     /**
@@ -15,7 +14,6 @@ namespace sqlite_orm::internal {
     template<class T>
     struct is_not_null_t : condition_t, negatable_t {
         using argument_type = T;
-        using self = is_not_null_t<argument_type>;
 
         argument_type argument;
 

--- a/dev/ast/is_null.h
+++ b/dev/ast/is_null.h
@@ -29,10 +29,10 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  IS NULL operator.
      */
     template<class T>
-    internal::is_null_t<T> is_null(T t) {
+    internal::is_null_t<T> is_null(T expression) {
         static_assert(internal::is_operand_or_bindable<T>::value,
                       "the tested expression must be a bindable value or one of sqlite_orm-recognized operands: member "
                       "pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(t)};
+        return {std::move(expression)};
     }
 }

--- a/dev/ast/is_null.h
+++ b/dev/ast/is_null.h
@@ -6,6 +6,7 @@
 
 #include "../tags.h"
 #include "../functional/config.h"
+#include "../vocabulary/algorithms/operand_predicates.h"
 
 namespace sqlite_orm::internal {
     /**
@@ -29,6 +30,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class T>
     internal::is_null_t<T> is_null(T t) {
+        static_assert(internal::is_operand_or_bindable<T>::value,
+                      "the tested expression must be a bindable value or one of sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(t)};
     }
 }

--- a/dev/ast/is_null.h
+++ b/dev/ast/is_null.h
@@ -5,8 +5,7 @@
 #endif
 
 #include "../tags.h"
-#include "../functional/config.h"
-#include "../vocabulary/algorithms/operand_predicates.h"
+#include "../vocabulary/node_algorithms.h"
 
 namespace sqlite_orm::internal {
     /**
@@ -15,7 +14,6 @@ namespace sqlite_orm::internal {
     template<class T>
     struct is_null_t : condition_t, negatable_t {
         using argument_type = T;
-        using self = is_null_t<argument_type>;
 
         argument_type argument;
 

--- a/dev/conditions.h
+++ b/dev/conditions.h
@@ -882,39 +882,39 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 #endif
 
     template<class L, class R>
-    constexpr auto and_(L l, R r) {
+    constexpr auto and_(L lhs, R rhs) {
         using namespace ::sqlite_orm::internal;
         static_assert(are_valid_operands<L, R>::value,
                       "and_() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
                       "column pointers, c()-wrapped values, aliases or expressions");
-        return and_condition_t<unwrap_expression_t<L>, unwrap_expression_t<R>>{unwrap_expression(std::forward<L>(l)),
-                                                                               unwrap_expression(std::forward<R>(r))};
+        return and_condition_t<unwrap_expression_t<L>, unwrap_expression_t<R>>{unwrap_expression(std::forward<L>(lhs)),
+                                                                               unwrap_expression(std::forward<R>(rhs))};
     }
 
     template<class L, class R>
-    constexpr auto or_(L l, R r) {
+    constexpr auto or_(L lhs, R rhs) {
         using namespace ::sqlite_orm::internal;
         static_assert(are_valid_operands<L, R>::value,
                       "or_() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
                       "column pointers, c()-wrapped values, aliases or expressions");
-        return or_condition_t<unwrap_expression_t<L>, unwrap_expression_t<R>>{unwrap_expression(std::forward<L>(l)),
-                                                                              unwrap_expression(std::forward<R>(r))};
+        return or_condition_t<unwrap_expression_t<L>, unwrap_expression_t<R>>{unwrap_expression(std::forward<L>(lhs)),
+                                                                              unwrap_expression(std::forward<R>(rhs))};
     }
 
     template<class L, class R>
-    constexpr internal::is_equal_t<L, R> is_equal(L l, R r) {
+    constexpr internal::is_equal_t<L, R> is_equal(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "is_equal() arguments must be bindable values or sqlite_orm-recognized operands: member "
                       "pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     template<class L, class R>
-    constexpr internal::is_equal_t<L, R> eq(L l, R r) {
+    constexpr internal::is_equal_t<L, R> eq(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "eq() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
                       "column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     /** 
@@ -928,59 +928,59 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     }
 
     template<class L, class R>
-    constexpr internal::is_not_equal_t<L, R> is_not_equal(L l, R r) {
+    constexpr internal::is_not_equal_t<L, R> is_not_equal(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "is_not_equal() arguments must be bindable values or sqlite_orm-recognized operands: member "
                       "pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     template<class L, class R>
-    constexpr internal::is_not_equal_t<L, R> ne(L l, R r) {
+    constexpr internal::is_not_equal_t<L, R> ne(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "ne() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
                       "column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     template<class L, class R>
-    constexpr internal::greater_than_t<L, R> greater_than(L l, R r) {
+    constexpr internal::greater_than_t<L, R> greater_than(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "greater_than() arguments must be bindable values or sqlite_orm-recognized operands: member "
                       "pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     template<class L, class R>
-    constexpr internal::greater_than_t<L, R> gt(L l, R r) {
+    constexpr internal::greater_than_t<L, R> gt(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "gt() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
                       "column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     template<class L, class R>
-    constexpr internal::greater_or_equal_t<L, R> greater_or_equal(L l, R r) {
+    constexpr internal::greater_or_equal_t<L, R> greater_or_equal(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "greater_or_equal() arguments must be bindable values or sqlite_orm-recognized operands: member "
                       "pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     template<class L, class R>
-    constexpr internal::greater_or_equal_t<L, R> ge(L l, R r) {
+    constexpr internal::greater_or_equal_t<L, R> ge(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "ge() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
                       "column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     template<class L, class R>
-    constexpr internal::less_than_t<L, R> less_than(L l, R r) {
+    constexpr internal::less_than_t<L, R> less_than(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "less_than() arguments must be bindable values or sqlite_orm-recognized operands: member "
                       "pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     /**
@@ -988,27 +988,27 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class L, class R>
     [[deprecated("Use the accurately named function `less_than(...)` instead")]] internal::less_than_t<L, R>
-    lesser_than(L l, R r) {
+    lesser_than(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "lesser_than() arguments must be bindable values or sqlite_orm-recognized operands: member "
                       "pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     template<class L, class R>
-    constexpr internal::less_than_t<L, R> lt(L l, R r) {
+    constexpr internal::less_than_t<L, R> lt(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "lt() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
                       "column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     template<class L, class R>
-    constexpr internal::less_or_equal_t<L, R> less_or_equal(L l, R r) {
+    constexpr internal::less_or_equal_t<L, R> less_or_equal(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "less_or_equal() arguments must be bindable values or sqlite_orm-recognized operands: member "
                       "pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     /**
@@ -1016,19 +1016,19 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class L, class R>
     [[deprecated("Use the accurately named function `less_or_equal(...)` instead")]] internal::less_or_equal_t<L, R>
-    lesser_or_equal(L l, R r) {
+    lesser_or_equal(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "lesser_or_equal() arguments must be bindable values or sqlite_orm-recognized operands: member "
                       "pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     template<class L, class R>
-    constexpr internal::less_or_equal_t<L, R> le(L l, R r) {
+    constexpr internal::less_or_equal_t<L, R> le(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "le() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
                       "column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     /**
@@ -1094,11 +1094,11 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  Example: storage.select(like(&User::name, "T%"))
      */
     template<class A, class T>
-    constexpr internal::like_t<A, T, void> like(A a, T t) {
+    constexpr internal::like_t<A, T, void> like(A expression, T pattern) {
         static_assert(internal::is_operand_or_bindable<A>::value,
                       "the matched expression must be a bindable value or one of sqlite_orm-recognized operands: "
                       "member pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(a), std::move(t), {}};
+        return {std::move(expression), std::move(pattern), {}};
     }
 
     /**
@@ -1106,11 +1106,11 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  Example: storage.select(like(&User::name, "T%", "%"))
      */
     template<class A, class T, class E>
-    constexpr internal::like_t<A, T, E> like(A a, T t, E e) {
+    constexpr internal::like_t<A, T, E> like(A expression, T pattern, E escape) {
         static_assert(internal::is_operand_or_bindable<A>::value,
                       "the matched expression must be a bindable value or one of sqlite_orm-recognized operands: "
                       "member pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(a), std::move(t), {std::move(e)}};
+        return {std::move(expression), std::move(pattern), {std::move(escape)}};
     }
 
     /**
@@ -1118,10 +1118,10 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  Example: storage.select(glob(&User::name, "*S"))
      */
     template<class A, class T>
-    constexpr internal::glob_t<A, T> glob(A a, T t) {
+    constexpr internal::glob_t<A, T> glob(A expression, T pattern) {
         static_assert(internal::is_operand_or_bindable<A>::value,
                       "the matched expression must be a bindable value or one of sqlite_orm-recognized operands: "
                       "member pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(a), std::move(t)};
+        return {std::move(expression), std::move(pattern)};
     }
 }

--- a/dev/conditions.h
+++ b/dev/conditions.h
@@ -26,9 +26,8 @@
 #include "literal.h"
 #include "ast/cross_join.h"
 #include "ast/rank.h"
-#include "vocabulary/node_algorithms.h"  // unwrap_expression
+#include "vocabulary/node_algorithms.h"  // unwrap_expression, is_operand_or_bindable, are_valid_operands
 #include "vocabulary/traits/grammar_traits_fwd.h"  // Included to specialize traits
-#include "vocabulary/algorithms/operand_predicates.h"
 
 namespace sqlite_orm::internal {
     /**

--- a/dev/conditions.h
+++ b/dev/conditions.h
@@ -28,6 +28,7 @@
 #include "ast/rank.h"
 #include "vocabulary/node_algorithms.h"  // unwrap_expression
 #include "vocabulary/traits/grammar_traits_fwd.h"  // Included to specialize traits
+#include "vocabulary/algorithms/operand_predicates.h"
 
 namespace sqlite_orm::internal {
     /**
@@ -883,6 +884,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     template<class L, class R>
     constexpr auto and_(L l, R r) {
         using namespace ::sqlite_orm::internal;
+        static_assert(are_valid_operands<L, R>::value,
+                      "and_() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
+                      "column pointers, c()-wrapped values, aliases or expressions");
         return and_condition_t<unwrap_expression_t<L>, unwrap_expression_t<R>>{unwrap_expression(std::forward<L>(l)),
                                                                                unwrap_expression(std::forward<R>(r))};
     }
@@ -890,17 +894,26 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     template<class L, class R>
     constexpr auto or_(L l, R r) {
         using namespace ::sqlite_orm::internal;
+        static_assert(are_valid_operands<L, R>::value,
+                      "or_() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
+                      "column pointers, c()-wrapped values, aliases or expressions");
         return or_condition_t<unwrap_expression_t<L>, unwrap_expression_t<R>>{unwrap_expression(std::forward<L>(l)),
                                                                               unwrap_expression(std::forward<R>(r))};
     }
 
     template<class L, class R>
     constexpr internal::is_equal_t<L, R> is_equal(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "is_equal() arguments must be bindable values or sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
     constexpr internal::is_equal_t<L, R> eq(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "eq() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
+                      "column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
@@ -916,36 +929,57 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 
     template<class L, class R>
     constexpr internal::is_not_equal_t<L, R> is_not_equal(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "is_not_equal() arguments must be bindable values or sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
     constexpr internal::is_not_equal_t<L, R> ne(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "ne() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
+                      "column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
     constexpr internal::greater_than_t<L, R> greater_than(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "greater_than() arguments must be bindable values or sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
     constexpr internal::greater_than_t<L, R> gt(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "gt() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
+                      "column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
     constexpr internal::greater_or_equal_t<L, R> greater_or_equal(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "greater_or_equal() arguments must be bindable values or sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
     constexpr internal::greater_or_equal_t<L, R> ge(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "ge() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
+                      "column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
     constexpr internal::less_than_t<L, R> less_than(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "less_than() arguments must be bindable values or sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
@@ -955,16 +989,25 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     template<class L, class R>
     [[deprecated("Use the accurately named function `less_than(...)` instead")]] internal::less_than_t<L, R>
     lesser_than(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "lesser_than() arguments must be bindable values or sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
     constexpr internal::less_than_t<L, R> lt(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "lt() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
+                      "column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
     constexpr internal::less_or_equal_t<L, R> less_or_equal(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "less_or_equal() arguments must be bindable values or sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
@@ -974,11 +1017,17 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     template<class L, class R>
     [[deprecated("Use the accurately named function `less_or_equal(...)` instead")]] internal::less_or_equal_t<L, R>
     lesser_or_equal(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "lesser_or_equal() arguments must be bindable values or sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
     constexpr internal::less_or_equal_t<L, R> le(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "le() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
+                      "column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
@@ -1046,6 +1095,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class A, class T>
     constexpr internal::like_t<A, T, void> like(A a, T t) {
+        static_assert(internal::is_operand_or_bindable<A>::value,
+                      "the matched expression must be a bindable value or one of sqlite_orm-recognized operands: "
+                      "member pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(a), std::move(t), {}};
     }
 
@@ -1055,6 +1107,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class A, class T, class E>
     constexpr internal::like_t<A, T, E> like(A a, T t, E e) {
+        static_assert(internal::is_operand_or_bindable<A>::value,
+                      "the matched expression must be a bindable value or one of sqlite_orm-recognized operands: "
+                      "member pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(a), std::move(t), {std::move(e)}};
     }
 
@@ -1064,6 +1119,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class A, class T>
     constexpr internal::glob_t<A, T> glob(A a, T t) {
+        static_assert(internal::is_operand_or_bindable<A>::value,
+                      "the matched expression must be a bindable value or one of sqlite_orm-recognized operands: "
+                      "member pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(a), std::move(t)};
     }
 }

--- a/dev/core_functions.h
+++ b/dev/core_functions.h
@@ -22,6 +22,7 @@
 #include "ast/into.h"
 #include "ast/window.h"
 #include "vocabulary/traits/grammar_traits_fwd.h"  // Included to specialize traits
+#include "vocabulary/traits/operand_traits_fwd.h"  // Included to specialize traits
 
 namespace sqlite_orm::internal {
     template<class T>
@@ -331,6 +332,12 @@ namespace sqlite_orm::internal {
      *          having(greater_than(count(), 2))))));
      */
     struct count_asterisk_without_type : count_string {};
+
+    template<class T>
+    constexpr bool is_operator_argument_v<
+        T,
+        std::enable_if_t<polyfill::disjunction<polyfill::is_specialization_of<T, count_asterisk_t>,
+                                               std::is_same<T, count_asterisk_without_type>>::value>> = true;
 
     struct avg_string {
         serialize_result_type serialize() const {

--- a/dev/field_printer.h
+++ b/dev/field_printer.h
@@ -13,6 +13,7 @@
 #endif
 
 #include "functional/cxx_type_traits_polyfill.h"
+#include "vocabulary/algorithms/field_predicates_fwd.h"  // Included to define is_printable_v
 #include "type_traits.h"
 #include "is_std_ptr.h"
 
@@ -30,19 +31,15 @@ namespace sqlite_orm::internal {
     /*
      *  Implementation note: the technique of indirect expression testing is because
      *  of older compilers having problems with the detection of dependent templates [SQLITE_ORM_BROKEN_ALIAS_TEMPLATE_DEPENDENT_EXPR_SFINAE].
-     *  It must also be a type that differs from those for `is_preparable_v`, `is_bindable_v`.
+     *  It must also be a type that differs from those for `is_preparable_statement_v`, `is_bindable_v`.
      */
     template<class Printer>
     struct indirectly_test_printable;
 
-    template<class T, class SFINAE = void>
-    inline constexpr bool is_printable_v = false;
+    template<class T, class SFINAE>
+    constexpr bool is_printable_v = false;
     template<class T>
-    inline constexpr bool is_printable_v<T, polyfill::void_t<indirectly_test_printable<decltype(field_printer<T>{})>>> =
-        true;
-
-    template<class T>
-    struct is_printable : polyfill::bool_constant<is_printable_v<T>> {};
+    constexpr bool is_printable_v<T, polyfill::void_t<indirectly_test_printable<decltype(field_printer<T>{})>>> = true;
 }
 
 namespace sqlite_orm {

--- a/dev/operators.h
+++ b/dev/operators.h
@@ -7,9 +7,9 @@
 #include "functional/cxx_type_traits_polyfill.h"
 #include "vocabulary/traits/grammar_traits_fwd.h"  // Included to specialize traits
 #include "vocabulary/traits/operand_traits_fwd.h"  // Included to specialize traits
+#include "vocabulary/node_algorithms.h"  // is_operand_or_bindable, are_valid_operands
 #include "serialize_result_type.h"
 #include "tags.h"
-#include "vocabulary/algorithms/operand_predicates.h"
 
 namespace sqlite_orm::internal {
     template<class L, class R, class... Ds>

--- a/dev/operators.h
+++ b/dev/operators.h
@@ -207,52 +207,52 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  name || '@gmail.com' FROM users
      */
     template<class L, class R>
-    constexpr internal::conc_t<L, R> conc(L l, R r) {
+    constexpr internal::conc_t<L, R> conc(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "conc() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
                       "column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     template<class T>
-    constexpr internal::unary_minus_t<T> minus(T t) {
+    constexpr internal::unary_minus_t<T> minus(T expression) {
         static_assert(internal::is_operand_or_bindable<T>::value,
                       "minus() argument must be a bindable value or one of sqlite_orm-recognized operands: member "
                       "pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(t)};
+        return {std::move(expression)};
     }
 
     /**
      *  Public interface for + operator. Example: `select(add(&User::age, 100));` => SELECT age + 100 FROM users
      */
     template<class L, class R>
-    constexpr internal::add_t<L, R> add(L l, R r) {
+    constexpr internal::add_t<L, R> add(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "add() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
                       "column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     /**
      *  Public interface for - operator. Example: `select(sub(&User::age, 1));` => SELECT age - 1 FROM users
      */
     template<class L, class R>
-    constexpr internal::sub_t<L, R> sub(L l, R r) {
+    constexpr internal::sub_t<L, R> sub(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "sub() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
                       "column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     /**
      *  Public interface for * operator. Example: `select(mul(&User::salary, 2));` => SELECT salary * 2 FROM users
      */
     template<class L, class R>
-    constexpr internal::mul_t<L, R> mul(L l, R r) {
+    constexpr internal::mul_t<L, R> mul(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "mul() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
                       "column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     /**
@@ -261,69 +261,69 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  If you use `using namespace sqlite_orm` directive you an specify which `div` you call explicitly using  `::div` or `sqlite_orm::div` statements.
      */
     template<class L, class R>
-    constexpr internal::div_t<L, R> div(L l, R r) {
+    constexpr internal::div_t<L, R> div(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "div() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
                       "column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     /**
      *  Public interface for % operator. Example: `select(mod(&User::age, 5));` => SELECT age % 5 FROM users
      */
     template<class L, class R>
-    constexpr internal::mod_t<L, R> mod(L l, R r) {
+    constexpr internal::mod_t<L, R> mod(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "mod() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
                       "column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     template<class L, class R>
-    constexpr internal::bitwise_shift_left_t<L, R> bitwise_shift_left(L l, R r) {
+    constexpr internal::bitwise_shift_left_t<L, R> bitwise_shift_left(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "bitwise_shift_left() arguments must be bindable values or sqlite_orm-recognized operands: "
                       "member pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     template<class L, class R>
-    constexpr internal::bitwise_shift_right_t<L, R> bitwise_shift_right(L l, R r) {
+    constexpr internal::bitwise_shift_right_t<L, R> bitwise_shift_right(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "bitwise_shift_right() arguments must be bindable values or sqlite_orm-recognized operands: "
                       "member pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     template<class L, class R>
-    constexpr internal::bitwise_and_t<L, R> bitwise_and(L l, R r) {
+    constexpr internal::bitwise_and_t<L, R> bitwise_and(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "bitwise_and() arguments must be bindable values or sqlite_orm-recognized operands: member "
                       "pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     template<class L, class R>
-    constexpr internal::bitwise_or_t<L, R> bitwise_or(L l, R r) {
+    constexpr internal::bitwise_or_t<L, R> bitwise_or(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "bitwise_or() arguments must be bindable values or sqlite_orm-recognized operands: member "
                       "pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     template<class T>
-    constexpr internal::bitwise_not_t<T> bitwise_not(T t) {
+    constexpr internal::bitwise_not_t<T> bitwise_not(T expression) {
         static_assert(internal::is_operand_or_bindable<T>::value,
                       "bitwise_not() argument must be a bindable value or one of sqlite_orm-recognized operands: "
                       "member pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(t)};
+        return {std::move(expression)};
     }
 
     template<class L, class R>
-    internal::assign_t<L, R> assign(L l, R r) {
+    internal::assign_t<L, R> assign(L lhs, R rhs) {
         static_assert(internal::is_referencable_operand<L>::value,
                       "the assignment target must be one of sqlite_orm-recognized operands: member pointers, column "
                       "pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 }

--- a/dev/operators.h
+++ b/dev/operators.h
@@ -9,6 +9,7 @@
 #include "vocabulary/traits/operand_traits_fwd.h"  // Included to specialize traits
 #include "serialize_result_type.h"
 #include "tags.h"
+#include "vocabulary/algorithms/operand_predicates.h"
 
 namespace sqlite_orm::internal {
     template<class L, class R, class... Ds>
@@ -207,11 +208,17 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class L, class R>
     constexpr internal::conc_t<L, R> conc(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "conc() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
+                      "column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
     template<class T>
     constexpr internal::unary_minus_t<T> minus(T t) {
+        static_assert(internal::is_operand_or_bindable<T>::value,
+                      "minus() argument must be a bindable value or one of sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(t)};
     }
 
@@ -220,6 +227,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class L, class R>
     constexpr internal::add_t<L, R> add(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "add() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
+                      "column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
@@ -228,6 +238,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class L, class R>
     constexpr internal::sub_t<L, R> sub(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "sub() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
+                      "column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
@@ -236,6 +249,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class L, class R>
     constexpr internal::mul_t<L, R> mul(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "mul() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
+                      "column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
@@ -246,6 +262,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class L, class R>
     constexpr internal::div_t<L, R> div(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "div() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
+                      "column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
@@ -254,36 +273,57 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class L, class R>
     constexpr internal::mod_t<L, R> mod(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "mod() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
+                      "column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
     constexpr internal::bitwise_shift_left_t<L, R> bitwise_shift_left(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "bitwise_shift_left() arguments must be bindable values or sqlite_orm-recognized operands: "
+                      "member pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
     constexpr internal::bitwise_shift_right_t<L, R> bitwise_shift_right(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "bitwise_shift_right() arguments must be bindable values or sqlite_orm-recognized operands: "
+                      "member pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
     constexpr internal::bitwise_and_t<L, R> bitwise_and(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "bitwise_and() arguments must be bindable values or sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
     constexpr internal::bitwise_or_t<L, R> bitwise_or(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "bitwise_or() arguments must be bindable values or sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
     template<class T>
     constexpr internal::bitwise_not_t<T> bitwise_not(T t) {
+        static_assert(internal::is_operand_or_bindable<T>::value,
+                      "bitwise_not() argument must be a bindable value or one of sqlite_orm-recognized operands: "
+                      "member pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(t)};
     }
 
     template<class L, class R>
     internal::assign_t<L, R> assign(L l, R r) {
+        static_assert(internal::is_referencable_operand<L>::value,
+                      "the assignment target must be one of sqlite_orm-recognized operands: member pointers, column "
+                      "pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 }

--- a/dev/schema/triggers.h
+++ b/dev/schema/triggers.h
@@ -8,6 +8,7 @@
 #endif
 
 #include "../optional_container.h"
+#include "../vocabulary/traits/operand_traits_fwd.h"  // Included to specialize traits
 
 // NOTE Idea : Maybe also implement a custom trigger system to call a c++ callback when a trigger triggers ?
 // (Could be implemented with a normal trigger that insert or update an internal table and then retreive
@@ -215,6 +216,12 @@ namespace sqlite_orm::internal {
 
         expression_type expression;
     };
+
+    template<class T>
+    constexpr bool is_operator_argument_v<
+        T,
+        std::enable_if_t<polyfill::disjunction<polyfill::is_specialization_of<T, new_t>,
+                                               polyfill::is_specialization_of<T, old_t>>::value>> = true;
 }
 
 SQLITE_ORM_EXPORT namespace sqlite_orm {

--- a/dev/select_constraints.h
+++ b/dev/select_constraints.h
@@ -355,6 +355,10 @@ namespace sqlite_orm::internal {
         optional_container<else_expression_type> else_expression;
     };
 
+    template<class T>
+    constexpr bool
+        is_operator_argument_v<T, std::enable_if_t<polyfill::is_specialization_of<T, simple_case_t>::value>> = true;
+
     /**
      *  T is a case expression type
      *  E is else type (void is ELSE is omitted)

--- a/dev/statement_binder.h
+++ b/dev/statement_binder.h
@@ -19,6 +19,7 @@
 
 #include "functional/cxx_type_traits_polyfill.h"
 #include "functional/cxx_functional_polyfill.h"  // std::invoke
+#include "vocabulary/algorithms/field_predicates_fwd.h"  // Included to define is_bindable_v
 #include "type_traits.h"
 #include "is_std_ptr.h"
 #include "tuple_helper/tuple_filter.h"
@@ -40,19 +41,15 @@ namespace sqlite_orm::internal {
     /*
      *  Implementation note: the technique of indirect expression testing is because
      *  of older compilers having problems with the detection of dependent templates [SQLITE_ORM_BROKEN_ALIAS_TEMPLATE_DEPENDENT_EXPR_SFINAE].
-     *  It must also be a type that differs from those for `is_printable_v`, `is_preparable_v`.
+     *  It must also be a type that differs from those for `is_printable_v`, `is_preparable_statement_v`.
      */
     template<class Binder>
     struct indirectly_test_bindable;
 
-    template<class T, class SFINAE = void>
-    inline constexpr bool is_bindable_v = false;
+    template<class T, class SFINAE>
+    constexpr bool is_bindable_v = false;
     template<class T>
-    inline constexpr bool
-        is_bindable_v<T, polyfill::void_t<indirectly_test_bindable<decltype(statement_binder<T>{})>>> = true;
-
-    template<class T>
-    struct is_bindable : polyfill::bool_constant<is_bindable_v<T>> {};
+    constexpr bool is_bindable_v<T, polyfill::void_t<indirectly_test_bindable<decltype(statement_binder<T>{})>>> = true;
 }
 
 // `statement_binder` specializations;

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -96,7 +96,6 @@ namespace sqlite_orm::internal {
      */
     template<class... DBO>
     struct storage_t : storage_base {
-        using self_type = storage_t;
         using db_objects_type = db_objects_tuple<DBO...>;
 
         /**
@@ -134,7 +133,7 @@ namespace sqlite_orm::internal {
          *  
          *  Hence, friend was replaced by `obtain_db_objects()` and `pick_const_impl()`.
          */
-        friend const db_objects_type& obtain_db_objects(const self_type& storage) noexcept {
+        friend const db_objects_type& obtain_db_objects(const storage_t& storage) noexcept {
             return storage.db_objects;
         }
 
@@ -301,7 +300,7 @@ namespace sqlite_orm::internal {
          *  meaning that iterators obtained from it are not tied to the lifetime of the view instance.
          */
         template<class T, class O = mapped_type_proxy_t<T>, class... Args>
-        mapped_view<O, self_type, Args...> iterate(Args&&... args) {
+        mapped_view<O, storage_t, Args...> iterate(Args&&... args) {
             this->assert_mapped_type<O>();
 
             auto conRef = this->get_connection();
@@ -889,7 +888,7 @@ namespace sqlite_orm::internal {
             class Ex = polyfill::remove_cvref_t<E>,
             std::enable_if_t<!is_prepared_statement<Ex>::value && !is_mapped<db_objects_type, Ex>::value, bool> = true>
         std::string dump(E&& expression, bool parametrized = false) const {
-            static_assert(is_preparable_statement_v<self_type, Ex>, "Expression must be a high-level statement");
+            static_assert(is_preparable_statement_v<storage_t, Ex>, "Expression must be a high-level statement");
 
             if constexpr (is_select_v<Ex>) {
                 auto e2 = std::forward<E>(expression);

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -74,9 +74,9 @@ namespace sqlite_orm::internal {
     struct indirectly_test_preparable;
 
     template<class S, class E, class SFINAE = void>
-    inline constexpr bool is_preparable_v = false;
+    inline constexpr bool is_preparable_statement_v = false;
     template<class S, class E>
-    inline constexpr bool is_preparable_v<
+    inline constexpr bool is_preparable_statement_v<
         S,
         E,
         polyfill::void_t<indirectly_test_preparable<decltype(std::declval<S>().prepare(std::declval<E>()))>>> = true;
@@ -889,7 +889,7 @@ namespace sqlite_orm::internal {
             class Ex = polyfill::remove_cvref_t<E>,
             std::enable_if_t<!is_prepared_statement<Ex>::value && !is_mapped<db_objects_type, Ex>::value, bool> = true>
         std::string dump(E&& expression, bool parametrized = false) const {
-            static_assert(is_preparable_v<self_type, Ex>, "Expression must be a high-level statement");
+            static_assert(is_preparable_statement_v<self_type, Ex>, "Expression must be a high-level statement");
 
             if constexpr (is_select_v<Ex>) {
                 auto e2 = std::forward<E>(expression);

--- a/dev/vocabulary/algorithms/field_predicates_fwd.h
+++ b/dev/vocabulary/algorithms/field_predicates_fwd.h
@@ -11,4 +11,31 @@ namespace sqlite_orm::internal {
 
     template<class F>
     using is_rowid_alias_capable = polyfill::bool_constant<is_rowid_alias_capable_v<F>>;
+
+    /*
+     *  Whether a field type can be bound as a parameter of a prepared statement.
+     *
+     *  In contrast to `is_rowid_alias_capable`, which is a capability derived from the field type itself,
+     *  this is tied to whether the `statement_binder` customization point is instantiable for it -
+     *  hence its definition stays with `statement_binder` in `statement_binder.h`.
+     */
+    template<class T, class SFINAE = void>
+    extern const bool is_bindable_v;
+
+    //  a derived struct in favor of an alias template, because it is passed on as a template-template argument
+    //  [SQLITE_ORM_BROKEN_ALIAS_TEMPLATE_DEPENDENT_NTTP_EXPR]
+    template<class T>
+    struct is_bindable : polyfill::bool_constant<is_bindable_v<T>> {};
+
+    /*
+     *  Whether a field type can be printed as a human-readable string.
+     *
+     *  Like `is_bindable`, this is tied to whether the `field_printer` customization point is
+     *  instantiable for it - hence its definition stays with `field_printer` in `field_printer.h`.
+     */
+    template<class T, class SFINAE = void>
+    extern const bool is_printable_v;
+
+    template<class T>
+    struct is_printable : polyfill::bool_constant<is_printable_v<T>> {};
 }

--- a/dev/vocabulary/algorithms/operand_predicates.h
+++ b/dev/vocabulary/algorithms/operand_predicates.h
@@ -18,11 +18,9 @@
 
 #include "../../functional/cxx_type_traits_polyfill.h"
 #include "../node_traits.h"
+#include "field_predicates_fwd.h"  // is_bindable
 
 namespace sqlite_orm::internal {
-    template<class T>
-    struct is_bindable;
-
     /**
      *  Whether a type may be referenced as a column expression by a named expression factory:
      *  a member pointer or anything the overloaded operators accept.

--- a/dev/vocabulary/algorithms/operand_predicates.h
+++ b/dev/vocabulary/algorithms/operand_predicates.h
@@ -1,0 +1,53 @@
+#pragma once
+
+/** @file Combined operand predicates gating the named expression factories.
+ *
+ *  The named factories (`eq()`, `and_()`, `add()`, `assign()`, ...) accept everything their
+ *  operator counterparts accept, plus a raw member pointer (which the named factories
+ *  reference without the `c()` wrapper), plus a bindable value - the named factories are
+ *  also the only spelling for literal-only SQL expressions such as `SELECT 60 | 13`.
+ *  Everything else - arbitrary structs, containers, statement clauses - cannot be
+ *  serialized into SQL and is rejected at the factory.
+ */
+
+#ifndef SQLITE_ORM_IMPORT_STD_MODULE
+#include <functional>  //  std::reference_wrapper
+#include <tuple>  //  std::tuple
+#include <type_traits>  //  std::is_member_pointer
+#endif
+
+#include "../../functional/cxx_type_traits_polyfill.h"
+#include "../node_traits.h"
+
+namespace sqlite_orm::internal {
+    template<class T>
+    struct is_bindable;
+
+    /**
+     *  Whether a type may be referenced as a column expression by a named expression factory:
+     *  a member pointer or anything the overloaded operators accept.
+     */
+    template<class T>
+    using is_referencable_operand = polyfill::disjunction<is_operator_argument<T>, std::is_member_pointer<T>>;
+
+    /**
+     *  Whether a type may appear as an operand of a named expression factory.
+     */
+    template<class T>
+    using is_operand_or_bindable = polyfill::disjunction<is_operator_argument<T>,
+                                                         std::is_member_pointer<T>,
+                                                         is_arithmetic_operand<T>,
+                                                         is_conditional_operand<T>,
+                                                         is_chainable_operand<T>,
+                                                         is_bindable<T>,
+                                                         //  a scalar subquery
+                                                         is_select<T>,
+                                                         is_compound_operator<T>,
+                                                         //  a row value
+                                                         polyfill::is_specialization_of<T, std::tuple>,
+                                                         //  a value bound by reference in a prepared statement
+                                                         polyfill::is_specialization_of<T, std::reference_wrapper>>;
+
+    template<class L, class R>
+    using are_valid_operands = polyfill::conjunction<is_operand_or_bindable<L>, is_operand_or_bindable<R>>;
+}

--- a/dev/vocabulary/node_algorithms.h
+++ b/dev/vocabulary/node_algorithms.h
@@ -8,4 +8,5 @@
 #include "algorithms/index_filters.h"
 #include "algorithms/ddl_predicates.h"
 #include "algorithms/clause_predicates.h"
+#include "algorithms/operand_predicates.h"
 #include "algorithms/accessors.h"

--- a/docs/internals/vocabulary-layer.md
+++ b/docs/internals/vocabulary-layer.md
@@ -76,8 +76,8 @@ vocabulary/
                             Safe for broad inclusion.
 
     node_algorithms.h       Umbrella, declaration-only: ddl_predicates.h,
-                            clause_predicates.h, index_filters.h,
-                            accessors.h, field_predicates_fwd.h,
+                            clause_predicates.h, operand_predicates.h,
+                            index_filters.h, accessors.h, field_predicates_fwd.h,
                             field_predicates_concepts.h. Deliberately does NOT include
                             field_predicates.h.
 ```
@@ -138,7 +138,7 @@ Four axes are keyed on a DSL node; one is keyed on a raw C++ type.
 | **Semantic** | `traits/semantic_traits_fwd.h` | a DSL node | What cross-cutting role does this play, across *dissimilar* grammar families? |
 | **Structural** | `traits/structural_traits_fwd.h` | a DSL node | Is this a DSL-tree-only node with no SQL grammar counterpart? |
 | **Operand** | `traits/operand_traits_fwd.h` | a DSL node | Can this node appear as an operand in an expression context? |
-| **Field** | `algorithms/field_predicates_fwd.h` | a raw C++ type | Does this C++ type qualify for a SQL-level role? |
+| **Field** | `algorithms/field_predicates_fwd.h` | a raw C++ type | Does this C++ type qualify for a SQL-level role — bindable, printable, rowid-alias capable? |
 
 All four node axes are **open**: the primary template is declared in the `_fwd.h` file, and
 each node specializes it **in the node's own header**.
@@ -206,10 +206,12 @@ being composed into a judgment; it is still extraction.
 |---|---|
 | `algorithms/ddl_predicates.h` | Closed, composed alias-template checks of whether a node is an admissible element of a column or table definition, with no significant header-weight dependency, e.g. `is_pkcol_implicitly_insertable`, `is_base_table_element_or_constraint`. Single file; no split needed. |
 | `algorithms/clause_predicates.h` | Closed checks of whether a node is an admissible statement-level clause, and of the canonical order clauses must appear in: `select_clause_rank_v`, `is_select_clause`, `select_clause_nests_no_clause`. One file across statement kinds, because they all share a single ranking mechanism. |
+| `algorithms/operand_predicates.h` | Closed checks of whether a type may appear as an operand of a named expression factory (`eq()`, `and_()`, `add()`, `assign()`, …): `is_referencable_operand`, `is_operand_or_bindable`, `are_valid_operands`. Composes the operand traits with grammar traits and the field-level `is_bindable` — which is why it takes `field_predicates_fwd.h` rather than the definition file. |
 | `algorithms/index_filters.h` | Closed alias templates that scan a node's `Elements` tuple and yield an `index_sequence` of matching positions — **not** a filtered tuple. E.g. `col_index_sequence_of`, `col_index_sequence_with_field_type`. Built on `filter_tuple_sequence_t` + grammar traits + projections. |
 | `algorithms/accessors.h` | Closed runtime and compile-time accessors that retrieve a node's relevant sub-part, or the node itself, uniformly across dissimilar grammar families: `access_main_select`/`main_select_t`, `access_main_dml`/`main_dml_t`, `access_column_expression`. This is the concrete payoff of the semantic traits. |
-| `algorithms/field_predicates_fwd.h` | Declarations of the closed field-level predicates, split off for dependency weight: `is_rowid_alias_capable_v`, and (C++17 only) `is_hidden_column_of_vtab_v`. |
-| `algorithms/field_predicates.h` | Their definitions, which need `type_printer.h` and `member_traits/`. Reached only through the `node_algorithm_definitions.h` manifest. |
+| `algorithms/field_predicates_fwd.h` | Declarations of the closed field-level predicates, split off for dependency weight: `is_rowid_alias_capable_v`, `is_bindable_v`, `is_printable_v`, and (C++17 only) `is_hidden_column_of_vtab_v`. |
+| — where their definitions live | `is_rowid_alias_capable_v` is a capability *derived from* the field type, so it is defined in `field_predicates.h` with the other computed predicates. `is_bindable_v` and `is_printable_v` instead test whether a customization point is instantiable for the type, so each stays with the point it tests — `statement_binder.h` and `field_printer.h` respectively, which include the `_fwd` header to define them. |
+| `algorithms/field_predicates.h` | The definitions of the *derived* field predicates — `is_rowid_alias_capable_v`, and (C++17 only) `is_hidden_column_of_vtab_v` — which need `type_printer.h` and `member_traits/`. Reached only through the `node_algorithm_definitions.h` manifest. |
 | `algorithms/field_predicates_concepts.h` | The `hidden_column_of_vtab` / `hidden_field_of_vtab` concepts, plus the C++17 fallback, under one guard. See [Concepts](#concepts-a-hard-constraint-on-splitting). |
 
 ## Open vs. closed

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -4714,52 +4714,52 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  name || '@gmail.com' FROM users
      */
     template<class L, class R>
-    constexpr internal::conc_t<L, R> conc(L l, R r) {
+    constexpr internal::conc_t<L, R> conc(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "conc() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
                       "column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     template<class T>
-    constexpr internal::unary_minus_t<T> minus(T t) {
+    constexpr internal::unary_minus_t<T> minus(T expression) {
         static_assert(internal::is_operand_or_bindable<T>::value,
                       "minus() argument must be a bindable value or one of sqlite_orm-recognized operands: member "
                       "pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(t)};
+        return {std::move(expression)};
     }
 
     /**
      *  Public interface for + operator. Example: `select(add(&User::age, 100));` => SELECT age + 100 FROM users
      */
     template<class L, class R>
-    constexpr internal::add_t<L, R> add(L l, R r) {
+    constexpr internal::add_t<L, R> add(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "add() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
                       "column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     /**
      *  Public interface for - operator. Example: `select(sub(&User::age, 1));` => SELECT age - 1 FROM users
      */
     template<class L, class R>
-    constexpr internal::sub_t<L, R> sub(L l, R r) {
+    constexpr internal::sub_t<L, R> sub(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "sub() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
                       "column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     /**
      *  Public interface for * operator. Example: `select(mul(&User::salary, 2));` => SELECT salary * 2 FROM users
      */
     template<class L, class R>
-    constexpr internal::mul_t<L, R> mul(L l, R r) {
+    constexpr internal::mul_t<L, R> mul(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "mul() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
                       "column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     /**
@@ -4768,70 +4768,70 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  If you use `using namespace sqlite_orm` directive you an specify which `div` you call explicitly using  `::div` or `sqlite_orm::div` statements.
      */
     template<class L, class R>
-    constexpr internal::div_t<L, R> div(L l, R r) {
+    constexpr internal::div_t<L, R> div(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "div() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
                       "column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     /**
      *  Public interface for % operator. Example: `select(mod(&User::age, 5));` => SELECT age % 5 FROM users
      */
     template<class L, class R>
-    constexpr internal::mod_t<L, R> mod(L l, R r) {
+    constexpr internal::mod_t<L, R> mod(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "mod() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
                       "column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     template<class L, class R>
-    constexpr internal::bitwise_shift_left_t<L, R> bitwise_shift_left(L l, R r) {
+    constexpr internal::bitwise_shift_left_t<L, R> bitwise_shift_left(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "bitwise_shift_left() arguments must be bindable values or sqlite_orm-recognized operands: "
                       "member pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     template<class L, class R>
-    constexpr internal::bitwise_shift_right_t<L, R> bitwise_shift_right(L l, R r) {
+    constexpr internal::bitwise_shift_right_t<L, R> bitwise_shift_right(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "bitwise_shift_right() arguments must be bindable values or sqlite_orm-recognized operands: "
                       "member pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     template<class L, class R>
-    constexpr internal::bitwise_and_t<L, R> bitwise_and(L l, R r) {
+    constexpr internal::bitwise_and_t<L, R> bitwise_and(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "bitwise_and() arguments must be bindable values or sqlite_orm-recognized operands: member "
                       "pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     template<class L, class R>
-    constexpr internal::bitwise_or_t<L, R> bitwise_or(L l, R r) {
+    constexpr internal::bitwise_or_t<L, R> bitwise_or(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "bitwise_or() arguments must be bindable values or sqlite_orm-recognized operands: member "
                       "pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     template<class T>
-    constexpr internal::bitwise_not_t<T> bitwise_not(T t) {
+    constexpr internal::bitwise_not_t<T> bitwise_not(T expression) {
         static_assert(internal::is_operand_or_bindable<T>::value,
                       "bitwise_not() argument must be a bindable value or one of sqlite_orm-recognized operands: "
                       "member pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(t)};
+        return {std::move(expression)};
     }
 
     template<class L, class R>
-    internal::assign_t<L, R> assign(L l, R r) {
+    internal::assign_t<L, R> assign(L lhs, R rhs) {
         static_assert(internal::is_referencable_operand<L>::value,
                       "the assignment target must be one of sqlite_orm-recognized operands: member pointers, column "
                       "pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 }
 
@@ -6258,39 +6258,39 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 #endif
 
     template<class L, class R>
-    constexpr auto and_(L l, R r) {
+    constexpr auto and_(L lhs, R rhs) {
         using namespace ::sqlite_orm::internal;
         static_assert(are_valid_operands<L, R>::value,
                       "and_() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
                       "column pointers, c()-wrapped values, aliases or expressions");
-        return and_condition_t<unwrap_expression_t<L>, unwrap_expression_t<R>>{unwrap_expression(std::forward<L>(l)),
-                                                                               unwrap_expression(std::forward<R>(r))};
+        return and_condition_t<unwrap_expression_t<L>, unwrap_expression_t<R>>{unwrap_expression(std::forward<L>(lhs)),
+                                                                               unwrap_expression(std::forward<R>(rhs))};
     }
 
     template<class L, class R>
-    constexpr auto or_(L l, R r) {
+    constexpr auto or_(L lhs, R rhs) {
         using namespace ::sqlite_orm::internal;
         static_assert(are_valid_operands<L, R>::value,
                       "or_() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
                       "column pointers, c()-wrapped values, aliases or expressions");
-        return or_condition_t<unwrap_expression_t<L>, unwrap_expression_t<R>>{unwrap_expression(std::forward<L>(l)),
-                                                                              unwrap_expression(std::forward<R>(r))};
+        return or_condition_t<unwrap_expression_t<L>, unwrap_expression_t<R>>{unwrap_expression(std::forward<L>(lhs)),
+                                                                              unwrap_expression(std::forward<R>(rhs))};
     }
 
     template<class L, class R>
-    constexpr internal::is_equal_t<L, R> is_equal(L l, R r) {
+    constexpr internal::is_equal_t<L, R> is_equal(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "is_equal() arguments must be bindable values or sqlite_orm-recognized operands: member "
                       "pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     template<class L, class R>
-    constexpr internal::is_equal_t<L, R> eq(L l, R r) {
+    constexpr internal::is_equal_t<L, R> eq(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "eq() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
                       "column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     /** 
@@ -6304,59 +6304,59 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     }
 
     template<class L, class R>
-    constexpr internal::is_not_equal_t<L, R> is_not_equal(L l, R r) {
+    constexpr internal::is_not_equal_t<L, R> is_not_equal(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "is_not_equal() arguments must be bindable values or sqlite_orm-recognized operands: member "
                       "pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     template<class L, class R>
-    constexpr internal::is_not_equal_t<L, R> ne(L l, R r) {
+    constexpr internal::is_not_equal_t<L, R> ne(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "ne() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
                       "column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     template<class L, class R>
-    constexpr internal::greater_than_t<L, R> greater_than(L l, R r) {
+    constexpr internal::greater_than_t<L, R> greater_than(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "greater_than() arguments must be bindable values or sqlite_orm-recognized operands: member "
                       "pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     template<class L, class R>
-    constexpr internal::greater_than_t<L, R> gt(L l, R r) {
+    constexpr internal::greater_than_t<L, R> gt(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "gt() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
                       "column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     template<class L, class R>
-    constexpr internal::greater_or_equal_t<L, R> greater_or_equal(L l, R r) {
+    constexpr internal::greater_or_equal_t<L, R> greater_or_equal(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "greater_or_equal() arguments must be bindable values or sqlite_orm-recognized operands: member "
                       "pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     template<class L, class R>
-    constexpr internal::greater_or_equal_t<L, R> ge(L l, R r) {
+    constexpr internal::greater_or_equal_t<L, R> ge(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "ge() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
                       "column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     template<class L, class R>
-    constexpr internal::less_than_t<L, R> less_than(L l, R r) {
+    constexpr internal::less_than_t<L, R> less_than(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "less_than() arguments must be bindable values or sqlite_orm-recognized operands: member "
                       "pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     /**
@@ -6364,27 +6364,27 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class L, class R>
     [[deprecated("Use the accurately named function `less_than(...)` instead")]] internal::less_than_t<L, R>
-    lesser_than(L l, R r) {
+    lesser_than(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "lesser_than() arguments must be bindable values or sqlite_orm-recognized operands: member "
                       "pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     template<class L, class R>
-    constexpr internal::less_than_t<L, R> lt(L l, R r) {
+    constexpr internal::less_than_t<L, R> lt(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "lt() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
                       "column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     template<class L, class R>
-    constexpr internal::less_or_equal_t<L, R> less_or_equal(L l, R r) {
+    constexpr internal::less_or_equal_t<L, R> less_or_equal(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "less_or_equal() arguments must be bindable values or sqlite_orm-recognized operands: member "
                       "pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     /**
@@ -6392,19 +6392,19 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class L, class R>
     [[deprecated("Use the accurately named function `less_or_equal(...)` instead")]] internal::less_or_equal_t<L, R>
-    lesser_or_equal(L l, R r) {
+    lesser_or_equal(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "lesser_or_equal() arguments must be bindable values or sqlite_orm-recognized operands: member "
                       "pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     template<class L, class R>
-    constexpr internal::less_or_equal_t<L, R> le(L l, R r) {
+    constexpr internal::less_or_equal_t<L, R> le(L lhs, R rhs) {
         static_assert(internal::are_valid_operands<L, R>::value,
                       "le() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
                       "column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(l), std::move(r)};
+        return {std::move(lhs), std::move(rhs)};
     }
 
     /**
@@ -6470,11 +6470,11 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  Example: storage.select(like(&User::name, "T%"))
      */
     template<class A, class T>
-    constexpr internal::like_t<A, T, void> like(A a, T t) {
+    constexpr internal::like_t<A, T, void> like(A expression, T pattern) {
         static_assert(internal::is_operand_or_bindable<A>::value,
                       "the matched expression must be a bindable value or one of sqlite_orm-recognized operands: "
                       "member pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(a), std::move(t), {}};
+        return {std::move(expression), std::move(pattern), {}};
     }
 
     /**
@@ -6482,11 +6482,11 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  Example: storage.select(like(&User::name, "T%", "%"))
      */
     template<class A, class T, class E>
-    constexpr internal::like_t<A, T, E> like(A a, T t, E e) {
+    constexpr internal::like_t<A, T, E> like(A expression, T pattern, E escape) {
         static_assert(internal::is_operand_or_bindable<A>::value,
                       "the matched expression must be a bindable value or one of sqlite_orm-recognized operands: "
                       "member pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(a), std::move(t), {std::move(e)}};
+        return {std::move(expression), std::move(pattern), {std::move(escape)}};
     }
 
     /**
@@ -6494,11 +6494,11 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  Example: storage.select(glob(&User::name, "*S"))
      */
     template<class A, class T>
-    constexpr internal::glob_t<A, T> glob(A a, T t) {
+    constexpr internal::glob_t<A, T> glob(A expression, T pattern) {
         static_assert(internal::is_operand_or_bindable<A>::value,
                       "the matched expression must be a bindable value or one of sqlite_orm-recognized operands: "
                       "member pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(a), std::move(t)};
+        return {std::move(expression), std::move(pattern)};
     }
 }
 
@@ -12779,11 +12779,11 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  IS NULL operator.
      */
     template<class T>
-    internal::is_null_t<T> is_null(T t) {
+    internal::is_null_t<T> is_null(T expression) {
         static_assert(internal::is_operand_or_bindable<T>::value,
                       "the tested expression must be a bindable value or one of sqlite_orm-recognized operands: member "
                       "pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(t)};
+        return {std::move(expression)};
     }
 }
 // #include "ast/is_not_null.h"
@@ -12819,11 +12819,11 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  IS NOT NULL operator.
      */
     template<class T>
-    internal::is_not_null_t<T> is_not_null(T t) {
+    internal::is_not_null_t<T> is_not_null(T expression) {
         static_assert(internal::is_operand_or_bindable<T>::value,
                       "the tested expression must be a bindable value or one of sqlite_orm-recognized operands: member "
                       "pointers, column pointers, c()-wrapped values, aliases or expressions");
-        return {std::move(t)};
+        return {std::move(expression)};
     }
 }
 

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -4473,6 +4473,8 @@ namespace sqlite_orm {
 // Included to specialize traits
 // #include "vocabulary/traits/operand_traits_fwd.h"
 // Included to specialize traits
+// #include "vocabulary/node_algorithms.h"
+// is_operand_or_bindable, are_valid_operands
 // #include "serialize_result_type.h"
 
 // #include "functional/cxx_string_view.h"
@@ -4540,8 +4542,6 @@ namespace sqlite_orm::internal {
     template<class T>
     constexpr bool is_conditional_operand_v = std::is_base_of<condition_t, T>::value;
 }
-
-// #include "vocabulary/algorithms/operand_predicates.h"
 
 namespace sqlite_orm::internal {
     template<class L, class R, class... Ds>
@@ -5426,10 +5426,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 }
 
 // #include "vocabulary/node_algorithms.h"
-// unwrap_expression
+// unwrap_expression, is_operand_or_bindable, are_valid_operands
 // #include "vocabulary/traits/grammar_traits_fwd.h"
 // Included to specialize traits
-// #include "vocabulary/algorithms/operand_predicates.h"
 
 namespace sqlite_orm::internal {
     /**
@@ -12604,7 +12603,8 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 
 // #include "../tags.h"
 
-// #include "../vocabulary/algorithms/operand_predicates.h"
+// #include "../vocabulary/node_algorithms.h"
+// is_operand_or_bindable
 
 namespace sqlite_orm::internal {
 
@@ -12731,9 +12731,11 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 #ifndef SQLITE_ORM_IMPORT_STD_MODULE
 #include <utility>  //  std::move
 #endif
-// #include "tags.h"
 
-// #include "../vocabulary/algorithms/operand_predicates.h"
+// #include "../tags.h"
+
+// #include "../vocabulary/node_algorithms.h"
+// is_operand_or_bindable
 
 namespace sqlite_orm::internal {
     /**
@@ -16745,11 +16747,12 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 
 #ifndef SQLITE_ORM_IMPORT_STD_MODULE
 #include <utility>  //  std::move
-// #include "../vocabulary/traits/operand_traits_fwd.h"
-// Included to specialize traits
+#endif
+
 // #include "../functional/cxx_type_traits_polyfill.h"
 
-#endif
+// #include "../vocabulary/traits/operand_traits_fwd.h"
+// Included to specialize traits
 
 namespace sqlite_orm::internal {
     template<class T>
@@ -16781,11 +16784,11 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 #include <utility>  //  std::move
 #endif
 
-// #include "../tags.h"
-
 // #include "../functional/cxx_type_traits_polyfill.h"
 
-// #include "../vocabulary/traits/grammar_traits_fwd.h"
+// #include "../tags.h"
+
+// #include "../vocabulary/node_traits.h"
 
 namespace sqlite_orm::internal {
     template<class T>

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -12617,8 +12617,6 @@ namespace sqlite_orm::internal {
      */
     template<class L, class A>
     struct dynamic_in_t : condition_t, in_base, negatable_t {
-        using self = dynamic_in_t<L, A>;
-
         L left;  //  left expression
         A argument;  //  in arg
 
@@ -12777,9 +12775,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 
 // #include "../tags.h"
 
-// #include "../functional/config.h"
-
-// #include "../vocabulary/algorithms/operand_predicates.h"
+// #include "../vocabulary/node_algorithms.h"
 
 namespace sqlite_orm::internal {
     /**
@@ -12788,7 +12784,6 @@ namespace sqlite_orm::internal {
     template<class T>
     struct is_null_t : condition_t, negatable_t {
         using argument_type = T;
-        using self = is_null_t<argument_type>;
 
         argument_type argument;
 
@@ -12817,9 +12812,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 
 // #include "../tags.h"
 
-// #include "../functional/config.h"
-
-// #include "../vocabulary/algorithms/operand_predicates.h"
+// #include "../vocabulary/node_algorithms.h"
 
 namespace sqlite_orm::internal {
     /**
@@ -12828,7 +12821,6 @@ namespace sqlite_orm::internal {
     template<class T>
     struct is_not_null_t : condition_t, negatable_t {
         using argument_type = T;
-        using self = is_not_null_t<argument_type>;
 
         argument_type argument;
 
@@ -16799,7 +16791,6 @@ namespace sqlite_orm::internal {
     template<class T>
     struct exists_t : condition_t, negatable_t {
         using expression_type = T;
-        using self = exists_t<expression_type>;
 
         expression_type expression;
 
@@ -25957,7 +25948,6 @@ namespace sqlite_orm::internal {
      */
     template<class... DBO>
     struct storage_t : storage_base {
-        using self_type = storage_t;
         using db_objects_type = db_objects_tuple<DBO...>;
 
         /**
@@ -25995,7 +25985,7 @@ namespace sqlite_orm::internal {
          *  
          *  Hence, friend was replaced by `obtain_db_objects()` and `pick_const_impl()`.
          */
-        friend const db_objects_type& obtain_db_objects(const self_type& storage) noexcept {
+        friend const db_objects_type& obtain_db_objects(const storage_t& storage) noexcept {
             return storage.db_objects;
         }
 
@@ -26162,7 +26152,7 @@ namespace sqlite_orm::internal {
          *  meaning that iterators obtained from it are not tied to the lifetime of the view instance.
          */
         template<class T, class O = mapped_type_proxy_t<T>, class... Args>
-        mapped_view<O, self_type, Args...> iterate(Args&&... args) {
+        mapped_view<O, storage_t, Args...> iterate(Args&&... args) {
             this->assert_mapped_type<O>();
 
             auto conRef = this->get_connection();
@@ -26750,7 +26740,7 @@ namespace sqlite_orm::internal {
             class Ex = polyfill::remove_cvref_t<E>,
             std::enable_if_t<!is_prepared_statement<Ex>::value && !is_mapped<db_objects_type, Ex>::value, bool> = true>
         std::string dump(E&& expression, bool parametrized = false) const {
-            static_assert(is_preparable_statement_v<self_type, Ex>, "Expression must be a high-level statement");
+            static_assert(is_preparable_statement_v<storage_t, Ex>, "Expression must be a high-level statement");
 
             if constexpr (is_select_v<Ex>) {
                 auto e2 = std::forward<E>(expression);

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -2536,6 +2536,33 @@ namespace sqlite_orm::internal {
 
     template<class F>
     using is_rowid_alias_capable = polyfill::bool_constant<is_rowid_alias_capable_v<F>>;
+
+    /*
+     *  Whether a field type can be bound as a parameter of a prepared statement.
+     *
+     *  In contrast to `is_rowid_alias_capable`, which is a capability derived from the field type itself,
+     *  this is tied to whether the `statement_binder` customization point is instantiable for it -
+     *  hence its definition stays with `statement_binder` in `statement_binder.h`.
+     */
+    template<class T, class SFINAE = void>
+    extern const bool is_bindable_v;
+
+    //  a derived struct in favor of an alias template, because it is passed on as a template-template argument
+    //  [SQLITE_ORM_BROKEN_ALIAS_TEMPLATE_DEPENDENT_NTTP_EXPR]
+    template<class T>
+    struct is_bindable : polyfill::bool_constant<is_bindable_v<T>> {};
+
+    /*
+     *  Whether a field type can be printed as a human-readable string.
+     *
+     *  Like `is_bindable`, this is tied to whether the `field_printer` customization point is
+     *  instantiable for it - hence its definition stays with `field_printer` in `field_printer.h`.
+     */
+    template<class T, class SFINAE = void>
+    extern const bool is_printable_v;
+
+    template<class T>
+    struct is_printable : polyfill::bool_constant<is_printable_v<T>> {};
 }
 
 // #include "algorithms/field_predicates_concepts.h"
@@ -2938,10 +2965,10 @@ namespace sqlite_orm::internal {
 
 // #include "../node_traits.h"
 
-namespace sqlite_orm::internal {
-    template<class T>
-    struct is_bindable;
+// #include "field_predicates_fwd.h"
+// is_bindable
 
+namespace sqlite_orm::internal {
     /**
      *  Whether a type may be referenced as a column expression by a named expression factory:
      *  a member pointer or anything the overloaded operators accept.
@@ -4246,6 +4273,8 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 
 // #include "functional/cxx_type_traits_polyfill.h"
 
+// #include "vocabulary/algorithms/field_predicates_fwd.h"
+// Included to define is_printable_v
 // #include "type_traits.h"
 
 // #include "is_std_ptr.h"
@@ -4296,19 +4325,15 @@ namespace sqlite_orm::internal {
     /*
      *  Implementation note: the technique of indirect expression testing is because
      *  of older compilers having problems with the detection of dependent templates [SQLITE_ORM_BROKEN_ALIAS_TEMPLATE_DEPENDENT_EXPR_SFINAE].
-     *  It must also be a type that differs from those for `is_preparable_v`, `is_bindable_v`.
+     *  It must also be a type that differs from those for `is_preparable_statement_v`, `is_bindable_v`.
      */
     template<class Printer>
     struct indirectly_test_printable;
 
-    template<class T, class SFINAE = void>
-    inline constexpr bool is_printable_v = false;
+    template<class T, class SFINAE>
+    constexpr bool is_printable_v = false;
     template<class T>
-    inline constexpr bool is_printable_v<T, polyfill::void_t<indirectly_test_printable<decltype(field_printer<T>{})>>> =
-        true;
-
-    template<class T>
-    struct is_printable : polyfill::bool_constant<is_printable_v<T>> {};
+    constexpr bool is_printable_v<T, polyfill::void_t<indirectly_test_printable<decltype(field_printer<T>{})>>> = true;
 }
 
 namespace sqlite_orm {
@@ -10062,6 +10087,8 @@ namespace sqlite_orm::internal {
 
 // #include "functional/cxx_functional_polyfill.h"
 // std::invoke
+// #include "vocabulary/algorithms/field_predicates_fwd.h"
+// Included to define is_bindable_v
 // #include "type_traits.h"
 
 // #include "is_std_ptr.h"
@@ -10664,19 +10691,15 @@ namespace sqlite_orm::internal {
     /*
      *  Implementation note: the technique of indirect expression testing is because
      *  of older compilers having problems with the detection of dependent templates [SQLITE_ORM_BROKEN_ALIAS_TEMPLATE_DEPENDENT_EXPR_SFINAE].
-     *  It must also be a type that differs from those for `is_printable_v`, `is_preparable_v`.
+     *  It must also be a type that differs from those for `is_printable_v`, `is_preparable_statement_v`.
      */
     template<class Binder>
     struct indirectly_test_bindable;
 
-    template<class T, class SFINAE = void>
-    inline constexpr bool is_bindable_v = false;
+    template<class T, class SFINAE>
+    constexpr bool is_bindable_v = false;
     template<class T>
-    inline constexpr bool
-        is_bindable_v<T, polyfill::void_t<indirectly_test_bindable<decltype(statement_binder<T>{})>>> = true;
-
-    template<class T>
-    struct is_bindable : polyfill::bool_constant<is_bindable_v<T>> {};
+    constexpr bool is_bindable_v<T, polyfill::void_t<indirectly_test_bindable<decltype(statement_binder<T>{})>>> = true;
 }
 
 // `statement_binder` specializations;
@@ -25912,9 +25935,9 @@ namespace sqlite_orm::internal {
     struct indirectly_test_preparable;
 
     template<class S, class E, class SFINAE = void>
-    inline constexpr bool is_preparable_v = false;
+    inline constexpr bool is_preparable_statement_v = false;
     template<class S, class E>
-    inline constexpr bool is_preparable_v<
+    inline constexpr bool is_preparable_statement_v<
         S,
         E,
         polyfill::void_t<indirectly_test_preparable<decltype(std::declval<S>().prepare(std::declval<E>()))>>> = true;
@@ -26727,7 +26750,7 @@ namespace sqlite_orm::internal {
             class Ex = polyfill::remove_cvref_t<E>,
             std::enable_if_t<!is_prepared_statement<Ex>::value && !is_mapped<db_objects_type, Ex>::value, bool> = true>
         std::string dump(E&& expression, bool parametrized = false) const {
-            static_assert(is_preparable_v<self_type, Ex>, "Expression must be a high-level statement");
+            static_assert(is_preparable_statement_v<self_type, Ex>, "Expression must be a high-level statement");
 
             if constexpr (is_select_v<Ex>) {
                 auto e2 = std::forward<E>(expression);

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -2916,6 +2916,61 @@ namespace sqlite_orm::internal {
         polyfill::disjunction<is_select_clause<expression_type_t<T>>, is_select_clause<offset_expression_type_t<T>>>>;
 }
 
+// #include "algorithms/operand_predicates.h"
+
+/** @file Combined operand predicates gating the named expression factories.
+ *
+ *  The named factories (`eq()`, `and_()`, `add()`, `assign()`, ...) accept everything their
+ *  operator counterparts accept, plus a raw member pointer (which the named factories
+ *  reference without the `c()` wrapper), plus a bindable value - the named factories are
+ *  also the only spelling for literal-only SQL expressions such as `SELECT 60 | 13`.
+ *  Everything else - arbitrary structs, containers, statement clauses - cannot be
+ *  serialized into SQL and is rejected at the factory.
+ */
+
+#ifndef SQLITE_ORM_IMPORT_STD_MODULE
+#include <functional>  //  std::reference_wrapper
+#include <tuple>  //  std::tuple
+#include <type_traits>  //  std::is_member_pointer
+#endif
+
+// #include "../../functional/cxx_type_traits_polyfill.h"
+
+// #include "../node_traits.h"
+
+namespace sqlite_orm::internal {
+    template<class T>
+    struct is_bindable;
+
+    /**
+     *  Whether a type may be referenced as a column expression by a named expression factory:
+     *  a member pointer or anything the overloaded operators accept.
+     */
+    template<class T>
+    using is_referencable_operand = polyfill::disjunction<is_operator_argument<T>, std::is_member_pointer<T>>;
+
+    /**
+     *  Whether a type may appear as an operand of a named expression factory.
+     */
+    template<class T>
+    using is_operand_or_bindable = polyfill::disjunction<is_operator_argument<T>,
+                                                         std::is_member_pointer<T>,
+                                                         is_arithmetic_operand<T>,
+                                                         is_conditional_operand<T>,
+                                                         is_chainable_operand<T>,
+                                                         is_bindable<T>,
+                                                         //  a scalar subquery
+                                                         is_select<T>,
+                                                         is_compound_operator<T>,
+                                                         //  a row value
+                                                         polyfill::is_specialization_of<T, std::tuple>,
+                                                         //  a value bound by reference in a prepared statement
+                                                         polyfill::is_specialization_of<T, std::reference_wrapper>>;
+
+    template<class L, class R>
+    using are_valid_operands = polyfill::conjunction<is_operand_or_bindable<L>, is_operand_or_bindable<R>>;
+}
+
 // #include "algorithms/accessors.h"
 
 /** @file Accessor functions for uniformly obtaining a node's relevant sub-expression or itself,
@@ -4461,6 +4516,8 @@ namespace sqlite_orm::internal {
     constexpr bool is_conditional_operand_v = std::is_base_of<condition_t, T>::value;
 }
 
+// #include "vocabulary/algorithms/operand_predicates.h"
+
 namespace sqlite_orm::internal {
     template<class L, class R, class... Ds>
     struct binary_operator : Ds... {
@@ -4658,11 +4715,17 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class L, class R>
     constexpr internal::conc_t<L, R> conc(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "conc() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
+                      "column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
     template<class T>
     constexpr internal::unary_minus_t<T> minus(T t) {
+        static_assert(internal::is_operand_or_bindable<T>::value,
+                      "minus() argument must be a bindable value or one of sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(t)};
     }
 
@@ -4671,6 +4734,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class L, class R>
     constexpr internal::add_t<L, R> add(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "add() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
+                      "column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
@@ -4679,6 +4745,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class L, class R>
     constexpr internal::sub_t<L, R> sub(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "sub() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
+                      "column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
@@ -4687,6 +4756,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class L, class R>
     constexpr internal::mul_t<L, R> mul(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "mul() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
+                      "column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
@@ -4697,6 +4769,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class L, class R>
     constexpr internal::div_t<L, R> div(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "div() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
+                      "column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
@@ -4705,36 +4780,57 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class L, class R>
     constexpr internal::mod_t<L, R> mod(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "mod() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
+                      "column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
     constexpr internal::bitwise_shift_left_t<L, R> bitwise_shift_left(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "bitwise_shift_left() arguments must be bindable values or sqlite_orm-recognized operands: "
+                      "member pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
     constexpr internal::bitwise_shift_right_t<L, R> bitwise_shift_right(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "bitwise_shift_right() arguments must be bindable values or sqlite_orm-recognized operands: "
+                      "member pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
     constexpr internal::bitwise_and_t<L, R> bitwise_and(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "bitwise_and() arguments must be bindable values or sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
     constexpr internal::bitwise_or_t<L, R> bitwise_or(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "bitwise_or() arguments must be bindable values or sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
     template<class T>
     constexpr internal::bitwise_not_t<T> bitwise_not(T t) {
+        static_assert(internal::is_operand_or_bindable<T>::value,
+                      "bitwise_not() argument must be a bindable value or one of sqlite_orm-recognized operands: "
+                      "member pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(t)};
     }
 
     template<class L, class R>
     internal::assign_t<L, R> assign(L l, R r) {
+        static_assert(internal::is_referencable_operand<L>::value,
+                      "the assignment target must be one of sqlite_orm-recognized operands: member pointers, column "
+                      "pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 }
@@ -5308,6 +5404,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 // unwrap_expression
 // #include "vocabulary/traits/grammar_traits_fwd.h"
 // Included to specialize traits
+// #include "vocabulary/algorithms/operand_predicates.h"
 
 namespace sqlite_orm::internal {
     /**
@@ -6163,6 +6260,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     template<class L, class R>
     constexpr auto and_(L l, R r) {
         using namespace ::sqlite_orm::internal;
+        static_assert(are_valid_operands<L, R>::value,
+                      "and_() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
+                      "column pointers, c()-wrapped values, aliases or expressions");
         return and_condition_t<unwrap_expression_t<L>, unwrap_expression_t<R>>{unwrap_expression(std::forward<L>(l)),
                                                                                unwrap_expression(std::forward<R>(r))};
     }
@@ -6170,17 +6270,26 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     template<class L, class R>
     constexpr auto or_(L l, R r) {
         using namespace ::sqlite_orm::internal;
+        static_assert(are_valid_operands<L, R>::value,
+                      "or_() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
+                      "column pointers, c()-wrapped values, aliases or expressions");
         return or_condition_t<unwrap_expression_t<L>, unwrap_expression_t<R>>{unwrap_expression(std::forward<L>(l)),
                                                                               unwrap_expression(std::forward<R>(r))};
     }
 
     template<class L, class R>
     constexpr internal::is_equal_t<L, R> is_equal(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "is_equal() arguments must be bindable values or sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
     constexpr internal::is_equal_t<L, R> eq(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "eq() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
+                      "column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
@@ -6196,36 +6305,57 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 
     template<class L, class R>
     constexpr internal::is_not_equal_t<L, R> is_not_equal(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "is_not_equal() arguments must be bindable values or sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
     constexpr internal::is_not_equal_t<L, R> ne(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "ne() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
+                      "column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
     constexpr internal::greater_than_t<L, R> greater_than(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "greater_than() arguments must be bindable values or sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
     constexpr internal::greater_than_t<L, R> gt(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "gt() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
+                      "column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
     constexpr internal::greater_or_equal_t<L, R> greater_or_equal(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "greater_or_equal() arguments must be bindable values or sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
     constexpr internal::greater_or_equal_t<L, R> ge(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "ge() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
+                      "column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
     constexpr internal::less_than_t<L, R> less_than(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "less_than() arguments must be bindable values or sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
@@ -6235,16 +6365,25 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     template<class L, class R>
     [[deprecated("Use the accurately named function `less_than(...)` instead")]] internal::less_than_t<L, R>
     lesser_than(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "lesser_than() arguments must be bindable values or sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
     constexpr internal::less_than_t<L, R> lt(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "lt() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
+                      "column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
     constexpr internal::less_or_equal_t<L, R> less_or_equal(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "less_or_equal() arguments must be bindable values or sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
@@ -6254,11 +6393,17 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     template<class L, class R>
     [[deprecated("Use the accurately named function `less_or_equal(...)` instead")]] internal::less_or_equal_t<L, R>
     lesser_or_equal(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "lesser_or_equal() arguments must be bindable values or sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
     template<class L, class R>
     constexpr internal::less_or_equal_t<L, R> le(L l, R r) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "le() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
+                      "column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(l), std::move(r)};
     }
 
@@ -6326,6 +6471,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class A, class T>
     constexpr internal::like_t<A, T, void> like(A a, T t) {
+        static_assert(internal::is_operand_or_bindable<A>::value,
+                      "the matched expression must be a bindable value or one of sqlite_orm-recognized operands: "
+                      "member pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(a), std::move(t), {}};
     }
 
@@ -6335,6 +6483,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class A, class T, class E>
     constexpr internal::like_t<A, T, E> like(A a, T t, E e) {
+        static_assert(internal::is_operand_or_bindable<A>::value,
+                      "the matched expression must be a bindable value or one of sqlite_orm-recognized operands: "
+                      "member pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(a), std::move(t), {std::move(e)}};
     }
 
@@ -6344,6 +6495,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class A, class T>
     constexpr internal::glob_t<A, T> glob(A a, T t) {
+        static_assert(internal::is_operand_or_bindable<A>::value,
+                      "the matched expression must be a bindable value or one of sqlite_orm-recognized operands: "
+                      "member pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(a), std::move(t)};
     }
 }
@@ -9428,6 +9582,10 @@ namespace sqlite_orm::internal {
         optional_container<else_expression_type> else_expression;
     };
 
+    template<class T>
+    constexpr bool
+        is_operator_argument_v<T, std::enable_if_t<polyfill::is_specialization_of<T, simple_case_t>::value>> = true;
+
     /**
      *  T is a case expression type
      *  E is else type (void is ELSE is omitted)
@@ -12370,6 +12528,8 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 
 #ifndef SQLITE_ORM_IMPORT_STD_MODULE
 #include <utility>  // std::move
+// #include "../vocabulary/traits/operand_traits_fwd.h"
+// Included to specialize traits
 #endif  //  SQLITE_ORM_IMPORT_STD_MODULE
 
 namespace sqlite_orm::internal {
@@ -12386,6 +12546,9 @@ namespace sqlite_orm::internal {
 
         expression_type expression;
     };
+
+    template<class T>
+    constexpr bool is_operator_argument_v<T, std::enable_if_t<polyfill::is_specialization_of<T, cast_t>::value>> = true;
 }
 
 SQLITE_ORM_EXPORT namespace sqlite_orm {
@@ -12409,6 +12572,8 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 #endif
 
 // #include "../tags.h"
+
+// #include "../vocabulary/algorithms/operand_predicates.h"
 
 namespace sqlite_orm::internal {
 
@@ -12451,6 +12616,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class L, class E>
     internal::dynamic_in_t<L, std::vector<E>> in(L left, std::vector<E> values) {
+        static_assert(internal::is_operand_or_bindable<L>::value,
+                      "the tested expression must be a bindable value or one of sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(left), std::move(values), false};
     }
 
@@ -12463,6 +12631,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class L, class E>
     internal::dynamic_in_t<L, std::vector<E>> in(L left, std::initializer_list<E> values) {
+        static_assert(internal::is_operand_or_bindable<L>::value,
+                      "the tested expression must be a bindable value or one of sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(left), std::move(values), false};
     }
 
@@ -12475,6 +12646,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class L, class A>
     internal::dynamic_in_t<L, A> in(L left, A argument) {
+        static_assert(internal::is_operand_or_bindable<L>::value,
+                      "the tested expression must be a bindable value or one of sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(left), std::move(argument), false};
     }
 
@@ -12487,6 +12661,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class L, class E>
     internal::dynamic_in_t<L, std::vector<E>> not_in(L left, std::vector<E> values) {
+        static_assert(internal::is_operand_or_bindable<L>::value,
+                      "the tested expression must be a bindable value or one of sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(left), std::move(values), true};
     }
 
@@ -12499,6 +12676,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class L, class E>
     internal::dynamic_in_t<L, std::vector<E>> not_in(L left, std::initializer_list<E> values) {
+        static_assert(internal::is_operand_or_bindable<L>::value,
+                      "the tested expression must be a bindable value or one of sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(left), std::move(values), true};
     }
 
@@ -12511,6 +12691,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class L, class A>
     internal::dynamic_in_t<L, A> not_in(L left, A argument) {
+        static_assert(internal::is_operand_or_bindable<L>::value,
+                      "the tested expression must be a bindable value or one of sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(left), std::move(argument), true};
     }
 }
@@ -12520,6 +12703,8 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 #include <utility>  //  std::move
 #endif
 // #include "tags.h"
+
+// #include "../vocabulary/algorithms/operand_predicates.h"
 
 namespace sqlite_orm::internal {
     /**
@@ -12547,6 +12732,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class A, class T>
     internal::between_t<A, T> between(A expression, T lower, T upper) {
+        static_assert(internal::is_operand_or_bindable<A>::value,
+                      "the tested expression must be a bindable value or one of sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(expression), std::move(lower), std::move(upper)};
     }
 }
@@ -12559,6 +12747,8 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 // #include "../tags.h"
 
 // #include "../functional/config.h"
+
+// #include "../vocabulary/algorithms/operand_predicates.h"
 
 namespace sqlite_orm::internal {
     /**
@@ -12582,6 +12772,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class T>
     internal::is_null_t<T> is_null(T t) {
+        static_assert(internal::is_operand_or_bindable<T>::value,
+                      "the tested expression must be a bindable value or one of sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(t)};
     }
 }
@@ -12594,6 +12787,8 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 // #include "../tags.h"
 
 // #include "../functional/config.h"
+
+// #include "../vocabulary/algorithms/operand_predicates.h"
 
 namespace sqlite_orm::internal {
     /**
@@ -12617,6 +12812,9 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class T>
     internal::is_not_null_t<T> is_not_null(T t) {
+        static_assert(internal::is_operand_or_bindable<T>::value,
+                      "the tested expression must be a bindable value or one of sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(t)};
     }
 }
@@ -16524,6 +16722,10 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 
 #ifndef SQLITE_ORM_IMPORT_STD_MODULE
 #include <utility>  //  std::move
+// #include "../vocabulary/traits/operand_traits_fwd.h"
+// Included to specialize traits
+// #include "../functional/cxx_type_traits_polyfill.h"
+
 #endif
 
 namespace sqlite_orm::internal {
@@ -16533,6 +16735,10 @@ namespace sqlite_orm::internal {
 
         expression_type expression;
     };
+
+    template<class T>
+    constexpr bool is_operator_argument_v<T, std::enable_if_t<polyfill::is_specialization_of<T, excluded_t>::value>> =
+        true;
 }
 
 SQLITE_ORM_EXPORT namespace sqlite_orm {
@@ -16553,6 +16759,10 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 #endif
 
 // #include "../tags.h"
+
+// #include "../functional/cxx_type_traits_polyfill.h"
+
+// #include "../vocabulary/traits/grammar_traits_fwd.h"
 
 namespace sqlite_orm::internal {
     template<class T>
@@ -16577,6 +16787,8 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class T>
     internal::exists_t<T> exists(T expression) {
+        static_assert(polyfill::disjunction<internal::is_select<T>, internal::is_compound_operator<T>>::value,
+                      "exists() requires a select statement");
         return {std::move(expression)};
     }
 }
@@ -21319,6 +21531,9 @@ namespace sqlite_orm::internal {
 
 // #include "../optional_container.h"
 
+// #include "../vocabulary/traits/operand_traits_fwd.h"
+// Included to specialize traits
+
 // NOTE Idea : Maybe also implement a custom trigger system to call a c++ callback when a trigger triggers ?
 // (Could be implemented with a normal trigger that insert or update an internal table and then retreive
 // the event in the C++ code, to call the C++ user callback, with update hooks: https://www.sqlite.org/c3ref/update_hook.html)
@@ -21525,6 +21740,12 @@ namespace sqlite_orm::internal {
 
         expression_type expression;
     };
+
+    template<class T>
+    constexpr bool is_operator_argument_v<
+        T,
+        std::enable_if_t<polyfill::disjunction<polyfill::is_specialization_of<T, new_t>,
+                                               polyfill::is_specialization_of<T, old_t>>::value>> = true;
 }
 
 SQLITE_ORM_EXPORT namespace sqlite_orm {

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -6548,6 +6548,8 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 
 // #include "vocabulary/traits/grammar_traits_fwd.h"
 // Included to specialize traits
+// #include "vocabulary/traits/operand_traits_fwd.h"
+// Included to specialize traits
 
 namespace sqlite_orm::internal {
     template<class T>
@@ -6857,6 +6859,12 @@ namespace sqlite_orm::internal {
      *          having(greater_than(count(), 2))))));
      */
     struct count_asterisk_without_type : count_string {};
+
+    template<class T>
+    constexpr bool is_operator_argument_v<
+        T,
+        std::enable_if_t<polyfill::disjunction<polyfill::is_specialization_of<T, count_asterisk_t>,
+                                               std::is_same<T, count_asterisk_without_type>>::value>> = true;
 
     struct avg_string {
         serialize_result_type serialize() const {

--- a/tests/static_tests/operand_validity.cpp
+++ b/tests/static_tests/operand_validity.cpp
@@ -1,0 +1,51 @@
+#include <sqlite_orm/sqlite_orm.h>
+#include <catch2/catch_all.hpp>
+#include <functional>  //  std::reference_wrapper
+#include <tuple>  //  std::tuple
+#include <vector>  //  std::vector
+
+using namespace sqlite_orm;
+
+namespace {
+    struct User {
+        int id = 0;
+        std::string name;
+    };
+}
+
+TEST_CASE("named factory operands are validated at compile time") {
+    SECTION("recognized operands and bindable values are accepted") {
+        STATIC_REQUIRE(internal::is_operand_or_bindable<int User::*>::value);
+        STATIC_REQUIRE(internal::is_operand_or_bindable<decltype(c(&User::id))>::value);
+        STATIC_REQUIRE(internal::is_operand_or_bindable<decltype(column<User>(&User::id))>::value);
+        STATIC_REQUIRE(internal::is_operand_or_bindable<int>::value);
+        STATIC_REQUIRE(internal::is_operand_or_bindable<const char*>::value);
+        STATIC_REQUIRE(internal::is_operand_or_bindable<std::reference_wrapper<int>>::value);
+        STATIC_REQUIRE(internal::is_operand_or_bindable<std::tuple<int, int>>::value);
+        STATIC_REQUIRE(internal::is_operand_or_bindable<decltype(select(&User::id))>::value);
+        STATIC_REQUIRE(internal::is_operand_or_bindable<decltype(length(&User::name))>::value);
+        STATIC_REQUIRE(internal::is_operand_or_bindable<decltype(cast<int>(&User::name))>::value);
+        STATIC_REQUIRE(internal::is_operand_or_bindable<decltype(new_(&User::id))>::value);
+        STATIC_REQUIRE(internal::is_operand_or_bindable<decltype(old(&User::id))>::value);
+        STATIC_REQUIRE(internal::is_operand_or_bindable<decltype(excluded(&User::id))>::value);
+    }
+    SECTION("garbage types and statement clauses are rejected") {
+        STATIC_REQUIRE_FALSE(internal::is_operand_or_bindable<User>::value);
+        STATIC_REQUIRE_FALSE(internal::is_operand_or_bindable<std::vector<int>>::value);
+        STATIC_REQUIRE_FALSE(internal::is_operand_or_bindable<decltype(where(c(&User::id) > 0))>::value);
+        STATIC_REQUIRE_FALSE(internal::is_operand_or_bindable<decltype(group_by(&User::id))>::value);
+        STATIC_REQUIRE_FALSE(internal::is_operand_or_bindable<decltype(limit(5))>::value);
+    }
+    SECTION("both operands are checked") {
+        STATIC_REQUIRE(internal::are_valid_operands<int User::*, int>::value);
+        STATIC_REQUIRE(internal::are_valid_operands<int, int>::value);
+        STATIC_REQUIRE_FALSE(internal::are_valid_operands<int User::*, User>::value);
+        STATIC_REQUIRE_FALSE(internal::are_valid_operands<User, int>::value);
+    }
+    SECTION("an assignment target must be referencable") {
+        STATIC_REQUIRE(internal::is_referencable_operand<int User::*>::value);
+        STATIC_REQUIRE(internal::is_referencable_operand<decltype(column<User>(&User::id))>::value);
+        STATIC_REQUIRE_FALSE(internal::is_referencable_operand<int>::value);
+        STATIC_REQUIRE_FALSE(internal::is_referencable_operand<const char*>::value);
+    }
+}

--- a/tests/static_tests/operand_validity.cpp
+++ b/tests/static_tests/operand_validity.cpp
@@ -29,11 +29,21 @@ TEST_CASE("named factory operands are validated at compile time") {
         STATIC_REQUIRE(internal::is_operand_or_bindable<decltype(old(&User::id))>::value);
         STATIC_REQUIRE(internal::is_operand_or_bindable<decltype(excluded(&User::id))>::value);
     }
-    SECTION("garbage types and statement clauses are rejected") {
+    SECTION("garbage types are rejected") {
         STATIC_REQUIRE_FALSE(internal::is_operand_or_bindable<User>::value);
         STATIC_REQUIRE_FALSE(internal::is_operand_or_bindable<std::vector<int>>::value);
+    }
+    //  `is_operand_or_bindable` is a whitelist, so it rejects the statement clauses by not listing them.
+    //  Covering every clause kind turns that into an asserted property, which would catch a clause node
+    //  being registered as an operator argument by mistake.
+    SECTION("no statement clause is an operand") {
+        STATIC_REQUIRE_FALSE(internal::is_operand_or_bindable<decltype(from<User>())>::value);
+        STATIC_REQUIRE_FALSE(internal::is_operand_or_bindable<internal::from2_t<User>>::value);
+        STATIC_REQUIRE_FALSE(internal::is_operand_or_bindable<decltype(cross_join<User>())>::value);
         STATIC_REQUIRE_FALSE(internal::is_operand_or_bindable<decltype(where(c(&User::id) > 0))>::value);
         STATIC_REQUIRE_FALSE(internal::is_operand_or_bindable<decltype(group_by(&User::id))>::value);
+        STATIC_REQUIRE_FALSE(internal::is_operand_or_bindable<decltype(window("w", partition_by(&User::id)))>::value);
+        STATIC_REQUIRE_FALSE(internal::is_operand_or_bindable<decltype(order_by(&User::id))>::value);
         STATIC_REQUIRE_FALSE(internal::is_operand_or_bindable<decltype(limit(5))>::value);
     }
     SECTION("both operands are checked") {


### PR DESCRIPTION
Second phase of the DSL strictness work (#1500 was phase 1). The named expression factories (`eq`/`lt`/`and_`/`like`/`between`/`in`/`is_null`/`add`/`assign`/...) accepted arbitrary types: `eq(User{}, 5)`, `add(std::vector<int>{}, 1)`, `assign(42, "x")`, `exists(42)`, `like(User{}, "a%")` all compiled and failed with 200-line template errors deep in the serializer, or generated invalid SQL.

## The gate

Every argument must now be **a bindable value or a recognized operand**, asserted with a readable message. The predicates live in the new `vocabulary/algorithms/operand_predicates.h`:

- `is_operand_or_bindable<T>` — operator-argument vocabulary ∪ member pointers ∪ bindable values ∪ scalar subqueries ∪ row-value tuples ∪ `std::reference_wrapper` (prepared-statement rebinding);
- `are_valid_operands<L, R>` — both sides checked;
- `is_referencable_operand<T>` — the stricter gate for `assign()`'s target;
- `exists()` requires a select statement.

**Deliberately as permissive as SQL itself**: raw literals stay valid operands, because the named factories are the only spelling for literal-only expressions — `bitwise_or(60, 13)` ⇒ `SELECT 60 | 13` (a tested use case), `and_(42, 42)` ⇒ valid SQL. What's rejected is what can never serialize: arbitrary structs, containers, statement clauses.

## Vocabulary additions surfaced by the compatibility envelope

Compiling the full test suite + examples against the gate revealed operand kinds missing from the operand vocabulary, now registered at their node headers per the vocabulary rules: `new_t`/`old_t` (trigger `NEW.`/`OLD.`), `excluded_t` (upsert), `cast_t`, `simple_case_t`. These registrations also benefit the overloaded operators.

Positive and negative `STATIC_REQUIRE`s in `tests/static_tests/operand_validity.cpp`; the whole suite and all examples compile unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)