### PR TITLE
Hoist the pack-indexed moniker digit into a variable for clang before 20.1

### DIFF
--- a/dev/cte_moniker.h
+++ b/dev/cte_moniker.h
@@ -74,7 +74,11 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 #ifdef SQLITE_ORM_PACK_INDEXING_SUPPORTED
             // numeric monikers are used for automatically assigning implicit aliases to unaliased column expressions,
             // which start at "1".
-            static_assert(Chars...[0] > '0');
+            // note: hoisted into a variable because clang before 20.1 fails to treat an indexed non-type
+            // template parameter pack as dependent when its value is converted in place [e.g. Apple clang 17:
+            // "invalid operands to binary expression ('<dependent type>' and 'char')"]
+            constexpr auto first = Chars...[0];
+            static_assert(first > '0');
 #endif
             return internal::cte_moniker<Chars...>{};
         }

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -5466,7 +5466,11 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 #ifdef SQLITE_ORM_PACK_INDEXING_SUPPORTED
             // numeric monikers are used for automatically assigning implicit aliases to unaliased column expressions,
             // which start at "1".
-            static_assert(Chars...[0] > '0');
+            // note: hoisted into a variable because clang before 20.1 fails to treat an indexed non-type
+            // template parameter pack as dependent when its value is converted in place [e.g. Apple clang 17:
+            // "invalid operands to binary expression ('<dependent type>' and 'char')"]
+            constexpr auto first = Chars...[0];
+            static_assert(first > '0');
 #endif
             return internal::cte_moniker<Chars...>{};
         }


### PR DESCRIPTION
Building `dev` on current Xcode (Apple clang 17) failed: the compiler advertises pack indexing via `__cpp_pack_indexing`, but fails to treat an indexed non-type template parameter pack as dependent when its value is converted in place — `static_assert(Chars...[0] > '0')` is an error in every language mode. Fixed upstream in clang 20.1 ([godbolt](https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXACx8BBAKoBnTAAUAHpwAMvAFYTStJg1DIApACYAQuYukl9ZATwDKjdAGFUtAK4sGIMwDspK4AMngMmAByPgBGmMQg0gAOqAqETgwe3r7%2BQSlpjgJhEdEscQnSdpgOGUIETMQEWT5%2BgbaY9oUMdQ0ExVGx8Ym29Y3NOW0Ko33hA2VDkgCUtqhexMjsHASYLEkG2yYAzG7ICA0AdJcA1G5nxApH2CYaAIJX7x/vJgCsVr8MGDwClExHQPwAIhCrmgGFNMAA3MRXJheIhXVBJeJMIjEcxmPEAfQcmDEeCYCggiyuJgCVlenwZHxhcNUSWIyNRqCuNHuBGph3BNzuCku5x%2BFg0EKOdLejIZU2xeGQBPJSka1DwvP52CuYA4Gj1i2lz1lco%2BCscytV8QIEFuDRFl3Fku%2Bgseuv1huN9LNH2ImAIawYV0lhxlZppkNeJvCfJYTHClOptJNn2Z21Z7JRaNU/MFXCJ21J5O9L0jJo4y1onG%2BvD8%2Bt4qE4bms1iuClW60w1LMhx4pAImkrywA1iBDodzlwNAA2b4Bb4AThnhwCXAAHOuzN99JxJHWh6QmxxeAoQBoB0PlnBYDBEChULs6PFyJQ0E/6AlkAYjFxF9O%2BDobZ7koGJDxicIGgAT04fsIOYYgoIAeRibRqkHbheHfNhBCQhhaBghtSCwGIvGANwxFoM9MOInZDGAcQiPwf0anhTBqK0YJVGqVFNk42MOkPWg8BiYhoI8LBDwIYg8BYWDeDY4gYlSTBwTooxhKMK8%2BAMYAFAANTwTAAHckMxet%2B34QQRDEdgpBkQRFBUdQiN0Mx9HolBW0sfQRLPSBlgxLpqIAWimMEBVMSxrDMGdG0UmSsH8yl2k6DIXAYdxPBaPRQlmUpyj0fJ0gEcY/C4Uhiq6foCqGCqqhqAQejGbKcnqjp0NqaYasGBJ6umMq9AVRoevmPrlg7NYNgkKsawPIjjyuVR1xnEKZ0kaEf2AK4/ync4NCuCBcEIEgez7RZeAwrRFmWBASSwBIUrHGcNCnQ4NCXGdNznVcNEOHdqw4fdSDkld9u%2BLgpBXddJEkAJFzXHd60449T3PS8G2vO8ICQVYCCSVFXwgd8kmfYhIlYTZltW9bNvow7pK8BgRwu4J8BxPB0D0KzhFEcR7J5py1EPNzSGMsSknk2aOFrUhkcbTgkNRAm%2BVQKglpWtaNu/endq4fbDo8D94jOsxWau4dSDupgHsoaXgbkw4Z3ORdJE3b4na4b5vjMDQzHXJHD1R2x0Ytm7SDHCdzm%2BF6NEXDQAj912AgD3cOEOeaUc4S7tJve8SbJomC8/FAtt9gCaFoYCzwgMCiPg6D5NIBvEJQtCHCb7DGAIPCCMPEiyIo2gqKbrB4w0vjeGYzq2I43hMG45BeKbgTAc44TRPEjBJ4HGS5JoxTlKUNTx4Y8JQExnSmD0wyTLMxgm55mz%2BekQWlGF1y9C2rzop8jfksCkkYKnAwoEAiuCKKVhLCxXivERK7F4ATQ6o1PwEBXCDQqnlEovUiqpBKpkVq5VKp4OqvlHB7U0pNQGoQoayCujNRmNgsaQ1qHZCIcNRhcxCpcAmp2aaPC06y3lkeTgGsabay2lcX2e0DpHXZqdcw50c6Y1HOOScE4NGaK0WnYGwjg5ngvGHaWZhM4KxPBja6yxFJpGcJIIAA%3D%3D)).

CI does not catch this because its macOS runner is on Apple clang 15.4, which does not define the feature-test macro yet.

Per review: hoisting the indexed value into a `constexpr auto` variable sidesteps the bug (the conversion in place is the trigger), so the check stays intact on every compiler that has pack indexing — no quirk macro, no compiler exclusion.

Repro of the bug shape:
```cpp
template<char... C> constexpr int f() { static_assert(C...[0] > '0'); return 0; }
auto v = f<'1'>();  // Apple clang 17: invalid operands to binary expression ('<dependent type>' and 'char')
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)