### PR TITLE
Add analyze(), reindex() and reindex_expressions()

### DIFF
--- a/dev/storage_base.h
+++ b/dev/storage_base.h
@@ -257,6 +257,57 @@ namespace sqlite_orm::internal {
 #endif
 
         /**
+         *  `ANALYZE` query: gathers statistics about tables and indexes for the query planner.
+         *  More info: https://www.sqlite.org/lang_analyze.html
+         */
+        void analyze() {
+            auto connection = this->get_connection();
+            this->executor.perform_void_exec(connection.get(), "ANALYZE");
+        }
+
+        /**
+         *  `ANALYZE` query limited to a single schema, table or index.
+         *  More info: https://www.sqlite.org/lang_analyze.html
+         */
+        void analyze(std::string_view name) {
+            std::stringstream ss;
+            ss << "ANALYZE " << streaming_identifier(name) << std::flush;
+            auto connection = this->get_connection();
+            this->executor.perform_void_exec(connection.get(), ss.str().c_str());
+        }
+
+        /**
+         *  `REINDEX` query: rebuilds all indexes.
+         *  More info: https://www.sqlite.org/lang_reindex.html
+         */
+        void reindex() {
+            auto connection = this->get_connection();
+            this->executor.perform_void_exec(connection.get(), "REINDEX");
+        }
+
+        /**
+         *  `REINDEX` query limited to a collation, table or index.
+         *  More info: https://www.sqlite.org/lang_reindex.html
+         */
+        void reindex(std::string_view name) {
+            std::stringstream ss;
+            ss << "REINDEX " << streaming_identifier(name) << std::flush;
+            auto connection = this->get_connection();
+            this->executor.perform_void_exec(connection.get(), ss.str().c_str());
+        }
+
+#if SQLITE_VERSION_NUMBER >= 3053000
+        /**
+         *  `REINDEX EXPRESSIONS` query: rebuilds indexes on expressions, repairing stale ones.
+         *  More info: https://www.sqlite.org/lang_reindex.html
+         */
+        void reindex_expressions() {
+            auto connection = this->get_connection();
+            this->executor.perform_void_exec(connection.get(), "REINDEX EXPRESSIONS");
+        }
+#endif
+
+        /**
          *  Checks whether table exists in db. Doesn't check storage itself - works only with actual database.
          *  Note: table can be not mapped to a storage
          *  @return true if table with a given name exists in db, false otherwise.

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -20334,6 +20334,57 @@ namespace sqlite_orm::internal {
 #endif
 
         /**
+         *  `ANALYZE` query: gathers statistics about tables and indexes for the query planner.
+         *  More info: https://www.sqlite.org/lang_analyze.html
+         */
+        void analyze() {
+            auto connection = this->get_connection();
+            this->executor.perform_void_exec(connection.get(), "ANALYZE");
+        }
+
+        /**
+         *  `ANALYZE` query limited to a single schema, table or index.
+         *  More info: https://www.sqlite.org/lang_analyze.html
+         */
+        void analyze(std::string_view name) {
+            std::stringstream ss;
+            ss << "ANALYZE " << streaming_identifier(name) << std::flush;
+            auto connection = this->get_connection();
+            this->executor.perform_void_exec(connection.get(), ss.str().c_str());
+        }
+
+        /**
+         *  `REINDEX` query: rebuilds all indexes.
+         *  More info: https://www.sqlite.org/lang_reindex.html
+         */
+        void reindex() {
+            auto connection = this->get_connection();
+            this->executor.perform_void_exec(connection.get(), "REINDEX");
+        }
+
+        /**
+         *  `REINDEX` query limited to a collation, table or index.
+         *  More info: https://www.sqlite.org/lang_reindex.html
+         */
+        void reindex(std::string_view name) {
+            std::stringstream ss;
+            ss << "REINDEX " << streaming_identifier(name) << std::flush;
+            auto connection = this->get_connection();
+            this->executor.perform_void_exec(connection.get(), ss.str().c_str());
+        }
+
+#if SQLITE_VERSION_NUMBER >= 3053000
+        /**
+         *  `REINDEX EXPRESSIONS` query: rebuilds indexes on expressions, repairing stale ones.
+         *  More info: https://www.sqlite.org/lang_reindex.html
+         */
+        void reindex_expressions() {
+            auto connection = this->get_connection();
+            this->executor.perform_void_exec(connection.get(), "REINDEX EXPRESSIONS");
+        }
+#endif
+
+        /**
          *  Checks whether table exists in db. Doesn't check storage itself - works only with actual database.
          *  Note: table can be not mapped to a storage
          *  @return true if table with a given name exists in db, false otherwise.

--- a/tests/storage_non_crud_tests.cpp
+++ b/tests/storage_non_crud_tests.cpp
@@ -810,3 +810,48 @@ TEST_CASE("vacuum into an existing file fails") {
     std::remove(sourcePath);
 }
 #endif
+
+TEST_CASE("analyze") {
+    struct User {
+        int id = 0;
+    };
+    auto storage = make_storage("", make_table("users", make_column("id", &User::id, primary_key())));
+    storage.sync_schema();
+    storage.replace(User{1});
+    SECTION("the whole database") {
+        storage.analyze();
+    }
+    SECTION("a single table") {
+        storage.analyze("users");
+    }
+    //  ANALYZE materializes its statistics in the sqlite_stat1 table
+    REQUIRE(storage.table_exists("sqlite_stat1"));
+}
+
+TEST_CASE("reindex") {
+    struct User {
+        int id = 0;
+        std::string name;
+    };
+    auto storage =
+        make_storage("",
+                     make_table("users", make_column("id", &User::id, primary_key()), make_column("name", &User::name)),
+                     make_index("idx_users_name", &User::name));
+    storage.sync_schema();
+    storage.replace(User{1, "Leony"});
+    SECTION("everything") {
+        storage.reindex();
+    }
+    SECTION("a single index") {
+        storage.reindex("idx_users_name");
+    }
+#if SQLITE_VERSION_NUMBER >= 3053000
+    SECTION("expression indexes") {
+        storage.reindex_expressions();
+    }
+#endif
+    //  the index must stay usable after the rebuild
+    auto rows = storage.select(&User::name, where(c(&User::name) == "Leony"));
+    decltype(rows) expected{"Leony"};
+    REQUIRE(rows == expected);
+}


### PR DESCRIPTION
Fifth S-tier item of the feature-design pass: `storage.analyze()` / `analyze(name)`, `storage.reindex()` / `reindex(name)` and `storage.reindex_expressions()` next to `vacuum()`/`vacuum_into()` in `storage_base`.

- `ANALYZE` gathers query-planner statistics (whole database, or one schema/table/index); the test pins that it materializes `sqlite_stat1`.
- `REINDEX` rebuilds all indexes, or those of one collation/table/index; the test checks the index stays usable after the rebuild.
- `REINDEX EXPRESSIONS` (3.53) repairs stale expression indexes; gated on `SQLITE_VERSION_NUMBER >= 3053000`. No CI configuration reaches 3.53 yet, so I verified the syntax by compiling a probe against a real 3.53.4 amalgamation (all four statement forms return SQLITE_OK); its test section sits under the same gate and will activate once the CI matrix gains a 3.53 entry.
- Names are identifiers (`streaming_identifier`), parameters are `std::string_view` by value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)