### PR TITLE
Add vacuum_into()

### DIFF
--- a/dev/storage_base.h
+++ b/dev/storage_base.h
@@ -248,9 +248,9 @@ namespace sqlite_orm::internal {
          *  into a new file, leaving the database itself untouched. The file must not exist yet.
          *  More info: https://www.sqlite.org/lang_vacuum.html#vacuuminto
          */
-        void vacuum_into(const std::string& filename) {
+        void vacuum_into(std::string_view filename) {
             std::stringstream ss;
-            ss << "VACUUM INTO " << quote_string_literal(filename) << std::flush;
+            ss << "VACUUM INTO " << quote_string_literal(std::string{filename}) << std::flush;
             auto connection = this->get_connection();
             this->executor.perform_void_exec(connection.get(), ss.str().c_str());
         }

--- a/dev/storage_base.h
+++ b/dev/storage_base.h
@@ -242,6 +242,20 @@ namespace sqlite_orm::internal {
             this->executor.perform_void_exec(connection.get(), "VACUUM");
         }
 
+#if SQLITE_VERSION_NUMBER >= 3027000
+        /**
+         *  `VACUUM INTO` query: writes a vacuumed, transactionally consistent copy of the database
+         *  into a new file, leaving the database itself untouched. The file must not exist yet.
+         *  More info: https://www.sqlite.org/lang_vacuum.html#vacuuminto
+         */
+        void vacuum_into(const std::string& filename) {
+            std::stringstream ss;
+            ss << "VACUUM INTO " << quote_string_literal(filename) << std::flush;
+            auto connection = this->get_connection();
+            this->executor.perform_void_exec(connection.get(), ss.str().c_str());
+        }
+#endif
+
         /**
          *  Checks whether table exists in db. Doesn't check storage itself - works only with actual database.
          *  Note: table can be not mapped to a storage

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -20325,9 +20325,9 @@ namespace sqlite_orm::internal {
          *  into a new file, leaving the database itself untouched. The file must not exist yet.
          *  More info: https://www.sqlite.org/lang_vacuum.html#vacuuminto
          */
-        void vacuum_into(const std::string& filename) {
+        void vacuum_into(std::string_view filename) {
             std::stringstream ss;
-            ss << "VACUUM INTO " << quote_string_literal(filename) << std::flush;
+            ss << "VACUUM INTO " << quote_string_literal(std::string{filename}) << std::flush;
             auto connection = this->get_connection();
             this->executor.perform_void_exec(connection.get(), ss.str().c_str());
         }

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -20319,6 +20319,20 @@ namespace sqlite_orm::internal {
             this->executor.perform_void_exec(connection.get(), "VACUUM");
         }
 
+#if SQLITE_VERSION_NUMBER >= 3027000
+        /**
+         *  `VACUUM INTO` query: writes a vacuumed, transactionally consistent copy of the database
+         *  into a new file, leaving the database itself untouched. The file must not exist yet.
+         *  More info: https://www.sqlite.org/lang_vacuum.html#vacuuminto
+         */
+        void vacuum_into(const std::string& filename) {
+            std::stringstream ss;
+            ss << "VACUUM INTO " << quote_string_literal(filename) << std::flush;
+            auto connection = this->get_connection();
+            this->executor.perform_void_exec(connection.get(), ss.str().c_str());
+        }
+#endif
+
         /**
          *  Checks whether table exists in db. Doesn't check storage itself - works only with actual database.
          *  Note: table can be not mapped to a storage

--- a/tests/storage_non_crud_tests.cpp
+++ b/tests/storage_non_crud_tests.cpp
@@ -2,6 +2,7 @@
 #include <sqlite_orm/sqlite_orm.h>
 #include <catch2/catch_all.hpp>
 #include <cstring>  //  std::strcmp
+#include <cstdio>  //  std::remove
 #include "catch_matchers.h"
 
 using namespace sqlite_orm;
@@ -766,3 +767,46 @@ TEST_CASE("Explicit insert") {
         }
     }
 }
+
+#if SQLITE_VERSION_NUMBER >= 3027000
+TEST_CASE("vacuum into") {
+    struct User {
+        int id = 0;
+        std::string name;
+    };
+    auto sourcePath = "vacuum_into_source.sqlite";
+    auto backupPath = "vacuum_into_backup.sqlite";
+    std::remove(sourcePath);
+    std::remove(backupPath);
+
+    auto makeTable = [] {
+        return make_table("users", make_column("id", &User::id, primary_key()), make_column("name", &User::name));
+    };
+    {
+        auto storage = make_storage(sourcePath, makeTable());
+        storage.sync_schema();
+        storage.replace(User{1, "Leony"});
+        storage.replace(User{2, "Ototo"});
+        storage.vacuum_into(backupPath);
+    }
+    auto backupStorage = make_storage(backupPath, makeTable());
+    auto rows = backupStorage.select(columns(&User::id, &User::name));
+    decltype(rows) expected{{1, "Leony"}, {2, "Ototo"}};
+    REQUIRE(rows == expected);
+    std::remove(sourcePath);
+    std::remove(backupPath);
+}
+
+TEST_CASE("vacuum into an existing file fails") {
+    struct User {
+        int id = 0;
+    };
+    auto sourcePath = "vacuum_into_occupied.sqlite";
+    std::remove(sourcePath);
+    auto storage = make_storage(sourcePath, make_table("users", make_column("id", &User::id, primary_key())));
+    storage.sync_schema();
+    //  the target must not exist yet; the database file itself surely does
+    REQUIRE_THROWS_AS(storage.vacuum_into(sourcePath), std::system_error);
+    std::remove(sourcePath);
+}
+#endif


### PR DESCRIPTION
Fourth S-tier item of the feature-design pass: `storage.vacuum_into(filename)` next to `vacuum()`, gated on SQLite 3.27.

`VACUUM INTO` writes a vacuumed, transactionally consistent copy of the database into a new file, leaving the database itself untouched — a one-statement compacted backup that complements the page-wise backup API (clone-as-is, incremental) with a rebuild-from-scratch copy (defragmented, smaller). The filename is quoted via `quote_string_literal`.

Tests: a roundtrip (populate → vacuum_into → open the copy → compare rows) and the error path (the target must not exist — vacuuming into an existing file throws).

🤖 Generated with [Claude Code](https://claude.com/claude-code)