### PR TITLE
Compile the examples in one Linux CI configuration again

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,6 +109,7 @@ jobs:
             cc: gcc-10
             cxx: g++-10
             cxx_standard: "-DSQLITE_ORM_ENABLE_CXX_17=ON"
+            build_examples: "-DBUILD_EXAMPLES=ON"
             install_compiler: true
             compiler_package: g++-10
 


### PR DESCRIPTION
The Linux configure step interpolates `${{ matrix.build_examples }}` since the CI refactor, but no matrix entry has been setting it, so the examples compiled only in the iOS/Android cross builds. Requested by @trueqbit.

The flag goes to the gcc-10, C++17 entry: a gating (non-experimental) job, and the examples' first desktop-GCC coverage - the recent breaks the examples caught were all discovered late precisely because no GCC configuration compiled them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)