### PR TITLE
Fix compilation with msvc v141 and v142, and extend CI to the older toolsets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,12 +53,24 @@ jobs:
             cxx_standard: "-DSQLITE_ORM_ENABLE_CXX_20=ON"
             triplet: x86-windows
 
-          # - name: "VS 2019, x64, C++17"
-          #   os: windows-2019
-          #   platform: x64
-          #   arch: x64
-          #   cxx_standard: "-DSQLITE_ORM_ENABLE_CXX_17=ON"
-          #   triplet: x64-windows
+          # The windows-2019 runner image was retired on 2025-06-30, so the VS 2019 toolset is exercised
+          # through the v142 component of the VS 2022 image instead. The overlay triplet makes vcpkg
+          # build the dependencies with v142 as well.
+          - name: "VS 2019 toolset, x64, C++17"
+            os: windows-2022
+            platform: x64
+            arch: x64
+            toolset: v142
+            cxx_standard: "-DSQLITE_ORM_ENABLE_CXX_17=ON"
+            triplet: x64-windows-v142
+
+          - name: "VS 2019 toolset, x64, C++20"
+            os: windows-2022
+            platform: x64
+            arch: x64
+            toolset: v142
+            cxx_standard: "-DSQLITE_ORM_ENABLE_CXX_20=ON"
+            triplet: x64-windows-v142
 
     name: Windows - ${{ matrix.name }}
 
@@ -74,11 +86,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          vcpkg install sqlite3[core,dbstat,math,json1,fts5,rtree,soundex] catch2 --triplet ${{ matrix.triplet }}
+          vcpkg install sqlite3[core,dbstat,math,json1,fts5,rtree,soundex] catch2 --triplet ${{ matrix.triplet }} --overlay-triplets=${{ github.workspace }}/vcpkg/triplets
 
       - name: Configure CMake
         run: |
-          cmake -S . -B build -A ${{ matrix.arch }} ${{ matrix.cxx_standard }} -DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }} -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake
+          cmake -S . -B build -A ${{ matrix.arch }} ${{ matrix.toolset && format('-T {0}', matrix.toolset) || '' }} ${{ matrix.cxx_standard }} -DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }} -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake
 
       - name: Build
         run: cmake --build build --config Release --parallel

--- a/.github/workflows/experimental-vs2017.yaml
+++ b/.github/workflows/experimental-vs2017.yaml
@@ -1,0 +1,115 @@
+name: Experimental - VS 2017 (v141)
+
+# The GitHub-hosted Windows images carry only the v143 and v142 toolsets. v141 was dropped when the
+# multi-version build tools were removed in May 2024, and actions/runner-images#12764 reports that adding
+# `Microsoft.VisualStudio.Component.VC.v141.x86.x64` to the installed VS 2022 fails with
+# "Toolset directory for version '14.16' was not found".
+#
+# This workflow probes whether the standalone VS 2017 Build Tools bootstrapper still yields a usable v141
+# on the current image. It cannot fail the run, so the answer can be gathered without putting the CI matrix
+# at risk. The steps are deliberately fine-grained, so that a failure says which part gave out: the
+# installer, the toolset layout, vcpkg's VS 2017 discovery, or the compile itself.
+#
+# Outcome so far: green on windows-2022 in roughly 9 minutes, with the toolset check confirming 14.16, so
+# both of the doubtful parts hold up -- vcpkg does discover a standalone Build Tools instance, and Catch2
+# builds under v141.
+#
+# TODO(release): decide what to do with this file before the release goes out.
+#   a. Keep it as its own workflow, or promote it into ci.yaml as a job of its own. It does not fit the
+#      Windows matrix, because the install, toolset assertion and overlay triplet steps are needed for this
+#      entry alone.
+#   b. Decide whether to drop `continue-on-error`. Nothing else in CI covers v141, so today a regression
+#      against it shows up as a red job that blocks nothing. Against making it gate: the job downloads a
+#      legacy installer from aka.ms, so an upstream change would redden CI for reasons unrelated to the code.
+# Caching the toolset was considered and rejected: restoring only the install directory leaves out the
+# registry and installer state that `vswhere` reads, which is what vcpkg needs to find the toolset at all.
+
+on:
+  # `workflow_dispatch` is only offered for workflows that already live on the default branch, which is
+  # master, while pull requests here target dev -- so the manual button does not appear when the PR lands,
+  # only once this file reaches master. Until then `pull_request` is what exercises the probe. The triggers
+  # otherwise mirror ci.yaml's cadence.
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: [dev, master]
+
+env:
+  VCPKG_COMMIT: 4334d8b4c8916018600212ab4dd4bbdc343065d1  # 2025.09.17
+  VS2017_PATH: C:\BuildTools2017
+
+jobs:
+  vs2017:
+    name: VS 2017 (v141), x64, C++17
+    runs-on: windows-2022
+    # never fail the run; this workflow exists to answer a question, not to gate anything
+    continue-on-error: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install VS 2017 Build Tools
+        shell: pwsh
+        run: |
+          Invoke-WebRequest -Uri https://aka.ms/vs/15/release/vs_buildtools.exe -OutFile vs_buildtools.exe
+          $proc = Start-Process -Wait -PassThru -FilePath .\vs_buildtools.exe -ArgumentList @(
+            '--quiet', '--wait', '--norestart', '--nocache',
+            '--installPath', $env:VS2017_PATH,
+            '--add', 'Microsoft.VisualStudio.Workload.VCTools',
+            '--add', 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
+            # VS 2017's vcvars does not recognise the newer SDKs already on the image
+            '--add', 'Microsoft.VisualStudio.Component.Windows10SDK.17763'
+          )
+          Write-Host "installer exit code: $($proc.ExitCode)"
+          # 0 = success, 3010 = success with a reboot pending; anything else is a real failure
+          if ($proc.ExitCode -notin 0, 3010) { exit $proc.ExitCode }
+
+      - name: Report the installed toolset
+        shell: pwsh
+        run: |
+          $root = Join-Path $env:VS2017_PATH 'VC\Tools\MSVC'
+          if (-not (Test-Path $root)) { throw "no MSVC toolset directory under $root" }
+          $version = (Get-ChildItem $root | Sort-Object Name | Select-Object -Last 1).Name
+          Write-Host "toolset: $version"
+          & (Join-Path $root "$version\bin\Hostx64\x64\cl.exe") 2>&1 | Select-Object -First 1
+          # 14.16.x is what v141 should report; anything else means we did not get what we asked for
+          if (-not $version.StartsWith('14.16')) { throw "expected a 14.16 toolset, got $version" }
+
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgGitCommitId: ${{ env.VCPKG_COMMIT }}
+          vcpkgDirectory: ${{ runner.temp }}/vcpkg
+
+      - name: Write the v141 overlay triplet
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path .vcpkg-triplets | Out-Null
+          @'
+          set(VCPKG_TARGET_ARCHITECTURE x64)
+          set(VCPKG_CRT_LINKAGE dynamic)
+          set(VCPKG_LIBRARY_LINKAGE dynamic)
+          set(VCPKG_PLATFORM_TOOLSET v141)
+          '@ | Set-Content .vcpkg-triplets/x64-windows-v141.cmake
+          Get-Content .vcpkg-triplets/x64-windows-v141.cmake
+
+      - name: Install dependencies
+        shell: pwsh
+        run: |
+          # whether vcpkg discovers the standalone Build Tools instance is itself part of the experiment
+          vcpkg install sqlite3[core,dbstat,math,json1,fts5,rtree,soundex] catch2 `
+            --triplet x64-windows-v141 --overlay-triplets=${{ github.workspace }}/.vcpkg-triplets
+
+      - name: Build and test
+        shell: cmd
+        run: |
+          where ninja || choco install ninja -y --no-progress
+          call "%VS2017_PATH%\VC\Auxiliary\Build\vcvars64.bat" || exit /b 1
+          cl 2>&1 | findstr /C:"Version"
+          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release ^
+            -DSQLITE_ORM_ENABLE_CXX_17=ON ^
+            -DVCPKG_TARGET_TRIPLET=x64-windows-v141 ^
+            -DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake || exit /b 1
+          cmake --build build --parallel || exit /b 1
+          ctest --test-dir build --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,10 +95,9 @@ if (MSVC)
         add_compile_definitions(_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING)
     endif()
 
-    if ("${CMAKE_GENERATOR}" MATCHES "(Win64|x64)")
-        message(STATUS "Add /bigobj flag to compiler")
-        add_compile_options(/bigobj)
-    endif()
+    # note: some translation units exceed the object file section limit without `/bigobj`;
+    # this is independent of the target architecture
+    add_compile_options(/bigobj)
 endif()
 
 ucm_print_flags()

--- a/dev/functional/cxx_compiler_quirks.h
+++ b/dev/functional/cxx_compiler_quirks.h
@@ -66,6 +66,16 @@
 #define SQLITE_ORM_BROKEN_ALIAS_TEMPLATE_DEPENDENT_EXPR_SFINAE
 #endif
 
+// msvc 16.11 in C++20 mode fails to look up a type alias declared in an enclosing lambda if the use site is
+// inside a lambda nested in that lambda; a single lambda level is fine.
+// Depending on the complexity of the translation unit this surfaces either as C2653, or as an internal compiler
+// error reported at the end of the translation unit without a source location.
+// Remedy: redeclare the alias in the generic lambda that uses it.
+// Verified broken with 19.29, verified fixed with 19.44 and 19.51; the versions in between were not tested.
+#if defined(SQLITE_ORM_MS_MSVC) && (_MSC_VER < 1944)
+#define SQLITE_ORM_BROKEN_NESTED_LAMBDA_SCOPE_LOOKUP
+#endif
+
 // overwrite SQLITE_ORM_CLASSTYPE_TEMPLATE_ARGS_SUPPORTED
 #if (__cpp_nontype_template_args < 201911L) &&                                                                         \
     (defined(__clang__) && (__clang_major__ >= 12) && (__cplusplus >= 202002L))

--- a/dev/serializing_util.h
+++ b/dev/serializing_util.h
@@ -433,7 +433,7 @@ namespace sqlite_orm::internal {
         std::tuple<const streaming<stream_as::column_constraints>&, const column_constraints<Op...>&, const bool&, Ctx>
             tpl) {
         const auto& column = std::get<1>(tpl);
-        const bool& isNotNull = std::get<2>(tpl);
+        [[maybe_unused]] const bool& isNotNull = std::get<2>(tpl);
         auto& context = std::get<3>(tpl);
 
         using constraints_tuple = decltype(column.constraints);

--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -551,10 +551,16 @@ namespace sqlite_orm::internal {
 
     template<class Tuple, class Ctx>
     void serialize_over_arguments(std::stringstream& ss, const Tuple& arguments, const Ctx& context) {
-        if constexpr (std::tuple_size<Tuple>::value == 0) {
+        if constexpr (std::tuple_size_v<Tuple> == 0) {
             ss << " OVER ()";
-        } else if constexpr (std::tuple_size<Tuple>::value == 1 && is_window_ref_v<std::tuple_element_t<0, Tuple>>) {
-            ss << " OVER " << std::get<0>(arguments).name;
+        } else if constexpr (std::tuple_size_v<Tuple> == 1 && is_window_ref_v<std::tuple_element_t<0, Tuple>>) {
+            //  note: msvc 141 resolves a `std::get<0>` at parse time, even here in a branch it has already ruled
+            //  out for an empty argument tuple, and forming that call trips the "tuple index out of bounds"
+            //  static_assert in `std::tuple_element`. Hoisting the index into a constexpr value defers the call
+            //  to instantiation time; the same remedy as b. of SQLITE_ORM_BROKEN_ALIAS_TEMPLATE_DEPENDENT_NTTP_EXPR,
+            //  although that quirk is about alias templates rather than calls.
+            constexpr size_t windowRefIndex = 0;
+            ss << " OVER " << std::get<windowRefIndex>(arguments).name;
         } else {
             ss << " OVER (" << streaming_actions_tuple(arguments, context) << ")";
         }

--- a/dev/statement_serializer.h
+++ b/dev/statement_serializer.h
@@ -550,7 +550,9 @@ namespace sqlite_orm::internal {
     };
 
     template<class Tuple, class Ctx>
-    void serialize_over_arguments(std::stringstream& ss, const Tuple& arguments, const Ctx& context) {
+    void serialize_over_arguments(std::stringstream& ss,
+                                  [[maybe_unused]] const Tuple& arguments,
+                                  [[maybe_unused]] const Ctx& context) {
         if constexpr (std::tuple_size_v<Tuple> == 0) {
             ss << " OVER ()";
         } else if constexpr (std::tuple_size_v<Tuple> == 1 && is_window_ref_v<std::tuple_element_t<0, Tuple>>) {

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -1679,6 +1679,10 @@ namespace sqlite_orm::internal {
 
                 table.template for_each_column_excluding<mpl::disjunction<is_pkcolumn_q, is_generated_always_q>>(
                     [&table, &bindValue, &object](auto& column) {
+                        // note: msvc 16.11 in C++20 mode fails to look up `table_type` from a lambda nested inside
+                        // another lambda; a single lambda level is fine, which is why the same pattern in the
+                        // statement serializers is unaffected
+                        using table_type = polyfill::remove_cvref_t<decltype(table)>;
                         if (!table_type::is_without_rowid::value &&
                             (is_single_table_primary_key(table, column) ||
                              (column.template is<is_default>() && table_primary_key_contains(table, column)))) {

--- a/dev/storage.h
+++ b/dev/storage.h
@@ -1679,10 +1679,9 @@ namespace sqlite_orm::internal {
 
                 table.template for_each_column_excluding<mpl::disjunction<is_pkcolumn_q, is_generated_always_q>>(
                     [&table, &bindValue, &object](auto& column) {
-                        // note: msvc 16.11 in C++20 mode fails to look up `table_type` from a lambda nested inside
-                        // another lambda; a single lambda level is fine, which is why the same pattern in the
-                        // statement serializers is unaffected
+#ifdef SQLITE_ORM_BROKEN_NESTED_LAMBDA_SCOPE_LOOKUP
                         using table_type = polyfill::remove_cvref_t<decltype(table)>;
+#endif
                         if (!table_type::is_without_rowid::value &&
                             (is_single_table_primary_key(table, column) ||
                              (column.template is<is_default>() && table_primary_key_contains(table, column)))) {

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -27762,6 +27762,10 @@ namespace sqlite_orm::internal {
 
                 table.template for_each_column_excluding<mpl::disjunction<is_pkcolumn_q, is_generated_always_q>>(
                     [&table, &bindValue, &object](auto& column) {
+                        // note: msvc 16.11 in C++20 mode fails to look up `table_type` from a lambda nested inside
+                        // another lambda; a single lambda level is fine, which is why the same pattern in the
+                        // statement serializers is unaffected
+                        using table_type = polyfill::remove_cvref_t<decltype(table)>;
                         if (!table_type::is_without_rowid::value &&
                             (is_single_table_primary_key(table, column) ||
                              (column.template is<is_default>() && table_primary_key_contains(table, column)))) {

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -22947,10 +22947,16 @@ namespace sqlite_orm::internal {
 
     template<class Tuple, class Ctx>
     void serialize_over_arguments(std::stringstream& ss, const Tuple& arguments, const Ctx& context) {
-        if constexpr (std::tuple_size<Tuple>::value == 0) {
+        if constexpr (std::tuple_size_v<Tuple> == 0) {
             ss << " OVER ()";
-        } else if constexpr (std::tuple_size<Tuple>::value == 1 && is_window_ref_v<std::tuple_element_t<0, Tuple>>) {
-            ss << " OVER " << std::get<0>(arguments).name;
+        } else if constexpr (std::tuple_size_v<Tuple> == 1 && is_window_ref_v<std::tuple_element_t<0, Tuple>>) {
+            //  note: msvc 141 resolves a `std::get<0>` at parse time, even here in a branch it has already ruled
+            //  out for an empty argument tuple, and forming that call trips the "tuple index out of bounds"
+            //  static_assert in `std::tuple_element`. Hoisting the index into a constexpr value defers the call
+            //  to instantiation time; the same remedy as b. of SQLITE_ORM_BROKEN_ALIAS_TEMPLATE_DEPENDENT_NTTP_EXPR,
+            //  although that quirk is about alias templates rather than calls.
+            constexpr size_t windowRefIndex = 0;
+            ss << " OVER " << std::get<windowRefIndex>(arguments).name;
         } else {
             ss << " OVER (" << streaming_actions_tuple(arguments, context) << ")";
         }

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -236,6 +236,16 @@ using std::nullptr_t;
 #define SQLITE_ORM_BROKEN_ALIAS_TEMPLATE_DEPENDENT_EXPR_SFINAE
 #endif
 
+// msvc 16.11 in C++20 mode fails to look up a type alias declared in an enclosing lambda if the use site is
+// inside a lambda nested in that lambda; a single lambda level is fine.
+// Depending on the complexity of the translation unit this surfaces either as C2653, or as an internal compiler
+// error reported at the end of the translation unit without a source location.
+// Remedy: redeclare the alias in the generic lambda that uses it.
+// Verified broken with 19.29, verified fixed with 19.44 and 19.51; the versions in between were not tested.
+#if defined(SQLITE_ORM_MS_MSVC) && (_MSC_VER < 1944)
+#define SQLITE_ORM_BROKEN_NESTED_LAMBDA_SCOPE_LOOKUP
+#endif
+
 // overwrite SQLITE_ORM_CLASSTYPE_TEMPLATE_ARGS_SUPPORTED
 #if (__cpp_nontype_template_args < 201911L) &&                                                                         \
     (defined(__clang__) && (__clang_major__ >= 12) && (__cplusplus >= 202002L))
@@ -27762,10 +27772,9 @@ namespace sqlite_orm::internal {
 
                 table.template for_each_column_excluding<mpl::disjunction<is_pkcolumn_q, is_generated_always_q>>(
                     [&table, &bindValue, &object](auto& column) {
-                        // note: msvc 16.11 in C++20 mode fails to look up `table_type` from a lambda nested inside
-                        // another lambda; a single lambda level is fine, which is why the same pattern in the
-                        // statement serializers is unaffected
+#ifdef SQLITE_ORM_BROKEN_NESTED_LAMBDA_SCOPE_LOOKUP
                         using table_type = polyfill::remove_cvref_t<decltype(table)>;
+#endif
                         if (!table_type::is_without_rowid::value &&
                             (is_single_table_primary_key(table, column) ||
                              (column.template is<is_default>() && table_primary_key_contains(table, column)))) {

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -18733,7 +18733,7 @@ namespace sqlite_orm::internal {
         std::tuple<const streaming<stream_as::column_constraints>&, const column_constraints<Op...>&, const bool&, Ctx>
             tpl) {
         const auto& column = std::get<1>(tpl);
-        const bool& isNotNull = std::get<2>(tpl);
+        [[maybe_unused]] const bool& isNotNull = std::get<2>(tpl);
         auto& context = std::get<3>(tpl);
 
         using constraints_tuple = decltype(column.constraints);
@@ -22946,7 +22946,9 @@ namespace sqlite_orm::internal {
     };
 
     template<class Tuple, class Ctx>
-    void serialize_over_arguments(std::stringstream& ss, const Tuple& arguments, const Ctx& context) {
+    void serialize_over_arguments(std::stringstream& ss,
+                                  [[maybe_unused]] const Tuple& arguments,
+                                  [[maybe_unused]] const Ctx& context) {
         if constexpr (std::tuple_size_v<Tuple> == 0) {
             ss << " OVER ()";
         } else if constexpr (std::tuple_size_v<Tuple> == 1 && is_window_ref_v<std::tuple_element_t<0, Tuple>>) {

--- a/vcpkg/triplets/x64-windows-v142.cmake
+++ b/vcpkg/triplets/x64-windows-v142.cmake
@@ -1,0 +1,8 @@
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+
+# Build the dependencies with the VS 2019 toolset, so that they are compiled against the same
+# standard library as sqlite_orm itself. Consuming v143 binaries from a v142 build is not covered
+# by the binary compatibility guarantee, which only extends from older toolsets to newer ones.
+set(VCPKG_PLATFORM_TOOLSET v142)


### PR DESCRIPTION
# Description

Two unrelated compiler quirks kept older MSVC toolsets from building the test suite. Both are worked around
at a small surface and marked so they can be removed when the baseline rises.

## msvc 142 (19.29), C++20

A `table_type` alias declared in an enclosing lambda and used from a nested *generic* lambda is not found.
The suite produced 43 internal compiler errors, 42 of them reported at EOF with no source context, which is
what made them expensive to locate. Reduced, it degrades to a plain
`C2653: 'table_type': is not a class or namespace name`.

Fixed by redeclaring the alias inside the generic lambda that uses it, guarded by
`SQLITE_ORM_BROKEN_NESTED_LAMBDA_SCOPE_LOOKUP`. Side-note: `/Zc:lambda-` is not an option as the old lambda processor
cannot parse the C++20 `<format>` header (`C3260`). Fixed in 19.44 and 19.51, and reported to Developer
Community.

## msvc 141 (19.16), C++17

`tests/window_function_tests.cpp` was the only translation unit that would not compile
(`C2338: tuple index out of bounds`). `count(...).over()` is the only place that serializes an `over_t` with
an empty argument tuple. `std::get<0>` has no dependent template arguments, so the call is resolved at parse
time even in the `else if constexpr` branch already ruled out for an empty tuple, and forming it instantiates
`std::tuple_element<0, std::tuple<>>`.

Hoisting the index into a `constexpr` value defers the call to instantiation time — the same remedy as b. of
`SQLITE_ORM_BROKEN_ALIAS_TEMPLATE_DEPENDENT_NTTP_EXPR`, and the same shape as b7e73f61 for clang.
Discarded branches are otherwise handled correctly, which is why `determine_cte_colref()` and friends were
never affected.

## `/bigobj`

Guarded by a match on the generator *name*, so it missed `-G "Visual Studio 17 2022" -A x64`, where the
architecture lives in `CMAKE_GENERATOR_PLATFORM`, as well as Ninja and NMake. Now unconditional under MSVC.

## CI

* **VS 2019 added to the matrix**, through the v142 component of `windows-2022` — the `windows-2019` image
  was retired on 2025-06-30, so the disabled entry could not have been enabled as written. C++17 and C++20;
  C++20 is what guards the nested lambda workaround. The `x64-windows-v142` overlay triplet builds the
  dependencies with v142 as well, since MSVC's binary compatibility runs from older toolsets to newer ones,
  not the other way round.
* **An experimental v141 probe** in its own workflow, installing the standalone VS 2017 Build Tools, since
  v141 is on no hosted image and adding it to the installed VS 2022 fails (actions/runner-images#12764).
  It works — green on `windows-2022` in about nine minutes. `continue-on-error`, with the open decisions
  recorded as a `TODO(release)` block in the file.

## Notes for reviewers

* `constexpr size_t windowRefIndex = 0;` is not redundant. Respelling it `std::get<0>` breaks 14.16, and
  nothing in CI would catch it: the new job is v142, and the v141 probe cannot gate.
* The `SQLITE_ORM_BROKEN_NESTED_LAMBDA_SCOPE_LOOKUP` bound is deliberately conservative. 19.29 is verified
  broken and 19.44 and 19.51 verified fixed, but the versions in between were not tested.
