### PR TITLE
Add the substring() alias for substr()

### DIFF
--- a/dev/core_functions.h
+++ b/dev/core_functions.h
@@ -383,6 +383,14 @@ namespace sqlite_orm::internal {
     };
 #endif
 
+#if SQLITE_VERSION_NUMBER >= 3034000
+    struct substring_string {
+        std::string_view serialize() const {
+            return "SUBSTRING";
+        }
+    };
+#endif
+
 #if SQLITE_VERSION_NUMBER >= 3035000
     struct sign_string {
         std::string_view serialize() const {
@@ -1936,6 +1944,24 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     constexpr internal::built_in_function_t<std::string, internal::substr_string, X, Y, Z> substr(X x, Y y, Z z) {
         return {std::tuple<X, Y, Z>{std::forward<X>(x), std::forward<Y>(y), std::forward<Z>(z)}};
     }
+
+#if SQLITE_VERSION_NUMBER >= 3034000
+    /**
+     *  SUBSTRING(X,Y) function https://www.sqlite.org/lang_corefunc.html#substr
+     */
+    template<class X, class Y>
+    constexpr internal::built_in_function_t<std::string, internal::substring_string, X, Y> substring(X x, Y y) {
+        return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
+    }
+
+    /**
+     *  SUBSTRING(X,Y,Z) function https://www.sqlite.org/lang_corefunc.html#substr
+     */
+    template<class X, class Y, class Z>
+    constexpr internal::built_in_function_t<std::string, internal::substring_string, X, Y, Z> substring(X x, Y y, Z z) {
+        return {std::tuple<X, Y, Z>{std::forward<X>(x), std::forward<Y>(y), std::forward<Z>(z)}};
+    }
+#endif
 
 #ifdef SQLITE_SOUNDEX
     /**

--- a/examples/core_functions.cpp
+++ b/examples/core_functions.cpp
@@ -1086,6 +1086,12 @@ int main(int, char** argv) {
     //  SELECT substr('SQLite substr', 1, 6);
     cout << "substr('SQLite substr', 1, 6) = " << storage.select(substr("SQLite substr", 1, 6)).front() << endl;
 
+#if SQLITE_VERSION_NUMBER >= 3034000
+    //  SELECT substring('SQLite substring', 1, 6);
+    cout << "substring('SQLite substring', 1, 6) = " << storage.select(substring("SQLite substring", 1, 6)).front()
+         << endl;
+#endif
+
     //  SELECT hex(67);
     cout << "hex(67) = " << storage.select(hex(67)).front() << endl;
 

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -8004,6 +8004,14 @@ namespace sqlite_orm::internal {
     };
 #endif
 
+#if SQLITE_VERSION_NUMBER >= 3034000
+    struct substring_string {
+        std::string_view serialize() const {
+            return "SUBSTRING";
+        }
+    };
+#endif
+
 #if SQLITE_VERSION_NUMBER >= 3035000
     struct sign_string {
         std::string_view serialize() const {
@@ -9557,6 +9565,24 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     constexpr internal::built_in_function_t<std::string, internal::substr_string, X, Y, Z> substr(X x, Y y, Z z) {
         return {std::tuple<X, Y, Z>{std::forward<X>(x), std::forward<Y>(y), std::forward<Z>(z)}};
     }
+
+#if SQLITE_VERSION_NUMBER >= 3034000
+    /**
+     *  SUBSTRING(X,Y) function https://www.sqlite.org/lang_corefunc.html#substr
+     */
+    template<class X, class Y>
+    constexpr internal::built_in_function_t<std::string, internal::substring_string, X, Y> substring(X x, Y y) {
+        return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
+    }
+
+    /**
+     *  SUBSTRING(X,Y,Z) function https://www.sqlite.org/lang_corefunc.html#substr
+     */
+    template<class X, class Y, class Z>
+    constexpr internal::built_in_function_t<std::string, internal::substring_string, X, Y, Z> substring(X x, Y y, Z z) {
+        return {std::tuple<X, Y, Z>{std::forward<X>(x), std::forward<Y>(y), std::forward<Z>(z)}};
+    }
+#endif
 
 #ifdef SQLITE_SOUNDEX
     /**

--- a/tests/built_in_functions_tests/core_functions_tests.cpp
+++ b/tests/built_in_functions_tests/core_functions_tests.cpp
@@ -1373,6 +1373,22 @@ TEST_CASE("iif") {
 }
 #endif
 
+#if SQLITE_VERSION_NUMBER >= 3034000
+TEST_CASE("substring") {
+    auto storage = make_storage({});
+    SECTION("start only") {
+        auto rows = storage.select(substring("SQLite substring", 8));
+        decltype(rows) expected{"substring"};
+        REQUIRE(rows == expected);
+    }
+    SECTION("start and length") {
+        auto rows = storage.select(substring("SQLite substring", 1, 6));
+        decltype(rows) expected{"SQLite"};
+        REQUIRE(rows == expected);
+    }
+}
+#endif
+
 #if SQLITE_VERSION_NUMBER >= 3035000
 TEST_CASE("sign") {
     auto storage = make_storage({});

--- a/tests/built_in_functions_tests/core_functions_tests.cpp
+++ b/tests/built_in_functions_tests/core_functions_tests.cpp
@@ -1376,16 +1376,9 @@ TEST_CASE("iif") {
 #if SQLITE_VERSION_NUMBER >= 3034000
 TEST_CASE("substring") {
     auto storage = make_storage({});
-    SECTION("start only") {
-        auto rows = storage.select(substring("SQLite substring", 8));
-        decltype(rows) expected{"substring"};
-        REQUIRE(rows == expected);
-    }
-    SECTION("start and length") {
-        auto rows = storage.select(substring("SQLite substring", 1, 6));
-        decltype(rows) expected{"SQLite"};
-        REQUIRE(rows == expected);
-    }
+    auto rows = storage.select(columns(substring("SQLite substring", 8), substring("SQLite substring", 1, 6)));
+    decltype(rows) expected{{"substring", "SQLite"}};
+    REQUIRE(rows == expected);
 }
 #endif
 

--- a/tests/built_in_functions_tests/core_functions_tests.cpp
+++ b/tests/built_in_functions_tests/core_functions_tests.cpp
@@ -1376,8 +1376,16 @@ TEST_CASE("iif") {
 #if SQLITE_VERSION_NUMBER >= 3034000
 TEST_CASE("substring") {
     auto storage = make_storage({});
-    auto rows = storage.select(columns(substring("SQLite substring", 8), substring("SQLite substring", 1, 6)));
-    decltype(rows) expected{{"substring", "SQLite"}};
+    std::vector<std::string> rows;
+    decltype(rows) expected;
+    SECTION("start only") {
+        rows = storage.select(substring("SQLite substring", 8));
+        expected = {"substring"};
+    }
+    SECTION("start and length") {
+        rows = storage.select(substring("SQLite substring", 1, 6));
+        expected = {"SQLite"};
+    }
     REQUIRE(rows == expected);
 }
 #endif

--- a/tests/statement_serializer_tests/core_functions.cpp
+++ b/tests/statement_serializer_tests/core_functions.cpp
@@ -382,6 +382,18 @@ TEST_CASE("statement_serializer core functions") {
         }
         value = serialize(expression, context);
     }
+#if SQLITE_VERSION_NUMBER >= 3034000
+    SECTION("SUBSTRING(X,Y)") {
+        constexpr auto expression = substring("Zara", 2);
+        expected = "SUBSTRING('Zara', 2)";
+        value = serialize(expression, context);
+    }
+    SECTION("SUBSTRING(X,Y,Z)") {
+        constexpr auto expression = substring("Natasha", 3, 2);
+        expected = "SUBSTRING('Natasha', 3, 2)";
+        value = serialize(expression, context);
+    }
+#endif
     SECTION("SOUNDEX") {
 #ifdef SQLITE_SOUNDEX
         constexpr auto expression = soundex("Vaso");


### PR DESCRIPTION
SQLite 3.34 accepts `substring()` as an alias of `substr()` for compatibility with SQL Server. Both arities are wrapped, serialized as `SUBSTRING` (SQLite reproduces the spelling used), gated on `SQLITE_VERSION_NUMBER >= 3034000`. Serializer tests, runtime tests and an example included.

First item of the S-tier from the feature-design pass over TODO.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)