### PR TITLE
Apply index redefinitions in sync_schema

### DIFF
--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -2324,7 +2324,9 @@ namespace sqlite_orm::internal {
                 ss << "UNIQUE ";
             }
             using indexed_type = typename statement_type::table_mapped_type;
-            ss << "INDEX IF NOT EXISTS " << streaming_identifier(statement.name) << " ON "
+            //  no `IF NOT EXISTS`: SQLite strips it from the statement text it stores in the schema table,
+            //  and `schema_status()` compares that text with this serialization verbatim
+            ss << "INDEX " << streaming_identifier(statement.name) << " ON "
                << streaming_identifier(lookup_table_name<indexed_type>(context.db_objects));
             std::vector<std::string> columnNames;
             std::string whereString;

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -1156,8 +1156,19 @@ namespace sqlite_orm::internal {
         }
 
         template<class... Cols>
-        sync_schema_result schema_status(const index_t<Cols...>&, sqlite3*, bool, bool*) {
-            return sync_schema_result::already_in_sync;
+        sync_schema_result schema_status(const index_t<Cols...>& index, sqlite3* db, bool, bool*) {
+            auto dbIndexSql = this->retrieve_object_sql(db, "index", index.name);
+            if (dbIndexSql.empty()) {
+                return sync_schema_result::new_table_created;
+            }
+
+            const serializer_context<db_objects_type> context{this->db_objects};
+            auto storageSql = serialize(index, context);
+
+            if (dbIndexSql == storageSql) {
+                return sync_schema_result::already_in_sync;
+            }
+            return sync_schema_result::dropped_and_recreated;
         }
 
 #ifdef SQLITE_ORM_WITH_VIEW
@@ -1306,11 +1317,16 @@ namespace sqlite_orm::internal {
         }
 
         template<class... Cols>
-        sync_schema_result sync_dbo(const index_t<Cols...>& index, sqlite3* db, bool) {
-            const auto res = sync_schema_result::already_in_sync;
-            const serializer_context<db_objects_type> context{this->db_objects};
-            const auto sql = serialize(index, context);
-            this->executor.perform_void_exec(db, sql.c_str());
+        sync_schema_result sync_dbo(const index_t<Cols...>& index, sqlite3* db, bool preserve) {
+            auto res = this->schema_status(index, db, preserve, nullptr);
+            if (res != sync_schema_result::already_in_sync) {
+                if (res == sync_schema_result::dropped_and_recreated) {
+                    this->drop_dbo_internal(db, "INDEX", index.name, true);
+                }
+                const serializer_context<db_objects_type> context{this->db_objects};
+                const auto sql = serialize(index, context);
+                this->executor.perform_void_exec(db, sql.c_str());
+            }
             return res;
         }
 

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -25010,7 +25010,9 @@ namespace sqlite_orm::internal {
                 ss << "UNIQUE ";
             }
             using indexed_type = typename statement_type::table_mapped_type;
-            ss << "INDEX IF NOT EXISTS " << streaming_identifier(statement.name) << " ON "
+            //  no `IF NOT EXISTS`: SQLite strips it from the statement text it stores in the schema table,
+            //  and `schema_status()` compares that text with this serialization verbatim
+            ss << "INDEX " << streaming_identifier(statement.name) << " ON "
                << streaming_identifier(lookup_table_name<indexed_type>(context.db_objects));
             std::vector<std::string> columnNames;
             std::string whereString;
@@ -27550,8 +27552,19 @@ namespace sqlite_orm::internal {
         }
 
         template<class... Cols>
-        sync_schema_result schema_status(const index_t<Cols...>&, sqlite3*, bool, bool*) {
-            return sync_schema_result::already_in_sync;
+        sync_schema_result schema_status(const index_t<Cols...>& index, sqlite3* db, bool, bool*) {
+            auto dbIndexSql = this->retrieve_object_sql(db, "index", index.name);
+            if (dbIndexSql.empty()) {
+                return sync_schema_result::new_table_created;
+            }
+
+            const serializer_context<db_objects_type> context{this->db_objects};
+            auto storageSql = serialize(index, context);
+
+            if (dbIndexSql == storageSql) {
+                return sync_schema_result::already_in_sync;
+            }
+            return sync_schema_result::dropped_and_recreated;
         }
 
 #ifdef SQLITE_ORM_WITH_VIEW
@@ -27700,11 +27713,16 @@ namespace sqlite_orm::internal {
         }
 
         template<class... Cols>
-        sync_schema_result sync_dbo(const index_t<Cols...>& index, sqlite3* db, bool) {
-            const auto res = sync_schema_result::already_in_sync;
-            const serializer_context<db_objects_type> context{this->db_objects};
-            const auto sql = serialize(index, context);
-            this->executor.perform_void_exec(db, sql.c_str());
+        sync_schema_result sync_dbo(const index_t<Cols...>& index, sqlite3* db, bool preserve) {
+            auto res = this->schema_status(index, db, preserve, nullptr);
+            if (res != sync_schema_result::already_in_sync) {
+                if (res == sync_schema_result::dropped_and_recreated) {
+                    this->drop_dbo_internal(db, "INDEX", index.name, true);
+                }
+                const serializer_context<db_objects_type> context{this->db_objects};
+                const auto sql = serialize(index, context);
+                this->executor.perform_void_exec(db, sql.c_str());
+            }
             return res;
         }
 

--- a/tests/schema/index_tests.cpp
+++ b/tests/schema/index_tests.cpp
@@ -124,7 +124,7 @@ TEST_CASE("Compound index") {
     auto index =
         make_index("idx_users_id_and_name", indexed_column(&User::id).asc(), indexed_column(&User::name).asc());
     value = internal::serialize(index, context);
-    expected = R"(CREATE INDEX IF NOT EXISTS "idx_users_id_and_name" ON "users" ("id" ASC, "name" ASC))";
+    expected = R"(CREATE INDEX "idx_users_id_and_name" ON "users" ("id" ASC, "name" ASC))";
     REQUIRE(value == expected);
     auto storage = make_storage("compound_index.sqlite", index, table);
     REQUIRE_NOTHROW(storage.sync_schema());

--- a/tests/statement_serializer_tests/schema/index.cpp
+++ b/tests/statement_serializer_tests/schema/index.cpp
@@ -18,37 +18,37 @@ TEST_CASE("statement_serializer index") {
     SECTION("simple") {
         auto index = make_index("id_index", &User::id);
         value = internal::serialize(index, context);
-        expected = R"(CREATE INDEX IF NOT EXISTS "id_index" ON "users" ("id"))";
+        expected = R"(CREATE INDEX "id_index" ON "users" ("id"))";
     }
     SECTION("desc") {
         auto index = make_index("idx_users_id", indexed_column(&User::id).desc());
         value = internal::serialize(index, context);
-        expected = R"(CREATE INDEX IF NOT EXISTS "idx_users_id" ON "users" ("id" DESC))";
+        expected = R"(CREATE INDEX "idx_users_id" ON "users" ("id" DESC))";
     }
     SECTION("asc") {
         auto index = make_index("idx_users_id", indexed_column(&User::id).asc());
         value = internal::serialize(index, context);
-        expected = R"(CREATE INDEX IF NOT EXISTS "idx_users_id" ON "users" ("id" ASC))";
+        expected = R"(CREATE INDEX "idx_users_id" ON "users" ("id" ASC))";
     }
     SECTION("collate") {
         auto index = make_index("idx_users_id", indexed_column(&User::id).collate("compare"));
         value = internal::serialize(index, context);
-        expected = R"(CREATE INDEX IF NOT EXISTS "idx_users_id" ON "users" ("id" COLLATE compare))";
+        expected = R"(CREATE INDEX "idx_users_id" ON "users" ("id" COLLATE compare))";
     }
     SECTION("collate asc") {
         auto index = make_index("my_index", indexed_column(&User::id).collate("compare").asc());
         value = internal::serialize(index, context);
-        expected = R"(CREATE INDEX IF NOT EXISTS "my_index" ON "users" ("id" COLLATE compare ASC))";
+        expected = R"(CREATE INDEX "my_index" ON "users" ("id" COLLATE compare ASC))";
     }
     SECTION("ifnull") {
         auto index = make_index("idx", &User::id, ifnull<std::string>(&User::name, ""));
         value = internal::serialize(index, context);
-        expected = R"(CREATE INDEX IF NOT EXISTS "idx" ON "users" ("id", IFNULL("name", '')))";
+        expected = R"(CREATE INDEX "idx" ON "users" ("id", IFNULL("name", '')))";
     }
     SECTION("where") {
         auto index = make_index("idx", &User::id, where(is_not_null(&User::id)));
         value = internal::serialize(index, context);
-        expected = R"(CREATE INDEX IF NOT EXISTS "idx" ON "users" ("id") WHERE ("id" IS NOT NULL))";
+        expected = R"(CREATE INDEX "idx" ON "users" ("id") WHERE ("id" IS NOT NULL))";
     }
 #ifdef SQLITE_ORM_JSON_SUPPORTED
     SECTION("json") {
@@ -60,7 +60,7 @@ TEST_CASE("statement_serializer index") {
             auto index = make_index<User>("idx", indexed_column(json_extract<bool>(&User::name, "$.field")));
             value = internal::serialize(index, context);
         }
-        expected = "CREATE INDEX IF NOT EXISTS \"idx\" ON \"users\" (JSON_EXTRACT(\"name\", '$.field'))";
+        expected = "CREATE INDEX \"idx\" ON \"users\" (JSON_EXTRACT(\"name\", '$.field'))";
     }
 #endif  //  SQLITE_ORM_JSON_SUPPORTED
     REQUIRE(value == expected);

--- a/tests/statement_serializer_tests/schema/index.cpp
+++ b/tests/statement_serializer_tests/schema/index.cpp
@@ -60,7 +60,7 @@ TEST_CASE("statement_serializer index") {
             auto index = make_index<User>("idx", indexed_column(json_extract<bool>(&User::name, "$.field")));
             value = internal::serialize(index, context);
         }
-        expected = "CREATE INDEX \"idx\" ON \"users\" (JSON_EXTRACT(\"name\", '$.field'))";
+        expected = R"(CREATE INDEX "idx" ON "users" (JSON_EXTRACT("name", '$.field')))";
     }
 #endif  //  SQLITE_ORM_JSON_SUPPORTED
     REQUIRE(value == expected);

--- a/tests/sync_schema_tests.cpp
+++ b/tests/sync_schema_tests.cpp
@@ -1406,6 +1406,57 @@ TEST_CASE("sync_schema syncs objects in dependency order") {
     std::remove(storagePath);
 }
 
+/**
+ *  Redefining an index under an existing name used to be a silent no-op: the sync executed
+ *  `CREATE INDEX IF NOT EXISTS`, which leaves the stale index in place, and reported it in sync.
+ *  The index definition is now compared against the schema table the way triggers and views are.
+ */
+TEST_CASE("sync_schema applies an index redefinition") {
+    struct User {
+        int id = 0;
+        std::string name;
+        std::string email;
+    };
+    auto storagePath = "sync_schema_index_redefinition.sqlite";
+    std::remove(storagePath);
+
+    auto indexSql = [&storagePath]() -> std::string {
+        auto inspectionStorage = make_storage(storagePath, make_sqlite_schema_table());
+        auto rows = inspectionStorage.select(
+            &sqlite_master::sql,
+            where(c(&sqlite_master::type) == "index" and c(&sqlite_master::name) == "idx_users"));
+        return rows.size() == 1 ? rows.front() : std::string{};
+    };
+
+    auto makeStorage = [&storagePath](auto index) {
+        return make_storage(storagePath,
+                            make_table("users",
+                                       make_column("id", &User::id, primary_key()),
+                                       make_column("name", &User::name),
+                                       make_column("email", &User::email)),
+                            std::move(index));
+    };
+
+    //  the starting point: an index on "name", in sync
+    makeStorage(make_index("idx_users", &User::name)).sync_schema();
+
+    SECTION("an unchanged index is left alone") {
+        auto syncResult = makeStorage(make_index("idx_users", &User::name)).sync_schema();
+        REQUIRE(syncResult.at("idx_users") == sync_schema_result::already_in_sync);
+    }
+    SECTION("a change of the indexed columns is applied") {
+        auto syncResult = makeStorage(make_index("idx_users", &User::email)).sync_schema();
+        REQUIRE(syncResult.at("idx_users") == sync_schema_result::dropped_and_recreated);
+        REQUIRE(indexSql() == R"(CREATE INDEX "idx_users" ON "users" ("email"))");
+    }
+    SECTION("a change to a unique index is applied") {
+        auto syncResult = makeStorage(make_unique_index("idx_users", &User::name)).sync_schema();
+        REQUIRE(syncResult.at("idx_users") == sync_schema_result::dropped_and_recreated);
+        REQUIRE(indexSql() == R"(CREATE UNIQUE INDEX "idx_users" ON "users" ("name"))");
+    }
+    std::remove(storagePath);
+}
+
 TEST_CASE("sync_schema dependency order state matrix") {
     struct User {
         int id = 0;


### PR DESCRIPTION
Redefining an index under an existing name — changed columns, a changed ordering or collation, or switching to `make_unique_index()` — used to be a silent no-op: `sync_schema()` executed `CREATE INDEX IF NOT EXISTS`, which leaves the stale index in place, and `schema_status()` reported `already_in_sync` unconditionally. The database kept serving the old index while the storage declared the new one.

The fix follows the pattern triggers and views already use: `schema_status()` compares the serialization against the statement text stored in the schema table, and `sync_dbo()` drops and recreates the index when they differ. Two consequences:

- The index serializer no longer emits `IF NOT EXISTS` — SQLite strips it from the text it stores in `sqlite_master`, so the comparison must be verbatim; creation is guarded by `schema_status()` instead, as for the other schema objects. Indexes created by previous sqlite_orm versions compare equal, since the stored text never contained the clause.
- `sync_schema()` now reports honest statuses for indexes: `new_table_created` on first creation and `dropped_and_recreated` on redefinition, instead of `already_in_sync` always.

Note: the first commit is #1508 (the clang pack-indexing quirk), which this branch needs to build on current Xcode; it will drop out once #1508 lands and this is rebased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)