### PR TITLE
Add NULLS FIRST / NULLS LAST to ORDER BY

### DIFF
--- a/dev/conditions.h
+++ b/dev/conditions.h
@@ -369,6 +369,7 @@ namespace sqlite_orm::internal {
     struct order_by_base {
         std::string _collate_argument;
         int _order = 0;  //  -1 = desc, 1 = asc, 0 = unspecified
+        int _nulls = 0;  //  1 = nulls first, -1 = nulls last, 0 = unspecified
     };
 
     struct order_by_string {
@@ -399,6 +400,20 @@ namespace sqlite_orm::internal {
             res._order = -1;
             return res;
         }
+
+#if SQLITE_VERSION_NUMBER >= 3030000
+        order_by_t nulls_first() const {
+            auto res = *this;
+            res._nulls = 1;
+            return res;
+        }
+
+        order_by_t nulls_last() const {
+            auto res = *this;
+            res._nulls = -1;
+            return res;
+        }
+#endif
 
         order_by_t collate_binary() const {
             auto res = *this;
@@ -447,8 +462,8 @@ namespace sqlite_orm::internal {
     struct dynamic_order_by_entry_t : order_by_base {
         std::string name;
 
-        dynamic_order_by_entry_t(decltype(name) name_, std::string collate_argument_, int asc_desc_) :
-            order_by_base{std::move(collate_argument_), asc_desc_}, name(std::move(name_)) {}
+        dynamic_order_by_entry_t(decltype(name) name_, std::string collate_argument_, int asc_desc_, int nulls_) :
+            order_by_base{std::move(collate_argument_), asc_desc_, nulls_}, name(std::move(name_)) {}
     };
 
     /**
@@ -467,7 +482,10 @@ namespace sqlite_orm::internal {
             auto newContext = this->context;
             newContext.omit_table_name = false;
             auto columnName = serialize(orderBy._expression, newContext);
-            this->entries.emplace_back(std::move(columnName), std::move(orderBy._collate_argument), orderBy._order);
+            this->entries.emplace_back(std::move(columnName),
+                                       std::move(orderBy._collate_argument),
+                                       orderBy._order,
+                                       orderBy._nulls);
         }
 
         const_iterator begin() const {

--- a/dev/order_by_serializer.h
+++ b/dev/order_by_serializer.h
@@ -31,6 +31,16 @@ namespace sqlite_orm::internal {
                 ss << " DESC";
                 break;
         }
+#if SQLITE_VERSION_NUMBER >= 3030000
+        switch (orderBy._nulls) {
+            case 1:
+                ss << " NULLS FIRST";
+                break;
+            case -1:
+                ss << " NULLS LAST";
+                break;
+        }
+#endif
     }
 
     template<class O>

--- a/include/sqlite_orm/sqlite_orm.h
+++ b/include/sqlite_orm/sqlite_orm.h
@@ -6959,6 +6959,7 @@ namespace sqlite_orm::internal {
     struct order_by_base {
         std::string _collate_argument;
         int _order = 0;  //  -1 = desc, 1 = asc, 0 = unspecified
+        int _nulls = 0;  //  1 = nulls first, -1 = nulls last, 0 = unspecified
     };
 
     struct order_by_string {
@@ -6989,6 +6990,20 @@ namespace sqlite_orm::internal {
             res._order = -1;
             return res;
         }
+
+#if SQLITE_VERSION_NUMBER >= 3030000
+        order_by_t nulls_first() const {
+            auto res = *this;
+            res._nulls = 1;
+            return res;
+        }
+
+        order_by_t nulls_last() const {
+            auto res = *this;
+            res._nulls = -1;
+            return res;
+        }
+#endif
 
         order_by_t collate_binary() const {
             auto res = *this;
@@ -7037,8 +7052,8 @@ namespace sqlite_orm::internal {
     struct dynamic_order_by_entry_t : order_by_base {
         std::string name;
 
-        dynamic_order_by_entry_t(decltype(name) name_, std::string collate_argument_, int asc_desc_) :
-            order_by_base{std::move(collate_argument_), asc_desc_}, name(std::move(name_)) {}
+        dynamic_order_by_entry_t(decltype(name) name_, std::string collate_argument_, int asc_desc_, int nulls_) :
+            order_by_base{std::move(collate_argument_), asc_desc_, nulls_}, name(std::move(name_)) {}
     };
 
     /**
@@ -7057,7 +7072,10 @@ namespace sqlite_orm::internal {
             auto newContext = this->context;
             newContext.omit_table_name = false;
             auto columnName = serialize(orderBy._expression, newContext);
-            this->entries.emplace_back(std::move(columnName), std::move(orderBy._collate_argument), orderBy._order);
+            this->entries.emplace_back(std::move(columnName),
+                                       std::move(orderBy._collate_argument),
+                                       orderBy._order,
+                                       orderBy._nulls);
         }
 
         const_iterator begin() const {
@@ -22355,6 +22373,16 @@ namespace sqlite_orm::internal {
                 ss << " DESC";
                 break;
         }
+#if SQLITE_VERSION_NUMBER >= 3030000
+        switch (orderBy._nulls) {
+            case 1:
+                ss << " NULLS FIRST";
+                break;
+            case -1:
+                ss << " NULLS LAST";
+                break;
+        }
+#endif
     }
 
     template<class O>

--- a/tests/select_constraints_tests.cpp
+++ b/tests/select_constraints_tests.cpp
@@ -2,6 +2,7 @@
 #include <catch2/catch_all.hpp>
 
 #include <ctime>  //  std::time_t
+#include <optional>  //  std::optional
 
 using namespace sqlite_orm;
 
@@ -557,3 +558,45 @@ TEST_CASE("rows") {
     decltype(rows) expected{true};
     REQUIRE(rows == expected);
 }
+
+#if SQLITE_VERSION_NUMBER >= 3030000
+TEST_CASE("order by null placement") {
+    struct Player {
+        int id = 0;
+        std::optional<int> score;
+    };
+    auto storage = make_storage(
+        {},
+        make_table("players", make_column("id", &Player::id, primary_key()), make_column("score", &Player::score)));
+    storage.sync_schema();
+    storage.replace(Player{1, 10});
+    storage.replace(Player{2, std::nullopt});
+    storage.replace(Player{3, 20});
+
+    std::vector<int> rows;
+    decltype(rows) expected;
+    SECTION("ascending puts NULLs first by default") {
+        rows = storage.select(&Player::id, order_by(&Player::score).asc());
+        expected = {2, 1, 3};
+    }
+    SECTION("ascending with NULLS LAST") {
+        rows = storage.select(&Player::id, order_by(&Player::score).asc().nulls_last());
+        expected = {1, 3, 2};
+    }
+    SECTION("descending puts NULLs last by default") {
+        rows = storage.select(&Player::id, order_by(&Player::score).desc());
+        expected = {3, 1, 2};
+    }
+    SECTION("descending with NULLS FIRST") {
+        rows = storage.select(&Player::id, order_by(&Player::score).desc().nulls_first());
+        expected = {2, 3, 1};
+    }
+    SECTION("dynamic order by with NULLS LAST") {
+        auto orderBy = dynamic_order_by(storage);
+        orderBy.push_back(order_by(&Player::score).desc().nulls_last());
+        rows = storage.select(&Player::id, orderBy);
+        expected = {3, 1, 2};
+    }
+    REQUIRE(rows == expected);
+}
+#endif

--- a/tests/select_constraints_tests.cpp
+++ b/tests/select_constraints_tests.cpp
@@ -336,7 +336,7 @@ TEST_CASE("Case") {
                 .end(),
             order_by(&Track2::name));
         auto verifyRows = [&storage](auto& rows) {
-            REQUIRE(rows.size() == storage.count<Track2>());
+            REQUIRE(rows.size() == static_cast<size_t>(storage.count<Track2>()));
             REQUIRE(rows[0] == "long");
             REQUIRE(rows[1] == "medium");
             REQUIRE(rows[2] == "long");

--- a/tests/statement_serializer_tests/conditions.cpp
+++ b/tests/statement_serializer_tests/conditions.cpp
@@ -50,6 +50,54 @@ TEST_CASE("statement_serializer conditions") {
             value = serialize(expression, ctx);
             expected = R"(ORDER BY "user"."id" DESC)";
         }
+#if SQLITE_VERSION_NUMBER >= 3030000
+        SECTION("nulls first") {
+            auto expression = order_by(&User::id).nulls_first();
+            value = serialize(expression, ctx);
+            expected = R"(ORDER BY "user"."id" NULLS FIRST)";
+        }
+        SECTION("nulls last") {
+            auto expression = order_by(&User::id).nulls_last();
+            value = serialize(expression, ctx);
+            expected = R"(ORDER BY "user"."id" NULLS LAST)";
+        }
+        SECTION("asc, nulls first") {
+            auto expression = order_by(&User::id).asc().nulls_first();
+            value = serialize(expression, ctx);
+            expected = R"(ORDER BY "user"."id" ASC NULLS FIRST)";
+        }
+        SECTION("asc, nulls last") {
+            auto expression = order_by(&User::id).asc().nulls_last();
+            value = serialize(expression, ctx);
+            expected = R"(ORDER BY "user"."id" ASC NULLS LAST)";
+        }
+        SECTION("desc, nulls first") {
+            auto expression = order_by(&User::id).desc().nulls_first();
+            value = serialize(expression, ctx);
+            expected = R"(ORDER BY "user"."id" DESC NULLS FIRST)";
+        }
+        SECTION("desc, nulls last") {
+            auto expression = order_by(&User::id).desc().nulls_last();
+            value = serialize(expression, ctx);
+            expected = R"(ORDER BY "user"."id" DESC NULLS LAST)";
+        }
+        SECTION("the builder order does not matter") {
+            auto expression = order_by(&User::id).nulls_last().desc();
+            value = serialize(expression, ctx);
+            expected = R"(ORDER BY "user"."id" DESC NULLS LAST)";
+        }
+        SECTION("collated, desc, nulls last") {
+            auto expression = order_by(&User::name).collate_nocase().desc().nulls_last();
+            value = serialize(expression, ctx);
+            expected = R"(ORDER BY "user"."name" COLLATE NOCASE DESC NULLS LAST)";
+        }
+        SECTION("multi with mixed null placements") {
+            auto expression =
+                multi_order_by(order_by(&User::id).asc().nulls_last(), order_by(&User::name).desc().nulls_first());
+            value = serialize(expression, ctx);
+            expected = R"(ORDER BY "user"."id" ASC NULLS LAST, "user"."name" DESC NULLS FIRST)";
+        }
+#endif
         SECTION("multi, single") {
             auto expression = multi_order_by(order_by(&User::id));
             value = serialize(expression, ctx);


### PR DESCRIPTION
Eighth S-tier item of the feature-design pass: the null-placement clause of SQLite 3.30.

`nulls_first()` / `nulls_last()` are copy-builders on `order_by_t` beside `asc()`/`desc()`, so they compose in any order with the direction and collation builders — `.collate_nocase().desc().nulls_last()` and `.nulls_last().desc()` serialize identically (pinned by a test). The tri-state lives in `order_by_base`, which makes the single ordering term, `multi_order_by()` and `dynamic_order_by()` (propagated through `push_back`) all carry it; the suffix is emitted at the one shared serialization choke point, after ASC/DESC as the ordering-term grammar prescribes. Gated on `SQLITE_VERSION_NUMBER >= 3030000`.

Tests cover the full combination matrix:
- serializer: bare, asc/desc × first/last, builder-order independence, collation + direction + placement, `multi_order_by` with mixed placements;
- runtime: the SQLite defaults pinned first (ASC puts NULLs first, DESC puts them last), then both non-default placements flipping them, plus a `dynamic_order_by` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)