### PR TITLE
Centralize `order_by_t` forward declaration

### DIFF
--- a/dev/serializing_util.h
+++ b/dev/serializing_util.h
@@ -17,14 +17,11 @@
 #include "tuple_helper/tuple_iteration.h"
 #include "type_traits.h"
 #include "vocabulary/node_traits.h"
-#include "vocabulary/node_fwd.h"  // column_constraints
+#include "vocabulary/node_fwd.h"  // column_constraints, order_by_t
 #include "schema/column_identifier.h"
 #include "error_code.h"
 
 namespace sqlite_orm::internal {
-    template<class O>
-    struct order_by_t;
-
     template<class T, class Ctx>
     auto serialize(const T& t, const Ctx& context);
 

--- a/dev/vocabulary/node_fwd.h
+++ b/dev/vocabulary/node_fwd.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /** @file Forward-declarations of concrete nodes that have to be used directly in template programming,
- *        e.g. for base-class overloads or metafunctions.
+ *        e.g. for base-class overloads, partial specializations or metafunctions.
  */
 
 namespace sqlite_orm::internal {
@@ -21,4 +21,7 @@ namespace sqlite_orm::internal {
 
     template<class C>
     struct indexed_column_t;
+
+    template<class O>
+    struct order_by_t;
 }

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -2588,7 +2588,7 @@ namespace sqlite_orm::internal {
 // #include "../node_fwd.h"
 
 /** @file Forward-declarations of concrete nodes that have to be used directly in template programming,
- *        e.g. for base-class overloads or metafunctions.
+ *        e.g. for base-class overloads, partial specializations or metafunctions.
  */
 
 namespace sqlite_orm::internal {
@@ -2608,6 +2608,9 @@ namespace sqlite_orm::internal {
 
     template<class C>
     struct indexed_column_t;
+
+    template<class O>
+    struct order_by_t;
 }
 
 namespace sqlite_orm::internal {
@@ -18303,15 +18306,12 @@ inline constexpr bool std::ranges::enable_borrowed_range<sqlite_orm::internal::r
 // #include "vocabulary/node_traits.h"
 
 // #include "vocabulary/node_fwd.h"
-// column_constraints
+// column_constraints, order_by_t
 // #include "schema/column_identifier.h"
 
 // #include "error_code.h"
 
 namespace sqlite_orm::internal {
-    template<class O>
-    struct order_by_t;
-
     template<class T, class Ctx>
     auto serialize(const T& t, const Ctx& context);
 


### PR DESCRIPTION
Move the `order_by_t` forward declaration to `node_fwd.h`, which is the dedicated header for vocabulary node forward declarations. This improves code organization and refines `node_fwd.h`'s description to include its use for partial specializations in template programming.