### PR TITLE
Add the IS, IS NOT, IS DISTINCT FROM and IS NOT DISTINCT FROM operators

### DIFF
--- a/dev/conditions.h
+++ b/dev/conditions.h
@@ -204,6 +204,64 @@ namespace sqlite_orm::internal {
         }
     };
 
+    struct is_string {
+        std::string_view serialize() const {
+            return "IS";
+        }
+    };
+
+    /**
+     *  IS operator object
+     */
+    template<class L, class R>
+    struct is_t : binary_condition<L, R, is_string, bool>, negatable_t {
+        using binary_condition<L, R, is_string, bool>::binary_condition;
+    };
+
+    struct is_not_string {
+        std::string_view serialize() const {
+            return "IS NOT";
+        }
+    };
+
+    /**
+     *  IS NOT operator object
+     */
+    template<class L, class R>
+    struct is_not_t : binary_condition<L, R, is_not_string, bool>, negatable_t {
+        using binary_condition<L, R, is_not_string, bool>::binary_condition;
+    };
+
+#if SQLITE_VERSION_NUMBER >= 3039000
+    struct is_distinct_from_string {
+        std::string_view serialize() const {
+            return "IS DISTINCT FROM";
+        }
+    };
+
+    /**
+     *  IS DISTINCT FROM operator object
+     */
+    template<class L, class R>
+    struct is_distinct_from_t : binary_condition<L, R, is_distinct_from_string, bool>, negatable_t {
+        using binary_condition<L, R, is_distinct_from_string, bool>::binary_condition;
+    };
+
+    struct is_not_distinct_from_string {
+        std::string_view serialize() const {
+            return "IS NOT DISTINCT FROM";
+        }
+    };
+
+    /**
+     *  IS NOT DISTINCT FROM operator object
+     */
+    template<class L, class R>
+    struct is_not_distinct_from_t : binary_condition<L, R, is_not_distinct_from_string, bool>, negatable_t {
+        using binary_condition<L, R, is_not_distinct_from_string, bool>::binary_condition;
+    };
+#endif
+
     struct greater_than_string {
         std::string_view serialize() const {
             return ">";
@@ -940,6 +998,58 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
                       "column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(lhs), std::move(rhs)};
     }
+
+    /**
+     *  IS operator: a NULL-safe equality comparison, `NULL IS NULL` evaluates to true.
+     *  Example: storage.select(is(&User::middleName, std::nullopt))
+     */
+    template<class L, class R>
+    constexpr internal::is_t<L, R> is(L lhs, R rhs) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "is() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
+                      "column pointers, c()-wrapped values, aliases or expressions");
+        return {std::move(lhs), std::move(rhs)};
+    }
+
+    /**
+     *  IS NOT operator: a NULL-safe inequality comparison, `1 IS NOT NULL` evaluates to true.
+     *  Example: storage.select(is_not(&User::middleName, std::nullopt))
+     */
+    template<class L, class R>
+    constexpr internal::is_not_t<L, R> is_not(L lhs, R rhs) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "is_not() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
+                      "column pointers, c()-wrapped values, aliases or expressions");
+        return {std::move(lhs), std::move(rhs)};
+    }
+
+#if SQLITE_VERSION_NUMBER >= 3039000
+    /**
+     *  IS DISTINCT FROM operator: equivalent to IS NOT, for compatibility with PostgreSQL
+     *  and the SQL standards.
+     *  Example: storage.select(is_distinct_from(&User::middleName, &User::name))
+     */
+    template<class L, class R>
+    constexpr internal::is_distinct_from_t<L, R> is_distinct_from(L lhs, R rhs) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "is_distinct_from() arguments must be bindable values or sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
+        return {std::move(lhs), std::move(rhs)};
+    }
+
+    /**
+     *  IS NOT DISTINCT FROM operator: equivalent to IS, for compatibility with PostgreSQL
+     *  and the SQL standards.
+     *  Example: storage.select(is_not_distinct_from(&User::middleName, &User::name))
+     */
+    template<class L, class R>
+    constexpr internal::is_not_distinct_from_t<L, R> is_not_distinct_from(L lhs, R rhs) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "is_not_distinct_from() arguments must be bindable values or sqlite_orm-recognized operands: "
+                      "member pointers, column pointers, c()-wrapped values, aliases or expressions");
+        return {std::move(lhs), std::move(rhs)};
+    }
+#endif
 
     template<class L, class R>
     constexpr internal::greater_than_t<L, R> greater_than(L lhs, R rhs) {

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -6794,6 +6794,64 @@ namespace sqlite_orm::internal {
         }
     };
 
+    struct is_string {
+        std::string_view serialize() const {
+            return "IS";
+        }
+    };
+
+    /**
+     *  IS operator object
+     */
+    template<class L, class R>
+    struct is_t : binary_condition<L, R, is_string, bool>, negatable_t {
+        using binary_condition<L, R, is_string, bool>::binary_condition;
+    };
+
+    struct is_not_string {
+        std::string_view serialize() const {
+            return "IS NOT";
+        }
+    };
+
+    /**
+     *  IS NOT operator object
+     */
+    template<class L, class R>
+    struct is_not_t : binary_condition<L, R, is_not_string, bool>, negatable_t {
+        using binary_condition<L, R, is_not_string, bool>::binary_condition;
+    };
+
+#if SQLITE_VERSION_NUMBER >= 3039000
+    struct is_distinct_from_string {
+        std::string_view serialize() const {
+            return "IS DISTINCT FROM";
+        }
+    };
+
+    /**
+     *  IS DISTINCT FROM operator object
+     */
+    template<class L, class R>
+    struct is_distinct_from_t : binary_condition<L, R, is_distinct_from_string, bool>, negatable_t {
+        using binary_condition<L, R, is_distinct_from_string, bool>::binary_condition;
+    };
+
+    struct is_not_distinct_from_string {
+        std::string_view serialize() const {
+            return "IS NOT DISTINCT FROM";
+        }
+    };
+
+    /**
+     *  IS NOT DISTINCT FROM operator object
+     */
+    template<class L, class R>
+    struct is_not_distinct_from_t : binary_condition<L, R, is_not_distinct_from_string, bool>, negatable_t {
+        using binary_condition<L, R, is_not_distinct_from_string, bool>::binary_condition;
+    };
+#endif
+
     struct greater_than_string {
         std::string_view serialize() const {
             return ">";
@@ -7530,6 +7588,58 @@ SQLITE_ORM_EXPORT namespace sqlite_orm {
                       "column pointers, c()-wrapped values, aliases or expressions");
         return {std::move(lhs), std::move(rhs)};
     }
+
+    /**
+     *  IS operator: a NULL-safe equality comparison, `NULL IS NULL` evaluates to true.
+     *  Example: storage.select(is(&User::middleName, std::nullopt))
+     */
+    template<class L, class R>
+    constexpr internal::is_t<L, R> is(L lhs, R rhs) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "is() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
+                      "column pointers, c()-wrapped values, aliases or expressions");
+        return {std::move(lhs), std::move(rhs)};
+    }
+
+    /**
+     *  IS NOT operator: a NULL-safe inequality comparison, `1 IS NOT NULL` evaluates to true.
+     *  Example: storage.select(is_not(&User::middleName, std::nullopt))
+     */
+    template<class L, class R>
+    constexpr internal::is_not_t<L, R> is_not(L lhs, R rhs) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "is_not() arguments must be bindable values or sqlite_orm-recognized operands: member pointers, "
+                      "column pointers, c()-wrapped values, aliases or expressions");
+        return {std::move(lhs), std::move(rhs)};
+    }
+
+#if SQLITE_VERSION_NUMBER >= 3039000
+    /**
+     *  IS DISTINCT FROM operator: equivalent to IS NOT, for compatibility with PostgreSQL
+     *  and the SQL standards.
+     *  Example: storage.select(is_distinct_from(&User::middleName, &User::name))
+     */
+    template<class L, class R>
+    constexpr internal::is_distinct_from_t<L, R> is_distinct_from(L lhs, R rhs) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "is_distinct_from() arguments must be bindable values or sqlite_orm-recognized operands: member "
+                      "pointers, column pointers, c()-wrapped values, aliases or expressions");
+        return {std::move(lhs), std::move(rhs)};
+    }
+
+    /**
+     *  IS NOT DISTINCT FROM operator: equivalent to IS, for compatibility with PostgreSQL
+     *  and the SQL standards.
+     *  Example: storage.select(is_not_distinct_from(&User::middleName, &User::name))
+     */
+    template<class L, class R>
+    constexpr internal::is_not_distinct_from_t<L, R> is_not_distinct_from(L lhs, R rhs) {
+        static_assert(internal::are_valid_operands<L, R>::value,
+                      "is_not_distinct_from() arguments must be bindable values or sqlite_orm-recognized operands: "
+                      "member pointers, column pointers, c()-wrapped values, aliases or expressions");
+        return {std::move(lhs), std::move(rhs)};
+    }
+#endif
 
     template<class L, class R>
     constexpr internal::greater_than_t<L, R> greater_than(L lhs, R rhs) {

--- a/tests/operators/is.cpp
+++ b/tests/operators/is.cpp
@@ -1,0 +1,45 @@
+#include <sqlite_orm/sqlite_orm.h>
+#include <catch2/catch_all.hpp>
+#include <optional>  //  std::optional
+
+using namespace sqlite_orm;
+
+TEST_CASE("is operators") {
+    struct User {
+        int id = 0;
+        std::optional<std::string> middleName;
+    };
+    auto storage = make_storage("",
+                                make_table("users",
+                                           make_column("id", &User::id, primary_key()),
+                                           make_column("middle_name", &User::middleName)));
+    storage.sync_schema();
+    storage.replace(User{1, std::nullopt});
+    storage.replace(User{2, "Eldarovich"});
+
+    std::vector<int> rows;
+    decltype(rows) expected;
+    SECTION("IS matches NULL") {
+        rows = storage.select(&User::id, where(is(&User::middleName, std::optional<std::string>{})));
+        expected = {1};
+    }
+    SECTION("IS NOT skips NULL") {
+        rows = storage.select(&User::id, where(is_not(&User::middleName, std::optional<std::string>{})));
+        expected = {2};
+    }
+    SECTION("a negated IS behaves like IS NOT") {
+        rows = storage.select(&User::id, where(not is(&User::middleName, std::optional<std::string>{})));
+        expected = {2};
+    }
+#if SQLITE_VERSION_NUMBER >= 3039000
+    SECTION("IS DISTINCT FROM treats NULLs as equal") {
+        rows = storage.select(&User::id, where(is_distinct_from(&User::middleName, std::optional<std::string>{})));
+        expected = {2};
+    }
+    SECTION("IS NOT DISTINCT FROM matches NULL") {
+        rows = storage.select(&User::id, where(is_not_distinct_from(&User::middleName, std::optional<std::string>{})));
+        expected = {1};
+    }
+#endif
+    REQUIRE(rows == expected);
+}

--- a/tests/statement_serializer_tests/comparison_operators.cpp
+++ b/tests/statement_serializer_tests/comparison_operators.cpp
@@ -91,6 +91,24 @@ TEST_CASE("statement_serializer comparison operators") {
         value = serialize(is_equal<User>("Tom Gregory"), context);
         expected = R"("users" = 'Tom Gregory')";
     }
+    SECTION("is") {
+        value = serialize(is(&User::name, "lala"), context);
+        expected = R"("name" IS 'lala')";
+    }
+    SECTION("is_not") {
+        value = serialize(is_not(&User::name, "lala"), context);
+        expected = R"("name" IS NOT 'lala')";
+    }
+#if SQLITE_VERSION_NUMBER >= 3039000
+    SECTION("is_distinct_from") {
+        value = serialize(is_distinct_from(&User::name, "lala"), context);
+        expected = R"("name" IS DISTINCT FROM 'lala')";
+    }
+    SECTION("is_not_distinct_from") {
+        value = serialize(is_not_distinct_from(&User::name, "lala"), context);
+        expected = R"("name" IS NOT DISTINCT FROM 'lala')";
+    }
+#endif
     SECTION("subquery") {
         context.use_parentheses = false;
         value = serialize(greater_than(&User::id, select(avg(&User::id))), context);


### PR DESCRIPTION
Seventh S-tier item of the feature-design pass, the first DSL one: the NULL-safe comparison operators.

- `is()` / `is_not()` — the bare `IS` / `IS NOT` spellings (ancient, ungated). `is(&User::middleName, std::optional<std::string>{})` matches the NULL rows that `=` never does.
- `is_distinct_from()` / `is_not_distinct_from()` — the 3.39 spellings, equivalent to `IS NOT` / `IS` respectively, for PostgreSQL/SQL-standard compatibility; gated on `SQLITE_VERSION_NUMBER >= 3039000`.

All four are `binary_condition` nodes, so serialization, AST iteration, node tuples and the conditional-operand classification come from the shared machinery; the factories carry the phase-2 operand gates, and every node is negatable (`not is(...)` works, pinned by a test).

Tests: serializer sections beside the other comparison operators, and a runtime NULL-semantics matrix (NULL row vs non-NULL row for each operator) in a new topical `tests/operators/is.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)