### PR TITLE
Add the introspection function wrappers

### DIFF
--- a/dev/core_functions.h
+++ b/dev/core_functions.h
@@ -212,6 +212,40 @@ namespace sqlite_orm::internal {
 
 #endif
 
+    struct sqlite_version_string {
+        std::string_view serialize() const {
+            return "SQLITE_VERSION";
+        }
+    };
+
+    struct sqlite_source_id_string {
+        std::string_view serialize() const {
+            return "SQLITE_SOURCE_ID";
+        }
+    };
+
+#ifndef SQLITE_OMIT_COMPILEOPTION_DIAGS
+    struct sqlite_compileoption_used_string {
+        std::string_view serialize() const {
+            return "SQLITE_COMPILEOPTION_USED";
+        }
+    };
+
+    struct sqlite_compileoption_get_string {
+        std::string_view serialize() const {
+            return "SQLITE_COMPILEOPTION_GET";
+        }
+    };
+#endif
+
+#ifdef SQLITE_ENABLE_OFFSET_SQL_FUNC
+    struct sqlite_offset_string {
+        std::string_view serialize() const {
+            return "SQLITE_OFFSET";
+        }
+    };
+#endif
+
     struct coalesce_string {
         std::string_view serialize() const {
             return "COALESCE";
@@ -1843,6 +1877,55 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     constexpr internal::built_in_function_t<int, internal::random_string> random() {
         return {{}};
+    }
+#endif
+
+    /**
+     *  SQLITE_VERSION() function https://www.sqlite.org/lang_corefunc.html#sqlite_version
+     */
+    constexpr internal::built_in_function_t<std::string, internal::sqlite_version_string> sqlite_version() {
+        return {{}};
+    }
+
+    /**
+     *  SQLITE_SOURCE_ID() function https://www.sqlite.org/lang_corefunc.html#sqlite_source_id
+     */
+    constexpr internal::built_in_function_t<std::string, internal::sqlite_source_id_string> sqlite_source_id() {
+        return {{}};
+    }
+
+#ifndef SQLITE_OMIT_COMPILEOPTION_DIAGS
+    /**
+     *  SQLITE_COMPILEOPTION_USED(X) function https://www.sqlite.org/lang_corefunc.html#sqlite_compileoption_used
+     */
+    template<class X>
+    constexpr internal::built_in_function_t<int, internal::sqlite_compileoption_used_string, X>
+    sqlite_compileoption_used(X option) {
+        return {std::tuple<X>{std::forward<X>(option)}};
+    }
+
+    /**
+     *  SQLITE_COMPILEOPTION_GET(N) function https://www.sqlite.org/lang_corefunc.html#sqlite_compileoption_get
+     */
+    template<class N>
+    constexpr internal::built_in_function_t<std::unique_ptr<std::string>, internal::sqlite_compileoption_get_string, N>
+    sqlite_compileoption_get(N n) {
+        return {std::tuple<N>{std::forward<N>(n)}};
+    }
+#endif
+
+#ifdef SQLITE_ENABLE_OFFSET_SQL_FUNC
+    /**
+     *  SQLITE_OFFSET(X) function https://www.sqlite.org/lang_corefunc.html#sqlite_offset
+     *
+     *  Only available if the linked SQLite is compiled with SQLITE_ENABLE_OFFSET_SQL_FUNC.
+     */
+    template<class C>
+    constexpr internal::built_in_function_t<std::unique_ptr<int64>, internal::sqlite_offset_string, C>
+    sqlite_offset(C column) {
+        static_assert(polyfill::disjunction<std::is_member_pointer<C>, internal::is_column_pointer<C>>::value,
+                      "sqlite_offset() argument must be a column");
+        return {std::tuple<C>{std::forward<C>(column)}};
     }
 #endif
 

--- a/examples/core_functions.cpp
+++ b/examples/core_functions.cpp
@@ -1099,6 +1099,15 @@ int main(int, char** argv) {
     cout << "likelihood(42, 0.0625) = " << storage.select(likelihood(42, 0.0625)).front() << endl;
 #endif
 
+    //  SELECT sqlite_version();
+    cout << "sqlite_version() = " << storage.select(sqlite_version()).front() << endl;
+
+#ifndef SQLITE_OMIT_COMPILEOPTION_DIAGS
+    //  SELECT sqlite_compileoption_used('THREADSAFE');
+    cout << "sqlite_compileoption_used('THREADSAFE') = "
+         << storage.select(sqlite_compileoption_used("THREADSAFE")).front() << endl;
+#endif
+
     //  SELECT hex(67);
     cout << "hex(67) = " << storage.select(hex(67)).front() << endl;
 

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -7848,6 +7848,40 @@ namespace sqlite_orm::internal {
 
 #endif
 
+    struct sqlite_version_string {
+        std::string_view serialize() const {
+            return "SQLITE_VERSION";
+        }
+    };
+
+    struct sqlite_source_id_string {
+        std::string_view serialize() const {
+            return "SQLITE_SOURCE_ID";
+        }
+    };
+
+#ifndef SQLITE_OMIT_COMPILEOPTION_DIAGS
+    struct sqlite_compileoption_used_string {
+        std::string_view serialize() const {
+            return "SQLITE_COMPILEOPTION_USED";
+        }
+    };
+
+    struct sqlite_compileoption_get_string {
+        std::string_view serialize() const {
+            return "SQLITE_COMPILEOPTION_GET";
+        }
+    };
+#endif
+
+#ifdef SQLITE_ENABLE_OFFSET_SQL_FUNC
+    struct sqlite_offset_string {
+        std::string_view serialize() const {
+            return "SQLITE_OFFSET";
+        }
+    };
+#endif
+
     struct coalesce_string {
         std::string_view serialize() const {
             return "COALESCE";
@@ -9479,6 +9513,55 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
      */
     constexpr internal::built_in_function_t<int, internal::random_string> random() {
         return {{}};
+    }
+#endif
+
+    /**
+     *  SQLITE_VERSION() function https://www.sqlite.org/lang_corefunc.html#sqlite_version
+     */
+    constexpr internal::built_in_function_t<std::string, internal::sqlite_version_string> sqlite_version() {
+        return {{}};
+    }
+
+    /**
+     *  SQLITE_SOURCE_ID() function https://www.sqlite.org/lang_corefunc.html#sqlite_source_id
+     */
+    constexpr internal::built_in_function_t<std::string, internal::sqlite_source_id_string> sqlite_source_id() {
+        return {{}};
+    }
+
+#ifndef SQLITE_OMIT_COMPILEOPTION_DIAGS
+    /**
+     *  SQLITE_COMPILEOPTION_USED(X) function https://www.sqlite.org/lang_corefunc.html#sqlite_compileoption_used
+     */
+    template<class X>
+    constexpr internal::built_in_function_t<int, internal::sqlite_compileoption_used_string, X>
+    sqlite_compileoption_used(X option) {
+        return {std::tuple<X>{std::forward<X>(option)}};
+    }
+
+    /**
+     *  SQLITE_COMPILEOPTION_GET(N) function https://www.sqlite.org/lang_corefunc.html#sqlite_compileoption_get
+     */
+    template<class N>
+    constexpr internal::built_in_function_t<std::unique_ptr<std::string>, internal::sqlite_compileoption_get_string, N>
+    sqlite_compileoption_get(N n) {
+        return {std::tuple<N>{std::forward<N>(n)}};
+    }
+#endif
+
+#ifdef SQLITE_ENABLE_OFFSET_SQL_FUNC
+    /**
+     *  SQLITE_OFFSET(X) function https://www.sqlite.org/lang_corefunc.html#sqlite_offset
+     *
+     *  Only available if the linked SQLite is compiled with SQLITE_ENABLE_OFFSET_SQL_FUNC.
+     */
+    template<class C>
+    constexpr internal::built_in_function_t<std::unique_ptr<int64>, internal::sqlite_offset_string, C>
+    sqlite_offset(C column) {
+        static_assert(polyfill::disjunction<std::is_member_pointer<C>, internal::is_column_pointer<C>>::value,
+                      "sqlite_offset() argument must be a column");
+        return {std::tuple<C>{std::forward<C>(column)}};
     }
 #endif
 

--- a/tests/built_in_functions_tests/core_functions_tests.cpp
+++ b/tests/built_in_functions_tests/core_functions_tests.cpp
@@ -1373,6 +1373,53 @@ TEST_CASE("iif") {
 }
 #endif
 
+TEST_CASE("introspection functions") {
+    auto storage = make_storage({});
+    std::vector<std::string> rows;
+    decltype(rows) expected;
+    SECTION("sqlite_version") {
+        rows = storage.select(sqlite_version());
+        expected = {SQLITE_VERSION};
+    }
+    SECTION("sqlite_source_id") {
+        rows = storage.select(sqlite_source_id());
+        expected = {SQLITE_SOURCE_ID};
+    }
+    REQUIRE(rows == expected);
+}
+
+#ifndef SQLITE_OMIT_COMPILEOPTION_DIAGS
+TEST_CASE("sqlite_compileoption_used") {
+    auto storage = make_storage({});
+    //  THREADSAFE is always among the reported compile options
+    auto rows = storage.select(sqlite_compileoption_used("THREADSAFE"));
+    decltype(rows) expected{1};
+    REQUIRE(rows == expected);
+}
+
+TEST_CASE("sqlite_compileoption_get") {
+    auto storage = make_storage({});
+    //  an out-of-range index yields NULL
+    auto rows = storage.select(sqlite_compileoption_get(100000));
+    decltype(rows) expected{};
+    expected.push_back(nullptr);
+    REQUIRE(rows == expected);
+}
+#endif
+
+#ifdef SQLITE_ENABLE_OFFSET_SQL_FUNC
+TEST_CASE("sqlite_offset") {
+    struct User {
+        int id = 0;
+    };
+    auto storage = make_storage("", make_table("users", make_column("id", &User::id, primary_key())));
+    storage.sync_schema();
+    storage.replace(User{1});
+    auto rows = storage.select(sqlite_offset(&User::id));
+    REQUIRE(rows.size() == 1);
+}
+#endif
+
 #if SQLITE_VERSION_NUMBER >= 3008006
 TEST_CASE("planner hints") {
     struct User {

--- a/tests/statement_serializer_tests/core_functions.cpp
+++ b/tests/statement_serializer_tests/core_functions.cpp
@@ -431,6 +431,28 @@ TEST_CASE("statement_serializer newer core functions") {
         value = serialize(expression, context);
     }
 #endif
+    SECTION("SQLITE_VERSION") {
+        constexpr auto expression = sqlite_version();
+        expected = "SQLITE_VERSION()";
+        value = serialize(expression, context);
+    }
+    SECTION("SQLITE_SOURCE_ID") {
+        constexpr auto expression = sqlite_source_id();
+        expected = "SQLITE_SOURCE_ID()";
+        value = serialize(expression, context);
+    }
+#ifndef SQLITE_OMIT_COMPILEOPTION_DIAGS
+    SECTION("SQLITE_COMPILEOPTION_USED") {
+        constexpr auto expression = sqlite_compileoption_used("THREADSAFE");
+        expected = "SQLITE_COMPILEOPTION_USED('THREADSAFE')";
+        value = serialize(expression, context);
+    }
+    SECTION("SQLITE_COMPILEOPTION_GET") {
+        constexpr auto expression = sqlite_compileoption_get(1);
+        expected = "SQLITE_COMPILEOPTION_GET(1)";
+        value = serialize(expression, context);
+    }
+#endif
 #if SQLITE_VERSION_NUMBER >= 3008001
     SECTION("LIKELIHOOD") {
         //  constexpr: an out-of-range probability would fail right here, at compile time


### PR DESCRIPTION
Third S-tier item of the feature-design pass over TODO.md: `sqlite_version()`, `sqlite_source_id()`, `sqlite_compileoption_used()`, `sqlite_compileoption_get()` and `sqlite_offset()`.

- The compile-option functions are guarded by `#ifndef SQLITE_OMIT_COMPILEOPTION_DIAGS` — the define under which SQLite omits them.
- `sqlite_offset()` exists only when the linked SQLite is built with `SQLITE_ENABLE_OFFSET_SQL_FUNC` (probed: absent from stock builds), and takes only a column — member pointer or column pointer — which a static assert enforces; it returns a nullable `std::unique_ptr<int64>` since SQLite yields NULL for values not taken directly from the database file.
- `sqlite_compileoption_get()` returns `std::unique_ptr<std::string>` (NULL on an out-of-range index — pinned by a test).
- Runtime tests anchor on stable facts: `sqlite_version()` equals `SQLITE_VERSION`, THREADSAFE is always among the reported options.
- The `*_string` serialization convention per the review conclusion in #1513.

🤖 Generated with [Claude Code](https://claude.com/claude-code)