### PR TITLE
Add the small C API wrappers batch

### DIFF
--- a/dev/prepared_statement.h
+++ b/dev/prepared_statement.h
@@ -82,6 +82,32 @@ namespace sqlite_orm::internal {
         std::string_view column_name(int index) const {
             return sqlite3_column_name(stmt, index);
         }
+
+        /**
+         *  sqlite3_stmt_readonly function: whether the statement makes no direct changes
+         *  to the content of the database file.
+         */
+        bool readonly() const {
+            return sqlite3_stmt_readonly(this->stmt) != 0;
+        }
+
+        /**
+         *  sqlite3_stmt_busy function: whether the statement has been stepped at least once
+         *  but has not run to completion or been reset.
+         */
+        bool busy() const {
+            return sqlite3_stmt_busy(this->stmt) != 0;
+        }
+
+#if SQLITE_VERSION_NUMBER >= 3028000
+        /**
+         *  sqlite3_stmt_isexplain function: 1 if the statement is an EXPLAIN statement,
+         *  2 if it is an EXPLAIN QUERY PLAN, 0 for an ordinary statement.
+         */
+        int is_explain() const {
+            return sqlite3_stmt_isexplain(this->stmt);
+        }
+#endif
     };
 
     template<class T>

--- a/dev/prepared_statement.h
+++ b/dev/prepared_statement.h
@@ -87,16 +87,16 @@ namespace sqlite_orm::internal {
          *  sqlite3_stmt_readonly function: whether the statement makes no direct changes
          *  to the content of the database file.
          */
-        bool readonly() const {
-            return sqlite3_stmt_readonly(this->stmt) != 0;
+        int readonly() const {
+            return sqlite3_stmt_readonly(this->stmt);
         }
 
         /**
          *  sqlite3_stmt_busy function: whether the statement has been stepped at least once
          *  but has not run to completion or been reset.
          */
-        bool busy() const {
-            return sqlite3_stmt_busy(this->stmt) != 0;
+        int busy() const {
+            return sqlite3_stmt_busy(this->stmt);
         }
 
 #if SQLITE_VERSION_NUMBER >= 3028000

--- a/dev/storage_base.h
+++ b/dev/storage_base.h
@@ -410,9 +410,9 @@ namespace sqlite_orm::internal {
          *  sqlite3_is_interrupted function: whether an interrupt is currently in effect
          *  on this connection.
          */
-        bool is_interrupted() {
+        int is_interrupted() {
             auto connection = this->get_connection();
-            return sqlite3_is_interrupted(connection.get()) != 0;
+            return sqlite3_is_interrupted(connection.get());
         }
 #endif
 

--- a/dev/storage_base.h
+++ b/dev/storage_base.h
@@ -7,6 +7,7 @@
 #include <functional>  //  std::function, std::bind, std::bind_front
 #include <string>  //  std::string
 #include <string_view>  //  std::string_view
+#include <optional>  //  std::optional
 #include <sstream>  //  std::stringstream
 #include <ostream>  //  std::flush
 #include <utility>  //  std::move
@@ -31,6 +32,7 @@
 #include "values_to_tuple.h"
 #include "arg_values.h"
 #include "util.h"
+#include "transaction_state.h"
 #include "xdestroy_handling.h"
 #include "udf_proxy.h"
 #include "serializing_util.h"
@@ -375,6 +377,117 @@ namespace sqlite_orm::internal {
             auto connection = this->get_connection();
             return sqlite3_last_insert_rowid(connection.get());
         }
+
+#if SQLITE_VERSION_NUMBER >= 3037000
+        /**
+         *  sqlite3_changes64 function.
+         */
+        int64 changes64() {
+            auto connection = this->get_connection();
+            return sqlite3_changes64(connection.get());
+        }
+
+        /**
+         *  sqlite3_total_changes64 function.
+         */
+        int64 total_changes64() {
+            auto connection = this->get_connection();
+            return sqlite3_total_changes64(connection.get());
+        }
+#endif
+
+        /**
+         *  sqlite3_interrupt function: causes any pending database operation on this connection
+         *  to abort and return at its earliest opportunity.
+         */
+        void interrupt() {
+            auto connection = this->get_connection();
+            sqlite3_interrupt(connection.get());
+        }
+
+#if SQLITE_VERSION_NUMBER >= 3041000
+        /**
+         *  sqlite3_is_interrupted function: whether an interrupt is currently in effect
+         *  on this connection.
+         */
+        bool is_interrupted() {
+            auto connection = this->get_connection();
+            return sqlite3_is_interrupted(connection.get()) != 0;
+        }
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3034000
+        /**
+         *  sqlite3_txn_state function: the transaction state across all schemas of this connection.
+         */
+        transaction_state txn_state() {
+            auto connection = this->get_connection();
+            return static_cast<transaction_state>(sqlite3_txn_state(connection.get(), nullptr));
+        }
+
+        /**
+         *  sqlite3_txn_state function limited to a single schema.
+         *  Returns an empty optional if no schema with the given name is attached.
+         */
+        std::optional<transaction_state> txn_state(std::string_view schema) {
+            auto connection = this->get_connection();
+            const int state = sqlite3_txn_state(connection.get(), std::string{schema}.c_str());
+            if (state < 0) {
+                return std::nullopt;
+            }
+            return static_cast<transaction_state>(state);
+        }
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3038000
+        /**
+         *  sqlite3_error_offset function: the byte offset of the token the most recent error
+         *  relates to within its SQL text, or -1 if not applicable.
+         */
+        int error_offset() {
+            auto connection = this->get_connection();
+            return sqlite3_error_offset(connection.get());
+        }
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3039000
+        /**
+         *  sqlite3_db_name function: the name of the schema at the given index.
+         *  Returns an empty optional if the index is out of range.
+         */
+        std::optional<std::string> db_name(int index) {
+            auto connection = this->get_connection();
+            if (orm_gsl::czstring name = sqlite3_db_name(connection.get(), index)) {
+                return std::string{name};
+            }
+            return std::nullopt;
+        }
+#endif
+
+        /**
+         *  sqlite3_db_readonly function: whether the schema with the given name is read-only.
+         *  Returns an empty optional if no schema with the given name is attached.
+         *  The parameterless overload below reports on the main schema.
+         */
+        std::optional<bool> db_readonly(std::string_view schema) {
+            auto connection = this->get_connection();
+            const int result = sqlite3_db_readonly(connection.get(), std::string{schema}.c_str());
+            if (result < 0) {
+                return std::nullopt;
+            }
+            return result != 0;
+        }
+
+#if SQLITE_VERSION_NUMBER >= 3050000
+        /**
+         *  sqlite3_setlk_timeout function: a separate timeout, distinct from the busy timeout,
+         *  for blocking locks on builds that support them. A no-op returning SQLITE_OK elsewhere.
+         */
+        int setlk_timeout(int ms, bool blockOnConnect = false) {
+            auto connection = this->get_connection();
+            return sqlite3_setlk_timeout(connection.get(), ms, blockOnConnect ? SQLITE_SETLK_BLOCK_ON_CONNECT : 0);
+        }
+#endif
 
         int busy_timeout(int ms) {
             auto connection = this->get_connection();

--- a/dev/storage_base.h
+++ b/dev/storage_base.h
@@ -458,7 +458,7 @@ namespace sqlite_orm::internal {
         std::optional<std::string> db_name(int index) {
             auto connection = this->get_connection();
             if (orm_gsl::czstring name = sqlite3_db_name(connection.get(), index)) {
-                return std::string{name};
+                return name;
             }
             return std::nullopt;
         }

--- a/dev/transaction_state.h
+++ b/dev/transaction_state.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <sqlite3.h>
+
+#if SQLITE_VERSION_NUMBER >= 3034000
+SQLITE_ORM_EXPORT namespace sqlite_orm {
+
+    /**
+     *  Transaction state of a database connection, as reported by `sqlite3_txn_state()`.
+     */
+    enum class transaction_state {
+        /**
+         *  no transaction is currently pending
+         */
+        none = SQLITE_TXN_NONE,
+
+        /**
+         *  currently executing a read transaction
+         */
+        read = SQLITE_TXN_READ,
+
+        /**
+         *  currently executing a write transaction
+         */
+        write = SQLITE_TXN_WRITE,
+    };
+}
+#endif

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -16484,6 +16484,32 @@ namespace sqlite_orm::internal {
         std::string_view column_name(int index) const {
             return sqlite3_column_name(stmt, index);
         }
+
+        /**
+         *  sqlite3_stmt_readonly function: whether the statement makes no direct changes
+         *  to the content of the database file.
+         */
+        bool readonly() const {
+            return sqlite3_stmt_readonly(this->stmt) != 0;
+        }
+
+        /**
+         *  sqlite3_stmt_busy function: whether the statement has been stepped at least once
+         *  but has not run to completion or been reset.
+         */
+        bool busy() const {
+            return sqlite3_stmt_busy(this->stmt) != 0;
+        }
+
+#if SQLITE_VERSION_NUMBER >= 3028000
+        /**
+         *  sqlite3_stmt_isexplain function: 1 if the statement is an EXPLAIN statement,
+         *  2 if it is an EXPLAIN QUERY PLAN, 0 for an ordinary statement.
+         */
+        int is_explain() const {
+            return sqlite3_stmt_isexplain(this->stmt);
+        }
+#endif
     };
 
     template<class T>
@@ -18534,6 +18560,7 @@ inline constexpr bool std::ranges::enable_borrowed_range<sqlite_orm::internal::r
 #include <functional>  //  std::function, std::bind, std::bind_front
 #include <string>  //  std::string
 #include <string_view>  //  std::string_view
+#include <optional>  //  std::optional
 #include <sstream>  //  std::stringstream
 #include <ostream>  //  std::flush
 #include <utility>  //  std::move
@@ -19879,6 +19906,35 @@ namespace sqlite_orm::internal {
 
 // #include "util.h"
 
+// #include "transaction_state.h"
+
+#include <sqlite3.h>
+
+#if SQLITE_VERSION_NUMBER >= 3034000
+SQLITE_ORM_EXPORT namespace sqlite_orm {
+
+    /**
+     *  Transaction state of a database connection, as reported by `sqlite3_txn_state()`.
+     */
+    enum class transaction_state {
+        /**
+         *  no transaction is currently pending
+         */
+        none = SQLITE_TXN_NONE,
+
+        /**
+         *  currently executing a read transaction
+         */
+        read = SQLITE_TXN_READ,
+
+        /**
+         *  currently executing a write transaction
+         */
+        write = SQLITE_TXN_WRITE,
+    };
+}
+#endif
+
 // #include "xdestroy_handling.h"
 
 // #include "udf_proxy.h"
@@ -20452,6 +20508,117 @@ namespace sqlite_orm::internal {
             auto connection = this->get_connection();
             return sqlite3_last_insert_rowid(connection.get());
         }
+
+#if SQLITE_VERSION_NUMBER >= 3037000
+        /**
+         *  sqlite3_changes64 function.
+         */
+        int64 changes64() {
+            auto connection = this->get_connection();
+            return sqlite3_changes64(connection.get());
+        }
+
+        /**
+         *  sqlite3_total_changes64 function.
+         */
+        int64 total_changes64() {
+            auto connection = this->get_connection();
+            return sqlite3_total_changes64(connection.get());
+        }
+#endif
+
+        /**
+         *  sqlite3_interrupt function: causes any pending database operation on this connection
+         *  to abort and return at its earliest opportunity.
+         */
+        void interrupt() {
+            auto connection = this->get_connection();
+            sqlite3_interrupt(connection.get());
+        }
+
+#if SQLITE_VERSION_NUMBER >= 3041000
+        /**
+         *  sqlite3_is_interrupted function: whether an interrupt is currently in effect
+         *  on this connection.
+         */
+        bool is_interrupted() {
+            auto connection = this->get_connection();
+            return sqlite3_is_interrupted(connection.get()) != 0;
+        }
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3034000
+        /**
+         *  sqlite3_txn_state function: the transaction state across all schemas of this connection.
+         */
+        transaction_state txn_state() {
+            auto connection = this->get_connection();
+            return static_cast<transaction_state>(sqlite3_txn_state(connection.get(), nullptr));
+        }
+
+        /**
+         *  sqlite3_txn_state function limited to a single schema.
+         *  Returns an empty optional if no schema with the given name is attached.
+         */
+        std::optional<transaction_state> txn_state(std::string_view schema) {
+            auto connection = this->get_connection();
+            const int state = sqlite3_txn_state(connection.get(), std::string{schema}.c_str());
+            if (state < 0) {
+                return std::nullopt;
+            }
+            return static_cast<transaction_state>(state);
+        }
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3038000
+        /**
+         *  sqlite3_error_offset function: the byte offset of the token the most recent error
+         *  relates to within its SQL text, or -1 if not applicable.
+         */
+        int error_offset() {
+            auto connection = this->get_connection();
+            return sqlite3_error_offset(connection.get());
+        }
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3039000
+        /**
+         *  sqlite3_db_name function: the name of the schema at the given index.
+         *  Returns an empty optional if the index is out of range.
+         */
+        std::optional<std::string> db_name(int index) {
+            auto connection = this->get_connection();
+            if (orm_gsl::czstring name = sqlite3_db_name(connection.get(), index)) {
+                return std::string{name};
+            }
+            return std::nullopt;
+        }
+#endif
+
+        /**
+         *  sqlite3_db_readonly function: whether the schema with the given name is read-only.
+         *  Returns an empty optional if no schema with the given name is attached.
+         *  The parameterless overload below reports on the main schema.
+         */
+        std::optional<bool> db_readonly(std::string_view schema) {
+            auto connection = this->get_connection();
+            const int result = sqlite3_db_readonly(connection.get(), std::string{schema}.c_str());
+            if (result < 0) {
+                return std::nullopt;
+            }
+            return result != 0;
+        }
+
+#if SQLITE_VERSION_NUMBER >= 3050000
+        /**
+         *  sqlite3_setlk_timeout function: a separate timeout, distinct from the busy timeout,
+         *  for blocking locks on builds that support them. A no-op returning SQLITE_OK elsewhere.
+         */
+        int setlk_timeout(int ms, bool blockOnConnect = false) {
+            auto connection = this->get_connection();
+            return sqlite3_setlk_timeout(connection.get(), ms, blockOnConnect ? SQLITE_SETLK_BLOCK_ON_CONNECT : 0);
+        }
+#endif
 
         int busy_timeout(int ms) {
             auto connection = this->get_connection();

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -16489,16 +16489,16 @@ namespace sqlite_orm::internal {
          *  sqlite3_stmt_readonly function: whether the statement makes no direct changes
          *  to the content of the database file.
          */
-        bool readonly() const {
-            return sqlite3_stmt_readonly(this->stmt) != 0;
+        int readonly() const {
+            return sqlite3_stmt_readonly(this->stmt);
         }
 
         /**
          *  sqlite3_stmt_busy function: whether the statement has been stepped at least once
          *  but has not run to completion or been reset.
          */
-        bool busy() const {
-            return sqlite3_stmt_busy(this->stmt) != 0;
+        int busy() const {
+            return sqlite3_stmt_busy(this->stmt);
         }
 
 #if SQLITE_VERSION_NUMBER >= 3028000
@@ -20541,9 +20541,9 @@ namespace sqlite_orm::internal {
          *  sqlite3_is_interrupted function: whether an interrupt is currently in effect
          *  on this connection.
          */
-        bool is_interrupted() {
+        int is_interrupted() {
             auto connection = this->get_connection();
-            return sqlite3_is_interrupted(connection.get()) != 0;
+            return sqlite3_is_interrupted(connection.get());
         }
 #endif
 

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -20589,7 +20589,7 @@ namespace sqlite_orm::internal {
         std::optional<std::string> db_name(int index) {
             auto connection = this->get_connection();
             if (orm_gsl::czstring name = sqlite3_db_name(connection.get(), index)) {
-                return std::string{name};
+                return name;
             }
             return std::nullopt;
         }

--- a/tests/storage_non_crud_tests.cpp
+++ b/tests/storage_non_crud_tests.cpp
@@ -855,3 +855,117 @@ TEST_CASE("reindex") {
     decltype(rows) expected{"Leony"};
     REQUIRE(rows == expected);
 }
+
+TEST_CASE("small C API wrappers") {
+    struct User {
+        int id = 0;
+    };
+    auto storage = make_storage("", make_table("users", make_column("id", &User::id, primary_key())));
+    storage.sync_schema();
+    storage.replace(User{1});
+
+#if SQLITE_VERSION_NUMBER >= 3037000
+    SECTION("changes64") {
+        REQUIRE(storage.changes64() == 1);
+    }
+#endif
+#if SQLITE_VERSION_NUMBER >= 3041000
+    SECTION("interrupt is reported while in effect") {
+        storage.interrupt();
+        REQUIRE(storage.is_interrupted());
+    }
+#endif
+#if SQLITE_VERSION_NUMBER >= 3034000
+    SECTION("transaction state") {
+        transaction_state actual;
+        decltype(actual) expected;
+        SECTION("idle") {
+            actual = storage.txn_state();
+            expected = transaction_state::none;
+        }
+        SECTION("inside a write transaction") {
+            storage.begin_transaction();
+            storage.replace(User{2});
+            actual = storage.txn_state();
+            expected = transaction_state::write;
+            storage.rollback();
+        }
+        REQUIRE(actual == expected);
+    }
+    SECTION("transaction state of an unknown schema") {
+        REQUIRE(storage.txn_state("nope") == std::nullopt);
+    }
+#endif
+#if SQLITE_VERSION_NUMBER >= 3038000
+    SECTION("error offset without an error") {
+        REQUIRE(storage.error_offset() == -1);
+    }
+#endif
+#if SQLITE_VERSION_NUMBER >= 3039000
+    SECTION("schema names") {
+        std::optional<std::string> actual;
+        decltype(actual) expected;
+        SECTION("the main schema") {
+            actual = storage.db_name(0);
+            expected = "main";
+        }
+        SECTION("an out-of-range index") {
+            actual = storage.db_name(5);
+            expected = std::nullopt;
+        }
+        REQUIRE(actual == expected);
+    }
+#endif
+    SECTION("read-only state") {
+        std::optional<bool> actual;
+        decltype(actual) expected;
+        SECTION("the main schema is writable") {
+            actual = storage.db_readonly();
+            expected = false;
+        }
+        SECTION("an unknown schema") {
+            actual = storage.db_readonly("nope");
+            expected = std::nullopt;
+        }
+        REQUIRE(actual == expected);
+    }
+#if SQLITE_VERSION_NUMBER >= 3050000
+    SECTION("setlk timeout") {
+        REQUIRE(storage.setlk_timeout(100) == SQLITE_OK);
+    }
+#endif
+}
+
+TEST_CASE("prepared statement introspection") {
+    struct User {
+        int id = 0;
+    };
+    auto storage = make_storage("", make_table("users", make_column("id", &User::id, primary_key())));
+    storage.sync_schema();
+
+    bool actual = false;
+    bool expected = false;
+    SECTION("a select statement is read-only") {
+        auto statement = storage.prepare(select(&User::id));
+        actual = statement.readonly();
+        expected = true;
+    }
+    SECTION("a remove statement is not read-only") {
+        auto statement = storage.prepare(remove<User>(1));
+        actual = statement.readonly();
+        expected = false;
+    }
+    SECTION("a fresh statement is not busy") {
+        auto statement = storage.prepare(select(&User::id));
+        actual = statement.busy();
+        expected = false;
+    }
+#if SQLITE_VERSION_NUMBER >= 3028000
+    SECTION("an ordinary statement is not an EXPLAIN") {
+        auto statement = storage.prepare(select(&User::id));
+        actual = statement.is_explain() != 0;
+        expected = false;
+    }
+#endif
+    REQUIRE(actual == expected);
+}

--- a/tests/storage_non_crud_tests.cpp
+++ b/tests/storage_non_crud_tests.cpp
@@ -872,7 +872,7 @@ TEST_CASE("small C API wrappers") {
 #if SQLITE_VERSION_NUMBER >= 3041000
     SECTION("interrupt is reported while in effect") {
         storage.interrupt();
-        REQUIRE(storage.is_interrupted());
+        REQUIRE(storage.is_interrupted() != 0);
     }
 #endif
 #if SQLITE_VERSION_NUMBER >= 3034000
@@ -943,21 +943,23 @@ TEST_CASE("prepared statement introspection") {
     auto storage = make_storage("", make_table("users", make_column("id", &User::id, primary_key())));
     storage.sync_schema();
 
+    //  the wrappers pass the C API values through; the SQLite contract for the boolean-like
+    //  answers is zero/non-zero, so that is what the assertions test
     bool actual = false;
     bool expected = false;
     SECTION("a select statement is read-only") {
         auto statement = storage.prepare(select(&User::id));
-        actual = statement.readonly();
+        actual = statement.readonly() != 0;
         expected = true;
     }
     SECTION("a remove statement is not read-only") {
         auto statement = storage.prepare(remove<User>(1));
-        actual = statement.readonly();
+        actual = statement.readonly() != 0;
         expected = false;
     }
     SECTION("a fresh statement is not busy") {
         auto statement = storage.prepare(select(&User::id));
-        actual = statement.busy();
+        actual = statement.busy() != 0;
         expected = false;
     }
 #if SQLITE_VERSION_NUMBER >= 3028000


### PR DESCRIPTION
Sixth S-tier item of the feature-design pass — the mechanical C API wrappers, all following the `changes()`/`busy_handler()` precedents.

Connection side (`storage_base`):
- `changes64()` / `total_changes64()` (3.37)
- `interrupt()` + `is_interrupted()` (3.41) — probed first: an interrupt issued while idle stays reported until the next statement
- `txn_state()` across all schemas and `txn_state(schema)` for one, with the new `transaction_state` enum (`dev/transaction_state.h`, 3.34); an unknown schema is an empty optional
- `error_offset()` (3.38)
- `db_name(index)` (3.39) — empty optional when out of range
- `db_readonly(schema)` beside the existing parameterless `db_readonly()` (which I only discovered mid-build — hence the overload, not a default argument)
- `setlk_timeout(ms, blockOnConnect)` (3.50) — probed: returns SQLITE_OK on builds without blocking-lock support too

Statement side (`prepared_statement_base`): `readonly()`, `busy()`, `is_explain()` (3.28).

Every behavioral claim in the tests was probed against the C API before wrapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)