### PR TITLE
Add the planner-hint functions likely(), unlikely() and likelihood()

### DIFF
--- a/dev/core_functions.h
+++ b/dev/core_functions.h
@@ -370,11 +370,17 @@ namespace sqlite_orm::internal {
     };
 
 #if SQLITE_VERSION_NUMBER >= 3008001
-    //  tag only; the serialization lives in the statement serializer
-    struct likelihood_t {};
+    struct likelihood_string {
+        std::string_view serialize() const {
+            return "LIKELIHOOD";
+        }
+    };
 
-    //  tag only; the serialization lives in the statement serializer
-    struct unlikely_t {};
+    struct unlikely_string {
+        std::string_view serialize() const {
+            return "UNLIKELY";
+        }
+    };
 #endif
 
 #if SQLITE_VERSION_NUMBER >= 3008003
@@ -386,8 +392,11 @@ namespace sqlite_orm::internal {
 #endif
 
 #if SQLITE_VERSION_NUMBER >= 3008006
-    //  tag only; the serialization lives in the statement serializer
-    struct likely_t {};
+    struct likely_string {
+        std::string_view serialize() const {
+            return "LIKELY";
+        }
+    };
 #endif
 
 #if SQLITE_VERSION_NUMBER >= 3032000
@@ -2112,7 +2121,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class X>
     constexpr internal::built_in_function_t<internal::field_type_or_type_t<X>,
-                                            internal::likelihood_t,
+                                            internal::likelihood_string,
                                             X,
                                             internal::literal_holder<double>>
     likelihood(X x, double probability) {
@@ -2130,7 +2139,8 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  UNLIKELY(X) function https://www.sqlite.org/lang_corefunc.html#unlikely
      */
     template<class X>
-    constexpr internal::built_in_function_t<internal::field_type_or_type_t<X>, internal::unlikely_t, X> unlikely(X x) {
+    constexpr internal::built_in_function_t<internal::field_type_or_type_t<X>, internal::unlikely_string, X>
+    unlikely(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 #endif
@@ -2150,7 +2160,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  LIKELY(X) function https://www.sqlite.org/lang_corefunc.html#likely
      */
     template<class X>
-    constexpr internal::built_in_function_t<internal::field_type_or_type_t<X>, internal::likely_t, X> likely(X x) {
+    constexpr internal::built_in_function_t<internal::field_type_or_type_t<X>, internal::likely_string, X> likely(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 #endif

--- a/dev/core_functions.h
+++ b/dev/core_functions.h
@@ -369,17 +369,11 @@ namespace sqlite_orm::internal {
     };
 
 #if SQLITE_VERSION_NUMBER >= 3008001
-    struct likelihood_string {
-        std::string_view serialize() const {
-            return "LIKELIHOOD";
-        }
-    };
+    //  tag only; the serialization lives in the statement serializer
+    struct likelihood_t {};
 
-    struct unlikely_string {
-        std::string_view serialize() const {
-            return "UNLIKELY";
-        }
-    };
+    //  tag only; the serialization lives in the statement serializer
+    struct unlikely_t {};
 #endif
 
 #if SQLITE_VERSION_NUMBER >= 3008003
@@ -391,11 +385,8 @@ namespace sqlite_orm::internal {
 #endif
 
 #if SQLITE_VERSION_NUMBER >= 3008006
-    struct likely_string {
-        std::string_view serialize() const {
-            return "LIKELY";
-        }
-    };
+    //  tag only; the serialization lives in the statement serializer
+    struct likely_t {};
 #endif
 
 #if SQLITE_VERSION_NUMBER >= 3032000
@@ -2120,7 +2111,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class X>
     constexpr internal::built_in_function_t<internal::field_type_or_type_t<X>,
-                                            internal::likelihood_string,
+                                            internal::likelihood_t,
                                             X,
                                             internal::literal_holder<double>>
     likelihood(X x, double probability) {
@@ -2131,8 +2122,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  UNLIKELY(X) function https://www.sqlite.org/lang_corefunc.html#unlikely
      */
     template<class X>
-    constexpr internal::built_in_function_t<internal::field_type_or_type_t<X>, internal::unlikely_string, X>
-    unlikely(X x) {
+    constexpr internal::built_in_function_t<internal::field_type_or_type_t<X>, internal::unlikely_t, X> unlikely(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 #endif
@@ -2152,7 +2142,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  LIKELY(X) function https://www.sqlite.org/lang_corefunc.html#likely
      */
     template<class X>
-    constexpr internal::built_in_function_t<internal::field_type_or_type_t<X>, internal::likely_string, X> likely(X x) {
+    constexpr internal::built_in_function_t<internal::field_type_or_type_t<X>, internal::likely_t, X> likely(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 #endif

--- a/dev/core_functions.h
+++ b/dev/core_functions.h
@@ -16,6 +16,7 @@
 #include "tuple_helper/tuple_traits.h"
 #include "conditions.h"
 #include "operators.h"
+#include "literal.h"  // literal_holder
 #include "tags.h"
 #include "alias_traits.h"
 #include "vocabulary/node_traits.h"
@@ -367,10 +368,32 @@ namespace sqlite_orm::internal {
         }
     };
 
+#if SQLITE_VERSION_NUMBER >= 3008001
+    struct likelihood_string {
+        std::string_view serialize() const {
+            return "LIKELIHOOD";
+        }
+    };
+
+    struct unlikely_string {
+        std::string_view serialize() const {
+            return "UNLIKELY";
+        }
+    };
+#endif
+
 #if SQLITE_VERSION_NUMBER >= 3008003
     struct printf_string {
         std::string_view serialize() const {
             return "PRINTF";
+        }
+    };
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3008006
+    struct likely_string {
+        std::string_view serialize() const {
+            return "LIKELY";
         }
     };
 #endif
@@ -2087,6 +2110,33 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
+#if SQLITE_VERSION_NUMBER >= 3008001
+    /**
+     *  LIKELIHOOD(X,Y) function https://www.sqlite.org/lang_corefunc.html#likelihood
+     *
+     *  The probability is stored as a literal, never as a bound parameter:
+     *  SQLite requires the second argument to be a floating point constant between 0.0 and 1.0,
+     *  and rejects a statement that binds it.
+     */
+    template<class X>
+    constexpr internal::built_in_function_t<internal::field_type_or_type_t<X>,
+                                            internal::likelihood_string,
+                                            X,
+                                            internal::literal_holder<double>>
+    likelihood(X x, double probability) {
+        return {std::tuple<X, internal::literal_holder<double>>{std::forward<X>(x), {probability}}};
+    }
+
+    /**
+     *  UNLIKELY(X) function https://www.sqlite.org/lang_corefunc.html#unlikely
+     */
+    template<class X>
+    constexpr internal::built_in_function_t<internal::field_type_or_type_t<X>, internal::unlikely_string, X>
+    unlikely(X x) {
+        return {std::tuple<X>{std::forward<X>(x)}};
+    }
+#endif
+
 #if SQLITE_VERSION_NUMBER >= 3008003
     /**
      *  PRINTF(FORMAT,...) function https://www.sqlite.org/lang_corefunc.html#printf
@@ -2094,6 +2144,16 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     template<class... Args>
     constexpr internal::built_in_function_t<std::string, internal::printf_string, Args...> printf(Args... args) {
         return {std::tuple<Args...>{std::forward<Args>(args)...}};
+    }
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3008006
+    /**
+     *  LIKELY(X) function https://www.sqlite.org/lang_corefunc.html#likely
+     */
+    template<class X>
+    constexpr internal::built_in_function_t<internal::field_type_or_type_t<X>, internal::likely_string, X> likely(X x) {
+        return {std::tuple<X>{std::forward<X>(x)}};
     }
 #endif
 

--- a/dev/core_functions.h
+++ b/dev/core_functions.h
@@ -2,8 +2,9 @@
 
 #ifndef SQLITE_ORM_IMPORT_STD_MODULE
 #include <string>  //  std::string
+#include <stdexcept>  //  std::domain_error
 #include <tuple>  //  std::make_tuple, std::tuple_size
-#include <type_traits>  //  std::forward, std::is_base_of, std::enable_if
+#include <type_traits>  //  std::forward, std::is_base_of, std::enable_if, std::is_constant_evaluated
 #include <memory>  //  std::unique_ptr
 #include <vector>  //  std::vector
 #include <optional>  //  std::optional
@@ -2115,6 +2116,13 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
                                             X,
                                             internal::literal_holder<double>>
     likelihood(X x, double probability) {
+#if __cpp_lib_is_constant_evaluated >= 201811L
+        //  a probability outside [0.0, 1.0] makes SQLite reject the statement at prepare time;
+        //  when the call is constant-evaluated the error surfaces right here, at compile time
+        if (std::is_constant_evaluated() && !(probability >= 0.0 && probability <= 1.0)) {
+            throw std::domain_error("likelihood() probability must be a constant between 0.0 and 1.0");
+        }
+#endif
         return {std::tuple<X, internal::literal_holder<double>>{std::forward<X>(x), {probability}}};
     }
 

--- a/dev/core_functions.h
+++ b/dev/core_functions.h
@@ -2116,7 +2116,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
                                             X,
                                             internal::literal_holder<double>>
     likelihood(X x, double probability) {
-#if __cpp_lib_is_constant_evaluated >= 201811L
+#ifdef SQLITE_ORM_CPP20_IS_CONSTANT_EVALUATED_SUPPORTED
         //  a probability outside [0.0, 1.0] makes SQLite reject the statement at prepare time;
         //  when the call is constant-evaluated the error surfaces right here, at compile time
         if (std::is_constant_evaluated() && !(probability >= 0.0 && probability <= 1.0)) {

--- a/dev/functional/config.h
+++ b/dev/functional/config.h
@@ -44,6 +44,10 @@
 #define SQLITE_ORM_CONSTEVAL constexpr
 #endif
 
+#if __cpp_lib_is_constant_evaluated >= 201811L
+#define SQLITE_ORM_CPP20_IS_CONSTANT_EVALUATED_SUPPORTED
+#endif
+
 #if defined(SQLITE_ORM_CONCEPTS_SUPPORTED) && __cpp_lib_concepts >= 202002L
 #define SQLITE_ORM_CPP20_CONCEPTS_SUPPORTED
 #endif

--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -734,6 +734,49 @@ namespace sqlite_orm::internal {
     struct statement_serializer<built_in_aggregate_function_t<R, S, Args...>, void>
         : statement_serializer<built_in_function_t<R, S, Args...>, void> {};
 
+#if SQLITE_VERSION_NUMBER >= 3008001
+    template<class R, class... Args>
+    struct statement_serializer<built_in_function_t<R, likelihood_t, Args...>, void> {
+        using statement_type = built_in_function_t<R, likelihood_t, Args...>;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
+                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
+            std::stringstream ss;
+            ss << "LIKELIHOOD(" << streaming_expressions_tuple(statement.args, context) << ")";
+            return ss.str();
+        }
+    };
+
+    template<class R, class... Args>
+    struct statement_serializer<built_in_function_t<R, unlikely_t, Args...>, void> {
+        using statement_type = built_in_function_t<R, unlikely_t, Args...>;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
+                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
+            std::stringstream ss;
+            ss << "UNLIKELY(" << streaming_expressions_tuple(statement.args, context) << ")";
+            return ss.str();
+        }
+    };
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3008006
+    template<class R, class... Args>
+    struct statement_serializer<built_in_function_t<R, likely_t, Args...>, void> {
+        using statement_type = built_in_function_t<R, likely_t, Args...>;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
+                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
+            std::stringstream ss;
+            ss << "LIKELY(" << streaming_expressions_tuple(statement.args, context) << ")";
+            return ss.str();
+        }
+    };
+#endif
+
     template<class F, class... CallArgs>
     struct statement_serializer<function_call<F, CallArgs...>, void> {
         using statement_type = function_call<F, CallArgs...>;

--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -742,49 +742,6 @@ namespace sqlite_orm::internal {
     struct statement_serializer<built_in_aggregate_function_t<R, S, Args...>, void>
         : statement_serializer<built_in_function_t<R, S, Args...>, void> {};
 
-#if SQLITE_VERSION_NUMBER >= 3008001
-    template<class R, class... Args>
-    struct statement_serializer<built_in_function_t<R, likelihood_t, Args...>, void> {
-        using statement_type = built_in_function_t<R, likelihood_t, Args...>;
-
-        template<class Ctx>
-        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
-                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
-            std::stringstream ss;
-            ss << "LIKELIHOOD(" << streaming_expressions_tuple(statement.args, context) << ")";
-            return ss.str();
-        }
-    };
-
-    template<class R, class... Args>
-    struct statement_serializer<built_in_function_t<R, unlikely_t, Args...>, void> {
-        using statement_type = built_in_function_t<R, unlikely_t, Args...>;
-
-        template<class Ctx>
-        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
-                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
-            std::stringstream ss;
-            ss << "UNLIKELY(" << streaming_expressions_tuple(statement.args, context) << ")";
-            return ss.str();
-        }
-    };
-#endif
-
-#if SQLITE_VERSION_NUMBER >= 3008006
-    template<class R, class... Args>
-    struct statement_serializer<built_in_function_t<R, likely_t, Args...>, void> {
-        using statement_type = built_in_function_t<R, likely_t, Args...>;
-
-        template<class Ctx>
-        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
-                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
-            std::stringstream ss;
-            ss << "LIKELY(" << streaming_expressions_tuple(statement.args, context) << ")";
-            return ss.str();
-        }
-    };
-#endif
-
     template<class F, class... CallArgs>
     struct statement_serializer<function_call<F, CallArgs...>, void> {
         using statement_type = function_call<F, CallArgs...>;

--- a/examples/core_functions.cpp
+++ b/examples/core_functions.cpp
@@ -1092,6 +1092,13 @@ int main(int, char** argv) {
          << endl;
 #endif
 
+#if SQLITE_VERSION_NUMBER >= 3008006
+    //  SELECT likely(42), unlikely(42), likelihood(42, 0.0625) -- planner hints, pass the value through
+    cout << "likely(42) = " << storage.select(likely(42)).front() << endl;
+    cout << "unlikely(42) = " << storage.select(unlikely(42)).front() << endl;
+    cout << "likelihood(42, 0.0625) = " << storage.select(likelihood(42, 0.0625)).front() << endl;
+#endif
+
     //  SELECT hex(67);
     cout << "hex(67) = " << storage.select(hex(67)).front() << endl;
 

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -7601,6 +7601,8 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
 
 // #include "operators.h"
 
+// #include "literal.h"
+// literal_holder
 // #include "tags.h"
 
 // #include "alias_traits.h"
@@ -7988,10 +7990,32 @@ namespace sqlite_orm::internal {
         }
     };
 
+#if SQLITE_VERSION_NUMBER >= 3008001
+    struct likelihood_string {
+        std::string_view serialize() const {
+            return "LIKELIHOOD";
+        }
+    };
+
+    struct unlikely_string {
+        std::string_view serialize() const {
+            return "UNLIKELY";
+        }
+    };
+#endif
+
 #if SQLITE_VERSION_NUMBER >= 3008003
     struct printf_string {
         std::string_view serialize() const {
             return "PRINTF";
+        }
+    };
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3008006
+    struct likely_string {
+        std::string_view serialize() const {
+            return "LIKELY";
         }
     };
 #endif
@@ -9708,6 +9732,33 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
         return {std::tuple<X, Y>{std::forward<X>(x), std::forward<Y>(y)}};
     }
 
+#if SQLITE_VERSION_NUMBER >= 3008001
+    /**
+     *  LIKELIHOOD(X,Y) function https://www.sqlite.org/lang_corefunc.html#likelihood
+     *
+     *  The probability is stored as a literal, never as a bound parameter:
+     *  SQLite requires the second argument to be a floating point constant between 0.0 and 1.0,
+     *  and rejects a statement that binds it.
+     */
+    template<class X>
+    constexpr internal::built_in_function_t<internal::field_type_or_type_t<X>,
+                                            internal::likelihood_string,
+                                            X,
+                                            internal::literal_holder<double>>
+    likelihood(X x, double probability) {
+        return {std::tuple<X, internal::literal_holder<double>>{std::forward<X>(x), {probability}}};
+    }
+
+    /**
+     *  UNLIKELY(X) function https://www.sqlite.org/lang_corefunc.html#unlikely
+     */
+    template<class X>
+    constexpr internal::built_in_function_t<internal::field_type_or_type_t<X>, internal::unlikely_string, X>
+    unlikely(X x) {
+        return {std::tuple<X>{std::forward<X>(x)}};
+    }
+#endif
+
 #if SQLITE_VERSION_NUMBER >= 3008003
     /**
      *  PRINTF(FORMAT,...) function https://www.sqlite.org/lang_corefunc.html#printf
@@ -9715,6 +9766,16 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
     template<class... Args>
     constexpr internal::built_in_function_t<std::string, internal::printf_string, Args...> printf(Args... args) {
         return {std::tuple<Args...>{std::forward<Args>(args)...}};
+    }
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3008006
+    /**
+     *  LIKELY(X) function https://www.sqlite.org/lang_corefunc.html#likely
+     */
+    template<class X>
+    constexpr internal::built_in_function_t<internal::field_type_or_type_t<X>, internal::likely_string, X> likely(X x) {
+        return {std::tuple<X>{std::forward<X>(x)}};
     }
 #endif
 

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -7991,17 +7991,11 @@ namespace sqlite_orm::internal {
     };
 
 #if SQLITE_VERSION_NUMBER >= 3008001
-    struct likelihood_string {
-        std::string_view serialize() const {
-            return "LIKELIHOOD";
-        }
-    };
+    //  tag only; the serialization lives in the statement serializer
+    struct likelihood_t {};
 
-    struct unlikely_string {
-        std::string_view serialize() const {
-            return "UNLIKELY";
-        }
-    };
+    //  tag only; the serialization lives in the statement serializer
+    struct unlikely_t {};
 #endif
 
 #if SQLITE_VERSION_NUMBER >= 3008003
@@ -8013,11 +8007,8 @@ namespace sqlite_orm::internal {
 #endif
 
 #if SQLITE_VERSION_NUMBER >= 3008006
-    struct likely_string {
-        std::string_view serialize() const {
-            return "LIKELY";
-        }
-    };
+    //  tag only; the serialization lives in the statement serializer
+    struct likely_t {};
 #endif
 
 #if SQLITE_VERSION_NUMBER >= 3032000
@@ -9742,7 +9733,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class X>
     constexpr internal::built_in_function_t<internal::field_type_or_type_t<X>,
-                                            internal::likelihood_string,
+                                            internal::likelihood_t,
                                             X,
                                             internal::literal_holder<double>>
     likelihood(X x, double probability) {
@@ -9753,8 +9744,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  UNLIKELY(X) function https://www.sqlite.org/lang_corefunc.html#unlikely
      */
     template<class X>
-    constexpr internal::built_in_function_t<internal::field_type_or_type_t<X>, internal::unlikely_string, X>
-    unlikely(X x) {
+    constexpr internal::built_in_function_t<internal::field_type_or_type_t<X>, internal::unlikely_t, X> unlikely(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 #endif
@@ -9774,7 +9764,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  LIKELY(X) function https://www.sqlite.org/lang_corefunc.html#likely
      */
     template<class X>
-    constexpr internal::built_in_function_t<internal::field_type_or_type_t<X>, internal::likely_string, X> likely(X x) {
+    constexpr internal::built_in_function_t<internal::field_type_or_type_t<X>, internal::likely_t, X> likely(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 #endif
@@ -23206,6 +23196,49 @@ namespace sqlite_orm::internal {
     template<class R, class S, class... Args>
     struct statement_serializer<built_in_aggregate_function_t<R, S, Args...>, void>
         : statement_serializer<built_in_function_t<R, S, Args...>, void> {};
+
+#if SQLITE_VERSION_NUMBER >= 3008001
+    template<class R, class... Args>
+    struct statement_serializer<built_in_function_t<R, likelihood_t, Args...>, void> {
+        using statement_type = built_in_function_t<R, likelihood_t, Args...>;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
+                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
+            std::stringstream ss;
+            ss << "LIKELIHOOD(" << streaming_expressions_tuple(statement.args, context) << ")";
+            return ss.str();
+        }
+    };
+
+    template<class R, class... Args>
+    struct statement_serializer<built_in_function_t<R, unlikely_t, Args...>, void> {
+        using statement_type = built_in_function_t<R, unlikely_t, Args...>;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
+                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
+            std::stringstream ss;
+            ss << "UNLIKELY(" << streaming_expressions_tuple(statement.args, context) << ")";
+            return ss.str();
+        }
+    };
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3008006
+    template<class R, class... Args>
+    struct statement_serializer<built_in_function_t<R, likely_t, Args...>, void> {
+        using statement_type = built_in_function_t<R, likely_t, Args...>;
+
+        template<class Ctx>
+        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
+                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
+            std::stringstream ss;
+            ss << "LIKELY(" << streaming_expressions_tuple(statement.args, context) << ")";
+            return ss.str();
+        }
+    };
+#endif
 
     template<class F, class... CallArgs>
     struct statement_serializer<function_call<F, CallArgs...>, void> {

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -5937,8 +5937,9 @@ namespace sqlite_orm::internal {
 
 #ifndef SQLITE_ORM_IMPORT_STD_MODULE
 #include <string>  //  std::string
+#include <stdexcept>  //  std::domain_error
 #include <tuple>  //  std::make_tuple, std::tuple_size
-#include <type_traits>  //  std::forward, std::is_base_of, std::enable_if
+#include <type_traits>  //  std::forward, std::is_base_of, std::enable_if, std::is_constant_evaluated
 #include <memory>  //  std::unique_ptr
 #include <vector>  //  std::vector
 #include <optional>  //  std::optional
@@ -9737,6 +9738,13 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
                                             X,
                                             internal::literal_holder<double>>
     likelihood(X x, double probability) {
+#if __cpp_lib_is_constant_evaluated >= 201811L
+        //  a probability outside [0.0, 1.0] makes SQLite reject the statement at prepare time;
+        //  when the call is constant-evaluated the error surfaces right here, at compile time
+        if (std::is_constant_evaluated() && !(probability >= 0.0 && probability <= 1.0)) {
+            throw std::domain_error("likelihood() probability must be a constant between 0.0 and 1.0");
+        }
+#endif
         return {std::tuple<X, internal::literal_holder<double>>{std::forward<X>(x), {probability}}};
     }
 

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -347,6 +347,10 @@ using std::nullptr_t;
 #define SQLITE_ORM_CONSTEVAL constexpr
 #endif
 
+#if __cpp_lib_is_constant_evaluated >= 201811L
+#define SQLITE_ORM_CPP20_IS_CONSTANT_EVALUATED_SUPPORTED
+#endif
+
 #if defined(SQLITE_ORM_CONCEPTS_SUPPORTED) && __cpp_lib_concepts >= 202002L
 #define SQLITE_ORM_CPP20_CONCEPTS_SUPPORTED
 #endif
@@ -9738,7 +9742,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
                                             X,
                                             internal::literal_holder<double>>
     likelihood(X x, double probability) {
-#if __cpp_lib_is_constant_evaluated >= 201811L
+#ifdef SQLITE_ORM_CPP20_IS_CONSTANT_EVALUATED_SUPPORTED
         //  a probability outside [0.0, 1.0] makes SQLite reject the statement at prepare time;
         //  when the call is constant-evaluated the error surfaces right here, at compile time
         if (std::is_constant_evaluated() && !(probability >= 0.0 && probability <= 1.0)) {

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -8006,11 +8006,17 @@ namespace sqlite_orm::internal {
     };
 
 #if SQLITE_VERSION_NUMBER >= 3008001
-    //  tag only; the serialization lives in the statement serializer
-    struct likelihood_t {};
+    struct likelihood_string {
+        std::string_view serialize() const {
+            return "LIKELIHOOD";
+        }
+    };
 
-    //  tag only; the serialization lives in the statement serializer
-    struct unlikely_t {};
+    struct unlikely_string {
+        std::string_view serialize() const {
+            return "UNLIKELY";
+        }
+    };
 #endif
 
 #if SQLITE_VERSION_NUMBER >= 3008003
@@ -8022,8 +8028,11 @@ namespace sqlite_orm::internal {
 #endif
 
 #if SQLITE_VERSION_NUMBER >= 3008006
-    //  tag only; the serialization lives in the statement serializer
-    struct likely_t {};
+    struct likely_string {
+        std::string_view serialize() const {
+            return "LIKELY";
+        }
+    };
 #endif
 
 #if SQLITE_VERSION_NUMBER >= 3032000
@@ -9748,7 +9757,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     template<class X>
     constexpr internal::built_in_function_t<internal::field_type_or_type_t<X>,
-                                            internal::likelihood_t,
+                                            internal::likelihood_string,
                                             X,
                                             internal::literal_holder<double>>
     likelihood(X x, double probability) {
@@ -9766,7 +9775,8 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  UNLIKELY(X) function https://www.sqlite.org/lang_corefunc.html#unlikely
      */
     template<class X>
-    constexpr internal::built_in_function_t<internal::field_type_or_type_t<X>, internal::unlikely_t, X> unlikely(X x) {
+    constexpr internal::built_in_function_t<internal::field_type_or_type_t<X>, internal::unlikely_string, X>
+    unlikely(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 #endif
@@ -9786,7 +9796,7 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      *  LIKELY(X) function https://www.sqlite.org/lang_corefunc.html#likely
      */
     template<class X>
-    constexpr internal::built_in_function_t<internal::field_type_or_type_t<X>, internal::likely_t, X> likely(X x) {
+    constexpr internal::built_in_function_t<internal::field_type_or_type_t<X>, internal::likely_string, X> likely(X x) {
         return {std::tuple<X>{std::forward<X>(x)}};
     }
 #endif
@@ -23226,49 +23236,6 @@ namespace sqlite_orm::internal {
     template<class R, class S, class... Args>
     struct statement_serializer<built_in_aggregate_function_t<R, S, Args...>, void>
         : statement_serializer<built_in_function_t<R, S, Args...>, void> {};
-
-#if SQLITE_VERSION_NUMBER >= 3008001
-    template<class R, class... Args>
-    struct statement_serializer<built_in_function_t<R, likelihood_t, Args...>, void> {
-        using statement_type = built_in_function_t<R, likelihood_t, Args...>;
-
-        template<class Ctx>
-        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
-                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
-            std::stringstream ss;
-            ss << "LIKELIHOOD(" << streaming_expressions_tuple(statement.args, context) << ")";
-            return ss.str();
-        }
-    };
-
-    template<class R, class... Args>
-    struct statement_serializer<built_in_function_t<R, unlikely_t, Args...>, void> {
-        using statement_type = built_in_function_t<R, unlikely_t, Args...>;
-
-        template<class Ctx>
-        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
-                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
-            std::stringstream ss;
-            ss << "UNLIKELY(" << streaming_expressions_tuple(statement.args, context) << ")";
-            return ss.str();
-        }
-    };
-#endif
-
-#if SQLITE_VERSION_NUMBER >= 3008006
-    template<class R, class... Args>
-    struct statement_serializer<built_in_function_t<R, likely_t, Args...>, void> {
-        using statement_type = built_in_function_t<R, likely_t, Args...>;
-
-        template<class Ctx>
-        SQLITE_ORM_STATIC_CALLOP std::string operator()(const statement_type& statement,
-                                                        const Ctx& context) SQLITE_ORM_OR_CONST_CALLOP {
-            std::stringstream ss;
-            ss << "LIKELY(" << streaming_expressions_tuple(statement.args, context) << ")";
-            return ss.str();
-        }
-    };
-#endif
 
     template<class F, class... CallArgs>
     struct statement_serializer<function_call<F, CallArgs...>, void> {

--- a/tests/built_in_functions_tests/core_functions_tests.cpp
+++ b/tests/built_in_functions_tests/core_functions_tests.cpp
@@ -1373,6 +1373,40 @@ TEST_CASE("iif") {
 }
 #endif
 
+#if SQLITE_VERSION_NUMBER >= 3008006
+TEST_CASE("planner hints") {
+    struct User {
+        int id = 0;
+    };
+    auto storage = make_storage("", make_table("users", make_column("id", &User::id, primary_key())));
+    storage.sync_schema();
+    storage.replace(User{7});
+
+    std::vector<int> rows;
+    decltype(rows) expected;
+    SECTION("likely") {
+        rows = storage.select(likely(&User::id));
+        expected = {7};
+    }
+    SECTION("unlikely") {
+        rows = storage.select(unlikely(&User::id));
+        expected = {7};
+    }
+    SECTION("likelihood") {
+        rows = storage.select(likelihood(&User::id, 0.9375));
+        expected = {7};
+    }
+    //  the probability is serialized as a literal while other values still bind:
+    //  SQLite rejects preparing a statement whose probability is a bound parameter
+    SECTION("likelihood in a prepared statement with bound parameters") {
+        auto statement = storage.prepare(select(likelihood(&User::id, 0.0625), where(c(&User::id) > 0)));
+        rows = storage.execute(statement);
+        expected = {7};
+    }
+    REQUIRE(rows == expected);
+}
+#endif
+
 #if SQLITE_VERSION_NUMBER >= 3034000
 TEST_CASE("substring") {
     auto storage = make_storage({});

--- a/tests/statement_serializer_tests/core_functions.cpp
+++ b/tests/statement_serializer_tests/core_functions.cpp
@@ -431,6 +431,25 @@ TEST_CASE("statement_serializer newer core functions") {
         value = serialize(expression, context);
     }
 #endif
+#if SQLITE_VERSION_NUMBER >= 3008001
+    SECTION("LIKELIHOOD") {
+        auto expression = likelihood(20, 0.0625);
+        expected = "LIKELIHOOD(20, 0.0625)";
+        value = serialize(expression, context);
+    }
+    SECTION("UNLIKELY") {
+        auto expression = unlikely(20);
+        expected = "UNLIKELY(20)";
+        value = serialize(expression, context);
+    }
+#endif
+#if SQLITE_VERSION_NUMBER >= 3008006
+    SECTION("LIKELY") {
+        auto expression = likely(20);
+        expected = "LIKELY(20)";
+        value = serialize(expression, context);
+    }
+#endif
 #if SQLITE_VERSION_NUMBER >= 3035000
     SECTION("SIGN") {
         auto expression = sign(-3);

--- a/tests/statement_serializer_tests/core_functions.cpp
+++ b/tests/statement_serializer_tests/core_functions.cpp
@@ -433,7 +433,8 @@ TEST_CASE("statement_serializer newer core functions") {
 #endif
 #if SQLITE_VERSION_NUMBER >= 3008001
     SECTION("LIKELIHOOD") {
-        auto expression = likelihood(20, 0.0625);
+        //  constexpr: an out-of-range probability would fail right here, at compile time
+        constexpr auto expression = likelihood(20, 0.0625);
         expected = "LIKELIHOOD(20, 0.0625)";
         value = serialize(expression, context);
     }


### PR DESCRIPTION
Second S-tier item of the feature-design pass: `likely()` (3.8.6), `unlikely()` and `likelihood()` (3.8.1), gated accordingly. All three pass their argument through unchanged, so the wrappers return `field_type_or_type_t` of the argument (the `iif()` mechanism).

The subtle part is binding, verified against the C API first: SQLite requires the second argument of `likelihood()` to be a floating point *constant* between 0.0 and 1.0 — preparing `SELECT likelihood(a, ?)` fails outright. The factory therefore takes a `double` and stores it in a `literal_holder`, which serializes inline and never binds; a prepared-statement test with a bound `WHERE` value next to the literal probability pins the behavior.

Serializer tests, runtime tests (single closing assertion over sections) and examples included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)